### PR TITLE
Upgrade java version to fix `unsatisfiable constraints` error when build `scala-builder` docker image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 -   Fixed broken document link in docs/README.md
 -   Show quality rating only if present
 -   Fixed: cached auth api response causing login problems
+-   Upgraded java version for `magda-scala-builder` docker image to fix `unsatisfiable constraints` error
 
 ## 0.0.49
 

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -20,8 +20,8 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
+ENV JAVA_VERSION 8u181
+ENV JAVA_ALPINE_VERSION 8.181.13-r0
 
 RUN set -x \
 	&& apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \


### PR DESCRIPTION
### What this PR does

Upgrade java version to fix `unsatisfiable constraints` error when builder docker image

At this moment, all pipelines failed at `builders-and-yarn` step.

Error:
```
+ apk add --no-cache openjdk8=8.171.11-r0
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  openjdk8-8.181.13-r0:
    breaks: world[openjdk8=8.171.11-r0]
The command '/bin/sh -c set -x  && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION"   && [ "$JAVA_HOME" = "$(docker-java-home)" ]' returned a non-zero code: 1
```

Seems caused by version changes of upstream repo

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
-   [ ] I've assigned this PR to someone (if you don't know who to assign it to, pick @AlexGilleran)
