### PR TITLE
Made the fallback banner url configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,8 @@
 -   Change non-homepage search placeholder text color to WCAG AAA compliant
 -   Added more details in organisations/publishers page to reflect design.
 -   Adjusted sitemap and robots.txt to help google navigate around better
--   Made the javascript work with chrome 44 (googlebot)
+-   Made the javascript work with chrome 41 (googlebot)
+-   Made the fallback banner site url configurable
 
 ## 0.0.44
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -90,6 +90,7 @@ search-api:
       cpu: 100m
       memory: 0
 web-server:
+  fallbackUrl: "https://data.gov.au"
   resources:
     requests:
       cpu: 100m

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -7,5 +7,5 @@ data:
   web.json: '{
     "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
     "baseUrl": {{ .Values.baseUrl | default "/" | quote }},
-    "showFallbackBanner": {{ .Values.showFallbackBanner }}
+    "fallbackUrl": {{ .Values.fallbackUrl }}
   }'

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   # When the config map is mounted as a volume, these will be created as files.
   web.json: '{
+    {{- if .Values.fallbackUrl -}} "fallbackUrl": {{ .Values.fallbackUrl | quote }}, {{- end -}}
     "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
-    "baseUrl": {{ .Values.baseUrl | default "/" | quote }},
-    "fallbackUrl": {{ .Values.fallbackUrl | quote }}
+    "baseUrl": {{ .Values.baseUrl | default "/" | quote }}
   }'

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -20,4 +20,3 @@ resources: {}
   #  memory: 128Mi
 disableAuthenticationFeatures: false
 service: {}
-fallbackUrl: "https://data.gov.au"

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -20,4 +20,4 @@ resources: {}
   #  memory: 128Mi
 disableAuthenticationFeatures: false
 service: {}
-showFallbackBanner: true
+fallbackUrl: "https://data.gov.au"

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -49,3 +49,5 @@ correspondence-api:
   smtpPort: 2525
   defaultRecipient: "alex.gilleran+magda@csiro.it"
   smtpHostname: "smtp.mailgun.org"
+web-server:
+  fallbackUrl: "https://data.gov.au"

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -83,6 +83,7 @@ search-api:
       cpu: 100m
       memory: 0
 web-server:
+  fallbackUrl: "https://data.gov.au"
   resources:
     requests:
       cpu: 100m

--- a/deploy/helm/search-data-gov-au.yml
+++ b/deploy/helm/search-data-gov-au.yml
@@ -115,6 +115,7 @@ web-server:
             cpu: 100m
             memory: 100Mi
     disableAuthenticationFeatures: true
+    fallbackUrl: "https://data.gov.au"
 sleuther-broken-link:
     resources:
         requests:

--- a/magda-web-client/src/AppContainer.js
+++ b/magda-web-client/src/AppContainer.js
@@ -43,9 +43,9 @@ class AppContainer extends React.Component {
                                 }
                             ]}
                         />
-                        {config.showFallbackBanner && (
+                        {config.fallbackUrl && (
                             <Medium>
-                                <Banner />
+                                <Banner fallbackUrl={config.fallbackUrl} />
                             </Medium>
                         )}
 

--- a/magda-web-client/src/UI/Banner.js
+++ b/magda-web-client/src/UI/Banner.js
@@ -34,7 +34,7 @@ class Banner extends React.Component {
             });
         }
 
-        window.location = "https://data.gov.au";
+        window.location = this.props.fallbackUrl;
     };
 
     render() {
@@ -45,7 +45,7 @@ class Banner extends React.Component {
                         A new look for Australia&apos;s data portal: our updated
                         site makes it easier for you to find relevant open data.
                         You can still{" "}
-                        <a onClick={this.goBack} href="https://data.gov.au/">
+                        <a onClick={this.goBack} href={this.props.fallbackUrl}>
                             go back to the old site
                         </a>
                     </span>

--- a/magda-web-client/src/config.js
+++ b/magda-web-client/src/config.js
@@ -157,5 +157,5 @@ export const config = {
         east: 155,
         north: -5
     },
-    showFallbackBanner: serverConfig.showFallbackBanner || false
+    fallbackUrl: serverConfig.fallbackUrl
 };

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -75,11 +75,10 @@ const argv = yargs
             "The base URL of the MAGDA admin API.  If not specified, the URL is built from the apiBaseUrl.",
         type: "string"
     })
-    .option("showFallbackBanner", {
+    .option("fallbackUrl", {
         describe:
-            "Show a banner that allows people to go back to an older system.",
-        type: "boolean",
-        default: false
+            "An older system to fall back to - this url will be shown in a banner that says 'you can still go back to old site'.",
+        type: "string"
     }).argv;
 
 var app = express();
@@ -163,7 +162,7 @@ app.get("/server-config.js", function(req, res) {
                     .segment("correspondence")
                     .toString()
         ),
-        showFallbackBanner: argv.showFallbackBanner
+        fallbackUrl: argv.fallbackUrl
     };
     res.type("application/javascript");
     res.send("window.magda_server_config = " + JSON.stringify(config) + ";");


### PR DESCRIPTION
### What this PR does
Previously we made it so that you could remove the fallback banner... this makes it so you can configure the url that the fallback banner redirects you to, or turn it off completely by not specifying one.

### Checklist
-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
