### PR TITLE
Raised the CPU limit on the registry-api to stop it taking too much ram.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 -   Fixed an issue that format enhancer may exit when dcat-string not available
 -   Updated email template & make email clickable
 -   Updated aims connector URL
+-   Raised the default resources for registry-api.
 
 ## 0.0.47
 

--- a/deploy/helm/magda/charts/registry-api/values.yaml
+++ b/deploy/helm/magda/charts/registry-api/values.yaml
@@ -2,7 +2,7 @@ image: {}
 livenessProbe: {}
 resources:
   requests:
-    cpu: 100m
-    memory: 300Mi
-  limits:
     cpu: 250m
+    memory: 500Mi
+  limits:
+    cpu: 750m


### PR DESCRIPTION
### What this PR does

Fixes #1670 (hopefully)

This raises the default CPU limit for the registry-api, which seems to alleviate the massive amount of RAM it's taking in dev. This is a stopgap until we give everything a better go in https://github.com/magda-io/magda/issues/1671.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
