### PR TITLE
Keep searchbox text in synch with search query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,8 +49,9 @@
 -   Fixed Organisation page router history issue
 -   Fixed Search Panel `Clear` button doesn't work
 -   Fixed bug where dataset ids where "undefined" in distribution URLs.
--   Corrected incorrect source-link-status aspect name in UI dataset request URL 
+-   Corrected incorrect source-link-status aspect name in UI dataset request URL
 -   Updated URL of City of Launceston connector.
+-   Keep search text in synch.
 
 ## 0.0.43
 

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -48,6 +48,20 @@ class SearchBox extends Component {
         });
     }
 
+    componentDidUpdate(prevProps) {
+        // figure out where the component update is from
+        // if it's not from home page or search page, but is leading to search page, then we need to update search text and initiate search
+        if (
+            prevProps.location.pathname &&
+            prevProps.location.pathname !== ("/search" || "/") &&
+            this.props.location.pathname === "/search"
+        ) {
+            this.setState({
+                searchText: this.props.location.search.q
+            });
+        }
+    }
+
     onSearchTextChange(event) {
         const text = event.target.value;
         this.setState({
@@ -73,7 +87,7 @@ class SearchBox extends Component {
         // when user hit enter, no need to submit the form
         if (event.charCode === 13) {
             event.preventDefault();
-            this.debounceUpdateSearchQuery.flush(this.getSearchBoxValue());
+            this.debounceUpdateSearchQuery.flush();
         }
     }
 
@@ -81,7 +95,6 @@ class SearchBox extends Component {
      * If the search button is clicked, we do the search immediately
      */
     onClickSearch() {
-        this.debounceUpdateSearchQuery(this.getSearchBoxValue());
         this.debounceUpdateSearchQuery.flush();
     }
 

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -48,20 +48,6 @@ class SearchBox extends Component {
         });
     }
 
-    componentDidUpdate(prevProps) {
-        // figure out where the component update is from
-        // if it's not from home page or search page, but is leading to search page, then we need to update search text and initiate search
-        if (
-            prevProps.location.pathname &&
-            prevProps.location.pathname !== ("/search" || "/") &&
-            this.props.location.pathname === "/search"
-        ) {
-            this.setState({
-                searchText: this.props.location.search.q
-            });
-        }
-    }
-
     onSearchTextChange(event) {
         const text = event.target.value;
         this.setState({
@@ -80,6 +66,9 @@ class SearchBox extends Component {
         this.updateQuery({
             q: text,
             page: undefined
+        });
+        this.setState({
+            searchText: null
         });
     }
 

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -31,7 +31,7 @@ class SearchBox extends Component {
         // it needs to be undefined here, so the default value should be from the url
         // once this value is set, the value should always be from the user input
         this.state = {
-            searchText: undefined,
+            searchText: null,
             width: 0,
             height: 0,
             isFocus: false
@@ -43,9 +43,6 @@ class SearchBox extends Component {
 
     componentDidMount() {
         this.props.fetchRegionMapping();
-        this.setState({
-            searchText: this.props.location.search.q
-        });
     }
 
     onSearchTextChange(event) {


### PR DESCRIPTION
### What this PR does
Fixed clicking on a tag doesn't replace the text in the search bar by removing searchText state, only one source of truth from URL, moved search initiation into the search box

### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
