### PR TITLE
Slowed down cron jobs outside of production.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ generate-connector-jobs:
   cache: {}
   script:
     - cd deploy
-    - yarn run generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod --imageVersion=$CI_COMMIT_REF_SLUG --imagePrefix=registry.gitlab.com/magda-data/magda/data61/
+    - yarn run generate-connector-jobs --in ./connector-config --out ./kubernetes/generated/prod --imageVersion=$CI_COMMIT_REF_SLUG --imagePrefix=registry.gitlab.com/magda-data/magda/data61/
     - mkdir kubernetes/generated/prod/cron
     - mv kubernetes/generated/prod/*-cron.json kubernetes/generated/prod/cron
   artifacts:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 -   Added mechanism to produce api documentation
 -   Fixed an issue where organisation Page dataset links set incorrect `publisher` query parameter
 -   Make source link wrap and add line break
+-   Made dev connector jobs execute every week only
 
 ## 0.0.45
 

--- a/scripts/generate-connector-jobs.js
+++ b/scripts/generate-connector-jobs.js
@@ -174,7 +174,10 @@ files.forEach(function(connectorConfigFile) {
             name: "connector-" + basename
         },
         spec: {
-            schedule: configFile.schedule || "* * */3 * *",
+            schedule:
+                configFile.schedule && prod
+                    ? configFile.schedule
+                    : "0 14 * * 0", // 12am Sydney time on Sunday
             jobTemplate: {
                 spec: jobSpec
             }

--- a/scripts/generate-connector-jobs.js
+++ b/scripts/generate-connector-jobs.js
@@ -177,7 +177,7 @@ files.forEach(function(connectorConfigFile) {
             schedule:
                 configFile.schedule && prod
                     ? configFile.schedule
-                    : "0 14 * * 0", // 12am Sydney time on Sunday
+                    : "0 14 * * 6", // 12am Sydney time on Sunday
             jobTemplate: {
                 spec: jobSpec
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,10 +587,6 @@
   dependencies:
     email-validator "*"
 
-"@types/escape-string-regexp@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz#052d16d87db583b72daceae4eaabddb66954424c"
-
 "@types/escape-string-regexp@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/escape-string-regexp/-/escape-string-regexp-0.0.32.tgz#296005808f51d27fb2a2de8d1ca080a91ee3375c"


### PR DESCRIPTION
### What this PR does
Fixes #1587.

Makes it so that the connector cron jobs in dev only run every week... they'll just all queue up at midnight on sunday and then execute then.

This is to alleviate what's happening at the moment where running the CKAN jobs every hour is causing the cluster to fill with slow connector jobs and stopping us from deploying.

### Checklist
-   [x] Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
