### PR TITLE
Issue/1294 Fixed sitemap timeout if input is invalid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 -   Improve distribution link alignment
 -   Improve UI for chart loading error
 -   Added auto gzip compress to gateway
+-   Fixed Sitemap times out if input is invalid
 
 ## 0.0.43
 

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -130,7 +130,9 @@ export default function buildSitemapRouter({
     function catchError<T>(res: express.Response, promise: Promise<T>) {
         return promise.catch(e => {
             console.error(e);
-            res.status(500).send("Internal Server Error");
+            res.status(500)
+                .set("Content-Type", "text/plain")
+                .send("Internal Server Error");
         });
     }
 

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -130,7 +130,7 @@ export default function buildSitemapRouter({
     function catchError<T>(res: express.Response, promise: Promise<T>) {
         return promise.catch(e => {
             console.error(e);
-            res.status(500).end();
+            res.status(500).send("Internal Server Error");
         });
     }
 

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -224,7 +224,10 @@ app.use(
     "/sitemap",
     buildSitemapRouter({
         baseExternalUrl: argv.baseExternalUrl,
-        registry: new Registry({ baseUrl: argv.registryApiBaseUrlInternal })
+        registry: new Registry({
+            baseUrl: argv.registryApiBaseUrlInternal,
+            maxRetries: 0
+        })
     })
 );
 


### PR DESCRIPTION
### What this PR does

Issue/1294 Fixed sitemap timeout if input is invalid
- Changed from `res.end` to `res.send`
- Set Registry Client max Retry Times to 0
- Override `Content-Type` header to avoid web browser from displaying an XML error

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
