### PR TITLE
Issue/1281 Logging system adjustment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 0.0.43
+
+-   Add breadcrumb for dataset page and distribution page
+-   Added UNSAFE\_ annotations or refactored to prepare for [React async rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+-   Use Async appender for logback logging
+-   Removed logging to file
+-   Akka logging setting adjustment
+
 ## 0.0.42
 
 -   Implemented the new pagination design

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,3 @@
-## 0.0.43
-
--   Add breadcrumb for dataset page and distribution page
--   Added UNSAFE\_ annotations or refactored to prepare for [React async rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
--   Use Async appender for logback logging
--   Removed logging to file
--   Akka logging setting adjustment
-
 ## 0.0.42
 
 -   Implemented the new pagination design
@@ -28,6 +20,9 @@
 -   Replaced underscores with spaces on distribution links, making them wrap on mobile
 -   Improved modal design on report/ask a question on a dataset
 -   Set default quality to 0 when indexing
+-   Use Async appender for logback logging
+-   Removed logging to file
+-   Akka logging setting adjustment
 
 ## 0.0.41
 

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -3,6 +3,28 @@ http {
   port = 6103
 }
 
+# we need to have this section in every module
+# Plus, logback.xml in resource of every module
+# Put into common module since not working properly
+# Although logging system does see config files in both paths
+akka {
+    # set this on to debug logging system itself
+    # useful when you not sure which config is loaded
+    log-config-on-start = off
+    loggers = ["akka.event.Logging$DefaultLogger"]
+    # have to set this in order make sure logs are filtered using xml config before enter log bus
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+    loglevel = "INFO"
+
+    # By default messages sent to dead letters are logged at info level
+    # We turned it off to avoid flooding the the logs when busy
+    # Alternatively, we can set log-dead-letters = 10 i.e. only display 10 dead letters
+    log-dead-letters = off
+    # We don't want to see dead letters during system shutdown
+    log-dead-letters-during-shutdown = off
+}
+
+
 indexer {
   readSnapshots = false
   alwaysReindex = false

--- a/magda-indexer/src/main/resources/logback.xml
+++ b/magda-indexer/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender" neverBlock="true">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <!-- Mute debug message from logback itself-->
+    <logger name="ch.qos.logback" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC" />
+    </root>
+
+</configuration>

--- a/magda-registry-api/src/main/resources/application.conf
+++ b/magda-registry-api/src/main/resources/application.conf
@@ -1,5 +1,22 @@
+# we need to have this section in every module
+# Plus, logback.xml in resource of every module
+# Put into common module since not working properly
+# Although logging system does see config files in both paths
 akka {
-  loglevel = "INFO"
+    # set this on to debug logging system itself
+    # useful when you not sure which config is loaded
+    log-config-on-start = off
+    loggers = ["akka.event.Logging$DefaultLogger"]
+    # have to set this in order make sure logs are filtered using xml config before enter log bus
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+    loglevel = "INFO"
+
+    # By default messages sent to dead letters are logged at info level
+    # We turned it off to avoid flooding the the logs when busy
+    # Alternatively, we can set log-dead-letters = 10 i.e. only display 10 dead letters
+    log-dead-letters = off
+    # We don't want to see dead letters during system shutdown
+    log-dead-letters-during-shutdown = off
 }
 
 http {

--- a/magda-registry-api/src/main/resources/logback.xml
+++ b/magda-registry-api/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern> sddsdds %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/magda-registry-api/src/main/resources/logback.xml
+++ b/magda-registry-api/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern> sddsdds %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender" neverBlock="true">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <!-- Mute debug message from logback itself-->
+    <logger name="ch.qos.logback" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC" />
+    </root>
+
+</configuration>

--- a/magda-scala-common/src/main/resources/log4j2.xml
+++ b/magda-scala-common/src/main/resources/log4j2.xml
@@ -4,14 +4,10 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
-        <File name="MyFile" fileName="all.log" immediateFlush="false" append="false">
-            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
     </Appenders>
     <Loggers>
         <Root level="warning">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="MyFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/magda-search-api/src/main/resources/application.conf
+++ b/magda-search-api/src/main/resources/application.conf
@@ -1,8 +1,23 @@
 akka {
-  http {
-    client.parsing.max-content-length = 50000000
-    server.request-timeout = 30 s
-  }
+    # set this on to debug logging system itself
+    # useful when you not sure which config is loaded
+    log-config-on-start = off
+    loggers = ["akka.event.Logging$DefaultLogger"]
+    # have to set this in order make sure logs are filtered using xml config before enter log bus
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+    loglevel = "INFO"
+
+    # By default messages sent to dead letters are logged at info level
+    # We turned it off to avoid flooding the the logs when busy
+    # Alternatively, we can set log-dead-letters = 10 i.e. only display 10 dead letters
+    log-dead-letters = off
+    # We don't want to see dead letters during system shutdown
+    log-dead-letters-during-shutdown = off
+
+    http {
+        client.parsing.max-content-length = 50000000
+        server.request-timeout = 30 s
+    }
 }
 
 http {

--- a/magda-search-api/src/main/resources/logback.xml
+++ b/magda-search-api/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender" neverBlock="true">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <!-- Mute debug message from logback itself-->
+    <logger name="ch.qos.logback" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
### What this PR does

- Use `logback` `AsyncAppender` for logging request to avoid potential blocking when busy
  - Set `neverBlock` field to true: If logging buffer is full, new log will be discarded (https://logback.qos.ch/manual/appenders.html#asyncNeverBlock)
  - Muted `info` log from `logback` itself
- Changed akka setting in order to make `logback.xml` to be used
  - Also disabled dead letters logging ( https://doc.akka.io/docs/akka/2.5/logging.html#logging-of-dead-letters )
- Remove `file appender` from log4j2 logger
  - it's still be used by old version `elastic4s`
  - New version `elastic4s` uses slf4j. Thus, the actual logger will become our `logback` implementation --- we can delete `log4j2.xml` then

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
