### PR TITLE
Issue/1772 Fixed magda-apidocs-server incorrectly builds into $PWD directory on windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 -   `create-secrets` will load ENV vars according to question data types
 -   Include Magda user agent in external HTTP resource accesses
 -   Made admin UI create CSV connector with internal URL
+-   Fixed magda-apidocs-server incorrectly builds into $PWD directory on windows
 
 ## 0.0.49
 

--- a/magda-apidocs-server/package.json
+++ b/magda-apidocs-server/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.50-0",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "generate-api-documentation --config $PWD/apidoc.json --output $PWD/build",
+    "build": "generate-api-documentation --config ./apidoc.json --output ./build",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
     "retag-and-push": "retag-and-push"


### PR DESCRIPTION
### What this PR does

Fixes #1772 

Fixed magda-apidocs-server incorrectly builds into $PWD directory on windows

### Test

Tested on windows 10 running in virtualbox (on a mac).

You can replicate my result by:

* Install git windows version
    * Select use `MinGW` commnd line option
    * Select checkout as it as checking in unix format
* Download Install Node v.10 from offical site
    * Select `chocolatey` & `boxstarter` option
    * You will see a couple of re-boot & a few command line scripts runs
* Open Powershell as `admin` & install packages
    * chocolatey install docker
    * chocolatey install kubernetes-cli
    * chocolatey install kubernetes-helm
    * chocolatey install yarn
        * You will asked to run a script for node v10, input Y
    * chocolatey install minikube
* Download & install vscode from offical site
    * Select use  `MinGW` commnd line as your terminal
        * "terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe"
        * C:\Program Files\Git\bin\bash.exe

As the windows 10 was in a virtual box, I can't install the virtual box on windows.

However, you can make windows side `minikube` talks to cluster installed outside windows by:
- Copy all certificates from Mac to windows in the virtual box
- Manually export docker env variables:
```
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.99.100:2376"
export DOCKER_CERT_PATH="C:/Users/IEUser/.minikube/certs"
export DOCKER_API_VERSION="1.35"
``` 

Probably worth creating a new `window setup doc` in Magda repo with steps above (created an issue here: #1866 ).

### Checklist

-   [ ] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
