### PR TITLE
Fixed trim with 0 deletions throwing 400 from registry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 -   Take open data connector license from dataset level to distribution level and add basic black box test
 -   Fix logo vertical alignment and partially hidden issue
 -   Made header padding even
+-   Fixed trim with zero records deleted returning 400
 
 ## 0.0.47
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -442,7 +442,7 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
     }
 
     val result = recordIds match {
-      case Success(Nil) => Success(0)
+      case Success(Nil) => Success(0l)
       case Success(ids) =>
         ids
           .map(recordId => deleteRecord(session, recordId))

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -132,6 +132,7 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
             case Success(result)                             => complete(MultipleDeleteResult(result))
             case Failure(timeoutException: TimeoutException) => complete(StatusCodes.Accepted)
             case Failure(exception) =>
+              logger.error(exception, "An error occurred while trimming with sourceTagToPreserve $1 sourceId $2", sourceTagToPreserve, sourceId)
               complete(StatusCodes.BadRequest, BadRequest("An error occurred while processing your request."))
           }
 


### PR DESCRIPTION
### What this PR does

Fixes #1651 

Right now because of scala silliness, a trim operation that trims 0 records falls through a `match` statement and results in an error...
... which in turn results in a 400 response
... which in turn results in the CSW connector retrying 10 times and failing with exit code 1
... which in turn results in the CSW connector rerunning itself forever

So this makes it _not_ return a 400 but instead return a 200 as expected.

There's a testing branch right now in gitlab, you can see that a CSW connector job has run and completed as usual.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
