### PR TITLE
Changed the go-to-distribution button to an <a> tag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 -   Akka logging setting adjustment
 -   Made publisher and format filter search use the search backend instead of client-side autocomplete.
 -   Updated data quality explanation
+-   Made go-to-external-distribution button into an <a> tag instead of a javascript button.
 
 ## 0.0.41
 

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -133,14 +133,15 @@ class DistributionRow extends Component {
     render() {
         const { datasetId, distribution } = this.props;
         let distributionLink;
-        if (!distribution.downloadURL && distribution.accessURL)
+        if (!distribution.downloadURL && distribution.accessURL) {
             distributionLink = distribution.accessURL;
-        else
+        } else {
             distributionLink = `/dataset/${encodeURIComponent(
                 datasetId
             )}/distribution/${encodeURIComponent(distribution.identifier)}/?q=${
                 this.props.searchText
             }`;
+        }
 
         return (
             <div
@@ -190,17 +191,14 @@ class DistributionRow extends Component {
                                         </span>)
                                     </Link>
                                 )}
-                                <button
+                                <a
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    href={distributionLink}
                                     className="new-tab-button"
-                                    onClick={() => {
-                                        window.open(
-                                            distributionLink,
-                                            distribution.title
-                                        );
-                                    }}
                                 >
                                     <img src={newTabIcon} alt="new tab" />
-                                </button>
+                                </a>
                             </div>
 
                             <div

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -116,7 +116,8 @@ const cspDirectives = {
         "allow-scripts",
         "allow-same-origin",
         "allow-popups",
-        "allow-forms"
+        "allow-forms",
+        "allow-popups-to-escape-sandbox"
     ]
 } as helmet.IHelmetContentSecurityPolicyDirectives;
 


### PR DESCRIPTION
### What this PR does
Makes external distribution accessURL links open using an `<a>` tag instead of a javascript button.

### Checklist

-   [x]  Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
