### PR TITLE
Issue/1816 Make CKAN connector to pick up jurisdiction field from Organisations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 -   Show quality rating only if present
 -   Fixed: cached auth api response causing login problems
 -   Upgraded java version for `magda-scala-builder` docker image to fix `unsatisfiable constraints` error
+-   Make jurisdiction field available from registry api
 
 ## 0.0.49
 

--- a/magda-ckan-connector/aspect-templates/organization-details.js
+++ b/magda-ckan-connector/aspect-templates/organization-details.js
@@ -3,6 +3,7 @@ const cleanOrgTitle = libraries.cleanOrgTitle;
 let phone = undefined;
 let website = undefined;
 let email = undefined;
+let jurisdiction = undefined;
 
 if (organization && organization.extras && organization.extras.length) {
     organization.extras.forEach(item => {
@@ -16,6 +17,9 @@ if (organization && organization.extras && organization.extras.length) {
             case "website":
                 website = item["value"];
                 break;
+            case "jurisdiction":
+                jurisdiction = item["value"];
+                break;
         }
     });
 }
@@ -23,6 +27,7 @@ if (organization && organization.extras && organization.extras.length) {
 const data = {
     name: organization.name,
     title: cleanOrgTitle(organization.title),
+    jurisdiction,
     description: organization.description,
     imageUrl: organization.image_display_url || organization.image_url,
     phone,

--- a/magda-registry-aspects/organization-details.schema.json
+++ b/magda-registry-aspects/organization-details.schema.json
@@ -11,6 +11,10 @@
             "title": "A name given to the organization.",
             "type": "string"
         },
+        "jurisdiction": {
+            "title": "the organization jurisdiction.",
+            "type": "string"
+        },
         "description": {
             "title": "Free-text account of the organization.",
             "type": "string"


### PR DESCRIPTION
### What this PR does

Fixes #1816 

Make CKAN connector to pick up jurisdiction field from Organisations

Has done a full recrawl on gitLab test site and here is statistics based on the result from all `CKAN` connectors:

| jurisdiction                            | org_count |
|-----------------------------------------|-----------|
| null                                    | 183       |
| Commonwealth of Australia               | 98        |
| Local Government                        | 65        |
| Tasmanian Government                    | 13        |
| Victoria Government                     | 12        |
| Western Australian Government           | 12        |
| New South Wales Government              | 11        |
| South Australian Government             | 3         |
| Queensland Government                   | 2         |
| Australian Capital Territory Government | 1         |
| Northern Territory Government           | 1         |

Test site & URL:

https://issue-1816.dev.magda.io/api/v0/registry/records?aspectQuery=organization-details.jurisdiction:Government%20of%20South%20Australia&aspect=organization-details

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
