### PR TITLE
Issue/1438 Added Auto GZip compress to gateway

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 -   Improved styling of suggest dataset form
 -   Improve distribution link alignment
 -   Improve UI for chart loading error
+-   Added auto gzip compress to gateway
 
 ## 0.0.43
 

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -40,7 +40,8 @@
     "pg": "^6.4.0",
     "tsmonad": "^0.7.2",
     "urijs": "^1.18.12",
-    "yargs": "^8.0.2"
+    "yargs": "^8.0.2",
+    "compression": "^1.7.2"
   },
   "devDependencies": {
     "@magda/scripts": "^0.0.44-0",
@@ -56,6 +57,7 @@
     "@types/pg": "^6.1.41",
     "@types/urijs": "^1.15.34",
     "@types/yargs": "^8.0.2",
+    "@types/compression": "^0.0.36",
     "typescript": "~2.5.0"
   },
   "config": {

--- a/magda-gateway/src/index.ts
+++ b/magda-gateway/src/index.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as yargs from "yargs";
 import * as ejs from "ejs";
 import * as helmet from "helmet";
+import * as compression from "compression";
 
 import addJwtSecretFromEnvVar from "@magda/typescript-common/dist/session/addJwtSecretFromEnvVar";
 
@@ -128,6 +129,7 @@ const authenticator = new Authenticator({
 
 // Create a new Express application.
 var app = express();
+app.use(compression());
 app.disable("x-powered-by");
 app.use(
     helmet({

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,6 +555,12 @@
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
 
+"@types/compression@^0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-0.0.36.tgz#7646602ffbfc43ea48a8bf0b2f1d5e5f9d75c0d0"
+  dependencies:
+    "@types/express" "*"
+
 "@types/config@0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.32.tgz#c106055802d78e234e28374adc4dad460d098558"
@@ -3729,7 +3735,7 @@ compressible@~2.0.13:
   dependencies:
     mime-db ">= 1.34.0 < 2"
 
-compression@^1.5.2, compression@^1.6.0:
+compression@^1.5.2, compression@^1.6.0, compression@^1.7.2:
   version "1.7.2"
   resolved "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
   dependencies:


### PR DESCRIPTION
### What this PR does

Issue/1438 Added Auto GZip compress to gateway
Used `compression` lib: https://github.com/expressjs/compression
Checked the source code. By default, It can:
- Only compress `compressible` content by looking at `Content-type` header of res
  - It uses [compressible](https://www.npmjs.com/package/compressible) for this
- Will add `Accept-Encoding` [Vary](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary) header (and [this](https://stackoverflow.com/questions/43217103/google-cdn-random-not-serving-gzip-content)) so CDN can serve non-compress copy to upsupported client and compressed copy to supported client.
- Will only compress if client accept gzip or deflate encoding (by looking at Accept Encoding from request)

### Checklist

-   [x] Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
