### PR TITLE
Make Apply button by default enabled in date filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## 0.0.46
--   Make pagination on mobile responsive.
 
+-   Make pagination on mobile responsive.
 -   Fixed a facet overflow issue on desktop
+-   Allow user apply default date in filter
 
 ## 0.0.45
 

--- a/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
@@ -88,11 +88,7 @@ class FacetTemporal extends Component {
             defined(this.state.startMonth) &&
             !isNaN(this.state.startMonth) &&
             defined(this.state.endMonth) &&
-            !isNaN(this.state.endMonth) &&
-            (this.state.startYear !== dateFrom.getUTCFullYear() ||
-                this.state.startMonth !== dateFrom.getUTCMonth() ||
-                this.state.endYear !== dateTo.getUTCFullYear() ||
-                this.state.endMonth !== dateTo.getUTCMonth())
+            !isNaN(this.state.endMonth)
         );
     }
 

--- a/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetTemporal.js
@@ -75,8 +75,6 @@ class FacetTemporal extends Component {
     }
 
     canApply() {
-        const dateFrom = new Date(this.props.temporalRange[0]);
-        const dateTo = new Date(this.props.temporalRange[1]);
         // we need to check those values are not
         // null
         // undefined


### PR DESCRIPTION
### What this PR does
Make Apply button in date filter work even when no date option has been selected (date picker display default state), and when Apply, default date range is applied 
![screen shot 2018-08-03 at 3 24 53 pm](https://user-images.githubusercontent.com/7508939/43625624-681bc98c-9731-11e8-8a43-3d18bce34588.png)


### Checklist


-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
