### PR TITLE
Issue/1705 Fixed DAP connector failing errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 -   Fixed an issue that `create-secrets` didn't handle `cloudsql-instance-credentials` & `storage-account-credentials` probably
 -   `create-secrets` will load ENV vars according to question data types
 -   Made admin UI create CSV connector with internal URL
+-   Fixed an issue that DAP connector not handle access error correctly
 
 ## 0.0.49
 

--- a/magda-dap-connector/src/Dap.ts
+++ b/magda-dap-connector/src/Dap.ts
@@ -287,6 +287,14 @@ export default class Dap implements ConnectorSource {
                                                 reject2(error);
                                                 return;
                                             }
+                                            if (detail.access) {
+                                                // --- added access info to description
+                                                // --- so that we know why the dataset has no distribution
+                                                // --- and when the distribution will be available for public
+                                                detail.description = `${
+                                                    detail.description
+                                                }\n\n${detail.access}`;
+                                            }
                                             resolve2(detail);
                                         }
                                     );
@@ -315,6 +323,33 @@ export default class Dap implements ConnectorSource {
                                                         response,
                                                         detail
                                                     ) => {
+                                                        if (
+                                                            detail &&
+                                                            detail.errors &&
+                                                            detail.errors.length
+                                                        ) {
+                                                            // --- handle access error
+                                                            const id =
+                                                                simpleData.id
+                                                                    .identifier;
+                                                            console.log(
+                                                                `** Unable to fetch files for collection: ${id}; url: ${
+                                                                    simpleData.data
+                                                                }`
+                                                            );
+                                                            console.log(
+                                                                `** Reason: ${
+                                                                    detail
+                                                                        .errors[0]
+                                                                        .defaultMessage
+                                                                }`
+                                                            );
+                                                            resolve3({
+                                                                identifier: id,
+                                                                distributions: []
+                                                            });
+                                                            return;
+                                                        }
                                                         console.log(
                                                             ">> request distribution of " +
                                                                 simpleData.data,

--- a/magda-dap-connector/src/Dap.ts
+++ b/magda-dap-connector/src/Dap.ts
@@ -293,7 +293,7 @@ export default class Dap implements ConnectorSource {
                                                 // --- and when the distribution will be available for public
                                                 detail.description = `${
                                                     detail.description
-                                                }\n\n${detail.access}`;
+                                                }\n\n${detail.access}\n\n`;
                                             }
                                             resolve2(detail);
                                         }

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.js
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.js
@@ -22,12 +22,12 @@ export default class DatasetSummary extends Component {
                 .filter(dis => defined(dis.format))
                 .map(dis => dis.format)
         );
-        return (
+        return formats.length ? (
             <div className="dataset-summary-downloads">
                 <img src={fileIcon} alt="File icon" />{" "}
                 {formats.map((f, i) => <span key={i}>{f}</span>)}
             </div>
-        );
+        ) : null;
     }
 
     render() {


### PR DESCRIPTION
### What this PR does

Fixes #1705 

It seems DAP introduced a new feature that many datasets are published with restricted access.

When you access the files (distribution data) access point:

https://data.csiro.au/dap/ws/v2/collections/36940/data

You will get the following response:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?><restApiError><requestUri>/dap/ws/v2/collections/36940/data</requestUri><errors><defaultMessage>This collection's files are not available due to access restrictions.</defaultMessage><objectName>dataCollectionFiles</objectName></errors></restApiError>
``` 

Its dataset data will look like this:
```json
{
    "id": {
        "identifierType": "Fedora PID",
        "identifier": "csiro:36940"
    },
    "dataCollectionId": 36940,
    "self": "https://data.csiro.au/dap/ws/v2/collections/36940",
    "landingPage": {
        "relationship": "alternate",
        "mediaType": "text/html",
        "href": "https://data.csiro.au/dap/landingpage?pid=csiro%3A36940"
    },
    "title": "Parkes observations for project P971 semester 2018OCTS_01",
    "description": "We propose timing observations of the relativistic pulsar - white-dwarf binary PSR J1141-6545. This unique system offers access to a wide range of physics, from relativistic phenomena through pulsar emission cone studies, to the structure and distribution of interstellar plasma along our line-of-sight. The recently installed Parkes Ultra Wide Band Low Frequency (UWL) receiver has opened up the possibility of performing first-ever studies of its orbital dynamics at high temporal resolution and study of the effects of the intra-binary medium on the dispersion and polarisation of the pulse profile. Our analysis of data obtained to date suggests that the pulsar would precess away from our line-of-sight in the next 3-5 years. Hence, regular observations are crucial to maximizing its science outcome",
    "fieldsOfResearch": [
        "Astronomical and Space Sciences not elsewhere classified"
    ],
    "dataStartDate": "2018-10-01",
    "dataEndDate": "2018-10-03",
    "keywords": "pulsars, neutron stars, P971_2018OCTS",
    "licence": "Creative Commons Attribution 4.0 International Licence",
    "licenceLink": {
        "relationship": "license",
        "mediaType": "text/html",
        "href": "https://data.csiro.au/dap/ws/v2/licences/1121"
    },
    "organisations": [
        "CSIRO (Australia)"
    ],
    "attributionStatement": "Venkatraman Krishnan, Vivek; Bailes, Matthew; Bhat, Ramesh; van Straten, Willem; Keane, Evan; Oslowski, Stefan; Flynn, Chris; Reardon, Daniel John; Rosado, Pablo (2018): Parkes observations for project P971 semester 2018OCTS_01. v1. CSIRO. Data Collection. 10.25919/5be80654300c1",
    "rights": "All Rights (including copyright) CSIRO 2018.",
    "access": "Access to this collection's metadata and/or files (if any) are restricted until 01 Oct 2020. ",
    "size": "atnf_pulsar",
    "published": "2018-11-11T21:38:46.503+11:00",
    "leadResearcher": "Vivek Venkatraman Krishnan",
    "versions": "https://data.csiro.au/dap/ws/v2/collections/36940/versions",
    "metadata": "https://data.csiro.au/dap/ws/v2/collections/36940/metadata",
    "data": "https://data.csiro.au/dap/ws/v2/collections/36940/data",
    "dataFileCount": 9,
    "serviceCount": 0,
    "totalCollectionSize": "297.80 MB",
    "supportingFiles": "https://data.csiro.au/dap/ws/v2/collections/36940/support",
    "contributors": [
        "Matthew Bailes",
        "Ramesh Bhat",
        "Willem van Straten",
        "Evan Keane",
        "Stefan Oslowski",
        "Chris Flynn",
        "Daniel John Reardon",
        "Pablo Rosado"
    ],
    "allNames": {
        "Vivek Venkatraman Krishnan": "Venkatraman Krishnan, Vivek",
        "Matthew Bailes": "Bailes, Matthew",
        "Ramesh Bhat": "Bhat, Ramesh",
        "Willem van Straten": "van Straten, Willem",
        "Evan Keane": "Keane, Evan",
        "Stefan Oslowski": "Oslowski, Stefan",
        "Chris Flynn": "Flynn, Chris",
        "Daniel John Reardon": "Reardon, Daniel John",
        "Pablo Rosado": "Rosado, Pablo"
    },
    "activity": {
        "activityId": 11029,
        "activityTitle": "P971 - Orbital dynamics and the intra-binary medium of PSR J1141-6545",
        "activityType": "Observation",
        "activityDescription": "Einstein's General Theory of relativity has passed all tests so far with flying colors. But most of the tests near the solar system where the effects of gravity are quite weak. Dense objects like neutron stars or black holes curve the space-time in their vicinity to much higher magnitudes. If these objects are in binary systems, such curvature affects the orbital motion. J1141-6545 is a distinctive laboratory where one object of the binary system is a neutron star and the other is a white-dwarf star.  Observing this system sheds light on how the uneven space-time curvature of the system affects our understanding of gravity.",
        "activityInstrument": "Parkes"
    },
    "domainType": "ATNF",
    "collectionContentType": "Data",
    "andsPid": "102.100.100/75299",
    "doi": "10.25919/5be80654300c1",
    "nationalFacility": "Australia Telescope National Facility",
    "nationalCollection": "Australia Telescope National Facility",
    "organisationalLevels": {
        "irpHierarchy": false,
        "businessUnit": "Astronomy and Space Science",
        "costCentre": "National Facility Operations",
        "researchProgram": "Astronomy and Space Science",
        "researchGroup": "Astronomy and Space Science"
    },
    "accessLevel": "Public",
    "dataRestricted": "FALSE",
    "voResource": {
        "ivoIdentifier": "ivo://au.csiro.atnf/P971-2018OCTS_01"
    },
    "fileExtensions": {
        "png": 2,
        "ftp": 2,
        "cf": 2,
        "rf": 2,
        "log": 1
    },
    "mounted": false
}
```

As the error responses are sent with status code 200, existing code can't handle this probably.

This PR tried to fix this.

Test site:

https://issue-1705.dev.magda.io


### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
