### PR TITLE
Make sure CKAN connector doesn't loop forever if server reports wrong dataset count or empty page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.0.48
 
+-   Make sure CKAN connector doesn't loop forever if server reports wrong dataset count or empty page
 -   Whitelist KMZ.
 -   Add ability to change content (logo).
 -   Updated email template & make email clickable

--- a/magda-ckan-connector/src/Ckan.ts
+++ b/magda-ckan-connector/src/Ckan.ts
@@ -129,7 +129,7 @@ export default class Ckan implements ConnectorSource {
 
         return AsyncPage.create<CkanPackageSearchResponse>(previous => {
             if (previous) {
-                startIndex += previous.result.results.length;
+                startIndex += this.pageSize;
                 if (
                     startIndex >= previous.result.count ||
                     (options.maxResults &&
@@ -292,7 +292,6 @@ export default class Ckan implements ConnectorSource {
         startIndex: number,
         maxResults: number
     ): Promise<CkanPackageSearchResponse> {
-
         const pageUrl = url.clone();
         pageUrl.addSearch("start", startIndex);
         pageUrl.addSearch("rows", this.pageSize);

--- a/magda-ckan-connector/src/Ckan.ts
+++ b/magda-ckan-connector/src/Ckan.ts
@@ -292,14 +292,10 @@ export default class Ckan implements ConnectorSource {
         startIndex: number,
         maxResults: number
     ): Promise<CkanPackageSearchResponse> {
-        const pageSize =
-            maxResults && maxResults < this.pageSize
-                ? maxResults
-                : this.pageSize;
 
         const pageUrl = url.clone();
         pageUrl.addSearch("start", startIndex);
-        pageUrl.addSearch("rows", pageSize);
+        pageUrl.addSearch("rows", this.pageSize);
 
         const operation = () =>
             new Promise<CkanPackageSearchResponse>((resolve, reject) => {


### PR DESCRIPTION
### What this PR does

Fixes #1621 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
