### PR TITLE
Fix scss compiler

### DIFF
--- a/magda-scss-compiler/package.json
+++ b/magda-scss-compiler/package.json
@@ -35,7 +35,6 @@
     "chai": "^4.1.0",
     "mocha": "^3.4.2",
     "nock": "^9.0.14",
-    "node-sass": "^4.9.3",
     "sinon": "^2.4.1",
     "typescript": "~2.5.0"
   },
@@ -52,7 +51,8 @@
     "request": "2.85.0",
     "tempy": "^0.2.1",
     "urijs": "^1.18.12",
-    "yargs": "^8.0.2"
+    "yargs": "^8.0.2",
+    "node-sass": "^4.9.3"
   },
   "config": {
     "docker": {

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -21,7 +21,6 @@
     "@types/mocha": "^2.2.41",
     "@types/nock": "^8.2.1",
     "@types/node": "^8.0.14",
-    "@types/request": "^2.0.0",
     "@types/sinon": "^4.1.3",
     "@types/superagent": "^3.5.5",
     "@types/supertest": "^2.0.3",
@@ -39,6 +38,7 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
+    "@types/request": "^2.0.0",
     "body-parser": "^1.18.2",
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
### What this PR does

Right now the build doesn't work because the SCSS compiler has had some weirdness introduced by the change to pull request out into typescript-common. Just needs package.json jostled a bit

(no changelog, tests etc because it's just a dependency change that fixes a recently introduced issue)