### PR TITLE
Made DAP connector get released along with other images.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 -   Added more configurable scss variables
 -   Switched `<a>` element in `HeaderNav` to be `<Link>` from `react-router-dom` to maintain router history
 -   Fixed an issue caused search Panel option filter stop working
+-   Fixed DAP connector not automatically being released to docker hub.
 
 ## 0.0.49
 

--- a/magda-dap-connector/package.json
+++ b/magda-dap-connector/package.json
@@ -11,7 +11,8 @@
     "start": "node dist/index.js",
     "dev": "run-typescript-in-nodemon src/index.ts",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
-    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
+    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
+    "retag-and-push": "retag-and-push"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What this PR does

Fixes #1847 

Essentially unless a service has `retag-and-push` it doesn't get released when we push release tags. So I've added it to the dap one.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
