### PR TITLE
Fix SEO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 -   Fixed `Clear All` button not clear filter panel UI state
 -   Change non-homepage search placeholder text color to WCAG AAA compliant
 -   Added more details in organisations/publishers page to reflect design.
+-   Adjusted sitemap and robots.txt to help google navigate around better
+-   Made the javascript work with chrome 44 (googlebot)
 
 ## 0.0.44
 

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -141,6 +141,11 @@
       "target": "http://localhost:6107/"
     }
   },
+  "browserslist": [
+    "last 2 versions",
+    "ie 11",
+    "chrome 44"
+  ],
   "pancake": {
     "auto-save": true,
     "plugins": true,

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -144,7 +144,7 @@
   "browserslist": [
     "last 2 versions",
     "ie 11",
-    "chrome 44"
+    "chrome 41"
   ],
   "pancake": {
     "auto-save": true,

--- a/magda-web-client/public/robots.txt
+++ b/magda-web-client/public/robots.txt
@@ -1,6 +1,0 @@
-User-agent: *
-Crawl-delay: 100
-Disallow: /api
-Disallow: /auth
-Disallow: /search
-Sitemap: /sitemap

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc -p tsconfig-build.json",
     "watch": "tsc -p tsconfig-build.json --watch",
     "start": "node dist/index.js",
-    "dev": "run-typescript-in-nodemon src/index.ts",
+    "dev": "run-typescript-in-nodemon src/index.ts --baseExternalUrl=http://localhost:6107/",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
     "retag-and-push": "retag-and-push",

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -17,13 +17,9 @@ export default function buildSitemapRouter({
     const app = express();
     const baseExternalUri = new URI(baseExternalUrl);
 
-    // Make sure every request is setting XML as the content type.
-    app.use((req, res, next) => {
+    app.get("/sitemap.xml", (req, res) => {
         res.header("Content-Type", "application/xml");
-        next();
-    });
 
-    app.get("/", (req, res) => {
         catchError(
             res,
             registry
@@ -62,7 +58,9 @@ export default function buildSitemapRouter({
         );
     });
 
-    app.get("/main", (req, res) => {
+    app.get("/sitemap/main.xml", (req, res) => {
+        res.header("Content-Type", "application/xml");
+
         // For now we just put the homepage in here, seeing as everything except the datasets should be reachable
         // from either the home page or the datasets pages.
         const sitemap = sm.createSitemap({
@@ -84,7 +82,9 @@ export default function buildSitemapRouter({
         });
     });
 
-    app.get("/dataset/afterToken/:afterToken", (req, res) => {
+    app.get("/sitemap/dataset/afterToken/:afterToken.xml", (req, res) => {
+        res.header("Content-Type", "application/xml");
+
         const afterToken: string = req.params.afterToken;
 
         catchError(

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -33,7 +33,7 @@ export default function buildSitemapRouter({
                                 URI.joinPaths(
                                     baseExternalUrl,
                                     "sitemap/dataset/afterToken",
-                                    token.toString()
+                                    token.toString() + ".xml"
                                 ).href()
                             )
                             .href();
@@ -46,7 +46,7 @@ export default function buildSitemapRouter({
                                 .path(
                                     URI.joinPaths(
                                         baseExternalUrl,
-                                        "sitemap/main"
+                                        "sitemap/main.xml"
                                     ).href()
                                 )
                                 .href()

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -225,8 +225,19 @@ if (argv.devProxy) {
     });
 }
 
+const robotsTxt = `User-agent: *
+Crawl-delay: 100
+Disallow: /auth
+Disallow: /search
+
+Sitemap: ${argv.baseExternalUrl}sitemap.xml
+`;
+
+app.use("/robots.txt", (_, res) => {
+    res.status(200).send(robotsTxt);
+});
+
 app.use(
-    "/sitemap",
     buildSitemapRouter({
         baseExternalUrl: argv.baseExternalUrl,
         registry: new Registry({

--- a/magda-web-server/src/test/sitemap.spec.ts
+++ b/magda-web-server/src/test/sitemap.spec.ts
@@ -37,7 +37,7 @@ describe("sitemap router", () => {
         }
     });
 
-    describe("/", () => {
+    describe("/sitemap.xml", () => {
         it("should reflect page tokens from registry", () => {
             const tokens = [0, 100, 200];
 
@@ -46,7 +46,7 @@ describe("sitemap router", () => {
                 .reply(200, tokens);
 
             return supertest(router)
-                .get("/")
+                .get("/sitemap.xml")
                 .expect(200)
                 .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
@@ -59,11 +59,12 @@ describe("sitemap router", () => {
                         token =>
                             baseExternalUrl +
                             "/sitemap/dataset/afterToken/" +
-                            token
+                            token +
+                            ".xml"
                     );
 
                     expect(urls).to.eql(
-                        [baseExternalUrl + "/sitemap/main"].concat(expected)
+                        [baseExternalUrl + "/sitemap/main.xml"].concat(expected)
                     );
                 });
         });
@@ -76,15 +77,15 @@ describe("sitemap router", () => {
                 .reply(500);
 
             return supertest(router)
-                .get("/")
+                .get("/sitemap.xml")
                 .expect(500);
         });
     });
 
-    describe("/main", () => {
+    describe("/sitemap/main.xml", () => {
         it("should return the home page", () => {
             return supertest(router)
-                .get("/main")
+                .get("/sitemap/main.xml")
                 .expect(200)
                 .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
@@ -96,7 +97,7 @@ describe("sitemap router", () => {
         });
     });
 
-    describe("/dataset/afterToken/:afterToken", () => {
+    describe("/sitemap/dataset/afterToken/:afterToken", () => {
         const token = "1234";
 
         it("should return the datasets pages for the corresponding datasets page with that token", () => {
@@ -113,7 +114,7 @@ describe("sitemap router", () => {
                 });
 
             return supertest(router)
-                .get(`/dataset/afterToken/${token}`)
+                .get(`/sitemap/dataset/afterToken/${token}.xml`)
                 .expect(200)
                 .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
@@ -143,7 +144,7 @@ describe("sitemap router", () => {
                 .reply(500);
 
             return supertest(router)
-                .get(`/dataset/afterToken/${token}`)
+                .get(`/sitemap/dataset/afterToken/${token}.xml`)
                 .expect(500);
         });
     });


### PR DESCRIPTION
### What this PR does
Currently our listings on google are a [complete fiasco](https://www.google.com.au/search?q=site%3Asearch.data.gov.au&oq=site%3Asearch.data.gov.au+&aqs=chrome..69i57j69i58j69i59.3362j0j8&sourceid=chrome&ie=UTF-8). This does a few things to fix that:

- Makes rendering work with Chrome 44, which is apparently what googlebot uses... before this it saw a white page for everything according to the search console
- Adjusts sitemap so that it has .xml suffixes, just in case it confuses googlebot
- Makes Robots.txt dynamically include an absolute link to the sitemap, because apparently google doesn't understand sitemap in robots.txt unless its on the last line with a blank line above it and it has a fully qualified url
- Removes /api from the disallowed urls in robots.txt, because it turns out that googlebot actually obeys it even when making ajax requests

### Checklist
-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
