### PR TITLE
Handle chart error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 -   Make suggestion form scrollable on short screen
 -   Default button color fix
 -   Fix the bug that which does not allow add another option to publisher or format filters once you have performed a search using the filter.
+-   Improve UI for chart loading error
 
 ## 0.0.43
 

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -33,7 +33,7 @@ class DatasetDetails extends Component {
                 <div className="row">
                     <div className="col-sm-12">
                         <div className="dataset-details-files-apis">
-                            <h3 className="clearfix">
+                            <h3 className="clearfix section-heading">
                                 <span className="section-heading">
                                     Files and APIs
                                 </span>
@@ -66,9 +66,9 @@ class DatasetDetails extends Component {
                             className="dataset-details-temporal-coverage"
                             style={{ display: "none" }}
                         >
-                            <h2 className="section-heading">
+                            <h3 className="section-heading">
                                 Temporal coverage
-                            </h2>
+                            </h3>
                             <TemporalAspectViewer
                                 data={dataset.temporalCoverage}
                             />

--- a/magda-web-client/src/Components/RecordHandler.scss
+++ b/magda-web-client/src/Components/RecordHandler.scss
@@ -1,11 +1,31 @@
 @import "../variables";
 
 .dataset-details {
-    h3 {
+    h3.section-heading {
         @include AU-fontgrid(lg, heading);
         margin-bottom: 10px;
         margin-top: 3rem;
         font-weight: 300;
+    }
+
+    .au-page-alerts {
+        h3,
+        p {
+            margin: 3px;
+        }
+        .switch-tab-btn {
+            border: 0;
+            border-bottom: 1px solid $magda-red;
+            padding-bottom: 4px;
+            text-decoration: none;
+            color: $magda-red;
+            font-size: 1rem;
+            padding: 0;
+            &:hover,
+            &:focus {
+                cursor: pointer;
+            }
+        }
     }
 }
 

--- a/magda-web-client/src/UI/DataPreviewChart.js
+++ b/magda-web-client/src/UI/DataPreviewChart.js
@@ -6,11 +6,20 @@ import ChartConfig from "./ChartConfig";
 import downArrowIcon from "../assets/downArrow.svg";
 import upArrowIcon from "../assets/upArrow.svg";
 import AUpageAlert from "../pancake/react/page-alerts";
+import memoize from "memoize-one";
 import "./DataPreviewChart.css";
 
 let ReactEcharts = null;
 
 const defaultChartType = "bar";
+
+// we only do the auto redirect in the first time,
+// subsequent tab switching does not trigger redirect
+const switchTabOnFirstGo = memoize(
+    props => props.onChangeTab("table"),
+    (prev, next) =>
+        prev.distribution.identifier === next.distribution.identifier
+);
 
 class DataPreviewChart extends Component {
     constructor(props) {
@@ -101,7 +110,7 @@ class DataPreviewChart extends Component {
                 })
             );
             // if there is error, automatically switch to table view
-            this.props.onChangeTab("table");
+            switchTabOnFirstGo(this.props);
         }
     }
 

--- a/magda-web-client/src/UI/DataPreviewChart.js
+++ b/magda-web-client/src/UI/DataPreviewChart.js
@@ -5,6 +5,7 @@ import ChartDatasetEncoder from "../helpers/ChartDatasetEncoder";
 import ChartConfig from "./ChartConfig";
 import downArrowIcon from "../assets/downArrow.svg";
 import upArrowIcon from "../assets/upArrow.svg";
+import AUpageAlert from "../pancake/react/page-alerts";
 import "./DataPreviewChart.css";
 
 let ReactEcharts = null;
@@ -25,6 +26,7 @@ class DataPreviewChart extends Component {
         this.chartDatasetEncoder = null;
         this.onChartConfigChanged = this.onChartConfigChanged.bind(this);
         this.onToggleButtonClick = this.onToggleButtonClick.bind(this);
+        this.onDismissError = this.onDismissError.bind(this);
     }
 
     getResetState(extraOptions = null) {
@@ -93,12 +95,13 @@ class DataPreviewChart extends Component {
                 ReactEcharts = (await import("echarts-for-react")).default;
             await this.initChartData();
         } catch (e) {
-            console.error(e);
             this.setState(
                 this.getResetState({
                     error: e
                 })
             );
+            // if there is error, automatically switch to table view
+            this.props.onChangeTab("table");
         }
     }
 
@@ -123,7 +126,8 @@ class DataPreviewChart extends Component {
                 await this.initChartData();
             }
         } catch (e) {
-            console.error(e);
+            // we do not automatically switch to table view here because chart has already successfully rendered.
+            // for subsequent error cause the chart to not render, we will just display an error message
             this.setState(
                 this.getResetState({
                     error: e
@@ -143,13 +147,24 @@ class DataPreviewChart extends Component {
         });
     }
 
+    onDismissError() {
+        // switch to table tab on dismiss error
+        this.props.onChangeTab("table");
+    }
+
     render() {
         if (this.state.error)
             return (
-                <div className="error">
-                    <h3>{this.state.error.name}</h3>
-                    {this.state.error.message}
-                </div>
+                <AUpageAlert as="error" className="notification__inner">
+                    <h3>Oops</h3>
+                    <p>Chart preview not available, please try table preview</p>
+                    <button
+                        onClick={this.onDismissError}
+                        className="switch-tab-btn"
+                    >
+                        Switch to table preview
+                    </button>
+                </AUpageAlert>
             );
         if (this.state.isLoading) return <Spinner height="420px" />;
         if (!ReactEcharts)

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -170,7 +170,7 @@ class DataPreviewMap extends Component {
 
         return (
             <div>
-                <h3>Map Preview</h3>
+                <h3 className="section-heading">Map Preview</h3>
                 <Small>
                     <DataPreviewMapOpenInNationalMapButton
                         distribution={selectedDistribution}

--- a/magda-web-client/src/UI/DataPreviewTable.js
+++ b/magda-web-client/src/UI/DataPreviewTable.js
@@ -4,6 +4,7 @@ import "./ReactTable.css";
 import { config } from "../config";
 import { Medium, Small } from "./Responsive";
 import Spinner from "../Components/Spinner";
+import AUpageAlert from "../pancake/react/page-alerts";
 
 function loadPapa() {
     return import(/* webpackChunkName: "papa" */ "papaparse")
@@ -94,10 +95,13 @@ export default class DataPreviewTable extends Component<
     render() {
         if (this.state.error) {
             return (
-                <div className="error">
-                    <h3>{this.state.error.name}</h3>
-                    {this.state.error.message}
-                </div>
+                <AUpageAlert as="error" className="notification__inner">
+                    <h3>Oops</h3>
+                    <p>
+                        Either there's something wrong with the file or there's
+                        an internet connection problem
+                    </p>
+                </AUpageAlert>
             );
         }
         if (this.state.loading) {

--- a/magda-web-client/src/UI/DataPreviewVis.js
+++ b/magda-web-client/src/UI/DataPreviewVis.js
@@ -23,16 +23,21 @@ class DataPreviewVis extends Component<{
     }
 
     renderChart() {
-        return <DataPreviewChart distribution={this.props.distribution} />;
+        return (
+            <DataPreviewChart
+                distribution={this.props.distribution}
+                onChangeTab={this.onChangeTab}
+            />
+        );
     }
 
     renderTable() {
         return <DataPreviewTable distribution={this.props.distribution} />;
     }
 
-    onChangeTab(e) {
+    onChangeTab(tab) {
         this.setState({
-            visType: e.target.value
+            visType: tab
         });
     }
 
@@ -58,7 +63,10 @@ class DataPreviewVis extends Component<{
                                         : null
                                 }`}
                                 value={t.value.toLowerCase()}
-                                onClick={this.onChangeTab}
+                                onClick={this.onChangeTab.bind(
+                                    this,
+                                    t.value.toLowerCase()
+                                )}
                             >
                                 {t.label}
                             </button>
@@ -90,7 +98,7 @@ class DataPreviewVis extends Component<{
         if (!bodyRenderResult) return null;
         return (
             <div className="data-preview-vis">
-                <h3>Data Preview</h3>
+                <h3 className="section-heading">Data Preview</h3>
                 {bodyRenderResult}
             </div>
         );

--- a/magda-web-client/src/UI/Notification.js
+++ b/magda-web-client/src/UI/Notification.js
@@ -26,12 +26,14 @@ function Notification(props) {
     return (
         <div className="notification-box">
             <AUpageAlert as={type} className="notification__inner">
-                <button
-                    onClick={props.onDismiss}
-                    className="au-btn close-btn au-btn--secondary"
-                >
-                    <img alt="close" src={close} />
-                </button>
+                {props.onDismiss && (
+                    <button
+                        onClick={props.onDismiss}
+                        className="au-btn close-btn au-btn--secondary"
+                    >
+                        <img alt="close" src={close} />
+                    </button>
+                )}
                 {title ? <h3>{title}</h3> : null}
                 <p>{detail}</p>
             </AUpageAlert>


### PR DESCRIPTION
### What this PR does

After discussing with @tkeuneman , this is how we are going to handle if the chart has loading error at the last step (after we checked the link is available and the format is correct):

1. automatically switch to table preview when the chart is not renderable when the page is firstly loaded.
2. when switching back to chart preview from table view, display error message on chart view and suggest user switch to table view 

To test, load page and turn off wifi while the chart is still loading

### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
