### PR TITLE
Stopped the staging pipeline running for non-RC tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -408,7 +408,7 @@ dockerize:dockerExtensions:
     - branches
   except:
     - master
-    - /^v.*$/
+    - /^v.*RC.*$/
   dependencies: []
   cache:
     paths: []
@@ -512,7 +512,7 @@ Deploy Master To Dev:
 Release Tags To Docker Hub:
   stage: release
   only:
-    - /^v.*$/
+    - /^v.*RC.*$/
   except:
     - branches
     - triggers


### PR DESCRIPTION
### What this PR does
Right now the staging pipeline (which pushes tags to docker hub then auto-creates a full cluster using them) runs for any tag that starts with `v`... but really it should only run for `v#.#.#-RC#` tags because we don't want to rebuild the release images, just take the last working RC images and retag them as the release. This makes that happen in gitlab-ci.yml.