### PR TITLE
Fixed undefined dataset ids in distribution URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 -   Made CSW connector retrieve country field from alternative JSON path
 -   Fixed Sitemap times out if input is invalid
 -   Fixed Search Panel `Clear` button doesn't work
+-   Fixed bug where dataset ids where "undefined" in distribution URLs.
 
 ## 0.0.43
 

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -138,7 +138,7 @@ class DistributionRow extends Component {
             distributionLink = distribution.accessURL;
         } else {
             distributionLink = `/dataset/${encodeURIComponent(
-                dataset.id
+                dataset.identifier
             )}/distribution/${encodeURIComponent(distribution.identifier)}/?q=${
                 this.props.searchText
             }`;


### PR DESCRIPTION
### What this PR does
Fixes links to distribution pages showing the distribution as `undefined`.

### Checklist
-   [x] Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
