### PR TITLE
Stopped first story not showing on mobile.

### DIFF
--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -164,7 +164,10 @@
 
 .home {
     .searchBox {
-        margin: 6rem auto 6rem auto;
+        margin: 2rem auto 2rem auto;
+        @media (min-width: $medium) {
+            margin: 6rem auto 6rem auto;
+        }
         box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.16),
             0px 3px 6px rgba(0, 0, 0, 0.23);
         border-radius: 4px;

--- a/magda-web-client/src/Pages/HomePageComponents/Stories.scss
+++ b/magda-web-client/src/Pages/HomePageComponents/Stories.scss
@@ -28,7 +28,7 @@
     .col-2 {
         width: calc(100% / 2 - 8px);
         & > div {
-            height: calc(100% - 13px);
+            height: calc(100%);
         }
     }
 

--- a/magda-web-client/src/Pages/HomePageComponents/StoryBox.js
+++ b/magda-web-client/src/Pages/HomePageComponents/StoryBox.js
@@ -54,13 +54,15 @@ class StoryBox extends Component {
                           content.titleUrl
                       )
                     : null}
-                {content.title
-                    ? this.getClickableElement(
-                          <h2 className="story-title">{content.title}</h2>,
-                          content.titleUrl
-                      )
-                    : null}
-                <MarkdownViewer markdown={content.__content} />
+                <div className="story-box-text">
+                    {content.title
+                        ? this.getClickableElement(
+                              <h2 className="story-title">{content.title}</h2>,
+                              content.titleUrl
+                          )
+                        : null}
+                    <MarkdownViewer markdown={content.__content} />
+                </div>
             </div>
         );
         return innerBody;

--- a/magda-web-client/src/Pages/HomePageComponents/StoryBox.scss
+++ b/magda-web-client/src/Pages/HomePageComponents/StoryBox.scss
@@ -1,48 +1,54 @@
 @import "../../variables";
 
 .homepage-stories {
+    .story-box {
+        background: #ffffff;
+        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+        border-radius: 4px;
+    }
+
     .story-title-link:hover {
         color: $AU-color-foreground-action;
         background-color: $AU-color-background;
     }
+
     .story-title-link {
         border: none;
     }
-    .story-box {
-        background: #ffffff;
-        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-        padding: 13px;
-        border-radius: 4px;
-        .story-title {
-            @include AU-fontgrid(lg, heading);
-        }
 
-        .story-title-image {
-            width: 100%;
-            height: auto;
-        }
+    .story-title {
+        @include AU-fontgrid(lg, heading);
+        margin-top: 0;
+    }
 
-        .story-box-body {
-            a {
-                text-decoration: none;
-            }
-            .markdown {
-                font-family: inherit;
-                font-style: normal;
-                font-weight: normal;
-            }
+    .story-title-image {
+        width: 100%;
+        height: auto;
+    }
+
+    .story-box-body {
+        padding: 16px;
+
+        a {
+            text-decoration: none;
+        }
+        .markdown {
+            font-family: inherit;
+            font-style: normal;
+            font-weight: normal;
         }
     }
 
     @media (max-width: $medium) {
+        .story-box-text {
+            padding: 16px;
+        }
+
+        .story-box-body {
+            padding: 0;
+        }
+
         .story-box {
-            .markdown {
-                padding: 16px;
-            }
-            h1 {
-                padding-left: 16px;
-                padding-right: 16px;
-            }
             margin-bottom: 16px;
             padding: 0px;
         }


### PR DESCRIPTION
### What this PR does
Makes it so that when you open the homepage on mobile (even on an iPhone SE), the top story moves up into view when you scroll or press the "view stories" button. As per what's showing currently on search.data.gov.au.

Fixes #1639 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] No changes.md, this fixes something that we broke this release
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
