### PR TITLE
Tooltip style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 -   Improved styling of suggest dataset form
 -   Improve distribution link alignment
 -   Improve UI for chart loading error
+-   Improve tooltip look
 
 ## 0.0.43
 

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.scss
@@ -73,6 +73,10 @@
     .dataset-summary-updated,
     .dataset-summary-quality {
         float: left;
-        line-height: 1.5em;
+        line-height: 1.5rem;
+    }
+
+    .dataset-summary-quality .tooltip {
+        line-height: 2;
     }
 }

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.scss
@@ -77,6 +77,6 @@
     }
 
     .dataset-summary-quality .tooltip {
-        line-height: 2;
+        line-height: 1.8rem;
     }
 }

--- a/magda-web-client/src/Components/RecordHandler.scss
+++ b/magda-web-client/src/Components/RecordHandler.scss
@@ -78,6 +78,9 @@
 
 .quality-rating-box {
     margin: 20px 0;
+    .tooltip {
+        line-height: 2rem;
+    }
 
     span {
         color: #535353;

--- a/magda-web-client/src/UI/Tooltip.scss
+++ b/magda-web-client/src/UI/Tooltip.scss
@@ -3,6 +3,11 @@
     display: inline;
     margin-left: 5px;
     margin-top: 1px;
+
+    span {
+        line-height: 1.2;
+        font-size: 0.9rem;
+    }
 }
 
 .tooltip .tooltiptext {

--- a/magda-web-client/src/UI/Tooltip.scss
+++ b/magda-web-client/src/UI/Tooltip.scss
@@ -3,14 +3,11 @@
     display: inline;
     margin-left: 5px;
     margin-top: 1px;
-
-    span {
-        line-height: 1.2;
-        font-size: 0.9rem;
-    }
 }
 
 .tooltip .tooltiptext {
+    line-height: 1.2;
+    font-size: 0.9rem;
     visibility: hidden;
     width: 140px;
     background-color: #222;
@@ -19,7 +16,7 @@
     padding: 7px;
     position: absolute;
     z-index: 1;
-    bottom: 150%;
+    bottom: 110%;
     left: 50%;
     margin-left: -77px;
     border-radius: 4px;


### PR DESCRIPTION
### What this PR does
1. unified the two mentioned tooltip styles, set font-size to 0.9rem
2. aligned with star rating box

Eventually, we want to unify tooltip design/implementation, as mentioned here: https://github.com/magda-io/magda/issues/1106. But that would be a different issue

### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
