### PR TITLE
Issue/780 Fixed Geo Spatial data indexing issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 -   Delete registry API /records/{recordId}/aspects endpoint
 -   Hook actors will report its status to its parent actor when changes
 -   Updated external links on About page to open in new window
+-   Fixed some WA source spatial data are not indexed properly
 
 ## 0.0.49
 

--- a/magda-ckan-connector/aspect-templates/dcat-dataset-strings.js
+++ b/magda-ckan-connector/aspect-templates/dcat-dataset-strings.js
@@ -13,7 +13,7 @@ return {
     languages: dataset.language ? [dataset.language] : [],
     publisher: (dataset.organization || {}).title,
     accrualPeriodicity: dataset.update_freq,
-    spatial: dataset.spatial_coverage,
+    spatial: dataset.spatial_coverage || dataset.spatial,
     temporal: {
         start: dataset.temporal_coverage_from,
         end: dataset.temporal_coverage_to

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -322,7 +322,7 @@ package misc {
             val multiPolygon = MultiPolygonFormat.read(json)
             val coordinates = multiPolygon.coordinates
             val firstPoint = coordinates(0)(0)(0)
-            val lastPoint = coordinates(0)(0)(coordinates.size - 1)
+            val lastPoint = coordinates(0)(0)(coordinates(0)(0).size - 1)
             if (firstPoint.x != lastPoint.x || firstPoint.y != lastPoint.y) {
               multiPolygon.copy(
                 coordinates = Seq(Seq(coordinates(0)(0) :+ firstPoint))

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -322,7 +322,7 @@ package misc {
             val multiPolygon = MultiPolygonFormat.read(json)
             val coordinates = multiPolygon.coordinates
             val firstPoint = coordinates(0)(0)(0)
-            val lastPoint = coordinates(0)(0)(coordinates.size)
+            val lastPoint = coordinates(0)(0)(coordinates.size - 1)
             if (firstPoint.x != lastPoint.x || firstPoint.y != lastPoint.y) {
               multiPolygon.copy(
                 coordinates = Seq(Seq(coordinates(0)(0) :+ firstPoint))

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -122,7 +122,7 @@ package misc {
     }
 
     def apply(stringWithNewLines: String): Location = {
-      val string = stringWithNewLines.replace("\n", " ")
+      val string = stringWithNewLines.replaceAll("[\\n\\r]", " ")
       Location.applySanitised(string, string match {
         case geoJsonPattern() => {
           Some(Protocols.GeometryFormat.read(string.parseJson))


### PR DESCRIPTION
### What this PR does

Fixes #780 

### Summary 

The issue for that particular dataset was:
- ckan connector should get spatial data from a different field
- For GeoJson Multipolygon type data, the last point position should be same as the first one.
  - Fixed it by checking this rule, if not, copy the first point and insert to List
Also, fixed other issue causing index error:
- Regex for removing lines should remove \r as well (some data use \r instead of \n)
- polygonPattern should match space using \s* as some data has no space between `POLYGON` and `(`
- polygonPattern should match [\d\.] (rather than \d) as most point data are something like: 34.22

### Other Issue

After all fixes above, there is still **ONE** dataset causing geoSpatial error. 
Its geoJson data is as followings:
```
{
  "type": "MultiPolygon",
  "coordinates": [
    [
      [
        [
          114.68616,
          -21.61868
        ],
        [
          114.68616,
          -21.34139
        ],
        [
          115.40264,
          -21.34139
        ],
        [
          115.40264,
          -21.61868
        ],
        [
          114.63272094726564,
          -21.61868
        ]
      ]
    ]
  ]
}
```
I guess the correct data should be (last point x was mistyped):
```
{
  "type": "MultiPolygon",
  "coordinates": [
    [
      [
        [
          114.68616,
          -21.61868
        ],
        [
          114.68616,
          -21.34139
        ],
        [
          115.40264,
          -21.34139
        ],
        [
          115.40264,
          -21.61868
        ],
        [
          114.68616,
          -21.61868
        ]
      ]
    ]
  ]
}
```
It breaks the GeoJosn`Right-hand` rule. Thus, invalid.
It's a bit hard to fix as you need to make sure:
>  A linear ring MUST follow the right-hand rule with respect to the area it bounds, i.e., exterior rings are counterclockwise, and holes are clockwise.

I will create a sperate issue for it and fix it when we get a chance.

### Testing

A test site is available at:

https://issue-780.dev.magda.io/search?q=shipwrecks&regionId=5&regionType=STE

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
