### PR TITLE
Fixed not being able to click on filter values

### DIFF
--- a/magda-web-client/src/Components/Publisher/PublishersViewer.js
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.js
@@ -113,7 +113,7 @@ class PublishersViewer extends Component {
                 <div className="publishers-viewer">
                     <Breadcrumbs
                         breadcrumbs={[
-                            <li>
+                            <li key="breadcrumb">
                                 <span>Organisations</span>
                             </li>
                         ]}

--- a/magda-web-client/src/Components/SearchFacets/ClearAllButton.js
+++ b/magda-web-client/src/Components/SearchFacets/ClearAllButton.js
@@ -25,7 +25,6 @@ const ClearAllButton = ({ location, history, dispatch }) => {
                         as="secondary"
                         className="btn-facet"
                         onClick={() => {
-                            console.log(location);
                             const query = queryString.parse(location.search);
                             const qStr = queryString.stringify({
                                 q: query.q ? query.q : ""

--- a/magda-web-client/src/Components/SearchFacets/FacetBasic.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasic.js
@@ -18,6 +18,7 @@ class FacetBasic extends Component {
                 />
                 {this.props.isOpen && (
                     <FacetBasicBody
+                        key={this.props.activeOptions}
                         options={this.props.options}
                         activeOptions={this.props.activeOptions}
                         facetSearchResults={this.props.facetSearchResults}

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -13,14 +13,8 @@ class FacetBasicBody extends Component {
         this.onToggleOption = this.onToggleOption.bind(this);
         this.searchBoxValueChange = this.searchBoxValueChange.bind(this);
         this.state = {
-            _activeOptions: [],
+            _activeOptions: props.activeOptions || [],
             showOptions: true
-        };
-    }
-
-    static getDerivedStateFromProps(props) {
-        return {
-            _activeOptions: props.activeOptions
         };
     }
 
@@ -51,6 +45,7 @@ class FacetBasicBody extends Component {
     onToggleOption(option) {
         const existingOptions = this.state._activeOptions.map(o => o.value);
         const index = existingOptions.indexOf(option.value);
+
         // if the option is already selected remove it from _activeOptions
         if (index > -1) {
             this.setState({

--- a/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
@@ -48,8 +48,6 @@ class FacetTemporal extends Component {
      * been clicked in the facetHeader. If it has, then don't applyFilter.
      */
     componentWillUnmount() {
-        console.log(this.state);
-
         if (this.canApply() && !this.props.disableApply) {
             this.onApplyFilter();
         }

--- a/magda-web-client/src/UI/DataPreviewChart.js
+++ b/magda-web-client/src/UI/DataPreviewChart.js
@@ -78,7 +78,6 @@ class DataPreviewChart extends Component {
                     chartType,
                     chartOption
                 });
-                if (console && console.log) console.log(chartOption);
             }
         } catch (e) {
             console.log(e);

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -57,10 +57,6 @@ class DataPreviewMap extends Component {
             });
             return;
         } else {
-            if (console && console.log) {
-                console.log("map preview distribution selection: ");
-                console.log(selectedDistribution);
-            }
             this.setState({
                 isInitLoading: false,
                 isMapLoading: true,

--- a/magda-web-client/src/actions/publisherActions.js
+++ b/magda-web-client/src/actions/publisherActions.js
@@ -114,7 +114,6 @@ function fetchPublisher(id) {
         const url = `${
             config.registryApiUrl
         }records/${id}?aspect=organization-details`;
-        console.log(url);
         return fetch(url)
             .then(response => {
                 if (response.status === 200) {


### PR DESCRIPTION
### What this PR does
- Makes it so you can click filter values again
- Adds a key to breadcrumbs in the org page so the console doesn't whinge
- Removes some debug `console.logs`.

### Checklist

-   [x] Unit tests aren't applicable (delete one)
-   [x] No CHANGES - this fixes something that worked last release
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
