### PR TITLE
Issue/1750 Web-client goes into redirect loop when registry return 404 for a dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 -   Made CSW connector gracefully handle datasets without ids instead of crashing
 -   Fixed Gitlab UI only preview failed to download main CSS file
 -   Removed CORS handling from Scala APIs, should be entirely handled by the gateway.
+-   Fixed an redirection issue when handling 404 status from registry API
 
 ## 0.0.48
 

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -314,7 +314,7 @@ class RecordHandler extends React.Component {
                 if (this.props.datasetFetchError.detail === "Not Found") {
                     return (
                         <Redirect
-                            to={`/search?notfound=true&q="${encodeURI(
+                            to={`/error?errorCode=404&recordType=Dataset&recordId="${encodeURI(
                                 this.props.match.params.datasetId
                             )}"`}
                         />


### PR DESCRIPTION
### What this PR does

Fixes #1750 

This issue only happens when a dataset has been indexed and available in `elasticsearch` but not available in the registry.

The problem is that the current 404 handling logic (in `RecordHandler.js`) will redirect page to `/search?notfound=true&q=[datasetID]` and the search page will redierct the page to the dataset page when `notfound` = true & only one record is located.

Change the 404 redirect url to an error page solves this problem (se below):

![image](https://user-images.githubusercontent.com/674387/46384051-efaac200-c6f6-11e8-8720-faa40dc3450a.png)

### Test

It's not easy to re-create the testing env for this issue.

The easiest way I can find is to:
- Delete a dataset record from database
- Re-push the docker image (web-server) to local cluster
- test the local cluster 


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
