### PR TITLE
Fix helm provided docker registry hostname

### DIFF
--- a/deploy/helm/kube-registry-proxy.yml
+++ b/deploy/helm/kube-registry-proxy.yml
@@ -1,4 +1,4 @@
 registry: 
-  host: docker-registry-docker-registry
+  host: docker-registry
   port: 5000
 hostPort: 5000


### PR DESCRIPTION
At some point, the helm provided docker registry started appearing as just docker-registry:
```
$ kubectl get svc | grep docker
docker-registry           ClusterIP   10.102.208.251   <none>        5000/TCP
```

Update exposing port 5000 to the host interface
