### PR TITLE
fixed some grid inconsistency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.0.45
 
 -   Display a 'clear search' link after error message
+-   Fixed inconsistent breakpoints
 
 ## 0.0.44
 
@@ -53,7 +54,7 @@
 -   Fixed Organisation page router history issue
 -   Fixed Search Panel `Clear` button doesn't work
 -   Fixed bug where dataset ids where "undefined" in distribution URLs.
--   Corrected incorrect source-link-status aspect name in UI dataset request URL 
+-   Corrected incorrect source-link-status aspect name in UI dataset request URL
 -   Updated URL of City of Launceston connector.
 
 ## 0.0.43

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -168,7 +168,7 @@ class DistributionRow extends Component {
                             </div>
                         </Medium>
 
-                        <div className="col-md-11">
+                        <div className="col-sm-11">
                             <div className="distribution-row-link">
                                 {!distribution.downloadURL &&
                                 distribution.accessURL ? (
@@ -216,7 +216,7 @@ class DistributionRow extends Component {
                         </div>
                     </div>
                 </div>
-                <div className="col-md-3 button-area">
+                <div className="col-sm-3 button-area">
                     {distribution.downloadURL && (
                         <a
                             className="download-button au-btn au-btn--secondary"

--- a/magda-web-client/src/UI/ChartConfig.js
+++ b/magda-web-client/src/UI/ChartConfig.js
@@ -68,16 +68,20 @@ export default class ChartConfig extends Component {
         return (
             <div className="chart-config_icon-select">
                 <label tabIndex="-1">Chart Type</label>
-                {ChartDatasetEncoder.avlChartTypes.map(v => (
-                    <button
-                        className={this.props.chartType === v ? "isActive" : ""}
-                        onClick={e => this.onChange("chartType", v)}
-                        key={v}
-                        title={chartTitles[v]}
-                    >
-                        <img alt={v} src={chartIcons[v]} />
-                    </button>
-                ))}
+                <div className="button-group">
+                    {ChartDatasetEncoder.avlChartTypes.map(v => (
+                        <button
+                            className={
+                                this.props.chartType === v ? "isActive" : ""
+                            }
+                            onClick={e => this.onChange("chartType", v)}
+                            key={v}
+                            title={chartTitles[v]}
+                        >
+                            <img alt={v} src={chartIcons[v]} />
+                        </button>
+                    ))}
+                </div>
             </div>
         );
     }

--- a/magda-web-client/src/UI/ChartConfig.scss
+++ b/magda-web-client/src/UI/ChartConfig.scss
@@ -1,6 +1,9 @@
 @import "../_variables.scss";
 .chart-config {
     .chart-config_icon-select {
+        .button-group {
+            display: flex;
+        }
         button {
             background: transparent;
             border: 0;
@@ -10,7 +13,7 @@
             padding: 4px;
             border: 2px solid $AU-color-foreground-action;
             border-radius: 2px;
-            padding: 0.8rem;
+            padding: 0.6rem;
             &.isActive {
                 background: $AU-color-foreground-action;
                 img {

--- a/magda-web-client/src/UI/DataPreviewChart.js
+++ b/magda-web-client/src/UI/DataPreviewChart.js
@@ -186,7 +186,7 @@ class DataPreviewChart extends Component {
                     this.chartWidthDiv = chartWidthDiv;
                 }}
             >
-                <div className="col-md-8 chart-panel-container">
+                <div className="col-sm-8 chart-panel-container">
                     <h4 className="chart-title">{this.state.chartTitle}</h4>
                     <ReactEcharts
                         className="data-preview-chart-container"
@@ -196,7 +196,7 @@ class DataPreviewChart extends Component {
                         theme="au_dga"
                     />
                 </div>
-                <div className="col-md-4 config-panel-container">
+                <div className="col-sm-4 config-panel-container">
                     {this.state.isExpanded ? (
                         <ChartConfig
                             chartType={this.state.chartType}


### PR DESCRIPTION
### What this PR does
Addresses the issue that distribution links are hard to click on tablet-sized dataset page because the bottom half of each of the links is behind a grid component (due to grid class error)

### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
