### PR TITLE
Issue/1098 Deletion of datasets in indexer via webhook isn't working

### DIFF
--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/RegisterWebhook.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/RegisterWebhook.scala
@@ -28,7 +28,7 @@ object RegisterWebhook {
     interface.getWebhook(config.getString("registry.webhookId")).flatMap {
       case Some(existingHook) =>
         logger.info("Hook already exists, updating...")
-        registerIndexerWebhook(interface, RegistryConstants.aspects, RegistryConstants.optionalAspects)
+        registerIndexerWebhook(interface, RegistryConstants.aspects, RegistryConstants.optionalAspects, true)
           .map { _ =>
             logger.info("Updated, attempting to resume...")
             interface.resumeWebhook(config.getString("registry.webhookId"))

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -456,13 +456,13 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
 
     result match {
       case Success(count:Long) =>
-        if(count % 100 == 0 && !logger.isEmpty) {
-          logger.get.info(s"Trimed ${count} records...")
+        if(!logger.isEmpty) {
+          logger.get.info(s"Trimed ${count} records.")
         }
         Success(count)
       case Failure(err) =>
         if(!logger.isEmpty) {
-          logger.get.error(err.getMessage)
+          logger.get.error(err, "Error happened when trim records.")
         }
         Failure(err)
     }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -5,10 +5,11 @@ import spray.json._
 import spray.json.lenses.JsonLenses._
 
 import scala.util.Try
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 import java.sql.SQLException
 
 import akka.NotUsed
+import akka.event.LoggingAdapter
 import akka.stream.scaladsl.Source
 import gnieh.diffson._
 import gnieh.diffson.sprayJson._
@@ -70,7 +71,7 @@ trait RecordPersistence {
 
   def deleteRecord(implicit session: DBSession, recordId: String): Try[Boolean]
 
-  def trimRecordsBySource(sourceTagToPreserve: String, sourceId: String)(implicit session: DBSession): Try[Long]
+  def trimRecordsBySource(sourceTagToPreserve: String, sourceId: String, logger: Option[LoggingAdapter] = None)(implicit session: DBSession): Try[Long]
 
   def createRecordAspect(implicit session: DBSession, recordId: String, aspectId: String, aspect: JsObject): Try[JsObject]
 
@@ -434,13 +435,13 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
     } yield rowsDeleted > 0
   }
 
-  def trimRecordsBySource(sourceTagToPreserve: String, sourceId: String)(implicit session: DBSession): Try[Long] = {
+  def trimRecordsBySource(sourceTagToPreserve: String, sourceId: String , logger: Option[LoggingAdapter] = None)(implicit session: DBSession): Try[Long] = {
     val recordIds = Try {
       sql"select distinct records.recordId, sourcetag from Records INNER JOIN recordaspects ON records.recordid = recordaspects.recordid where (sourcetag != $sourceTagToPreserve OR sourcetag IS NULL) and recordaspects.aspectid = 'source' and recordaspects.data->>'id' = $sourceId"
         .map(rs => rs.string("recordId")).list.apply()
     }
 
-    recordIds match {
+    val result = recordIds match {
       case Success(Nil) => Success(0)
       case Success(ids) =>
         ids
@@ -452,6 +453,20 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
           })
       case Failure(err) => Failure(err)
     }
+
+    result match {
+      case Success(count:Long) =>
+        if(count % 100 == 0 && !logger.isEmpty) {
+          logger.get.info(s"Trimed ${count} records...")
+        }
+        Success(count)
+      case Failure(err) =>
+        if(!logger.isEmpty) {
+          logger.get.error(err.getMessage)
+        }
+        Failure(err)
+    }
+
   }
 
   def createRecordAspect(implicit session: DBSession, recordId: String, aspectId: String, aspect: JsObject): Try[JsObject] = {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -185,7 +185,7 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
             // --- DB session needs to be created within the `Future`
             // --- as the `Future` will keep running after timeout and require active DB session
             DB localTx { implicit session =>
-              recordPersistence.trimRecordsBySource(sourceTagToPreserve, sourceId)
+              recordPersistence.trimRecordsBySource(sourceTagToPreserve, sourceId, Some(logger))
             }
           } map { result =>
             webHookActor ! WebHookActor.Process()

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -100,6 +100,15 @@ class RegistryExternalInterface(httpFetcher: HttpFetcher)(implicit val config: C
     }
   }
 
+  def createWebhook(webhook: WebHook): Future[WebHook] = {
+    fetcher.post(s"${baseApiPath}/hooks", webhook, Seq(authHeader)).flatMap { response =>
+      response.status match {
+        case OK => Unmarshal(response.entity).to[WebHook]
+        case _  => Unmarshal(response.entity).to[String].flatMap(onError(response))
+      }
+    }
+  }
+
   def resumeWebhook(webhookId: String): Future[WebHookAcknowledgementResponse] = {
     fetcher.post(s"${baseApiPath}/hooks/$webhookId/ack", WebHookAcknowledgement(succeeded = false), Seq(authHeader)).flatMap { response =>
       response.status match {


### PR DESCRIPTION
### What this PR does

Fixes #1098 mainly the followings:

- If the trim cannot complete in 10 seconds, the trim process will stop (with no error) due to DB session cleanup (as web serving thread exit)
  - Also make sure the trim process will output the log in the background so we will know the result in future
- Indexer didn't setup webhook properly --- event type never setup
  - Should request create `hook` endpoint (POST) for creating a hook
  - The update (PUT) endpoint will also create a hook if no existing hook but it won't touch webhook events table
  - This issue only impacts deletion as changed records are still sent to the indexer (via webhook) even eventTypes setup for the hook is empty

### Limitation of this PR:

Currently, only dataset deletion events will be processed at indexer.

We probbaly want to deal with (Will create a seperate issue for this):
- distribution deletion events: 
  - As we don't have a seperate distribution index, it might be easier to reindex the particular dataset
- Organisation deletion events:
  - This probably will not impact the *Organisation search* funciton as it aggregated result from datasets
  - We probably still take care of this as the search panel might use Organisation index (need to review the code to confirm)
- Record aspects deletion events
  - We might want to think about whether we need to deal with this as well (likely don't need)

### Deployment of this PR

It seems there could be a lot `unused` records left in database due to previous seccessful trim.
Best way to deal with it is to do a full crawl. 

### Checklist

-   [ ] Unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
