### PR TITLE
Issue/1617 Fixed dataset / organisation debounced search request not cancel upon URL changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 -   Uses the Header component from Design System
 -   Fixed an issue that connector record triming might not fully completed
 -   Fixed an issue that indexer webhook event types not properly setup
+-   Fixed an issue that dataset / organisation debounced search request not cancel upon URL changes
 
 ## 0.0.46
 

--- a/magda-web-client/src/Components/Publisher/PublishersViewer.js
+++ b/magda-web-client/src/Components/Publisher/PublishersViewer.js
@@ -17,6 +17,7 @@ import "./PublishersViewer.css";
 import search from "../../assets/search-dark.svg";
 import { Medium } from "../../UI/Responsive";
 import AUpageAlert from "../../pancake/react/page-alerts";
+import { withRouter } from "react-router-dom";
 
 class PublishersViewer extends Component {
     constructor(props) {
@@ -32,6 +33,9 @@ class PublishersViewer extends Component {
         this.clearSearch = this.clearSearch.bind(this);
         this.onClickSearch = this.onClickSearch.bind(this);
         this.searchInputFieldRef = null;
+        props.history.listen(location => {
+            this.debounceUpdateSearchQuery.cancel();
+        });
     }
 
     debounceUpdateSearchQuery = debounce(this.updateSearchQuery, 3000);
@@ -46,6 +50,7 @@ class PublishersViewer extends Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.location.search !== this.props.location.search) {
+            this.debounceUpdateSearchQuery.cancel();
             this.fetchData();
         }
     }
@@ -269,13 +274,11 @@ function mapStateToProps(state, ownProps) {
     const isFetching: boolean = state.publisher.isFetchingPublishers;
     const hitCount: number = state.publisher.hitCount;
     const error: Object = state.publisher.errorFetchingPublishers;
-    const location: Location = ownProps.location;
     const keyword = state.publisher.keyword;
     return {
         publishers,
         isFetching,
         hitCount,
-        location,
         error,
         keyword
     };
@@ -285,7 +288,11 @@ PublishersViewer.contextTypes = {
     router: PropTypes.object.isRequired
 };
 
+const PublishersViewerWithRouter = withRouter(props => (
+    <PublishersViewer {...props} />
+));
+
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(PublishersViewer);
+)(PublishersViewerWithRouter);

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -15,6 +15,7 @@ import queryString from "query-string";
 import SearchSuggestionBox from "./SearchSuggestionBox";
 import { Small, Medium } from "../../UI/Responsive";
 import stripFiltersFromQuery from "./stripFiltersFromQuery";
+import { withRouter } from "react-router-dom";
 
 class SearchBox extends Component {
     constructor(props) {
@@ -38,6 +39,9 @@ class SearchBox extends Component {
             isFocus: false
         };
         this.searchInputFieldRef = null;
+        props.history.listen(location => {
+            this.debounceUpdateSearchQuery.cancel();
+        });
     }
 
     debounceUpdateSearchQuery = debounce(this.updateSearchText, 3000);
@@ -213,7 +217,9 @@ const mapDispatchToProps = dispatch =>
         dispatch
     );
 
+const SearchBoxWithRouter = withRouter(props => <SearchBox {...props} />);
+
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(SearchBox);
+)(SearchBoxWithRouter);

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -41,6 +41,9 @@ class SearchBox extends Component {
         this.searchInputFieldRef = null;
         props.history.listen(location => {
             this.debounceUpdateSearchQuery.cancel();
+            this.setState({
+                searchText: null
+            });
         });
     }
 

--- a/magda-web-client/src/storage/localStorage.js
+++ b/magda-web-client/src/storage/localStorage.js
@@ -76,7 +76,7 @@ export function prependToLocalStorageArray(
     if (limit && limit >= 1) {
         items = items.slice(0, limit);
     }
-    setLocalData(key, items, defaultValue);
+    return setLocalData(key, items, defaultValue);
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Fixes #1617 

What happened is the search input box (for both dataset search & organization search ) will always delay search request for 3 seconds.  This delayed timer should be canceled upon browser URL changes --- otherwise, users will be dragged back to old search page if he types something into the search input and goes to another page (e.g. homepage, about page) before the 3 seconds. 

Why monitor through `history.listen` rather than `componentDidUpdate`?
According to the [doc](https://reacttraining.com/react-router/web/api/withRouter): `withRouter does not subscribe to location changes`

### Also fixed an issue @chloeleichen found out during the test. See comments below for more testing details

### Test URL: 

https://issue-1617.dev.magda.io

@aneesha09 @AlexGilleran @chloeleichen 

It seems a lot of logic running around this search box component. 

Please help to test (especially search related function e.g. Search filter panel) just in case my fix broke something else~ 


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
