### PR TITLE
Made "ask a question" button go to custodian directly where possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.0.49
 
 -   Set CSW connector MD_Metadata dateStamp as issue date
+-   Made "Ask a question" button send the question directly to the contactPoint for the dataset if possible.
 
 ## 0.0.48
 

--- a/magda-correspondence-api/src/createApiRouter.ts
+++ b/magda-correspondence-api/src/createApiRouter.ts
@@ -61,25 +61,28 @@ export default function createApiRouter(
     );
 
     /**
-     * @apiGroup Correspondence
+     * @apiGroup Correspondence API
      *
      * @api {post} /v0/send/dataset/request Send Dataset Request
-     * @apiDescription TODO
      *
-     * @apiParam (Request body) {string} csp-report TODO
+     * @apiDescription Sends a request for a dataset to the site administrators
      *
-     * @apiSuccess {string} result SUCCESS
+     * @apiParam (Request body) {string} senderName The name of the sender
+     * @apiParam (Request body) {string} senderEmail The email address of the sender
+     * @apiParam (Request body) {string} message The message to send
+     *
+     * @apiSuccess {string} status OK
      *
      * @apiSuccessExample {json} 200
      *    {
-     *         "result": "SUCCESS"
+     *         "status": "OK"
      *    }
      *
-     * @apiError {string} result FAILED
+     * @apiError {string} status FAILED
      *
      * @apiErrorExample {json} 400
      *    {
-     *         "result": "FAILED"
+     *         "status": "Failed"
      *    }
      */
     router.post("/public/send/dataset/request", validateMiddleware, function(
@@ -107,16 +110,49 @@ export default function createApiRouter(
         );
     });
 
+    /**
+     * @apiGroup Correspondence API
+     *
+     * @api {post} /v0/send/dataset/:datasetId/question Send a question about a dataest
+     *
+     * @apiDescription Sends a question about a dataset to the data custodian if available,
+     *  and to the administrators if not
+     *
+     * @apiParam (Request body) {string} senderName The name of the sender
+     * @apiParam (Request body) {string} senderEmail The email address of the sender
+     * @apiParam (Request body) {string} message The message to send
+     *
+     * @apiSuccess {string} status OK
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *         "status": "OK"
+     *    }
+     *
+     * @apiError {string} status FAILED
+     *
+     * @apiErrorExample {json} 400
+     *    {
+     *         "status": "Failed"
+     *    }
+     */
     router.post(
         "/public/send/dataset/:datasetId/question",
         validateMiddleware,
-        function(req, res) {
+        async function(req, res) {
             const body: DatasetMessage = req.body;
 
             const promise = getDataset(req.params.datasetId).then(dataset => {
-                const subject = `Question About ${
-                    dataset.aspects["dcat-dataset-strings"].title
-                }`;
+                const dcatDatasetStrings =
+                    dataset.aspects["dcat-dataset-strings"];
+
+                const subject = `Question About ${dcatDatasetStrings.title}`;
+
+                const { contactPoint } = dcatDatasetStrings;
+                const recipient =
+                    contactPoint && emailValidator.validate(contactPoint)
+                        ? contactPoint
+                        : options.defaultRecipient;
 
                 const html = renderTemplate(
                     Templates.Question,
@@ -132,41 +168,7 @@ export default function createApiRouter(
                     body,
                     html,
                     subject,
-                    // TODO: Send to the dataset's contactPoint
-                    options.defaultRecipient
-                );
-            });
-
-            handlePromise(promise, res, req.params.datasetId);
-        }
-    );
-
-    router.post(
-        "/public/send/dataset/:datasetId/report",
-        validateMiddleware,
-        function(req, res) {
-            const body: DatasetMessage = req.body;
-
-            const promise = getDataset(req.params.datasetId).then(dataset => {
-                const subject = `Feedback Regarding ${
-                    dataset.aspects["dcat-dataset-strings"].title
-                }`;
-
-                const html = renderTemplate(
-                    Templates.Feedback,
-                    body,
-                    subject,
-                    options.externalUrl,
-                    dataset
-                );
-
-                return sendMail(
-                    options.smtpMailer,
-                    options.defaultRecipient,
-                    body,
-                    html,
-                    subject,
-                    options.defaultRecipient
+                    recipient
                 );
             });
 

--- a/magda-correspondence-api/src/test/createApiRouter.spec.ts
+++ b/magda-correspondence-api/src/test/createApiRouter.spec.ts
@@ -41,6 +41,7 @@ const DEFAULT_DATASET_ID =
 const ENCODED_DEFAULT_DATASET_ID = encodeURIComponent(DEFAULT_DATASET_ID);
 const DEFAULT_DATASET_TITLE = "thisisatitle";
 const DEFAULT_DATASET_PUBLISHER = "publisher";
+const DEFAULT_DATASET_CONTACT_POINT = "contactpoint@example.com";
 const EXTERNAL_URL = "datagov.au.example.com";
 
 describe("send dataset request mail", () => {
@@ -135,67 +136,90 @@ describe("send dataset request mail", () => {
         checkEmailErrorCases("/public/send/dataset/request");
     });
 
-    describe("/public/send/dataset/:datasetId/report", () => {
+    describe("/public/send/dataset/:datasetId/question", () => {
         it("should respond with an 200 response if everything was successful", () => {
-            sendStub.returns(Promise.resolve());
+            return sendQuestion().then(() => {
+                const args: Message = sendStub.firstCall.args[0];
 
-            stubGetRecordCall();
+                expect(args.to).to.equal(DEFAULT_DATASET_CONTACT_POINT);
+                expect(args.from).to.contain(DEFAULT_SENDER_NAME);
+                expect(args.from).to.contain(DEFAULT_RECIPIENT);
+                expect(args.replyTo).to.contain(DEFAULT_SENDER_EMAIL);
 
-            return supertest(app)
-                .post(
-                    `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/report`
-                )
-                .set({
-                    "Content-Type": "application/json"
-                })
-                .send({
-                    senderName: DEFAULT_SENDER_NAME,
-                    senderEmail: DEFAULT_SENDER_EMAIL,
-                    message: DEFAULT_MESSAGE_TEXT
-                })
-                .expect(200)
-                .then(() => {
-                    const args: Message = sendStub.firstCall.args[0];
+                expect(args.text).to.contain(DEFAULT_MESSAGE_TEXT);
+                expect(args.text).to.contain(DEFAULT_DATASET_PUBLISHER);
+                expect(args.text).to.contain(
+                    EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
+                );
+                expect(args.text).to.contain("question");
 
-                    expect(args.to).to.equal(DEFAULT_RECIPIENT);
-                    expect(args.from).to.contain(DEFAULT_SENDER_NAME);
-                    expect(args.from).to.contain(DEFAULT_RECIPIENT);
-                    expect(args.replyTo).to.contain(DEFAULT_SENDER_EMAIL);
+                expect(args.html).to.contain(DEFAULT_MESSAGE_HTML);
+                expect(args.html).to.contain(DEFAULT_DATASET_PUBLISHER);
+                expect(args.html).to.contain(
+                    EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
+                );
+                expect(args.html).to.contain("question");
 
-                    expect(args.text).to.contain(DEFAULT_MESSAGE_TEXT);
-                    expect(args.text).to.contain(DEFAULT_DATASET_PUBLISHER);
-                    expect(args.text).to.contain(
-                        EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
-                    );
-                    expect(args.text).to.contain("feedback");
+                expect(args.subject).to.contain(DEFAULT_DATASET_TITLE);
 
-                    expect(args.html).to.contain(DEFAULT_MESSAGE_HTML);
-                    expect(args.html).to.contain(DEFAULT_DATASET_PUBLISHER);
-                    expect(args.html).to.contain(
-                        EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
-                    );
-                    expect(args.html).to.contain("feedback");
+                checkAttachments(args.attachments);
+            });
+        });
 
-                    expect(args.subject).to.contain(DEFAULT_DATASET_TITLE);
+        it("should fall back to default recipient if there's no contact point", () => {
+            return sendQuestion({
+                contactPoint: undefined
+            }).then(() => {
+                const args: Message = sendStub.firstCall.args[0];
 
-                    checkAttachments(args.attachments);
-                });
+                expect(args.to).to.equal(DEFAULT_RECIPIENT);
+            });
+        });
+
+        it("should fall back to default recipient if dataset contact point is a phone number", () => {
+            return sendQuestion({
+                contactPoint: "02 9411 1111"
+            }).then(() => {
+                const args: Message = sendStub.firstCall.args[0];
+
+                expect(args.to).to.equal(DEFAULT_RECIPIENT);
+            });
+        });
+
+        it("should fall back to default recipient if dataset contact point is a malformed email address", () => {
+            return sendQuestion({
+                contactPoint: "hello@blah"
+            }).then(() => {
+                const args: Message = sendStub.firstCall.args[0];
+
+                expect(args.to).to.equal(DEFAULT_RECIPIENT);
+            });
+        });
+
+        it("should fall back to default recipient if dataset contact point is a bunch of nonsense", () => {
+            return sendQuestion({
+                contactPoint:
+                    "You can contact me on my mobile phone between the hours of 9am and 5pm"
+            }).then(() => {
+                const args: Message = sendStub.firstCall.args[0];
+
+                expect(args.to).to.equal(DEFAULT_RECIPIENT);
+            });
         });
 
         checkEmailErrorCases(
-            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/report`,
+            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/question`,
             true
         );
 
         checkRegistryErrorCases(
-            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/report`
+            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/question`
         );
-    });
-    describe("/public/send/dataset/:datasetId/question", () => {
-        it("should respond with an 200 response if everything was successful", () => {
+
+        function sendQuestion(overrideDataset: {} = {}) {
             sendStub.returns(Promise.resolve());
 
-            stubGetRecordCall();
+            stubGetRecordCall(overrideDataset);
 
             return supertest(app)
                 .post(
@@ -209,46 +233,11 @@ describe("send dataset request mail", () => {
                     senderEmail: DEFAULT_SENDER_EMAIL,
                     message: DEFAULT_MESSAGE_TEXT
                 })
-                .expect(200)
-                .then(() => {
-                    const args: Message = sendStub.firstCall.args[0];
-
-                    expect(args.to).to.equal(DEFAULT_RECIPIENT);
-                    expect(args.from).to.contain(DEFAULT_SENDER_NAME);
-                    expect(args.from).to.contain(DEFAULT_RECIPIENT);
-                    expect(args.replyTo).to.contain(DEFAULT_SENDER_EMAIL);
-
-                    expect(args.text).to.contain(DEFAULT_MESSAGE_TEXT);
-                    expect(args.text).to.contain(DEFAULT_DATASET_PUBLISHER);
-                    expect(args.text).to.contain(
-                        EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
-                    );
-                    expect(args.text).to.contain("question");
-
-                    expect(args.html).to.contain(DEFAULT_MESSAGE_HTML);
-                    expect(args.html).to.contain(DEFAULT_DATASET_PUBLISHER);
-                    expect(args.html).to.contain(
-                        EXTERNAL_URL + "/dataset/" + ENCODED_DEFAULT_DATASET_ID
-                    );
-                    expect(args.html).to.contain("question");
-
-                    expect(args.subject).to.contain(DEFAULT_DATASET_TITLE);
-
-                    checkAttachments(args.attachments);
-                });
-        });
-
-        checkEmailErrorCases(
-            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/question`,
-            true
-        );
-
-        checkRegistryErrorCases(
-            `/public/send/dataset/${ENCODED_DEFAULT_DATASET_ID}/question`
-        );
+                .expect(200);
+        }
     });
 
-    function stubGetRecordCall() {
+    function stubGetRecordCall(overrideObject: {} = {}) {
         registryScope
             .get(
                 `/records/${ENCODED_DEFAULT_DATASET_ID}?aspect=dcat-dataset-strings&dereference=false`
@@ -258,7 +247,9 @@ describe("send dataset request mail", () => {
                 aspects: {
                     "dcat-dataset-strings": {
                         title: DEFAULT_DATASET_TITLE,
-                        publisher: DEFAULT_DATASET_PUBLISHER
+                        publisher: DEFAULT_DATASET_PUBLISHER,
+                        contactPoint: DEFAULT_DATASET_CONTACT_POINT,
+                        ...overrideObject
                     }
                 }
             });

--- a/magda-web-client/src/Components/RequestDataset/RequestFormLogic.js
+++ b/magda-web-client/src/Components/RequestDataset/RequestFormLogic.js
@@ -47,7 +47,9 @@ export default class RequestFormLogic extends React.Component {
         } else {
             url =
                 config.correspondenceApiUrl +
-                `send/dataset/${this.props.datasetId}/report`;
+                `send/dataset/${encodeURIComponent(
+                    this.props.datasetId
+                )}/question`;
         }
         fetch(url, {
             method: "POST",

--- a/magda-web-client/src/actions/recordActions.js
+++ b/magda-web-client/src/actions/recordActions.js
@@ -59,30 +59,10 @@ export function fetchDatasetFromRegistry(id: string): Function {
         dispatch(requestDataset(id));
         let parameters =
             "dereference=true&aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=source-link-status&optionalAspect=dataset-quality-rating";
-        let url: string;
-        if (id.startsWith("ds-")) {
-            url =
-                config.registryApiUrl +
-                `records/${encodeURIComponent(id)}?${parameters}`;
-        } else if (
-            // lookup CKAN UUIDs
-            id.match(
-                /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g
-            )
-        ) {
-            url =
-                config.registryApiUrl +
-                `records?aspectQuery=ckan-dataset.id:${encodeURIComponent(
-                    id
-                )}&${parameters}`;
-        } else {
-            // lookup CKAN dataset slugs
-            url =
-                config.registryApiUrl +
-                `records?aspectQuery=ckan-dataset.name:${encodeURIComponent(
-                    id
-                )}&${parameters}`;
-        }
+        const url =
+            config.registryApiUrl +
+            `records/${encodeURIComponent(id)}?${parameters}`;
+
         return fetch(url)
             .then(response => {
                 if (!response.ok) {


### PR DESCRIPTION
### What this PR does

Fixes #1378 

- Makes the correspondence api see whether a viable contactPoint email is available for a dataset. If so, it sends it to that email, otherwise it sends it to the default recipient for the instance.
- Removes the "report a dataset" correspondence endpoint that we've never used (intentionally)
- Changes the frontend to use the "ask a question" endpoint that it should've used in the first place
- Fixes up the correspondence api apidocs
- Removes the client-side CKAN redirection that depends on datasets starting with "ds", which isn't necessarily a requirement and is now done server-side anyway.

### To test
I've made a lovely little test environment for you already!

There's two datasets. One has a contactPoint, which it emails to, the other has no contact point so it goes to the magda-dev google group.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
