### PR TITLE
Issue/1366 Fixed: Enter a dataset page with `*` query string will see a blank page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 -   Map filter clear button only active when region is selected
 -   Fixed a bug on not able to get correct distribution and blank dataset title in breadcrumb
 -   Changed chart icons on dataset page
+-   Fixed: Enter a dataset page with `*` query string will see a blank page
 
 ## 0.0.42
 

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -181,7 +181,10 @@ class RecordHandler extends React.Component {
                                 />
                                 <Redirect
                                     from="/dataset/:datasetId/distribution/:distributionId"
-                                    to={`${baseUrlDistribution}/details?q=${searchText}`}
+                                    to={{
+                                        pathname: `${baseUrlDistribution}/details`,
+                                        search: `?q=${searchText}`
+                                    }}
                                 />
                             </Switch>
                         </div>
@@ -270,12 +273,18 @@ class RecordHandler extends React.Component {
                                 <Redirect
                                     exact
                                     from="/dataset/:datasetId"
-                                    to={`${baseUrlDataset}/details?q=${searchText}`}
+                                    to={{
+                                        pathname: `${baseUrlDataset}/details`,
+                                        search: `?q=${searchText}`
+                                    }}
                                 />
                                 <Redirect
                                     exact
                                     from="/dataset/:datasetId/resource/*"
-                                    to={`${baseUrlDataset}/details?q=${searchText}`}
+                                    to={{
+                                        pathname: `${baseUrlDataset}/details`,
+                                        search: `?q=${searchText}`
+                                    }}
                                 />
                             </Switch>
                         </div>


### PR DESCRIPTION
### What this PR does

Issue/1366 Fixed: Enter a dataset page with `*` query string will see a blank page

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
