### PR TITLE
Issue/1837 Minion initial crawl can continue indefinitely

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 -   Fixed an issue of scss-compiler not updated all variables
 -   Added more configurable scss variables
 -   Switched `<a>` element in `HeaderNav` to be `<Link>` from `react-router-dom` to maintain router history
+-   Fixed: minion crawler may go into an endless loop
 
 ## 0.0.49
 

--- a/magda-minion-framework/src/Crawler.ts
+++ b/magda-minion-framework/src/Crawler.ts
@@ -61,11 +61,21 @@ class Crawler {
 
             const registryPage = AsyncPage.create<RecordsPage<Record>>(
                 previous => {
-                    if (previous && previous.records.length === 0) {
+                    if (previous && previous.hasMore === false) {
                         console.info("No more records left");
                         // Last page was an empty page, no more records left
                         return undefined;
                     } else {
+                        console.info(
+                            "Crawling after token " +
+                                (previous && previous.nextPageToken
+                                    ? previous.nextPageToken
+                                    : "<first page>")
+                        );
+                        this.crawlingPageToken =
+                            previous && previous.nextPageToken
+                                ? previous.nextPageToken
+                                : "";
                         // TODO: Retry with reduced limit if entity size too large error.
                         return this.registry
                             .getRecords<Record>(
@@ -80,17 +90,6 @@ class Crawler {
                                 this.crawledRecordNumber += page.records.length;
                                 console.info(
                                     `Crawled ${page.records.length} records`
-                                );
-                                this.crawlingPageToken =
-                                    page && page.nextPageToken
-                                        ? page.nextPageToken
-                                        : "";
-
-                                console.info(
-                                    "Crawling after token " +
-                                        (page && page.nextPageToken
-                                            ? page.nextPageToken
-                                            : "<first page>")
                                 );
                                 return page;
                             });

--- a/magda-minion-framework/src/test/Crawler.spec.ts
+++ b/magda-minion-framework/src/test/Crawler.spec.ts
@@ -180,6 +180,7 @@ baseSpec(
                             200,
                             {
                                 totalCount: this.registryRecords.length,
+                                hasMore: false,
                                 records: new Array()
                             }
                         ];
@@ -191,6 +192,7 @@ baseSpec(
                         200,
                         {
                             totalCount: this.registryRecords.length,
+                            hasMore: true,
                             nextPageToken: String(pageIdx + recordPage.length),
                             records: recordPage
                         }
@@ -211,19 +213,6 @@ baseSpec(
             return basePropertyTest(
                 function(this: any) {
                     //---envInit
-                    const crawlingProgressHistory: {
-                        recordIds: number[];
-                        isCrawling: boolean;
-                        crawlingPageToken: string;
-                        crawledRecordNumber: number;
-                    }[] = [
-                        {
-                            recordIds: [],
-                            isCrawling: false,
-                            crawlingPageToken: "",
-                            crawledRecordNumber: 0
-                        }
-                    ];
                     const totalCrawledRecordsNumber = 0;
 
                     const registryRecords: Record[] = new Array(
@@ -237,7 +226,6 @@ baseSpec(
                             sourceTag: ""
                         }));
                     return {
-                        crawlingProgressHistory,
                         totalCrawledRecordsNumber,
                         registryRecords
                     };
@@ -248,16 +236,6 @@ baseSpec(
                     foundRecord: Record,
                     registry: Registry
                 ) {
-                    const progress = this.crawler.getProgress();
-                    const id = parseInt(foundRecord.id, 10);
-                    const foundProgressIdx = this.crawlingProgressHistory.findIndex(
-                        (item: any) => item.recordIds.indexOf(id) !== -1
-                    );
-                    const foundProgress = {
-                        ...this.crawlingProgressHistory[foundProgressIdx]
-                    };
-                    delete foundProgress.recordIds;
-                    expect(progress).to.deep.equal(foundProgress);
                     return Promise.resolve();
                 },
                 function(this: any, uri: string, requestBody: string) {
@@ -274,6 +252,7 @@ baseSpec(
                             200,
                             {
                                 totalCount: this.registryRecords.length,
+                                hasMore: false,
                                 records: []
                             }
                         ];
@@ -285,18 +264,17 @@ baseSpec(
                     const crawlingPageTokenValue = pageIdx + recordPage.length;
                     const crawlingPageToken = String(crawlingPageTokenValue);
                     this.totalCrawledRecordsNumber += recordPage.length;
-                    this.crawlingProgressHistory.push({
-                        recordIds: recordPage.map((item: any) =>
-                            parseInt(item.id, 10)
-                        ),
+                    const progress = this.crawler.getProgress();
+                    expect(progress).to.deep.equal({
                         isCrawling: true,
-                        crawlingPageToken: crawlingPageToken,
-                        crawledRecordNumber: this.totalCrawledRecordsNumber
+                        crawlingPageToken: String(pageIdx ? pageIdx : ""),
+                        crawledRecordNumber: pageIdx
                     });
                     return [
                         200,
                         {
                             totalCount: this.registryRecords.length,
+                            hasMore: true,
                             nextPageToken: crawlingPageToken,
                             records: recordPage
                         }

--- a/magda-minion-framework/src/test/Crawler.spec.ts
+++ b/magda-minion-framework/src/test/Crawler.spec.ts
@@ -188,15 +188,22 @@ baseSpec(
                         pageIdx,
                         pageIdx + limit - 1
                     );
-                    return [
-                        200,
-                        {
-                            totalCount: this.registryRecords.length,
-                            hasMore: true,
-                            nextPageToken: String(pageIdx + recordPage.length),
-                            records: recordPage
-                        }
-                    ];
+
+                    const resData: any = {
+                        totalCount: this.registryRecords.length,
+                        hasMore: true,
+                        records: recordPage
+                    };
+
+                    const nextPageToken = pageIdx + recordPage.length;
+
+                    if (nextPageToken < this.registryRecords.length) {
+                        resData.nextPageToken = String(nextPageToken);
+                    } else {
+                        resData.hasMore = false;
+                    }
+
+                    return [200, resData];
                 },
                 function(this: any) {
                     //---propertyCheckingFunc

--- a/magda-minion-framework/src/test/registry.spec.ts
+++ b/magda-minion-framework/src/test/registry.spec.ts
@@ -84,7 +84,7 @@ baseSpec(
                 registryScope
                     .get("/records")
                     .query(true)
-                    .reply(200, { records: [] });
+                    .reply(200, { totalCount: 0, records: [], hasMore: false });
             }
         );
 

--- a/magda-minion-framework/src/test/startup.spec.ts
+++ b/magda-minion-framework/src/test/startup.spec.ts
@@ -87,6 +87,7 @@ baseSpec(
                         })
                         .reply(200, {
                             totalCount: records.length,
+                            hasMore: false,
                             nextPageToken: parseInt(index) + 1,
                             records: pageRecords
                         });

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -24,6 +24,7 @@ export interface PutResult {
 
 export interface RecordsPage<I extends Record> {
     totalCount: number;
+    hasMore: boolean;
     nextPageToken?: string;
     records: I[];
 }


### PR DESCRIPTION
### What this PR does

Fixes #1837 

Changes Summary:
- Used the new `hasMore` field to test whether has more records for minions to go through
- Adjusted relevant test cases to send the `hasMore` field as well (otherwise would break)
- Make sure the test case also test the scenario that `records.length` > 0 but no records available to pull
- Simplified `checking progress` test case logic

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
