### PR TITLE
Issue/1790 Fixed login issue with cached auth API 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 -   Fixed content-api migrator script version conflict issue
 -   Fixed broken document link in docs/README.md
 -   Show quality rating only if present
+-   Fixed: cached auth api response causing login problems
 
 ## 0.0.49
 

--- a/magda-authorization-api/src/createApiRouter.ts
+++ b/magda-authorization-api/src/createApiRouter.ts
@@ -123,6 +123,11 @@ export default function createApiRouter(options: ApiRouterOptions) {
 
     router.get("/public/users/whoami", async function(req, res) {
         try {
+            res.set({
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                Pragma: "no-cache",
+                Expires: "0"
+            });
             const userId = getUserId(req, options.jwtSecret).valueOr(null);
             if (!userId) {
                 throw new AuthError();
@@ -164,8 +169,12 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *    Nothing
      */
     router.get("/public/users/:userId", (req, res) => {
+        res.set({
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+            Expires: "0"
+        });
         const userId = req.params.userId;
-
         const getPublicUser = database.getUser(userId).then(userMaybe =>
             userMaybe.map(user => {
                 const publicUser: PublicUser = {


### PR DESCRIPTION
### What this PR does

Fixes #1790 

Change Summary:
- Set `Cache-Control` header to public Auth APIs response so that `http-proxy` in `gateway` won't auto-add `Cache-Control` header

Test Site: 

https://issue-1790.dev.magda.io/

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
