### PR TITLE
Issue/1469 Fixed "Clear" button inside filter dropdown is the same as the apply button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 -   Added auto gzip compress to gateway
 -   Made CSW connector retrieve country field from alternative JSON path
 -   Fixed Sitemap times out if input is invalid
+-   Fixed Search Panel `Clear` button doesn't work
 
 ## 0.0.43
 

--- a/magda-web-client/src/Components/SearchFacets/FacetBasic.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasic.js
@@ -16,20 +16,20 @@ class FacetBasic extends Component {
                     hasQuery={this.props.hasQuery}
                     onClick={this.props.toggleFacet}
                 />
-                {this.props.isOpen && (
-                    <FacetBasicBody
-                        options={this.props.options}
-                        activeOptions={this.props.activeOptions}
-                        facetSearchResults={this.props.facetSearchResults}
-                        onToggleOption={this.props.onToggleOption}
-                        onResetFacet={this.props.onResetFacet}
-                        searchFacet={this.props.searchFacet}
-                        toggleFacet={this.props.toggleFacet}
-                        title={this.props.title}
-                        resetFilterEvent={this.props.resetFilterEvent}
-                        closeFacet={this.props.closeFacet}
-                    />
-                )}
+
+                <FacetBasicBody
+                    isOpen={this.props.isOpen}
+                    options={this.props.options}
+                    activeOptions={this.props.activeOptions}
+                    facetSearchResults={this.props.facetSearchResults}
+                    onToggleOption={this.props.onToggleOption}
+                    onResetFacet={this.props.onResetFacet}
+                    searchFacet={this.props.searchFacet}
+                    toggleFacet={this.props.toggleFacet}
+                    title={this.props.title}
+                    resetFilterEvent={this.props.resetFilterEvent}
+                    closeFacet={this.props.closeFacet}
+                />
             </div>
         );
     }

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -12,6 +12,7 @@ class FacetBasicBody extends Component {
         this.onApplyFilter = this.onApplyFilter.bind(this);
         this.onToggleOption = this.onToggleOption.bind(this);
         this.searchBoxValueChange = this.searchBoxValueChange.bind(this);
+        this.hasUnappliedChanges = false;
         this.state = {
             _activeOptions: [],
             showOptions: true
@@ -38,11 +39,9 @@ class FacetBasicBody extends Component {
             this.setState({
                 _activeOptions: []
             });
+        } else if (!this.props.isOpen && prevProps.isOpen) {
+            this.props.onToggleOption(this.state._activeOptions);
         }
-    }
-
-    componentWillUnmount() {
-        this.props.onToggleOption(this.state._activeOptions);
     }
 
     checkActiveOption(option) {

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -113,6 +113,7 @@ class FacetBasicBody extends Component {
     }
 
     render() {
+        if (!this.props.isOpen) return null;
         let options = this.props.options;
         // the option that has the max hit value, use to calculate volumne indicator
         let maxOptionOptionList = maxBy(this.props.options, o => +o.hitCount);

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -12,7 +12,6 @@ class FacetBasicBody extends Component {
         this.onApplyFilter = this.onApplyFilter.bind(this);
         this.onToggleOption = this.onToggleOption.bind(this);
         this.searchBoxValueChange = this.searchBoxValueChange.bind(this);
-        this.hasUnappliedChanges = false;
         this.state = {
             _activeOptions: [],
             showOptions: true

--- a/magda-web-client/src/Components/SearchFacets/FacetRegion.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetRegion.js
@@ -30,6 +30,18 @@ class FacetRegion extends Component {
         };
     }
 
+    static getDerivedStateFromProps(props, state) {
+        // only set props to state if state is not already set and if props is not empty
+        if (!state._activeRegion.regionId && props.activeRegion.regionId) {
+            return {
+                ...state,
+                applyButtonDisabled: false,
+                _activeRegion: props.activeRegion
+            };
+        }
+        return null;
+    }
+
     onToggleOption(option) {
         this.setState({
             applyButtonDisabled: false,
@@ -54,8 +66,17 @@ class FacetRegion extends Component {
             _activeRegion: region
         });
     }
-    componentWillUnmount() {
-        if (this.state._activeRegion.regionId !== undefined) {
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.resetFilterEvent !== this.props.resetFilterEvent) {
+            this.props.closeFacet();
+            this.setState({
+                _activeRegion: {
+                    regionId: undefined,
+                    regionType: undefined
+                }
+            });
+        } else if (!this.props.isOpen && prevProps.isOpen) {
             this.onApplyFilter();
         }
     }
@@ -158,6 +179,7 @@ class FacetRegion extends Component {
     }
 
     render() {
+        if (!this.props.isOpen) return null;
         return <div className="facet-wrapper">{this.renderBox()}</div>;
     }
 }

--- a/magda-web-client/src/Components/SearchFacets/Format.js
+++ b/magda-web-client/src/Components/SearchFacets/Format.js
@@ -11,9 +11,9 @@ class Format extends Component {
         this.onSearchFormatFacet = this.onSearchFormatFacet.bind(this);
         this.onToggleFormatOption = this.onToggleFormatOption.bind(this);
         // we use an integer event to notify children of the reset event
-        this.state = {
-            resetFilterEvent: 0
-        };
+        //-- we should find a better way to do this. At least, its value should be set synchronously
+        //-- Can't use state as you don't know when it's in place
+        this.resetFilterEvent = 0;
     }
 
     onToggleFormatOption(formats) {
@@ -35,9 +35,7 @@ class Format extends Component {
         // update redux
         this.props.dispatch(resetFormat());
         // let children know that the filter is being reset
-        this.setState({
-            resetFilterEvent: this.state.resetFilterEvent + 1
-        });
+        this.resetFilterEvent++;
     }
 
     onSearchFormatFacet(facetQuery) {
@@ -62,7 +60,7 @@ class Format extends Component {
                 toggleFacet={this.props.toggleFacet}
                 isOpen={this.props.isOpen}
                 closeFacet={this.props.closeFacet}
-                resetFilterEvent={this.state.resetFilterEvent}
+                resetFilterEvent={this.resetFilterEvent}
             />
         );
     }

--- a/magda-web-client/src/Components/SearchFacets/Publisher.js
+++ b/magda-web-client/src/Components/SearchFacets/Publisher.js
@@ -14,10 +14,9 @@ class Publisher extends Component {
         this.onSearchPublisherFacet = this.onSearchPublisherFacet.bind(this);
         this.onTogglePublisherOption = this.onTogglePublisherOption.bind(this);
         // we use an integer event to notify children of the reset event
-        this.state = {
-            resetFilterEvent: 0,
-            facetQuery: ""
-        };
+        //-- we should find a better way to do this. At least, its value should be set synchronously
+        //-- Can't use state as you don't know when it's in place
+        this.resetFilterEvent = 0;
     }
 
     onTogglePublisherOption(publishers) {
@@ -39,9 +38,7 @@ class Publisher extends Component {
         // update redux
         this.props.dispatch(resetPublisher());
         // let children know that the filter is being reset
-        this.setState({
-            resetFilterEvent: this.state.resetFilterEvent + 1
-        });
+        this.resetFilterEvent++;
     }
 
     onSearchPublisherFacet(facetQuery) {
@@ -67,7 +64,7 @@ class Publisher extends Component {
                 toggleFacet={this.props.toggleFacet}
                 isOpen={this.props.isOpen}
                 closeFacet={this.props.closeFacet}
-                resetFilterEvent={this.state.resetFilterEvent}
+                resetFilterEvent={this.resetFilterEvent}
             />
         );
     }

--- a/magda-web-client/src/Components/SearchFacets/Region.js
+++ b/magda-web-client/src/Components/SearchFacets/Region.js
@@ -11,6 +11,10 @@ class Region extends Component {
         this.onResetRegionFacet = this.onResetRegionFacet.bind(this);
         this.onSearchRegionFacet = this.onSearchRegionFacet.bind(this);
         this.onToggleRegionOption = this.onToggleRegionOption.bind(this);
+        // we use an integer event to notify children of the reset event
+        //-- we should find a better way to do this. At least, its value should be set synchronously
+        //-- Can't use state as you don't know when it's in place
+        this.resetFilterEvent = 0;
     }
 
     onToggleRegionOption(region) {
@@ -24,14 +28,15 @@ class Region extends Component {
         this.props.closeFacet();
     }
 
-    async onResetRegionFacet() {
+    onResetRegionFacet() {
         this.props.updateQuery({
             regionId: undefined,
             regionType: undefined,
             page: undefined
         });
-        await this.props.dispatch(resetRegion());
-        this.props.closeFacet();
+        this.props.dispatch(resetRegion());
+        // let children know that the filter is being reset
+        this.resetFilterEvent++;
     }
 
     onSearchRegionFacet(facetKeyword) {
@@ -55,6 +60,8 @@ class Region extends Component {
                 regionMapping={this.props.regionMapping}
                 toggleFacet={this.props.toggleFacet}
                 isOpen={this.props.isOpen}
+                closeFacet={this.props.closeFacet}
+                resetFilterEvent={this.resetFilterEvent}
             />
         );
     }

--- a/magda-web-client/src/Components/SearchFacets/RegionWrapper.js
+++ b/magda-web-client/src/Components/SearchFacets/RegionWrapper.js
@@ -17,24 +17,24 @@ export default class RegionWrapper extends React.Component {
                     onClick={this.props.toggleFacet}
                     isOpen={this.props.isOpen}
                 />
-                {this.props.isOpen && (
-                    <FacetRegion
-                        title={this.props.title}
-                        id={this.props.id}
-                        hasQuery={
-                            defined(this.props.activeRegion.regionType) &&
-                            defined(this.props.activeRegion.regionId)
-                        }
-                        activeRegion={this.props.activeRegion}
-                        facetSearchResults={this.props.facetSearchResults}
-                        onToggleOption={this.props.onToggleOption}
-                        onResetFacet={this.props.onResetFacet}
-                        searchFacet={this.props.searchFacet}
-                        regionMapping={this.props.regionMapping}
-                        toggleFacet={this.props.toggleFacet}
-                        isOpen={this.props.isOpen}
-                    />
-                )}
+                <FacetRegion
+                    title={this.props.title}
+                    id={this.props.id}
+                    hasQuery={
+                        defined(this.props.activeRegion.regionType) &&
+                        defined(this.props.activeRegion.regionId)
+                    }
+                    activeRegion={this.props.activeRegion}
+                    facetSearchResults={this.props.facetSearchResults}
+                    onToggleOption={this.props.onToggleOption}
+                    onResetFacet={this.props.onResetFacet}
+                    searchFacet={this.props.searchFacet}
+                    regionMapping={this.props.regionMapping}
+                    toggleFacet={this.props.toggleFacet}
+                    isOpen={this.props.isOpen}
+                    closeFacet={this.props.closeFacet}
+                    resetFilterEvent={this.props.resetFilterEvent}
+                />
             </React.Fragment>
         );
     }


### PR DESCRIPTION
### What this PR does

Issue/1469 Fixed "Clear" button inside the filter drop-down is the same as the apply button (#1469 )

It's probably easy to make `clear` button functional again but hard to keep the `click outside the box to apply filter` feature work at the same time.

We have to refactor the code a little bit (I didn't touch `Temporal` as it works well).  Basically,
- Make facet body live longer so we can maintain the relevant information required for the logic
- Instead of hook up to `componentWillUnmount` for auto apply function. Monitor property changes via `componentDidUpdate`

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
