### PR TITLE
Issue/1280 Change registry /records API `pageToken` parameter to a Long type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 -   Add breadcrumb for dataset page and distribution page
 -   Added UNSAFE\_ annotations or refactored to prepare for [React async rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+-   Changed registry /records api `pageToken` as long type parameter to avoid runtime error
 
 ## 0.0.42
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -20,7 +20,7 @@ trait RecordPersistence {
   def getAllWithAspects(implicit session: DBSession,
                         aspectIds: Iterable[String],
                         optionalAspectIds: Iterable[String],
-                        pageToken: Option[String] = None,
+                        pageToken: Option[Long] = None,
                         start: Option[Int] = None,
                         limit: Option[Int] = None,
                         dereference: Option[Boolean] = None,
@@ -86,7 +86,7 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
   def getAllWithAspects(implicit session: DBSession,
                         aspectIds: Iterable[String],
                         optionalAspectIds: Iterable[String],
-                        pageToken: Option[String] = None,
+                        pageToken: Option[Long] = None,
                         start: Option[Int] = None,
                         limit: Option[Int] = None,
                         dereference: Option[Boolean] = None,
@@ -549,7 +549,7 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
   private def getRecords(implicit session: DBSession,
                          aspectIds: Iterable[String],
                          optionalAspectIds: Iterable[String],
-                         pageToken: Option[String] = None,
+                         pageToken: Option[Long] = None,
                          start: Option[Int] = None,
                          limit: Option[Int] = None,
                          dereference: Option[Boolean] = None,
@@ -567,7 +567,7 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
     }
 
     var lastSequence: Option[Long] = None
-    val whereClauseParts = countWhereClauseParts :+ pageToken.map(token => sqls"Records.sequence > ${token.toLong}")
+    val whereClauseParts = countWhereClauseParts :+ pageToken.map(token => sqls"Records.sequence > ${token}")
     val aspectSelectors = aspectIdsToSelectClauses(List.concat(aspectIds, optionalAspectIds), dereferenceDetails)
 
     val pageResults =

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -42,14 +42,14 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "aspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response."),
     new ApiImplicitParam(name = "optionalAspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The optional aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  These aspects will be included in a record if available, but a record will be included even if it is missing these aspects."),
-    new ApiImplicitParam(name = "pageToken", required = false, dataType = "string", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
+    new ApiImplicitParam(name = "pageToken", required = false, dataType = "number", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
     new ApiImplicitParam(name = "start", required = false, dataType = "number", paramType = "query", value = "The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve."),
     new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off."),
     new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter."),
     new ApiImplicitParam(name = "aspectQuery", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "Filter the records returned by a value within the aspect JSON. Expressed as 'aspectId.path.to.field:value', url encoded. NOTE: This is an early stage API and may change greatly in the future")))
   def getAll = get {
     pathEnd {
-      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
+      parameters('aspect.*, 'optionalAspect.*, 'pageToken.as[Long].?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
         (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQueries) =>
           val parsedAspectQueries = aspectQueries.map(AspectQuery.parse)
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -42,22 +42,34 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "aspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response."),
     new ApiImplicitParam(name = "optionalAspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The optional aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  These aspects will be included in a record if available, but a record will be included even if it is missing these aspects."),
-    new ApiImplicitParam(name = "pageToken", required = false, dataType = "number", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
+    new ApiImplicitParam(name = "pageToken", required = false, dataType = "string", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
     new ApiImplicitParam(name = "start", required = false, dataType = "number", paramType = "query", value = "The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve."),
     new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off."),
     new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter."),
     new ApiImplicitParam(name = "aspectQuery", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "Filter the records returned by a value within the aspect JSON. Expressed as 'aspectId.path.to.field:value', url encoded. NOTE: This is an early stage API and may change greatly in the future")))
   def getAll = get {
     pathEnd {
-      parameters('aspect.*, 'optionalAspect.*, 'pageToken.as[Long].?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
+      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
         (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQueries) =>
           val parsedAspectQueries = aspectQueries.map(AspectQuery.parse)
-
-          complete {
-            DB readOnly { session =>
-              recordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference, parsedAspectQueries)
+          try{
+            val pageTokenConverted = pageToken.map(_.toLong)
+            complete {
+              DB readOnly { session =>
+                recordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageTokenConverted, start, limit, dereference, parsedAspectQueries)
+              }
             }
+          }catch{
+            case e: NumberFormatException =>
+              complete(StatusCodes.BadRequest,
+                s"""The query parameter 'pageToken' was malformed:
+                   |'${pageToken.get}' is not a valid 64-bit signed integer value
+                 """.stripMargin)
+            case e: Throwable =>
+              logger.error("Error when process `/records` request: {}", e)
+              complete(StatusCodes.InternalServerError)
           }
+
       }
     }
   }


### PR DESCRIPTION
### What this PR does

Change registry /records API `pageToken` parameter to a Long type to avoid the possible runtime exceptions.

Currently, it's declared as String type and convert to Long in the runtime before sent to DB.

Any incorrect format will trigger an uncaught `NumberFormatException`, which will print an error log entry.

Declare it as `number` type parameter will prevent uncaught exception be thrown (thus,, no log will be printed) and users will get correct `400 bad request` response:

```
The query parameter 'pageToken' was malformed:
'dsd12800' is not a valid 64-bit signed integer value
```

Updated:
- to avoid impact typescript API, the parameter was converted manually 

### Checklist

-   [x]  Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
