### PR TITLE
Issue/1773 Admin Area CSV connector Creation function should use internal content-api domain / URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 -   Fixed DAP connector not automatically being released to docker hub.
 -   Fixed an issue that `create-secrets` didn't handle `cloudsql-instance-credentials` & `storage-account-credentials` probably
 -   `create-secrets` will load ENV vars according to question data types
+-   Made admin UI create CSV connector with internal URL
 
 ## 0.0.49
 

--- a/magda-gateway/views/admin.js
+++ b/magda-gateway/views/admin.js
@@ -546,9 +546,7 @@ async function deleteContent(name) {
 }
 
 async function createConnector(name) {
-    let sourceUrl = window.location.toString();
-    sourceUrl = sourceUrl.substr(0, sourceUrl.indexOf("/", 8));
-    sourceUrl += `/api/v0/content/${name}.bin`;
+    const sourceUrl = `http://content-api/v0/content/${name}.bin`;
 
     const body = {
         id: name,

--- a/magda-gateway/views/admin.js
+++ b/magda-gateway/views/admin.js
@@ -546,7 +546,7 @@ async function deleteContent(name) {
 }
 
 async function createConnector(name) {
-    const sourceUrl = `http://content-api/v0/content/${name}.bin`;
+    const sourceUrl = `http://content-api/v0/${name}.bin`;
 
     const body = {
         id: name,


### PR DESCRIPTION
### What this PR does

Fixes #1773 

Admin Area CSV connector Creation function should use internal content-api domain / URL

A test site is available at:

https://issue-1773.dev.magda.io/search?q=%2A

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
