### PR TITLE
Issue/1852 When `match-part` search strategy is used, a message should be shown on UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@
 -   Include Magda user agent in external HTTP resource accesses
 -   Made admin UI create CSV connector with internal URL
 -   Fixed an issue that DAP connector not handle access error correctly
+-   When `match-part` search strategy is used, a message is shown on UI
 
 ## 0.0.49
 

--- a/magda-web-client/src/Components/Search/Search.js
+++ b/magda-web-client/src/Components/Search/Search.js
@@ -191,12 +191,10 @@ class Search extends Component {
                             {!this.props.isFetching &&
                                 !this.props.error && (
                                     <div>
-                                        {!this.searchBoxEmpty() && (
-                                            <MatchingStatus
-                                                datasets={this.props.datasets}
-                                                strategy={this.props.strategy}
-                                            />
-                                        )}
+                                        <MatchingStatus
+                                            datasets={this.props.datasets}
+                                            strategy={this.props.strategy}
+                                        />
 
                                         {// redirect if we came from a 404 error and there is only one result
                                         queryString.parse(


### PR DESCRIPTION
### What this PR does

Fixes #1852 

This PR make sure when `match-part` search strategy is used, a message should be shown on UI

![image](https://user-images.githubusercontent.com/674387/48923826-f2ab7d00-ef05-11e8-8f37-64762b0bd5d2.png)

Changes Summary:

We used to have the message. However, the message only triggers when search box is not empty. Since we now allow empty search box (rather than having to specify `*` ), the message failed to show when `match-part` search strategy is used.

Test URL:

https://issue-1852.dev.magda.io/search?organisation=Department%20of%20Health%20and%20Human%20Services&page=7&regionId=3&regionType=STE

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
