### PR TITLE
disable inactive link & distribution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 -   Upgraded `rollbar.js` 2.3.9 -> 2.4.1
 -   Added community link to header
 -   Map filter clear button only active when region is selected
+-   Disable interaction with broken links
 
 ## 0.0.42
 

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -14,37 +14,38 @@ class DistributionDetails extends Component {
     }
 
     renderLinkText(distribution) {
-        const downloadText = distribution.downloadURL ? (
-            <span key={distribution.identifier}>
-                This data file or API can be downloaded from: <br />
-                <a
-                    onClick={distribution => {
-                        // google analytics download tracking
-                        const resource_url = encodeURIComponent(
-                            distribution.downloadURL
-                        );
-                        if (resource_url) {
-                            ga("send", {
-                                hitType: "event",
-                                eventCategory: "Resource",
-                                eventAction: "Download",
-                                eventLabel: resource_url
-                            });
-                        }
-                    }}
-                    href={distribution.downloadURL}
-                >
-                    {" "}
-                    {distribution.downloadURL}
-                </a>
-                {this.renderLinkStatus(
-                    distribution.linkStatusAvailable,
-                    distribution.linkActive
-                )}
-            </span>
-        ) : (
-            ""
-        );
+        const downloadText =
+            distribution.downloadURL && distribution.linkActive ? (
+                <span key={distribution.identifier}>
+                    This data file or API can be downloaded from: <br />
+                    <a
+                        onClick={distribution => {
+                            // google analytics download tracking
+                            const resource_url = encodeURIComponent(
+                                distribution.downloadURL
+                            );
+                            if (resource_url) {
+                                ga("send", {
+                                    hitType: "event",
+                                    eventCategory: "Resource",
+                                    eventAction: "Download",
+                                    eventLabel: resource_url
+                                });
+                            }
+                        }}
+                        href={distribution.downloadURL}
+                    >
+                        {" "}
+                        {distribution.downloadURL}
+                    </a>
+                    {this.renderLinkStatus(
+                        distribution.linkStatusAvailable,
+                        distribution.linkActive
+                    )}
+                </span>
+            ) : (
+                ""
+            );
         const accessText = distribution.accessURL ? (
             <span>
                 This dataset can be accessed from: <br />{" "}

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -132,6 +132,11 @@ class DistributionRow extends Component {
 
     render() {
         const { datasetId, distribution } = this.props;
+
+        const linkActive =
+            distribution.linkActive &&
+            (distribution.downloadURL || distribution.accessURL);
+
         let distributionLink;
         if (!distribution.downloadURL && distribution.accessURL) {
             distributionLink = distribution.accessURL;
@@ -219,18 +224,8 @@ class DistributionRow extends Component {
                     {distribution.downloadURL ? (
                         <button
                             className="download-button au-btn au-btn--secondary"
+                            disabled={!linkActive}
                             onClick={() => {
-                                if (!distribution.downloadURL) {
-                                    this.props.dispatch(
-                                        showTopNotification(
-                                            "Download link is not available for this data source!",
-                                            "Error:",
-                                            "error"
-                                        )
-                                    );
-                                    return;
-                                }
-
                                 // google analytics download tracking
                                 const resource_url = encodeURIComponent(
                                     distribution.downloadURL
@@ -250,6 +245,7 @@ class DistributionRow extends Component {
                             <a
                                 className="button-text"
                                 itemProp="contentUrl"
+                                disabled={!linkActive}
                                 href={distribution.downloadURL}
                             >
                                 Download

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -76,6 +76,40 @@ class RecordHandler extends React.Component {
             ? this.props.dataset.publisher.id
             : null;
 
+        const downloadLink =
+            this.props.distribution.linkActive &&
+            this.props.distribution.downloadURL ? (
+                <div>
+                    <AUbutton
+                        className="distribution-download-button"
+                        href={this.props.distribution.downloadURL}
+                        alt="distribution download button"
+                    >
+                        Download
+                    </AUbutton>
+                    <Small>
+                        <DescriptionBox
+                            content={this.props.distribution.description}
+                            truncateLength={200}
+                        />
+                    </Small>
+                    <Medium>
+                        <DescriptionBox
+                            content={this.props.distribution.description}
+                            truncateLength={500}
+                        />
+                    </Medium>
+                </div>
+            ) : (
+                <div
+                    role="alert"
+                    className="au-page-alerts au-page-alerts--info"
+                    aria-label="download not available"
+                >
+                    Oops this data set is not available
+                </div>
+            );
+
         if (this.props.match.params.distributionId) {
             if (this.props.distributionIsFetching) {
                 return <ProgressBar />;
@@ -130,25 +164,7 @@ class RecordHandler extends React.Component {
                             {this.props.distribution.license}
                         </div>
                         <br />
-                        <AUbutton
-                            className="distribution-download-button"
-                            href={this.props.distribution.downloadURL}
-                            alt="distribution download button"
-                        >
-                            Download
-                        </AUbutton>{" "}
-                        <Small>
-                            <DescriptionBox
-                                content={this.props.distribution.description}
-                                truncateLength={200}
-                            />
-                        </Small>
-                        <Medium>
-                            <DescriptionBox
-                                content={this.props.distribution.description}
-                                truncateLength={500}
-                            />
-                        </Medium>
+                        {downloadLink}
                         <div className="tab-content">
                             <Switch>
                                 <Route

--- a/magda-web-client/src/helpers/record.js
+++ b/magda-web-client/src/helpers/record.js
@@ -75,7 +75,8 @@ export type RawDistribution = {
     aspects: {
         "dcat-distribution-strings": dcatDistributionStrings,
         "source-link-status": {
-            status: ?string
+            status: ?string,
+            httpStatusCode: number
         },
         "visualization-info": {
             fields: Object,


### PR DESCRIPTION

### What this PR does
on distribution page: 

> don't show the download button for data sets that have broken links. Instead, show a visual indicator & text - "Oops this data set is not available" or something similar


<img width="989" alt="screen shot 2018-07-03 at 11 54 28 am" src="https://user-images.githubusercontent.com/7508939/42194554-dbee8f62-7eb7-11e8-8596-9dde19022b0d.png">

On dataset page: 
Disable download button if link is broken
<img width="985" alt="screen shot 2018-07-03 at 11 54 42 am" src="https://user-images.githubusercontent.com/7508939/42194563-eaaa527a-7eb7-11e8-9e6e-4b8d1a6708ad.png">

To test locally: http://localhost:6108/dataset/ds-sa-b48c6307-e1d1-4399-9660-c5d32b4c858a/details?q=water

### Checklist
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [ ] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
