### PR TITLE
Made search backwards-compatible with datasets version 32

### DIFF
--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -320,7 +320,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
     case x              => Some(fn(x))
   }
   private def buildEsQuery(query: Query, strategy: SearchStrategy): QueryDefinition = {
-    functionScoreQuery().query(queryToQueryDef(query, strategy)).scorers(fieldFactorScore("quality"))
+    functionScoreQuery().query(queryToQueryDef(query, strategy)).scorers(fieldFactorScore("quality").missing(0))
   }
 
   /** Processes a general magda Query into a specific ES QueryDefinition */


### PR DESCRIPTION
### What this PR does
This makes it so that the new search-api can continue to do searches on the old datasets version, which means that we can continue to have it pointing to the old datasets index while the new one gets built during this deployment.

### Checklist

-   [x] Unit tests aren't applicable (delete one)
-   [x] No CHANGES, this is to maintain a status quo.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
