### PR TITLE
Issue/1029 Make email address contains in emails mailto links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 -   Whitelist KMZ.
 -   Add ability to change content (logo).
+-   Updated email template & make email clickable
 
 ## 0.0.47
 

--- a/magda-correspondence-api/templates/feedback.pug
+++ b/magda-correspondence-api/templates/feedback.pug
@@ -9,7 +9,7 @@ body
     |published by #{dataset.publisher}, at 
     |<a href="#{datasetUrl}">#{dataset.url}</a>.
 
-    |The feedback is from  #{message.senderName}, #{message.senderEmail}: <br/><br/>
+    |The feedback is from  #{message.senderName}, <a href="mailto:#{message.senderEmail}">#{message.senderEmail}</a>: <br/><br/>
 
     |!{message.html} <br/><br/>
 

--- a/magda-correspondence-api/templates/question.pug
+++ b/magda-correspondence-api/templates/question.pug
@@ -10,7 +10,7 @@ body
     |<a href="#{datasetUrl}">#{dataset.url}</a>.
     |Please respond to this query as soon as possible.<br/><br/>
 
-    |The query is from  #{message.senderName}, #{message.senderEmail}: <br/><br/>
+    |The query is from  #{message.senderName}, <a href="mailto:#{message.senderEmail}">#{message.senderEmail}</a>: <br/><br/>
 
     |!{message.html} <br/><br/>
 

--- a/magda-correspondence-api/templates/request.pug
+++ b/magda-correspondence-api/templates/request.pug
@@ -7,7 +7,7 @@ body
     |Hi there, <br/><br/>
     |A request has been raised for a dataset. Please respond to this request as soon as possible.<br/><br/>
 
-    |The query is from #{message.senderName}, #{message.senderEmail}: <br/><br/>
+    |The query is from #{message.senderName}, <a href="mailto:#{message.senderEmail}">#{message.senderEmail}</a>: <br/><br/>
 
     |!{message.html} <br/><br/>
 


### PR DESCRIPTION
### What this PR does

Fixes #1029 

Updated three email templated so that the users supplied email address is now a `mailto` link.

Tested on:

http://issue-1029.dev.magda.io/ 
(It seems https still doesn't work)

Tested only two templates:
- question
- request

the `feedback` one (although I updated) seems not used anymore.

### Checklist

-   [ ] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
