### PR TITLE
Made broken link minion not fail on big files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -433,19 +433,19 @@ dockerize:dockerExtensions:
     # Helm upgrade
     - helm init --upgrade
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io --timeout 1200 --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io --timeout 3600 --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 (UI) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,ingress.targetService=web,tags.all=false,tags.web-server=true,web-server.baseUrl=https://dev.magda.io --timeout 1200 --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,ingress.targetService=web,tags.all=false,tags.web-server=true,web-server.baseUrl=https://dev.magda.io --timeout 3600 --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 (No Data) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,combined-db.waleBackup.method=NONE,elasticsearch.useGcsSnapshots=false --timeout 1200 --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,combined-db.waleBackup.method=NONE,elasticsearch.useGcsSnapshots=false --timeout 3600 --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 Stop Preview: &stopPreview
@@ -489,7 +489,7 @@ Deploy Master To Dev:
   - echo "$KUBECTL_CONFIG" > kubectlconfig.yaml
   - export KUBECONFIG=kubectlconfig.yaml
   - kubectl create secret docker-registry regcred --namespace default --docker-server=registry.gitlab.com --docker-username=gitlab-ci-token --docker-password=$CI_JOB_TOKEN --docker-email=alex.gilleran@data61.csiro.au --dry-run -o json | kubectl apply --namespace default -f -
-  - helm upgrade magda deploy/helm/magda --install --recreate-pods -f deploy/helm/magda-dev.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=master --timeout 1200 --wait
+  - helm upgrade magda deploy/helm/magda --install --recreate-pods -f deploy/helm/magda-dev.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=master --timeout 3600 --wait
 
 Release Tags To Docker Hub:
   stage: release
@@ -559,7 +559,7 @@ Publish Helm Chart:
 #     # Get version from lerna json
 #     - apk add --update jq
 #     - TAG=$(jq -r ".version" lerna.json)
-#     - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=data61,global.image.tag=$TAG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,global.externalUrl=https://$CI_COMMIT_REF_SLUG.dev.magda.io --timeout 1200 --wait
+#     - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=data61,global.image.tag=$TAG,ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,global.externalUrl=https://$CI_COMMIT_REF_SLUG.dev.magda.io --timeout 3600 --wait
 
 Stop Staging:
   <<: *stopPreview

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 -   Take open data connector license from dataset level to distribution level and add basic black box test
 -   Fix logo vertical alignment and partially hidden issue
 -   Made header padding even
+-   Made the broken link minion use `GET` for everything and ignore the data.
 
 ## 0.0.47
 

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -59,6 +59,10 @@ combined-db:
       fileName: db-service-account-private-key.json
   data:
     storage: 250Gi
+  resources:
+    limits:
+      cpu: 2000m
+
 elasticsearch:
   data:
     heapSize: 500m

--- a/magda-minion-broken-link/src/index.ts
+++ b/magda-minion-broken-link/src/index.ts
@@ -10,7 +10,7 @@ const argv = commonYargs(ID, 6111, "http://localhost:6111", argv =>
         describe:
             "Number of times to retry external links when checking whether they're broken",
         type: "number",
-        default: 3
+        default: 1
     })
 );
 

--- a/magda-minion-broken-link/src/onRecordFound.ts
+++ b/magda-minion-broken-link/src/onRecordFound.ts
@@ -267,35 +267,35 @@ function retrieveHttp(
                     ) {
                         resolve(response.statusCode);
                     } else {
-                        request.get(
-                            {
+                        const thisReq = request
+                            .get({
                                 url,
                                 headers: {
                                     Range: "bytes=0-50"
                                 }
-                            },
-                            (err: Error, response: http.IncomingMessage) => {
-                                if (err) {
-                                    reject(err);
+                            })
+                            .on("error", err => {
+                                thisReq.abort();
+                                reject(err);
+                            })
+                            .on("response", response => {
+                                thisReq.abort();
+                                if (
+                                    (response.statusCode >= 200 &&
+                                        response.statusCode <= 299) ||
+                                    response.statusCode === 429
+                                ) {
+                                    resolve(response.statusCode);
                                 } else {
-                                    if (
-                                        (response.statusCode >= 200 &&
-                                            response.statusCode <= 299) ||
-                                        response.statusCode === 429
-                                    ) {
-                                        resolve(response.statusCode);
-                                    } else {
-                                        reject(
-                                            new BadHttpResponseError(
-                                                response.statusMessage,
-                                                response,
-                                                response.statusCode
-                                            )
-                                        );
-                                    }
+                                    reject(
+                                        new BadHttpResponseError(
+                                            response.statusMessage,
+                                            response,
+                                            response.statusCode
+                                        )
+                                    );
                                 }
-                            }
-                        );
+                            });
                     }
                 }
             });

--- a/magda-minion-broken-link/src/test/RandomStream.ts
+++ b/magda-minion-broken-link/src/test/RandomStream.ts
@@ -1,0 +1,37 @@
+/*
+ * random-stream
+ * Ben Postlethwaite
+ * 2013 MIT
+ */
+import { Readable } from "stream";
+
+export default function RandomStream(options: any) {
+    options = options || {};
+    var stream = new Readable();
+
+    var randInt = randIntGenerator(options.min, options.max);
+
+    stream._read = function(n) {
+        var self = this;
+        setTimeout(function() {
+            self.push(randChar());
+        }, randInt());
+    };
+
+    return stream;
+}
+
+var randAscii = randIntGenerator(33, 126);
+
+function randChar() {
+    return String.fromCharCode(randAscii());
+}
+
+function randIntGenerator(min: number, max: number) {
+    if (!min) min = 50;
+    if (!max) max = 250;
+
+    return function() {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    };
+}

--- a/magda-minion-broken-link/src/test/arbitraries.ts
+++ b/magda-minion-broken-link/src/test/arbitraries.ts
@@ -41,12 +41,7 @@ export const recordArbWithSuccesses = arbFlatMap(
                     {} as { [a: string]: CheckResult }
                 );
 
-                // some server configurations will disallow HEAD
-                // method requests. When that fails, we try
-                // to make a get request to verify the link
-                const disallowHead = jsc.bool.generator(0);
-
-                return { record, successLookup, disallowHead };
+                return { record, successLookup };
             },
             ({ record, successLookup }) => {
                 return getKnownProtocolUrls(record).map(

--- a/magda-minion-broken-link/src/test/onRecordFound.spec.ts
+++ b/magda-minion-broken-link/src/test/onRecordFound.spec.ts
@@ -30,6 +30,7 @@ import {
 import FtpHandler from "../FtpHandler";
 import AuthorizedRegistryClient from "@magda/typescript-common/dist/registry/AuthorizedRegistryClient";
 import parseUriSafe from "../parseUriSafe";
+import RandomStream from "./RandomStream";
 
 describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
     this.timeout(20000);
@@ -192,9 +193,20 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                                 }
                             } else {
                                 intercept.reply(405);
-                                scope
-                                    .get(url.endsWith("/") ? "/" : "")
-                                    .reply(success === "success" ? 200 : 404);
+                                const scopeGet = scope.get(
+                                    url.endsWith("/") ? "/" : ""
+                                );
+
+                                if (success) {
+                                    scopeGet.reply(200, () => {
+                                        return RandomStream({
+                                            min: 250, // in milliseconds
+                                            max: 1000 // in milliseconds
+                                        });
+                                    });
+                                } else {
+                                    scopeGet.reply(404);
+                                }
                             }
                         } else {
                             intercept.replyWithError("fail");

--- a/magda-minion-broken-link/src/test/onRecordFound.spec.ts
+++ b/magda-minion-broken-link/src/test/onRecordFound.spec.ts
@@ -142,10 +142,15 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
         return jsc.assert(
             jsc.forall(recordArbWithSuccesses, function({
                 record,
-                successLookup,
-                disallowHead
+                successLookup
             }) {
                 beforeEachProperty();
+
+                /** Endless stream of nonsense, similar to what you'd get if you tried to download a massive file */
+                const randomStream = RandomStream({
+                    min: 250, // in milliseconds
+                    max: 1000 // in milliseconds
+                });
 
                 // Tell the FTP server to return success/failure for the various FTP
                 // paths with this dodgy method. Note that because the FTP server can
@@ -177,39 +182,19 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                     }) => {
                         const scope = nock(url);
 
-                        const intercept = scope.head(
-                            url.endsWith("/") ? "/" : ""
-                        );
-
                         if (success !== "error") {
-                            if (!disallowHead) {
-                                intercept.reply(
-                                    success === "success" ? 200 : 404
+                            scope
+                                .get(url.endsWith("/") ? "/" : "")
+                                .reply(
+                                    success === "success" ? 200 : 404,
+                                    () => {
+                                        return randomStream;
+                                    }
                                 );
-                                if (success !== "success") {
-                                    scope
-                                        .get(url.endsWith("/") ? "/" : "")
-                                        .reply(404);
-                                }
-                            } else {
-                                intercept.reply(405);
-                                const scopeGet = scope.get(
-                                    url.endsWith("/") ? "/" : ""
-                                );
-
-                                if (success) {
-                                    scopeGet.reply(200, () => {
-                                        return RandomStream({
-                                            min: 250, // in milliseconds
-                                            max: 1000 // in milliseconds
-                                        });
-                                    });
-                                } else {
-                                    scopeGet.reply(404);
-                                }
-                            }
                         } else {
-                            intercept.replyWithError("fail");
+                            scope
+                                .get(url.endsWith("/") ? "/" : "")
+                                .replyWithError("fail");
                         }
 
                         return scope;
@@ -333,17 +318,19 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                         .reply(201);
                 });
 
-                return onRecordFound(record, registry, 0, 0, 0, fakeFtpHandler)
+                return onRecordFound(record, registry, 0, 0, fakeFtpHandler)
                     .then(() => {
                         distScopes.forEach(scope => scope.done());
                         registryScope.done();
                     })
                     .then(() => {
                         afterEachProperty();
+                        randomStream.destroy();
                         return true;
                     })
                     .catch(e => {
                         afterEachProperty();
+                        randomStream.destroy();
                         throw e;
                     });
             }),
@@ -460,11 +447,6 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                                     allResults.forEach((failureCodes, i) => {
                                         failureCodes.forEach(failureCode => {
                                             scope
-                                                .head(
-                                                    url.endsWith("/") ? "/" : ""
-                                                )
-                                                .reply(failureCode);
-                                            scope
                                                 .get(
                                                     url.endsWith("/") ? "/" : ""
                                                 )
@@ -475,7 +457,7 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                                             result === "fail429"
                                         ) {
                                             scope
-                                                .head(
+                                                .get(
                                                     url.endsWith("/") ? "/" : ""
                                                 )
                                                 .reply(429);
@@ -484,7 +466,7 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
 
                                     if (result === "success") {
                                         scope
-                                            .head(url.endsWith("/") ? "/" : "")
+                                            .get(url.endsWith("/") ? "/" : "")
                                             .reply(200);
                                     }
 
@@ -613,17 +595,13 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
 
                             failures.forEach(failureCode => {
                                 scope
-                                    .head(uri.path())
-                                    .delay(delayMs)
-                                    .reply(failureCode);
-                                scope
                                     .get(uri.path())
                                     .delay(delayMs)
                                     .reply(failureCode);
                             });
 
                             scope
-                                .head(uri.path())
+                                .get(uri.path())
                                 .delay(delayMs)
                                 .reply(200);
                             return scopeLookup;


### PR DESCRIPTION
### What this PR does

Fixes #1680 

This stops the broken link minion from doing a `HEAD` because we've found support for that is pretty patchy, now it just does a `GET` with the range headers set and aborts the request as soon as it gets response headers.

I also reduced the retry count to `1` because having a job that redoes it every 2 weeks means that there's not much call for retries really, and these slow down the minion _massively_.

Also increased the timeout and the cpu limit for combined-db on preview deployments in the hope of making deploy with data work more reliably.

You can see that the preview deployment has worked by looking at the logs of the minion:
```
kubectl logs -f minion-broken-link-6665ff8d6d-82npb --namespace 1680-make-broken-link-sleuther-do-big-files | grep https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Retrieving https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Finished retrieving  https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Retrieving https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Finished retrieving  https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
```


```
kubectl logs -f minion-broken-link-6665ff8d6d-82npb --namespace 1680-make-broken-link-sleuther-do-big-files | grep https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Retrieving https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Finished retrieving  https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Retrieving https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
Finished retrieving  https://data.melbourne.vic.gov.au/api/views/dj7e-rdx9/rows.csv?accessType=DOWNLOAD
```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
