### PR TITLE
Issue/1460 Fixed organisation page content jumping issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 -   Added auto gzip compress to gateway
 -   Made CSW connector retrieve country field from alternative JSON path
 -   Fixed Sitemap times out if input is invalid
+-   Fixed Organisation content position moved (flicking) during data loading
 
 ## 0.0.43
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 -   Made CSW connector retrieve country field from alternative JSON path
 -   Fixed Sitemap times out if input is invalid
 -   Fixed Organisation content position moved (flicking) during data loading
+-   Fixed Organisation page router history issue
 -   Fixed Search Panel `Clear` button doesn't work
 
 ## 0.0.43

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.js
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.js
@@ -21,6 +21,9 @@ import AUpageAlert from "../../pancake/react/page-alerts";
 class PublishersViewer extends Component {
     constructor(props) {
         super(props);
+        this.state = {
+            inputText: ""
+        };
         this.onUpdateSearchText = this.onUpdateSearchText.bind(this);
         this.handleSearchFieldEnterKeyPress = this.handleSearchFieldEnterKeyPress.bind(
             this
@@ -30,61 +33,56 @@ class PublishersViewer extends Component {
         this.onClickSearch = this.onClickSearch.bind(this);
         this.searchInputFieldRef = null;
     }
+
     debounceUpdateSearchQuery = debounce(this.updateSearchQuery, 3000);
 
     onPageChange(i) {
-        this.context.router.history.push({
-            pathname: this.props.location.pathname,
-            search: queryString.stringify(
-                Object.assign(queryString.parse(this.props.location.search), {
-                    page: i
-                })
-            )
-        });
-
-        this.updateSearchQuery(
+        this.debounceUpdateSearchQuery(
             queryString.parse(this.props.location.search).q,
             i
         );
+        this.debounceUpdateSearchQuery.flush();
     }
 
-    componentDidMount() {
-        const q = queryString.parse(this.props.location.search).q;
-        this.props.fetchPublishersIfNeeded(
-            getPageNumber(this.props) || 1,
-            q && q.trim().length > 0 ? q : "*"
-        );
-    }
-
-    updateQuery(query) {
-        this.context.router.history.push({
-            pathname: "/organisations",
-            search: queryString.stringify(
-                Object.assign(
-                    queryString.parse(this.props.location.search),
-                    query
-                )
-            )
-        });
-    }
-
-    handleSearchFieldEnterKeyPress(event) {
-        // when user hit enter, no need to submit the form
-        if (event.charCode === 13) {
-            event.preventDefault();
-            this.updateSearchQuery(
-                queryString.parse(this.props.location.search).q,
-                1
-            );
+    componentDidUpdate(prevProps) {
+        if (prevProps.location.search !== this.props.location.search) {
+            this.fetchData();
         }
     }
 
-    updateSearchQuery(text, page) {
-        this.debounceUpdateSearchQuery.flush();
-        if (this.searchInputFieldRef) this.searchInputFieldRef.blur();
+    componentDidMount() {
+        const { q } = queryString.parse(this.props.location.search);
+        const inputText = q && q.trim().length > 0 ? q : "";
+        this.setState({ inputText });
+        this.fetchData();
+    }
+
+    updateQuery(query) {
+        if (
+            typeof query.q === "undefined" &&
+            typeof query.page === "undefined"
+        ) {
+            this.context.router.history.push({
+                pathname: "/organisations"
+            });
+        } else {
+            this.context.router.history.push({
+                pathname: "/organisations",
+                search: queryString.stringify(
+                    Object.assign(
+                        queryString.parse(this.props.location.search),
+                        query
+                    )
+                )
+            });
+        }
+    }
+
+    fetchData() {
+        const { q, page } = queryString.parse(this.props.location.search);
         let searchText = "*";
-        if (text && text.trim().length > 0) {
-            searchText = text;
+        if (q && q.trim().length > 0) {
+            searchText = q;
         }
         const pageIndex = page
             ? page
@@ -94,28 +92,36 @@ class PublishersViewer extends Component {
         this.props.fetchPublishersIfNeeded(pageIndex, searchText);
     }
 
-    clearSearch() {
+    handleSearchFieldEnterKeyPress(event) {
+        if (event.charCode === 13) {
+            this.debounceUpdateSearchQuery(this.state.inputText, 1);
+            this.debounceUpdateSearchQuery.flush();
+        }
+    }
+
+    updateSearchQuery(text, page) {
+        if (this.searchInputFieldRef) this.searchInputFieldRef.blur();
         this.updateQuery({
-            q: "",
-            page: 1
+            q: text ? text.trim() : text,
+            page: page
         });
-        this.debounceUpdateSearchQuery("", 1);
+    }
+
+    clearSearch() {
+        this.setState({
+            inputText: ""
+        });
+        this.debounceUpdateSearchQuery();
         this.debounceUpdateSearchQuery.flush();
     }
 
     onUpdateSearchText(e) {
-        this.updateQuery({
-            q: e.target.value,
-            page: 1
-        });
+        this.setState({ inputText: e.target.value });
         this.debounceUpdateSearchQuery(e.target.value, 1);
     }
 
     onClickSearch() {
-        this.debounceUpdateSearchQuery(
-            queryString.parse(this.props.location.search).q,
-            1
-        );
+        this.debounceUpdateSearchQuery(this.state.inputText, 1);
         this.debounceUpdateSearchQuery.flush();
     }
 
@@ -158,7 +164,6 @@ class PublishersViewer extends Component {
     }
 
     renderSearchBar() {
-        const q = queryString.parse(this.props.location.search).q;
         return (
             <div className="organization-search">
                 <label htmlFor="organization-search" className="sr-only">
@@ -169,7 +174,7 @@ class PublishersViewer extends Component {
                     name="organization-search"
                     id="organization-search"
                     type="text"
-                    value={q ? q : ""}
+                    value={this.state.inputText}
                     placeholder="Search for Organisations"
                     onChange={this.onUpdateSearchText}
                     onKeyPress={this.handleSearchFieldEnterKeyPress}

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.js
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.js
@@ -189,8 +189,6 @@ class PublishersViewer extends Component {
         return (
             <ReactDocumentTitle title={"Organisations | " + config.appName}>
                 <div className="publishers-viewer">
-                    {this.props.isFetching && <ProgressBar />}
-
                     <Medium>
                         <Breadcrumbs
                             breadcrumbs={[
@@ -213,7 +211,11 @@ class PublishersViewer extends Component {
                         </div>
 
                         <div className="col-sm-8">
-                            {!this.props.isFetching && this.renderContent()}
+                            {this.props.isFetching ? (
+                                <ProgressBar />
+                            ) : (
+                                this.renderContent()
+                            )}
                         </div>
                     </div>
                     {!this.props.isFetching &&

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.js
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.js
@@ -210,7 +210,7 @@ class PublishersViewer extends Component {
                             </div>
                         </div>
 
-                        <div className="col-sm-8">
+                        <div className="col-sm-8 org-result-page-body">
                             {this.props.isFetching ? (
                                 <ProgressBar />
                             ) : (

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.scss
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.scss
@@ -65,6 +65,3 @@
         min-height: 650px;
     }
 }
-body {
-    overflow-y: scroll !important;
-}

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.scss
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.scss
@@ -61,4 +61,10 @@
             cursor: pointer;
         }
     }
+    .org-result-page-body {
+        min-height: 650px;
+    }
+}
+body {
+    overflow-y: scroll !important;
 }

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -2,7 +2,7 @@
 @import "./pancake/sass/pancake.scss";
 html {
 }
-.au-body {
+body {
     overflow-y: scroll;
 }
 .au-body .au-grid {

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -2,7 +2,9 @@
 @import "./pancake/sass/pancake.scss";
 html {
 }
-
+.au-body {
+    overflow-y: scroll;
+}
 .au-body .au-grid {
     p,
     input,


### PR DESCRIPTION
### What this PR does

Fixed organisation page content jumping issue (#1460)

What happened was the loading bar component didn't play well with `Breadcrumbs` (Don't know the root cause).

Once loading bar is under the same parent as `Breadcrumbs`,  `Breadcrumbs` will get extra margin --- although loading bar is an `absolute positioned` element.

Move the loading bar away (into content part) as other pages fixed this.

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
