### PR TITLE
Location in query text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.0.48
 
 -   Add ability to change content (logo).
+-   Added boosting to results which have location information that overlaps a known region whose name/shortname appears in query text.
 
 ## 0.0.47
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
@@ -262,8 +262,6 @@ class DataSetSearchSpec extends BaseSearchApiSpec with RegistryConverters {
     // The Austrlian one happens to be slightly more "relevant" due to the description, but the
     //  Queensland dataset should be boosted if a user searches for wildlife density in Queensland
 
-    indexedRegions.foreach{case (a,b) => println(s"a: $a, b: $b")}
-
     val qldGeometry = Location.fromBoundingBox(Seq(BoundingBox(-20.0, 147.0, -25.0, 139.0)))
 
     val qldDataset = DataSet(
@@ -312,9 +310,6 @@ class DataSetSearchSpec extends BaseSearchApiSpec with RegistryConverters {
   }
 
   it("for a region in query text should boost results from that region by acronym") {
-
-    indexedRegions.foreach{case (a,b) => println(s"a: $a, b: $b")}
-
     val saGeometry = Location.fromBoundingBox(Seq(BoundingBox(-27, 134, -30, 130)))
 
     val saDataset = DataSet(
@@ -376,8 +371,6 @@ class DataSetSearchSpec extends BaseSearchApiSpec with RegistryConverters {
     // 2 fake datasets. One that relates to Alfredton, the other to all of Australia
     // The Austrlian one happens to be slightly more "relevant" due to the description, but the
     //  Alfredton dataset should be boosted if a user searches for wildlife density in Alfredton
-
-    indexedRegions.foreach{case (a,b) => println(s"a: $a, b: $b")}
 
     val alfGeometry = Location.fromBoundingBox(Seq(BoundingBox(-37.555, 143.81, -37.56, 143.80)))
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/api/BaseApiSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/api/BaseApiSpec.scala
@@ -154,5 +154,11 @@ trait BaseApiSpec extends FunSpec with Matchers with ScalatestRouteTest with Mag
 }
 
 object BaseApiSpec {
-  val indexedRegions = Generators.indexedRegionsGen(mutable.HashMap.empty).retryUntil(_ => true).sample.get
+  val qld = {
+    import spray.json._
+    (new RegionSource("ithinkthisisregiontype",new URL("http://example.com"), "STE_CODE11", "STE_NAME11", Some("STE_ABBREV"), false, false, 10), """
+      {"type":"Feature","properties":{"STE_NAME11":"Queensland","STE_CODE11":"3","STE_ABBREV":"QLD"},"geometry":{"type":"Polygon","coordinates":[[[142.4,-10.7],[141.5,-13.6],[141.6,-15.1],[140.8,-17.5],[139.9,-17.7],[139,-17.3],[137.9,-16.4],[137.9,-26],[140.9,-26],[141,-29],[148.9,-28.9],[150,-28.6],[150.8,-28.7],[151.3,-29.1],[151.9,-28.9],[152,-28.6],[152.5,-28.4],[153.4,-28.2],[152.9,-27.4],[153,-26],[152.4,-24.9],[150.9,-23.6],[150.5,-22.4],[149.5,-22.3],[149.1,-21],[147.4,-19.5],[146.2,-18.9],[145.8,-17.3],[145.2,-16.3],[145.3,-15],[144.4,-14.2],[143.6,-14.3],[143.4,-12.7],[142.4,-10.7]]]}}
+    """.parseJson.asJsObject)
+  }
+  val indexedRegions = Generators.indexedRegionsGen(mutable.HashMap.empty).retryUntil(_ => true).sample.get :+ qld
 }

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/api/BaseApiSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/api/BaseApiSpec.scala
@@ -154,11 +154,17 @@ trait BaseApiSpec extends FunSpec with Matchers with ScalatestRouteTest with Mag
 }
 
 object BaseApiSpec {
-  val qld = {
+  val testStates = {
     import spray.json._
-    (new RegionSource("ithinkthisisregiontype",new URL("http://example.com"), "STE_CODE11", "STE_NAME11", Some("STE_ABBREV"), false, false, 10), """
+    List(
+      (new RegionSource("ithinkthisisregiontype",new URL("http://example.com"), "STE_CODE11", "STE_NAME11", Some("STE_ABBREV"), false, false, 10), """
       {"type":"Feature","properties":{"STE_NAME11":"Queensland","STE_CODE11":"3","STE_ABBREV":"QLD"},"geometry":{"type":"Polygon","coordinates":[[[142.4,-10.7],[141.5,-13.6],[141.6,-15.1],[140.8,-17.5],[139.9,-17.7],[139,-17.3],[137.9,-16.4],[137.9,-26],[140.9,-26],[141,-29],[148.9,-28.9],[150,-28.6],[150.8,-28.7],[151.3,-29.1],[151.9,-28.9],[152,-28.6],[152.5,-28.4],[153.4,-28.2],[152.9,-27.4],[153,-26],[152.4,-24.9],[150.9,-23.6],[150.5,-22.4],[149.5,-22.3],[149.1,-21],[147.4,-19.5],[146.2,-18.9],[145.8,-17.3],[145.2,-16.3],[145.3,-15],[144.4,-14.2],[143.6,-14.3],[143.4,-12.7],[142.4,-10.7]]]}}
-    """.parseJson.asJsObject)
+      """.parseJson.asJsObject),
+      (new RegionSource("ithinkthisisregiontype",new URL("http://example.com"), "STE_CODE11", "STE_NAME11", Some("STE_ABBREV"), false, false, 10), """
+      {"type":"Feature","properties":{"STE_NAME11":"South Australia","STE_CODE11":"4","STE_ABBREV":"SA"},"geometry":{"type":"Polygon","coordinates":[[[128.9,-26],[129.1,-31.5],[132.5,-31.9],[135.6,-34.8],[138.5,-34.9],[140.9,-38],[141,-26],[128.9,-26]]]}}
+      """.parseJson.asJsObject)
+    )
+
   }
-  val indexedRegions = Generators.indexedRegionsGen(mutable.HashMap.empty).retryUntil(_ => true).sample.get :+ qld
+  val indexedRegions = Generators.indexedRegionsGen(mutable.HashMap.empty).retryUntil(_ => true).sample.get ++ testStates
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -215,6 +215,7 @@ object IndexDefinition extends DefaultJsonProtocol {
               keywordField("regionType"),
               keywordField("regionId"),
               magdaTextField("regionName"),
+              textField("regionNameComplete"),
               magdaTextField("regionShortName"),
               geoshapeField("boundingBox"),
               geoshapeField("geometry"),

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/QueryParser.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/QueryParser.scala
@@ -34,7 +34,7 @@ case class Query(
   dateFrom: Option[FilterValue[OffsetDateTime]] = None,
   dateTo: Option[FilterValue[OffsetDateTime]] = None,
   regions: Set[FilterValue[Region]] = Set(),
-  regionsInFreeText: Set[FilterValue[Region]] = Set(),
+  boostRegions: Set[Region] = Set(),
   formats: Set[FilterValue[String]] = Set())
 
 object Query {
@@ -47,17 +47,8 @@ object Query {
       dateFrom = dateFilterValueFromString(dateFrom),
       dateTo = dateFilterValueFromString(dateTo),
       regions = regions.map(regionValueFromString).flatten.toSet,
-      regionsInFreeText = regionsFromFreeText(freeText),
+      boostRegions = Set(),
       formats = formats.map(x => filterValueFromString(Some(x))).flatten.toSet)
-  }
-
-  private def regionsFromFreeText(freeText: Option[String])(implicit config: Config): Set[FilterValue[Region]] = {
-    filterValueFromString(freeText).map(_.map(string => if (string.toLowerCase.contains("queensland")) Some(Region(QueryRegion("ithinkthisisregiontype", "3"))) else None)) match {
-      case Some(Specified(Some(x))) => Set(Specified(x))
-      case Some(Specified(None))    => Set()
-      case Some(Unspecified())      => Set(Unspecified())
-      case None                     => Set()
-    }
   }
 
   private def regionValueFromString(input: String)(implicit config: Config): Option[FilterValue[Region]] = {

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
@@ -55,7 +55,10 @@ trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Pr
   implicit def stringFilterValueFormat(implicit config: Config) = new FilterValueFormat[String]
   implicit def offsetDateFilterValueFormat(implicit config: Config) = new FilterValueFormat[OffsetDateTime]
   implicit def queryRegionFilterValueFormat(implicit config: Config) = new FilterValueFormat[Region]()(apiRegionFormat, config)
-  implicit def queryFormat(implicit config: Config) = jsonFormat7(Query.apply)
+  implicit def queryFormat(implicit config: Config) = {
+    implicit val regionFormat = apiRegionFormat
+    jsonFormat7(Query.apply)
+  }
   implicit def searchResultFormat(implicit config: Config) = jsonFormat7(SearchResult.apply)
   implicit val regionSearchResultFormat = {
     implicit val regionFormat = apiRegionFormat

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
@@ -55,7 +55,7 @@ trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Pr
   implicit def stringFilterValueFormat(implicit config: Config) = new FilterValueFormat[String]
   implicit def offsetDateFilterValueFormat(implicit config: Config) = new FilterValueFormat[OffsetDateTime]
   implicit def queryRegionFilterValueFormat(implicit config: Config) = new FilterValueFormat[Region]()(apiRegionFormat, config)
-  implicit def queryFormat(implicit config: Config) = jsonFormat6(Query.apply)
+  implicit def queryFormat(implicit config: Config) = jsonFormat7(Query.apply)
   implicit def searchResultFormat(implicit config: Config) = jsonFormat7(SearchResult.apply)
   implicit val regionSearchResultFormat = {
     implicit val regionFormat = apiRegionFormat

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -121,8 +121,6 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
       ).map {
         case Left(ESGenericException(e)) => throw e
         case Right(results) => {
-          println(s"Searching for boost regions with phrase '$freeText' found ${results.result.totalHits} results")
-          println(results.result.totalHits)
           results.result.totalHits match {
             case 0 => Set[Region]() // If there's no hits, no need to do anything more
             case _ => results.result.to[Region].toSet

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/Queries.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/Queries.scala
@@ -54,8 +54,7 @@ object Queries {
     }
   }
 
-  def regionIdQuery(regionValue: FilterValue[Region], indices: Indices)(implicit config: Config) = {
-    def normal(region: Region) = new GeoShapeQueryDefinition(
+  def regionToGeoShapeQuery(region: Region, indices: Indices)(implicit config: Config) = new GeoShapeQueryDefinition(
       "spatial.geoJson",
       PreindexedShape(
         generateRegionId(region.queryRegion.regionType, region.queryRegion.regionId),
@@ -66,7 +65,8 @@ object Queries {
       Some(ShapeRelation.INTERSECTS)
     )
 
-    handleFilterValue(regionValue, normal, "spatial.geoJson")
+  def regionIdQuery(regionValue: FilterValue[Region], indices: Indices)(implicit config: Config) = {
+    handleFilterValue(regionValue, (region: Region) => regionToGeoShapeQuery(region, indices), "spatial.geoJson")
   }
   def dateQueries(dateFrom: Option[FilterValue[OffsetDateTime]], dateTo: Option[FilterValue[OffsetDateTime]]) = {
     Seq(


### PR DESCRIPTION
### What this PR does

Adds boosting to results that have a spatial reference that overlaps a known region referred to in search text. I.e. searching for "schools Queensland" should boost datasets in results that are located in Queensland.

Fixes #983.

### Problems:
- [ ] Failing tests 
    - [ ] "South" boosts datasets in South Australia
- [ ] Will search all region types for matches (not just states)
- [ ] Adding regions for indexing for tests is a hack
- [ ] Haven't tested outside of unit tests
    - [ ] Not sure if I've changed the output format of a query in the API (I added a field to `Query` which should be serialised in returned `SearchResult`. Other query decision outputs are in `SearchResult` instead of Query though, which is probably a better place for it).
- [x] ~~Debugging prints everywhere~~
- [ ] Boost is arbitrary, and probably way too high (x100)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
