### PR TITLE
Issue/1127 show dataset count per organisation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 -   Added Zendesk feedback widget activated via footer link
 -   Made end of content spacing consistent
 -   Added `flex` display and set consistent padding from footer.
+-   Organisation page now displays the number of datasets for that organisation
 
 ## 0.0.41
 

--- a/magda-web-client/src/Components/Publisher/PublisherSummary.js
+++ b/magda-web-client/src/Components/Publisher/PublisherSummary.js
@@ -16,6 +16,10 @@ function PublisherSummary(props) {
                     {props.publisher.name}
                 </Link>
             </h2>
+            <div className="publisher-dataset-count">{`[${
+                props.publisher.datasetCount
+            }] datasets`}</div>
+            <br />
             <div className="publisher-description">
                 {details.description &&
                     details.description.slice(0, 200) + "..."}

--- a/magda-web-client/src/Components/Publisher/PublisherSummary.js
+++ b/magda-web-client/src/Components/Publisher/PublisherSummary.js
@@ -16,9 +16,14 @@ function PublisherSummary(props) {
                     {props.publisher.name}
                 </Link>
             </h2>
-            <div className="publisher-dataset-count">{`[${
-                props.publisher.datasetCount
-            }] datasets`}</div>
+            <div className="publisher-dataset-count">
+                <Link
+                    to={
+                        "organisations/" +
+                        encodeURIComponent(props.publisher.id)
+                    }
+                >{`[${props.publisher.datasetCount}] datasets`}</Link>
+            </div>
             <br />
             <div className="publisher-description">
                 {details.description &&

--- a/magda-web-client/src/Components/Publisher/PublisherSummary.scss
+++ b/magda-web-client/src/Components/Publisher/PublisherSummary.scss
@@ -13,7 +13,6 @@
 
     .publisher-title {
         @include AU-fontgrid(md);
-        color: $AU-color-foreground-action;
         font-weight: 300;
         margin-bottom: 0;
         a {
@@ -41,5 +40,13 @@
 
     .publisher-dataset-count {
         color: $AU-color-foreground-action;
+        a {
+            text-decoration: none;
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+                color: $AU-color-foreground-focus;
+            }
+        }
     }
 }

--- a/magda-web-client/src/Components/Publisher/PublisherSummary.scss
+++ b/magda-web-client/src/Components/Publisher/PublisherSummary.scss
@@ -28,6 +28,7 @@
 
     .publisher-description {
         @include AU-fontgrid(xs);
+        font-weight: lighter;
         margin-bottom: 8px;
         overflow: hidden;
         h1,
@@ -36,5 +37,9 @@
         h4 {
             margin: 0 0 10px;
         }
+    }
+
+    .publisher-dataset-count {
+        color: $AU-color-foreground-action;
     }
 }


### PR DESCRIPTION
### What this PR does
**PLEASE IGNORE FOR NOW, THIS PR IS JUST SO WE DON'T DUPLICATE WORK!**

Got sidetracked earlier in the day and quickly did the frontend for the dataset count, was waiting to have a chat with Jacky. Organisation aspect will use `datasetCount`

Made some unrelated `font-weight` changes so the style is inline with the Figma mockups.  

## Preview:
![screen shot 2018-06-12 at 4 18 16 pm](https://user-images.githubusercontent.com/1501560/41273318-4354be68-6e5c-11e8-88e7-48c186bc20d3.png)


### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
