### PR TITLE
Organisation page query parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 -   Make pagination on mobile responsive.
 -   Fixed a facet overflow issue on desktop
 -   Allow user apply default date in filter
+-   Fixed an issue where organisation Page dataset links set incorrect `publisher` query parameter
 
 ## 0.0.45
 

--- a/magda-web-client/src/Components/Publisher/PublisherDetails.js
+++ b/magda-web-client/src/Components/Publisher/PublisherDetails.js
@@ -109,7 +109,7 @@ class PublisherDetails extends Component {
                         <div>
                             <Link
                                 className="au-cta-link"
-                                to={`/search?publisher=${encodeURIComponent(
+                                to={`/search?organisation=${encodeURIComponent(
                                     publisher.name
                                 )}`}
                             >

--- a/magda-web-client/src/Components/Publisher/PublisherSummary.js
+++ b/magda-web-client/src/Components/Publisher/PublisherSummary.js
@@ -17,7 +17,7 @@ function PublisherSummary(props) {
             </h2>
             <div className="publisher-meta">
                 <Link
-                    to={`/search?publisher=${encodeURIComponent(
+                    to={`/search?organisation=${encodeURIComponent(
                         props.publisher.name
                     )}`}
                 >


### PR DESCRIPTION
Fixed an issue where organisation Page dataset links set incorrect `publisher` query parameter

### What this PR does

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
