### PR TITLE
Issue/1671 Better way of retrieving hook actor status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.0.50
 
 -   Delete registry API /records/{recordId}/aspects endpoint
+-   Hook actors will report its status to its parent actor when changes
 
 ## 0.0.49
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -76,10 +76,10 @@ class HooksService(config: Config, webHookActor: ActorRef, authClient: AuthApiCl
           HookPersistence.getAll(session)
         }
 
-        implicit val timeout = Timeout(5 seconds)
+        implicit val timeout = Timeout(30 seconds)
 
         hooks.map { hook =>
-          val status = Await.result(webHookActor ? WebHookActor.GetStatus(hook.id.get), 5 seconds).asInstanceOf[WebHookActor.Status]
+          val status = Await.result(webHookActor ? WebHookActor.GetStatus(hook.id.get), 30 seconds).asInstanceOf[WebHookActor.Status]
           hook.copy(
             isRunning = Some(!status.isProcessing.isEmpty),
             isProcessing = Some(status.isProcessing.getOrElse(false)))
@@ -228,9 +228,9 @@ class HooksService(config: Config, webHookActor: ActorRef, authClient: AuthApiCl
           HookPersistence.getById(session, id)
         } match {
           case Some(hook) =>
-            implicit val timeout = Timeout(5 seconds)
+            implicit val timeout = Timeout(30 seconds)
 
-            val status = Await.result(webHookActor ? WebHookActor.GetStatus(hook.id.get), 5 seconds).asInstanceOf[WebHookActor.Status]
+            val status = Await.result(webHookActor ? WebHookActor.GetStatus(hook.id.get), 30 seconds).asInstanceOf[WebHookActor.Status]
 
             complete(hook.copy(
               isRunning = Some(!status.isProcessing.isEmpty),

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
@@ -26,26 +26,49 @@ import akka.util.Timeout
 import scala.util.control.NonFatal
 
 object WebHookActor {
-  case class Process(ignoreWaitingForResponse: Boolean = false, aspectIds: Option[List[String]] = None, webHookId: Option[String] = None)
+  case class Process(ignoreWaitingForResponse: Boolean = false,
+                     aspectIds: Option[List[String]] = None,
+                     webHookId: Option[String] = None)
   case class GetStatus(webHookId: String)
-  case class UpdateHookStatus(webHookId: String, isRunning:Boolean, isProcessing:Boolean)
+  case class UpdateHookStatus(webHookId: String,
+                              isRunning: Boolean,
+                              isProcessing: Boolean)
   case object InvalidateWebhookCache
   case object RetryInactiveHooks
 
-  val defaultWebHooksRetryInterval:Long = 600000
+  val defaultWebHooksRetryInterval: Long = 600000
 
   case class Status(isProcessing: Option[Boolean])
 
-  def props(registryApiBaseUrl: String, webHooksRetryInterval: Long = defaultWebHooksRetryInterval)(implicit config: Config) = Props(new AllWebHooksActor(registryApiBaseUrl, webHooksRetryInterval))
+  def props(registryApiBaseUrl: String,
+            webHooksRetryInterval: Long = defaultWebHooksRetryInterval)(
+      implicit config: Config) =
+    Props(new AllWebHooksActor(registryApiBaseUrl, webHooksRetryInterval))
 
-  private def createWebHookActor(context: ActorContext, registryApiBaseUrl: String, hook: WebHook, forceWakeUpInterval:Long)(implicit config: Config): ActorRef = {
-    context.actorOf(Props(new SingleWebHookActor(hook.id.get, registryApiBaseUrl, forceWakeUpInterval)), name = "WebHookActor-" + java.net.URLEncoder.encode(hook.id.get, "UTF-8") + "-" + java.util.UUID.randomUUID.toString)
+  private def createWebHookActor(
+      context: ActorContext,
+      registryApiBaseUrl: String,
+      hook: WebHook,
+      forceWakeUpInterval: Long)(implicit config: Config): ActorRef = {
+    context.actorOf(
+      Props(
+        new SingleWebHookActor(hook.id.get,
+                               registryApiBaseUrl,
+                               forceWakeUpInterval)),
+      name = "WebHookActor-" + java.net.URLEncoder
+        .encode(hook.id.get, "UTF-8") + "-" + java.util.UUID.randomUUID.toString
+    )
   }
 
   private case class GotAllWebHooks(webHooks: List[WebHook], startup: Boolean)
-  private case class DoneProcessing(result: Option[WebHookProcessingResult], exception: Option[Throwable] = None)
+  private case class DoneProcessing(result: Option[WebHookProcessingResult],
+                                    exception: Option[Throwable] = None)
 
-  private class AllWebHooksActor(val registryApiBaseUrl: String, val webHooksRetryInterval:Long)(implicit val config: Config) extends Actor with ActorLogging {
+  private class AllWebHooksActor(
+      val registryApiBaseUrl: String,
+      val webHooksRetryInterval: Long)(implicit val config: Config)
+      extends Actor
+      with ActorLogging {
     import context.dispatcher
 
     private var webHookActors = Map[String, ActorRef]()
@@ -54,54 +77,74 @@ object WebHookActor {
     private implicit val scheduler = this.context.system.scheduler
 
     def setup =
-      Await.result(ErrorHandling.retry(() => Future { queryForAllWebHooks() }, 30 seconds, 10, (retryCount, e) => log.error(e, "Failed to get webhooks, {} retries left until I crash", retryCount))
-        .recover {
-          case (e: Throwable) =>
-            log.error(e, "Failed to get webhooks for processing")
-            // This is a massive deal. Let it crash and let kubernetes deal with it.
-            System.exit(1)
-            throw e
-        }
-        .map { webHooks =>
-          // Create a child actor for each WebHook that doesn't already have one.
-          // Send a `Process` message to all existing and new WebHook actors.
-          val currentHooks = webHooks.filter(_.active).filter(_.enabled).map(_.id.get).toSet
-          val existingHooks = webHookActors.keySet
-
-          // Shut down actors for WebHooks that no longer exist
-          val obsoleteHooks = existingHooks.diff(currentHooks)
-          obsoleteHooks.foreach { id =>
-            log.info("Removing old web hook actor for {}.", id)
-            this.webHookActors.get(id).get ! "kill"
-            this.webHookActors -= id
-            this.webHooks -= id
-          } // Create actors for new WebHooks and post to all actors (new and old).
-          webHooks.filter(_.active).filter(_.enabled).foreach { hook =>
-            val id = hook.id.get
-            val actorRef = this.webHookActors.get(id) match {
-              case Some(actorRef) => actorRef
-              case None => {
-                log.info("Creating new web hook actor for {}.", id)
-                val actorRef = WebHookActor.createWebHookActor(context, registryApiBaseUrl, hook, webHooksRetryInterval)
-                this.webHookActors += (id -> actorRef)
-                this.webHooks += (id -> hook.copy(
-                  isRunning = Some(true),
-                  isProcessing = Some(false)
-                ))
-                actorRef
-              }
-            }
+      Await.result(
+        ErrorHandling
+          .retry(
+            () => Future { queryForAllWebHooks() },
+            30 seconds,
+            10,
+            (retryCount, e) =>
+              log.error(e,
+                        "Failed to get webhooks, {} retries left until I crash",
+                        retryCount))
+          .recover {
+            case (e: Throwable) =>
+              log.error(e, "Failed to get webhooks for processing")
+              // This is a massive deal. Let it crash and let kubernetes deal with it.
+              System.exit(1)
+              throw e
           }
-        }, 10 minutes)
+          .map { webHooks =>
+            // Create a child actor for each WebHook that doesn't already have one.
+            // Send a `Process` message to all existing and new WebHook actors.
+            val currentHooks =
+              webHooks.filter(_.active).filter(_.enabled).map(_.id.get).toSet
+            val existingHooks = webHookActors.keySet
+
+            // Shut down actors for WebHooks that no longer exist
+            val obsoleteHooks = existingHooks.diff(currentHooks)
+            obsoleteHooks.foreach { id =>
+              log.info("Removing old web hook actor for {}.", id)
+              this.webHookActors.get(id).get ! "kill"
+              this.webHookActors -= id
+              this.webHooks -= id
+            } // Create actors for new WebHooks and post to all actors (new and old).
+            webHooks.filter(_.active).filter(_.enabled).foreach {
+              hook =>
+                val id = hook.id.get
+                val actorRef = this.webHookActors.get(id) match {
+                  case Some(actorRef) => actorRef
+                  case None => {
+                    log.info("Creating new web hook actor for {}.", id)
+                    val actorRef =
+                      WebHookActor.createWebHookActor(context,
+                                                      registryApiBaseUrl,
+                                                      hook,
+                                                      webHooksRetryInterval)
+                    this.webHookActors += (id -> actorRef)
+                    this.webHooks += (id -> hook.copy(
+                      isRunning = Some(true),
+                      isProcessing = Some(false)
+                    ))
+                    actorRef
+                  }
+                }
+            }
+          },
+        10 minutes
+      )
 
     setup
 
-    scheduler.schedule(500 milliseconds, webHooksRetryInterval milliseconds, self, RetryInactiveHooks)
+    scheduler.schedule(500 milliseconds,
+                       webHooksRetryInterval milliseconds,
+                       self,
+                       RetryInactiveHooks)
 
-    def getStatus(webHookId:String) : WebHookActor.Status = {
+    def getStatus(webHookId: String): WebHookActor.Status = {
       webHooks.get(webHookId) match {
-        case None               => WebHookActor.Status(None)
-        case Some(hook:WebHook) => WebHookActor.Status(hook.isProcessing)
+        case None                => WebHookActor.Status(None)
+        case Some(hook: WebHook) => WebHookActor.Status(hook.isProcessing)
       }
     }
 
@@ -124,10 +167,11 @@ object WebHookActor {
       }
       case UpdateHookStatus(webHookId, isRunning, isProcessing) => {
         webHooks.get(webHookId) match {
-          case Some(hook:WebHook) => webHooks += (webHookId -> hook.copy(
-            isRunning = Some(isRunning),
-            isProcessing = Some(isProcessing)
-          ))
+          case Some(hook: WebHook) =>
+            webHooks += (webHookId -> hook.copy(
+              isRunning = Some(isRunning),
+              isProcessing = Some(isProcessing)
+            ))
           case _ => Nil
         }
       }
@@ -135,7 +179,7 @@ object WebHookActor {
 
     }
 
-    private def retryAllInactiveHooks(retryInterval:Long): Unit ={
+    private def retryAllInactiveHooks(retryInterval: Long): Unit = {
 
       log.info("Start to retry all inactive webhooks...")
 
@@ -143,46 +187,54 @@ object WebHookActor {
         HookPersistence.getAll(session).filter(_.enabled)
       }
 
-      val hookIds = hooks.map{ hook =>
-        if(!hook.active){
-          hook.copy(
-            isProcessing = Some(false),
-            isRunning = Some(false)
-          )
-        }else{
-          val status = getStatus(hook.id.get)
-          hook.copy(
-            isRunning = Some(!status.isProcessing.isEmpty),
-            isProcessing = Some(status.isProcessing.getOrElse(false))
-          )
-        }
-      }.filter{ hook =>
-        if(hook.active && hook.isRunning.get) {
-          false
-        } else {
-          if (hook.lastRetryTime.isEmpty) true
-          else {
-            val expectedDiff = Math.pow(2, hook.retryCount) * retryInterval / 1000
-            val isOutOfBackoffTimeWin = OffsetDateTime.now.minusSeconds(expectedDiff.toLong).isAfter(hook.lastRetryTime.get)
-            if (!isOutOfBackoffTimeWin) {
-              log.info(s"Skip retry ${hook.id} as it is still in backoff time window. Last retry time: ${hook.lastRetryTime.get}..")
-            }
-            isOutOfBackoffTimeWin
+      val hookIds = hooks
+        .map { hook =>
+          if (!hook.active) {
+            hook.copy(
+              isProcessing = Some(false),
+              isRunning = Some(false)
+            )
+          } else {
+            val status = getStatus(hook.id.get)
+            hook.copy(
+              isRunning = Some(!status.isProcessing.isEmpty),
+              isProcessing = Some(status.isProcessing.getOrElse(false))
+            )
           }
         }
-      }.flatMap(_.id.toList)
+        .filter { hook =>
+          if (hook.active && hook.isRunning.get) {
+            false
+          } else {
+            if (hook.lastRetryTime.isEmpty) true
+            else {
+              val expectedDiff = Math.pow(2, hook.retryCount) * retryInterval / 1000
+              val isOutOfBackoffTimeWin = OffsetDateTime.now
+                .minusSeconds(expectedDiff.toLong)
+                .isAfter(hook.lastRetryTime.get)
+              if (!isOutOfBackoffTimeWin) {
+                log.info(
+                  s"Skip retry ${hook.id} as it is still in backoff time window. Last retry time: ${hook.lastRetryTime.get}..")
+              }
+              isOutOfBackoffTimeWin
+            }
+          }
+        }
+        .flatMap(_.id.toList)
 
-      if(hookIds.size>0){
-        log.info(s"Invalidate Webhook Cache for retry ${hookIds.size} inactive hooks...")
+      if (hookIds.size > 0) {
+        log.info(
+          s"Invalidate Webhook Cache for retry ${hookIds.size} inactive hooks...")
         DB localTx { implicit session =>
-          hookIds.foreach( hookId => HookPersistence.retry(session, hookId))
+          hookIds.foreach(hookId => HookPersistence.retry(session, hookId))
         }
         setup
         log.info("Sending Process message...")
         self ! Process(true)
         log.info("Completed retry all inactive webhooks.")
-      }else{
-        log.info("Completed retry all inactive webhooks: No inactive webhook need to be restarted...")
+      } else {
+        log.info(
+          "Completed retry all inactive webhooks: No inactive webhook need to be restarted...")
       }
 
     }
@@ -194,7 +246,13 @@ object WebHookActor {
     }
   }
 
-  private class SingleWebHookActor(val id: String, val registryApiBaseUrl: String, forceWakeUpInterval: Long = defaultWebHooksRetryInterval)(implicit val config: Config) extends Actor with ActorLogging {
+  private class SingleWebHookActor(val id: String,
+                                   val registryApiBaseUrl: String,
+                                   forceWakeUpInterval: Long =
+                                     defaultWebHooksRetryInterval)(
+      implicit val config: Config)
+      extends Actor
+      with ActorLogging {
 
     case object WakeUp
 
@@ -202,88 +260,129 @@ object WebHookActor {
 
     val MAX_EVENTS = 100
 
-    private val processor = new WebHookProcessor(context.system, registryApiBaseUrl, context.dispatcher)
+    private val processor = new WebHookProcessor(context.system,
+                                                 registryApiBaseUrl,
+                                                 context.dispatcher)
     implicit val materializer = ActorMaterializer()
 
-    private var isProcessing:Boolean = false
+    private var isProcessing: Boolean = false
     private var currentQueueLength = 0
 
     def getWebhook() =
       DB readOnly { implicit session =>
         HookPersistence.getById(session, id) match {
-          case None          => throw new RuntimeException(s"No WebHook with ID ${id} was found.")
+          case None =>
+            throw new RuntimeException(s"No WebHook with ID ${id} was found.")
           case Some(webHook) => webHook
         }
       }
 
     def notifyHookStatus() = {
       val currentlyIsProcessing = (currentQueueLength != 0)
-      if(isProcessing != currentlyIsProcessing) {
+      if (isProcessing != currentlyIsProcessing) {
         isProcessing = currentlyIsProcessing
         context.parent ! UpdateHookStatus(id, true, isProcessing)
       }
     }
 
     private val indexQueue: SourceQueueWithComplete[Boolean] =
-      Source.queue[Boolean](0, OverflowStrategy.dropNew)
+      Source
+        .queue[Boolean](0, OverflowStrategy.dropNew)
         .map { x =>
           currentQueueLength += 1
           notifyHookStatus()
           x
         }
-        .delay(config.getInt("webhookActorTickRate") milliseconds, OverflowStrategy.backpressure).withAttributes(Attributes.inputBuffer(1, 1)) // Make sure we only execute once per webhookActorTickRate to prevent sending an individual post for every event.
-        .mapAsync(1) {
-          ignoreWaitingForResponse =>
+        .delay(config.getInt("webhookActorTickRate") milliseconds,
+               OverflowStrategy.backpressure)
+        .withAttributes(Attributes.inputBuffer(1, 1)) // Make sure we only execute once per webhookActorTickRate to prevent sending an individual post for every event.
+        .mapAsync(1) { ignoreWaitingForResponse =>
+          try {
+            val webHook = getWebhook()
 
-            try{
-              val webHook = getWebhook()
+            if (!ignoreWaitingForResponse && webHook.isWaitingForResponse
+                  .getOrElse(false)) {
+              log.info(
+                "Skipping WebHook {} as it's marked as waiting for response",
+                webHook.id)
+              Future.successful(false)
+            } else {
+              val aspects = webHook.config.aspects ++ webHook.config.optionalAspects
 
-              if (!ignoreWaitingForResponse && webHook.isWaitingForResponse.getOrElse(false)) {
-                log.info("Skipping WebHook {} as it's marked as waiting for response", webHook.id)
+              val eventPage = DB readOnly { implicit session =>
+                EventPersistence.getEvents(
+                  session,
+                  webHook.lastEvent,
+                  None,
+                  Some(MAX_EVENTS),
+                  None,
+                  None,
+                  (webHook.config.aspects ++ webHook.config.optionalAspects).flatten.toSet,
+                  webHook.eventTypes)
+              }
+
+              val previousLastEvent = webHook.lastEvent
+              val lastEvent = eventPage.events.lastOption.flatMap(_.id)
+
+              if (lastEvent.isEmpty) {
+                log.info("WebHook {}: Up to date at event {}",
+                         this.id,
+                         previousLastEvent)
                 Future.successful(false)
               } else {
-                val aspects = webHook.config.aspects ++ webHook.config.optionalAspects
+                log.info("WebHook {} Processing {}-{}: STARTING",
+                         this.id,
+                         previousLastEvent,
+                         lastEvent)
 
-                val eventPage = DB readOnly { implicit session =>
-                  EventPersistence.getEvents(session, webHook.lastEvent, None, Some(MAX_EVENTS), None, None, (webHook.config.aspects ++ webHook.config.optionalAspects).flatten.toSet, webHook.eventTypes)
-                }
-
-                val previousLastEvent = webHook.lastEvent
-                val lastEvent = eventPage.events.lastOption.flatMap(_.id)
-
-                if (lastEvent.isEmpty) {
-                  log.info("WebHook {}: Up to date at event {}", this.id, previousLastEvent)
-                  Future.successful(false)
-                } else {
-                  log.info("WebHook {} Processing {}-{}: STARTING", this.id, previousLastEvent, lastEvent)
-
-                  processor.sendSomeNotificationsForOneWebHook(this.id, webHook, eventPage).map {
+                processor
+                  .sendSomeNotificationsForOneWebHook(this.id,
+                                                      webHook,
+                                                      eventPage)
+                  .map {
                     case WebHookProcessor.Deferred =>
                       // response deferred
-                      log.info("WebHook {} Processing {}-{}: DEFERRED BY RECEIVER", this.id, previousLastEvent, lastEvent)
+                      log.info(
+                        "WebHook {} Processing {}-{}: DEFERRED BY RECEIVER",
+                        this.id,
+                        previousLastEvent,
+                        lastEvent)
                     case WebHookProcessor.NotDeferred =>
                       // POST succeeded, is there more to do?
-                      log.info("WebHook {} Processing {}-{}: DELIVERED", this.id, previousLastEvent, lastEvent)
+                      log.info("WebHook {} Processing {}-{}: DELIVERED",
+                               this.id,
+                               previousLastEvent,
+                               lastEvent)
 
                       if (previousLastEvent != lastEvent) {
                         self ! Process()
                       }
                     case WebHookProcessor.HttpError(status) =>
                       // encountered an error while communicating with the hook recipient - deactivate the hook until its manually fixed
-                      log.info("WebHook {} Processing {}-{}: HTTP FAILURE {}, DEACTIVATING", this.id, previousLastEvent, lastEvent, status.reason())
+                      log.info(
+                        "WebHook {} Processing {}-{}: HTTP FAILURE {}, DEACTIVATING",
+                        this.id,
+                        previousLastEvent,
+                        lastEvent,
+                        status.reason())
                       context.parent ! InvalidateWebhookCache
-                  }.recover {
+                  }
+                  .recover {
                     case e =>
                       // Error communicating with the hook recipient - log the failure and wait until the next Process() call to resume.
-                      log.error(e, "WebHook {} Processing {}-{}: FAILED", this.id, previousLastEvent, lastEvent)
+                      log.error(e,
+                                "WebHook {} Processing {}-{}: FAILED",
+                                this.id,
+                                previousLastEvent,
+                                lastEvent)
                   }
-                }
               }
-            }catch{
-              // --- make only capture nonFatal error
-              // --- So that fatal error can still terminate JVM
-              case NonFatal(e) => Future.successful(false)
             }
+          } catch {
+            // --- make only capture nonFatal error
+            // --- So that fatal error can still terminate JVM
+            case NonFatal(e) => Future.successful(false)
+          }
         }
         .map { x =>
           currentQueueLength -= 1
@@ -293,14 +392,17 @@ object WebHookActor {
         .to(Sink.ignore)
         .run()
 
-    context.system.scheduler.schedule(forceWakeUpInterval milliseconds, forceWakeUpInterval milliseconds, self, WakeUp)
+    context.system.scheduler.schedule(forceWakeUpInterval milliseconds,
+                                      forceWakeUpInterval milliseconds,
+                                      self,
+                                      WakeUp)
 
     def receive = {
       case Process(ignoreWaitingForResponse, _, _) => {
         indexQueue.offer(ignoreWaitingForResponse)
       }
       case WakeUp =>
-        if(currentQueueLength == 0){
+        if (currentQueueLength == 0) {
           log.info("Force to wake up idle WebHook {}...", this.id)
           indexQueue.offer(true)
         }


### PR DESCRIPTION
### What this PR does

Fixes #1671 

Trying to go for the option 3. 
i.e.
> Have the webhook actor report send a message to some kind of listener whenever it changes, which stores the last state it received and returns it when the API is invoked 

What I have done is to make all hook actors to report their status changes to their parent actor. Parent actor save the status in a local map. However, we still need to send message to the parent (main) actor to retrieve the status.

I couldn't find a way to directly access the local MAP structure held by the main actor. The `ActorRef` seems only allows to interacte with the actor via messages. If you know a `thread safe` way to access actor's data directly, please let me know~


### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
