### PR TITLE
Stopped Magda showing up as a Perl repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.sh text eol=lf
 CHANGES.md merge=union
+magda-elastic-search/*.pl linguist-vendored


### PR DESCRIPTION
### What this PR does
Right now magda shows up like this on github:

![image](https://user-images.githubusercontent.com/900555/45204678-50470a80-b2c3-11e8-87c7-f2e15fbdd27d.png)

Which is weird. This fixes that.

I don't really think it deserves a changelog entry because it doesn't actually affect the product at all, just how it shows up on github.