### PR TITLE
Made CKAN harvesters run hourly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 -   Updated URL of City of Launceston connector.
 -   Keep search text in synch.
 -   Make pagination on mobile responsive.
+-   Made CKAN harvesters execute on an hourly basis.
 
 ## 0.0.43
 

--- a/deploy/connector-config/brisbane-city-council.json
+++ b/deploy/connector-config/brisbane-city-council.json
@@ -4,5 +4,5 @@
     "name": "Brisbane City Council",
     "sourceUrl": "https://www.data.brisbane.qld.gov.au/data/",
     "pageSize": 100,
-    "schedule": "0 2 */3 * *"
+    "schedule": "10 * * * *"
 }

--- a/deploy/connector-config/data-gov-au.json
+++ b/deploy/connector-config/data-gov-au.json
@@ -4,6 +4,6 @@
     "name": "data.gov.au",
     "sourceUrl": "https://data.gov.au/",
     "pageSize": 1000,
-    "schedule": "0 4 */3 * *",
+    "schedule": "0 * * * *",
     "ignoreHarvestSources": ["*"]
 }

--- a/deploy/connector-config/new-south-wales.json
+++ b/deploy/connector-config/new-south-wales.json
@@ -4,5 +4,5 @@
     "name": "New South Wales Government",
     "sourceUrl": "https://data.nsw.gov.au/data/",
     "pageSize": 100,
-    "schedule": "30 8 */3 * *"
+    "schedule": "20 * * * *"
 }

--- a/deploy/connector-config/queensland-government.json
+++ b/deploy/connector-config/queensland-government.json
@@ -4,5 +4,5 @@
     "name": "Queensland Government",
     "sourceUrl": "https://data.qld.gov.au/",
     "pageSize": 100,
-    "schedule": "30 9 */3 * *"
+    "schedule": "30 * * * *"
 }

--- a/deploy/connector-config/south-australia-government.json
+++ b/deploy/connector-config/south-australia-government.json
@@ -4,5 +4,5 @@
     "name": "South Australia Government",
     "sourceUrl": "https://data.sa.gov.au/data/",
     "pageSize": 100,
-    "schedule": "0 10 */3 * *"
+    "schedule": "40 * * * *"
 }

--- a/deploy/connector-config/victoria-government.json
+++ b/deploy/connector-config/victoria-government.json
@@ -4,5 +4,5 @@
     "name": "Victoria Government",
     "sourceUrl": "https://www.data.vic.gov.au/data/",
     "pageSize": 100,
-    "schedule": "30 11 */3 * *"
+    "schedule": "50 * * * *"
 }

--- a/deploy/connector-config/western-australia-government.json
+++ b/deploy/connector-config/western-australia-government.json
@@ -4,5 +4,5 @@
     "name": "Western Australia Government",
     "sourceUrl": "http://catalogue.beta.data.wa.gov.au/",
     "pageSize": 100,
-    "schedule": "0 12 */3 * *"
+    "schedule": "55 * * * *"
 }


### PR DESCRIPTION
### What this PR does
Makes the CKAN harvesters run hourly, as per Gordon's instructions. Fortunately CKAN servers are pretty good and our process for harvesting them is pretty low-resources (unlike the XML parsing of CSW). 

### Checklist

-   [x] Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
