### PR TITLE
Switched to react-router-dom <Link> in HeaderNav

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 -   Make jurisdiction field available from registry api
 -   Fixed an issue of scss-compiler not updated all variables
 -   Added more configurable scss variables
+-   Switched `<a>` element in `HeaderNav` to be `<Link>` from `react-router-dom` to maintain router history
 
 ## 0.0.49
 

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -42,6 +42,7 @@
     "@gov.au/skip-link": "^2.0.6",
     "@gov.au/tags": "^3.1.1",
     "@gov.au/text-inputs": "^2.0.6",
+    "is-url-external": "^1.0.3",
     "leaflet": "^0.7.7",
     "urijs": "^1.19.1"
   },

--- a/magda-web-client/src/Components/Header/HeaderNav.js
+++ b/magda-web-client/src/Components/Header/HeaderNav.js
@@ -13,7 +13,12 @@ const headerNavigationPlugins = {
         }
         return (
             <li key={i}>
-                <Link to={opts.href} title={`Go to ${nav.label}`}>
+                <Link
+                    to={opts.href}
+                    target={opts.target}
+                    rel={opts.rel}
+                    title={`Go to ${nav.label}`}
+                >
                     <span>{nav.label}</span>
                 </Link>
             </li>

--- a/magda-web-client/src/Components/Header/HeaderNav.js
+++ b/magda-web-client/src/Components/Header/HeaderNav.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import AccountNavbar from "../Account/AccountNavbar";
 import { config } from "../../config.js";
+import isExternalURL from "is-url-external";
 
 const headerNavigationPlugins = {
     default: function(nav, i) {
@@ -13,14 +14,20 @@ const headerNavigationPlugins = {
         }
         return (
             <li key={i}>
-                <Link
-                    to={opts.href}
-                    target={opts.target}
-                    rel={opts.rel}
-                    title={`Go to ${nav.label}`}
-                >
-                    <span>{nav.label}</span>
-                </Link>
+                {isExternalURL(opts.href) ? (
+                    <a {...opts} title={`Go to ${nav.label}`}>
+                        <span>{nav.label}</span>
+                    </a>
+                ) : (
+                    <Link
+                        to={opts.href}
+                        target={opts.target}
+                        rel={opts.rel}
+                        title={`Go to ${nav.label}`}
+                    >
+                        <span>{nav.label}</span>
+                    </Link>
+                )}
             </li>
         );
     },

--- a/magda-web-client/src/Components/Header/HeaderNav.js
+++ b/magda-web-client/src/Components/Header/HeaderNav.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-// import { NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 import AccountNavbar from "../Account/AccountNavbar";
 import { config } from "../../config.js";
 
@@ -13,9 +13,9 @@ const headerNavigationPlugins = {
         }
         return (
             <li key={i}>
-                <a {...opts}>
+                <Link to={opts.href} title={`Go to ${nav.label}`}>
                     <span>{nav.label}</span>
-                </a>
+                </Link>
             </li>
         );
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9499,6 +9499,11 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
+is-url-external@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-url-external/-/is-url-external-1.0.3.tgz#caa320864a37a05752084ea5a1e5a66ee315ee97"
+  integrity sha1-yqMghko3oFdSCE6loeWmbuMV7pc=
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"


### PR DESCRIPTION
### What this PR does

Fixes #1831 

The `href` key stops us from using spread operator however, I think it reads nicer without.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
