### PR TITLE
Made CORS work for localhost connecting to dev.magda.io again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 -   Made the CSW connector look for names for service-based datasets in another place
 -   Made CSW connector gracefully handle datasets without ids instead of crashing
 -   Fixed Gitlab UI only preview failed to download main CSS file
+-   Removed CORS handling from Scala APIs, should be entirely handled by the gateway.
 
 ## 0.0.48
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -29,6 +29,7 @@ gateway:
     googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
   cors:
     credentials: true
+    origin: true
   helmet:
     frameguard: false
   csp:

--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -12,6 +12,7 @@ autoscaler:
   targetCPUUtilizationPercentage: 80
 
 enableAuthEndpoint: false
+enableWebAccessControl: false
 
 helmet:
   frameguard: false

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -22,6 +22,8 @@ gateway:
     enabled: false
   enableAuthEndpoint: true
   ckanRedirectionDomain: "ckan.data.gov.au"
+  helmet:
+    frameguard: false
   cors:
     credentials: true
     origin: true
@@ -51,6 +53,7 @@ gateway:
       - allow-forms
       - allow-popups-to-escape-sandbox
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
+      
 combined-db:
   waleBackup:
     method: WAL

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -22,6 +22,9 @@ gateway:
     enabled: false
   enableAuthEndpoint: true
   ckanRedirectionDomain: "ckan.data.gov.au"
+  cors:
+    credentials: true
+    origin: true
   csp:
     directives:
       scriptSrc:

--- a/magda-indexer/build.sbt
+++ b/magda-indexer/build.sbt
@@ -17,7 +17,6 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
     "com.typesafe.akka" %% "akka-http-xml" % akkaHttpV,
     "com.typesafe.akka" %% "akka-contrib" % akkaV,
-    "ch.megard" %% "akka-http-cors" % "0.2.1",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
     "com.rockymadden.stringmetric" %% "stringmetric-core" % "0.27.4",
     "com.monsanto.labs" %% "mwundo" % "0.1.0" exclude("xerces", "xercesImpl"),

--- a/magda-registry-api/build.sbt
+++ b/magda-registry-api/build.sbt
@@ -14,7 +14,6 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http" % akkaHttpV,
     "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV,
-    "ch.megard" %% "akka-http-cors" % "0.2.1",
     "org.scalikejdbc" %% "scalikejdbc" % "3.0.0-RC3",
     "org.scalikejdbc" %% "scalikejdbc-config" % "3.0.0-RC3",
     "org.scalikejdbc" %% "scalikejdbc-test" % "3.0.0-RC3" % "test",

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -15,7 +15,6 @@ libraryDependencies ++= {
        "com.typesafe.akka" %% "akka-http" % akkaHttpV,
        "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
        "com.typesafe.akka" %% "akka-slf4j" % akkaV,
-       "ch.megard" %% "akka-http-cors" % "0.2.1",
        "ch.qos.logback" % "logback-classic" % "1.1.3",
        "com.monsanto.labs" %% "mwundo" % "0.1.0" exclude("xerces", "xercesImpl"),
        "org.scalaz" %% "scalaz-core" % "7.2.8",


### PR DESCRIPTION
### What this PR does
Makes the gateway reflect the CORS origin for preview and dev so that we can continue using it as the API when running locally or in ui-only previews. This involved changing the config and also stripping the CORS plugin out of the scala APIs.

Fixes #1743 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
