### PR TITLE
cancel set state after unmount

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 -   prevent old content being loaded when navigating through page history
 -   Display a 'clear search' link after error message
 -   Fixed a date filter bug that freeze UI on slow internet
+-   Fixed the error 'Can't call setState (or forceUpdate) on an unmounted component' for Data Preview
 
 ## 0.0.44
 

--- a/magda-web-client/src/UI/DataPreviewTable.js
+++ b/magda-web-client/src/UI/DataPreviewTable.js
@@ -16,16 +16,7 @@ function loadPapa() {
         });
 }
 
-export default class DataPreviewTable extends Component<
-    {
-        distribution: ParsedDistribution
-    },
-    {
-        error: Error,
-        loading: Boolean,
-        parsedResults: any
-    }
-> {
+export default class DataPreviewTable extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -33,6 +24,7 @@ export default class DataPreviewTable extends Component<
             loading: true,
             parsedResults: null
         };
+        this.isCancelled = false;
     }
 
     componentDidMount() {
@@ -46,6 +38,10 @@ export default class DataPreviewTable extends Component<
             this.fetchData(this.props.distribution.downloadURL);
         }
         // this.updateDimensions();
+    }
+
+    componentWillUnmount() {
+        this.isCancelled = true;
     }
 
     fetchData(url) {
@@ -71,18 +67,22 @@ export default class DataPreviewTable extends Component<
                 });
             })
             .then(results => {
-                this.setState({
-                    error: null,
-                    loading: false,
-                    parsedResults: results
-                });
+                if (!this.isCancelled) {
+                    this.setState({
+                        error: null,
+                        loading: false,
+                        parsedResults: results
+                    });
+                }
             })
             .catch(err => {
-                this.setState({
-                    error: err,
-                    loading: false,
-                    parsedResults: null
-                });
+                if (!this.isCancelled) {
+                    this.setState({
+                        error: err,
+                        loading: false,
+                        parsedResults: null
+                    });
+                }
             });
     }
 


### PR DESCRIPTION
### What this PR does
Fixed `Can't call setState (or forceUpdate) on an unmounted component` in data preview when switching to table view before the chart has been mounted by setting `isCancelled` flag to true when a component will be unmounted.

### Checklist
-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
