### PR TITLE
Resolve timeout for some DAP marine dataset

### DIFF
--- a/magda-dap-connector/src/Dap.ts
+++ b/magda-dap-connector/src/Dap.ts
@@ -116,7 +116,7 @@ export default class Dap implements ConnectorSource {
     public getJsonDataset(id: string): Promise<any> {
         const url = this.urlBuilder.getPackageShowUrl(id);
         return new Promise<any>((resolve, reject) => {
-            request(url, { json: true }, (error, response, body) => {
+            request(url, { json: true, timeout: 60000, pool: { maxSockets: 1000} }, (error, response, body) => {
                 if (error) {
                     reject(error);
                     return;
@@ -249,7 +249,7 @@ export default class Dap implements ConnectorSource {
                 // console.log("Requesting " + requestUrl);
                 request(
                     requestUrl,
-                    { json: true },
+                    { json: true, timeout: 60000, pool: { maxSockets: 1000} },
                     async (error, response, body) => {
                         if (error) {
                             reject(error);
@@ -278,7 +278,7 @@ export default class Dap implements ConnectorSource {
                                 return new Promise<any>((resolve2, reject2) => {
                                     request(
                                         url,
-                                        { json: true },
+                                        { json: true, timeout: 60000,pool: { maxSockets: 1000} },
                                         (error, response, detail) => {
                                             console.log(
                                                 ">> request detail of " + url
@@ -317,7 +317,7 @@ export default class Dap implements ConnectorSource {
                                             (resolve3, reject3) => {
                                                 request(
                                                     simpleData.data,
-                                                    { json: true },
+                                                    { json: true, timeout: 60000, pool: { maxSockets: 1000} },
                                                     (
                                                         error,
                                                         response,


### PR DESCRIPTION
### What this PR does

Fixes # timeout for some DAP marine dataset

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)

Dap marine dataset may spend more than 10 seconds to response. After talking with Dap team, they realized that this is a bug, but they will not plan to fix it until there are more reports. 

This update only increases the default `request` timeout (read from operate system). 