### PR TITLE
Made it possible to keep statefulsets off preemptible nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 -   Make jurisdiction field available from registry api
 -   Fixed an issue of scss-compiler not updated all variables
 -   Added more configurable scss variables
+-   Updated helm config to allow for statefulsets to be kept off GKE preemptible nodes.
 
 ## 0.0.49
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -70,15 +70,16 @@ combined-db:
       fileName: TerriaJS-5e042b649f8a.json
   data:
     storage: 250Gi
+  antiPreemptibleAffinity: 100
 
 elasticsearch:
   data:
     heapSize: 500m
-    pluginsInstall: "repository-gcs"
   backup:
     googleApplicationCreds:
       secretName: storage-account-credentials
       fileName: db-service-account-private-key.json
+  antiPreemptibleAffinity: 99
 
 indexer:
   readSnapshots: false

--- a/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
         service: authorization-db
     spec:
       terminationGracePeriodSeconds: 60
+      affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
       containers:
       - name: authorization-db
         resources:

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
         service: combined-db
     spec:
       terminationGracePeriodSeconds: 10
+      affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
       containers:
       - name: combined-db
         resources:

--- a/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
         service: content-db
     spec:
       terminationGracePeriodSeconds: 60
+      affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
       containers:
       - name: content-db
         resources:

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -20,6 +20,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50

--- a/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
         service: registry-db
     spec:
       terminationGracePeriodSeconds: 10
+      affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
       containers:
       - name: registry-db
         resources:

--- a/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
         service: session-db
     spec:
       terminationGracePeriodSeconds: 60
+      affinity:
+        {{ include "magda.antiPreemptibleAffinity" . }}
       containers:
       - name: session-db
         resources:

--- a/deploy/helm/magda/templates/_helpers.tpl
+++ b/deploy/helm/magda/templates/_helpers.tpl
@@ -216,3 +216,16 @@ spec:
               - key: "{{ .jobConfig.id }}.json"
                 path: "connector.json"
 {{- end }}
+
+
+{{- define "magda.antiPreemptibleAffinity" }}
+        {{- if .Values.antiPreemptibleAffinity }}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: DoesNotExist
+            weight: {{ .Values.antiPreemptibleAffinity }}
+        {{- end }}
+{{- end }}


### PR DESCRIPTION
### What this PR does

Adds `antiPreemptibleAffinity` config option to help for elasticsearch and postgres. Pods that have this affinity set will avoid being scheduled on preemptible pods whenever possible.

I've also added a single non-preemptible node to the dev cluster and made the dev config use this value. So hopefully this means less up-and-down for our statefulsets in dev. Preview statefulsets will continue to be on preemptible infrastructure.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
