### PR TITLE
Re-index performance improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 -   Redirect HTTP requests to HTTPS URLs
 -   Fixed chart won't displayed correctly under IE11
+-   Fixed stream processing issue when re-indexing, mitigating out-of-memory risk too
+-   Fixed index trimming failure issue when re-indexing
 
 ## 0.0.50
 
@@ -56,7 +58,7 @@
 -   `create-secrets` will load ENV vars according to question data types
 -   Include Magda user agent in external HTTP resource accesses
 -   Made admin UI create CSV connector with internal URL
--   Fixed magda-apidocs-server incorrectly builds into $PWD directory on windows
+-   Fixed magda-apidocs-server incorrectly builds into \$PWD directory on windows
 -   Fixed an issue that DAP connector not handle access error correctly
 -   Stopped caching anything requested through the admin ui.
 -   Removed old admin ui code

--- a/magda-indexer/build.sbt
+++ b/magda-indexer/build.sbt
@@ -10,6 +10,8 @@ libraryDependencies ++= {
   val akkaV       = "2.4.18"
   val akkaHttpV   = "10.0.7"
   val scalaTestV  = "2.2.6"
+  val akkaTestKitV = "2.4.18"
+  val akkaStreamTestKitV = "2.4.18"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "com.typesafe.akka" %% "akka-stream" % akkaV,
@@ -20,7 +22,11 @@ libraryDependencies ++= {
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
     "com.rockymadden.stringmetric" %% "stringmetric-core" % "0.27.4",
     "com.monsanto.labs" %% "mwundo" % "0.1.0" exclude("xerces", "xercesImpl"),
-    "org.scalaz" %% "scalaz-core" % "7.2.8"
+    "org.scalaz" %% "scalaz-core" % "7.2.8",
+    "com.typesafe.akka" %% "akka-testkit" % akkaTestKitV % Test,
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaStreamTestKitV % Test,
+    "org.scalatest" %% "scalatest" % scalaTestV % Test,
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test
   )
 }
 

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,14 +31,14 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
-  indexingBufferSize = 100
-  indexingQueueBufferSize = 50
-  indexingMaxBatchSize = 100
-  indexingInitialBatchDelayMs = 500
+  indexingBufferSize = 50
+  indexingQueueBufferSize = 1
+  indexingMaxBatchSize = 50
+  indexingInitialBatchDelayMs = 1000
 }
 
 crawler {
-  streamControllerSourceBufferSize = 1000
+  streamControllerSourceBufferSize = 100
 }
 
 registry {

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,13 +31,31 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
+
+  # Setting indexingBufferSize to be equal to indexingMaxBatchSize is recommended. This is because
+  # the database crawling is usually faster than the elastic search bulk indexing . While the
+  # current bulk indexing is underway, the crawling can quickly fill the stream buffer. When the
+  # current bulk indexing is completed, there will be just enough datasets for the next round.
   indexingBufferSize = 500
   indexingMaxBatchSize = 500
+
+  # It is recommended to set this value to a small value, such as 100 milliseconds, because this
+  # delay is used in both indexing and re-indexing.
+  # For the indexing, there are likely not many datasets to be bulk indexed; therefore it only needs
+  # to wait for a short period time before starting the bulk indexing.
+  # For the re-indexing, because the stream buffer is usually full (except for the beginning),
+  # containing enough datasets for the next round of bulk indexing; therefore it is likely to get
+  # the required bulk of datasets in a very short period of time.
   indexingInitialBatchDelayMs = 100
 }
 
 crawler {
-  streamControllerSourceBufferSize = 1000
+  # In the current implementation, the initial crawling will fetch max of
+  # streamControllerSourceBufferSize datasets. All the following crawlings will fetch max of
+  # streamControllerSourceBufferSize/2 datasets. Set this size properly so that each crawling will
+  # not fetch too many datasets. Otherwise an EntityStreamSizeException might occur.
+  # The value of 100 is recommended.
+  streamControllerSourceBufferSize = 100
 }
 
 registry {

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,8 +31,8 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
-  indexingBufferSize = 100
-  indexingQueueBufferSize = 50
+  indexingBufferSize = 2
+  indexingQueueBufferSize = 2
   indexingMaxBatchSize = 100
   indexingInitialBatchDelayMs = 500
 }

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,14 +31,14 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
-  indexingBufferSize = 1000
+  indexingBufferSize = 100
   indexingQueueBufferSize = 50
-  indexingMaxBatchSize = 500
+  indexingMaxBatchSize = 100
   indexingInitialBatchDelayMs = 500
 }
 
 crawler {
-  streamControllerSourceBufferSize = 2000
+  streamControllerSourceBufferSize = 1000
 }
 
 registry {

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -32,7 +32,6 @@ indexer {
   connectionRetries = 10
   requestThrottleMs = 1000
   indexingBufferSize = 50
-  indexingQueueBufferSize = 1
   indexingMaxBatchSize = 50
   indexingInitialBatchDelayMs = 1000
 }

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -33,7 +33,7 @@ indexer {
   requestThrottleMs = 1000
   indexingBufferSize = 50
   indexingMaxBatchSize = 50
-  indexingInitialBatchDelayMs = 1000
+  indexingInitialBatchDelayMs = 100
 }
 
 crawler {

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,13 +31,13 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
-  indexingBufferSize = 50
-  indexingMaxBatchSize = 50
+  indexingBufferSize = 500
+  indexingMaxBatchSize = 500
   indexingInitialBatchDelayMs = 100
 }
 
 crawler {
-  streamControllerSourceBufferSize = 100
+  streamControllerSourceBufferSize = 1000
 }
 
 registry {

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,8 +31,8 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
-  indexingBufferSize = 2
-  indexingQueueBufferSize = 2
+  indexingBufferSize = 100
+  indexingQueueBufferSize = 50
   indexingMaxBatchSize = 100
   indexingInitialBatchDelayMs = 500
 }

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -31,6 +31,14 @@ indexer {
   makeSnapshots = false
   connectionRetries = 10
   requestThrottleMs = 1000
+  indexingBufferSize = 1000
+  indexingQueueBufferSize = 50
+  indexingMaxBatchSize = 500
+  indexingInitialBatchDelayMs = 500
+}
+
+crawler {
+  streamControllerSourceBufferSize = 2000
 }
 
 registry {

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -1,26 +1,22 @@
 package au.csiro.data61.magda.indexer.crawler
 
+import java.time.OffsetDateTime
+
 import akka.NotUsed
-import akka.actor.{ActorRef, ActorSystem, PoisonPill}
+import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.stream.{Materializer, OverflowStrategy, ThrottleMode}
-import akka.stream.scaladsl.{Keep, Merge, Sink, Source}
-import au.csiro.data61.magda.AppConfig
-import au.csiro.data61.magda.model.misc.DataSet
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import au.csiro.data61.magda.client.RegistryExternalInterface
+import au.csiro.data61.magda.indexer.helpers.StreamController
 import au.csiro.data61.magda.indexer.search.SearchIndexer
+import au.csiro.data61.magda.indexer.search.elasticsearch.ElasticSearchIndexer
+import au.csiro.data61.magda.model.misc.DataSet
+import au.csiro.data61.magda.util.ErrorHandling
 import com.typesafe.config.Config
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import au.csiro.data61.magda.model.misc.Agent
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
-
-import au.csiro.data61.magda.util.ErrorHandling
-import au.csiro.data61.magda.client.RegistryExternalInterface
-import au.csiro.data61.magda.indexer.search.elasticsearch.ElasticSearchIndexer
-import org.reactivestreams.Publisher
 
 class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndexer)(implicit val system: ActorSystem, implicit val config: Config, implicit val materializer: Materializer) extends Crawler {
   val log = Logging(system, getClass)
@@ -28,6 +24,8 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
   implicit val scheduler = system.scheduler
 
   var lastCrawl: Option[Future[Unit]] = None
+  private val streamControllerSourceBufferSize = config.getInt("crawler.streamControllerSourceBufferSize")
+  private val streamController = new StreamController(interface, streamControllerSourceBufferSize)
 
   def crawlInProgress: Boolean = lastCrawl.map(!_.isCompleted).getOrElse(false)
 
@@ -131,77 +129,8 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
   }
 
 
-  private val bufferSize = 1000
-  private val crawledCount = new AtomicLong(0)
-  private val newCrawlThreshold = 500
-  private val (ref, source) = createStreamSource()
-  private var tokenOption: Option[String] = None
-  private var isCrawling = false
-
-  private def createStreamSource() = {
-    val (ref: ActorRef, publisher: Publisher[DataSet]) =
-      Source.actorRef[DataSet](bufferSize = bufferSize, OverflowStrategy.fail)
-        .toMat(Sink.asPublisher(false))(Keep.both).run()
-
-    val source = Source.fromPublisher(publisher)
-
-    (ref, source)
-  }
-
-  private def tokenCrawl2(nextFuture: () => Future[(Option[String], List[DataSet])]): Future[(Option[String], List[DataSet])] = {
-    val onRetry = (retryCount: Int, e: Throwable) => log.error(e, "Failed while fetching from registry, retries left: {}", retryCount + 1)
-
-    val safeFuture: Future[(Option[String], List[DataSet])] = ErrorHandling.retry(nextFuture, 30 seconds, 30, onRetry)
-      .recover {
-        case e: Throwable =>
-          log.error(e, "Failed completely while fetching from registry. This means we can't go any further!!")
-          (None, Nil)
-      }
-    safeFuture
-  }
-
-  private def fillStreamSource(nextFuture: () => Future[(Option[String], List[DataSet])]) = {
-
-    tokenCrawl2(nextFuture)
-      .map(results => {
-        tokenOption = results._1
-        val dataSets: Seq[DataSet] = results._2
-        crawledCount.addAndGet(dataSets.size)
-        log.info("Total crawled {} datasets from registry", crawledCount.get())
-        dataSets foreach (dataSet => {
-          dataSet.copy(publisher = dataSet.publisher)
-          ref ! dataSet
-        })
-
-        isCrawling = false
-
-        if (tokenOption.isEmpty)
-          endSource()
-      })
-  }
-
   private def streamForInterface2(): Source[DataSet, NotUsed] = {
-    val firstPageFuture = () => interface.getDataSetsReturnToken(0, bufferSize)
-    fillStreamSource(firstPageFuture)
-    source
-  }
-
-  private def endSource(): Unit = {
-    log.info("End of crawling.")
-    ref ! PoisonPill
-  }
-
-  def updateSource(pCount: Int): String = {
-
-    if (pCount % bufferSize == 0) {
-      log.info("Total pulled: {}", pCount)
-    }
-
-    if (!isCrawling && tokenOption.nonEmpty && pCount >= newCrawlThreshold){
-      fillStreamSource(() => interface.getDataSetsToken(tokenOption.get, newCrawlThreshold))
-      isCrawling = true
-    }
-
-    "Ok"
+    streamController.start()
+    streamController.getSource
   }
 }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -1,10 +1,10 @@
 package au.csiro.data61.magda.indexer.crawler
 
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.event.Logging
-import akka.stream.{ Materializer, ThrottleMode }
-import akka.stream.scaladsl.{ Merge, Sink, Source }
+import akka.stream.{Materializer, OverflowStrategy, ThrottleMode}
+import akka.stream.scaladsl.{Keep, Merge, Sink, Source}
 import au.csiro.data61.magda.AppConfig
 import au.csiro.data61.magda.model.misc.DataSet
 import au.csiro.data61.magda.indexer.search.SearchIndexer
@@ -15,8 +15,12 @@ import scala.concurrent.duration._
 import au.csiro.data61.magda.model.misc.Agent
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+
 import au.csiro.data61.magda.util.ErrorHandling
 import au.csiro.data61.magda.client.RegistryExternalInterface
+import au.csiro.data61.magda.indexer.search.elasticsearch.ElasticSearchIndexer
+import org.reactivestreams.Publisher
 
 class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndexer)(implicit val system: ActorSystem, implicit val config: Config, implicit val materializer: Materializer) extends Crawler {
   val log = Logging(system, getClass)
@@ -40,7 +44,9 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
 
     log.info("Crawling registry at {}", interface.baseApiPath)
 
-    val interfaceSource = streamForInterface()
+    val interfaceSource = streamForInterface2()
+
+    ElasticSearchIndexer.setRegistryCrawler(this)
 
     indexer.index(interfaceSource)
       .flatMap { result =>
@@ -122,5 +128,80 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
       })
 
     crawlSource
+  }
+
+
+  private val bufferSize = 1000
+  private val crawledCount = new AtomicLong(0)
+  private val newCrawlThreshold = 500
+  private val (ref, source) = createStreamSource()
+  private var tokenOption: Option[String] = None
+  private var isCrawling = false
+
+  private def createStreamSource() = {
+    val (ref: ActorRef, publisher: Publisher[DataSet]) =
+      Source.actorRef[DataSet](bufferSize = bufferSize, OverflowStrategy.fail)
+        .toMat(Sink.asPublisher(false))(Keep.both).run()
+
+    val source = Source.fromPublisher(publisher)
+
+    (ref, source)
+  }
+
+  private def tokenCrawl2(nextFuture: () => Future[(Option[String], List[DataSet])]): Future[(Option[String], List[DataSet])] = {
+    val onRetry = (retryCount: Int, e: Throwable) => log.error(e, "Failed while fetching from registry, retries left: {}", retryCount + 1)
+
+    val safeFuture: Future[(Option[String], List[DataSet])] = ErrorHandling.retry(nextFuture, 30 seconds, 30, onRetry)
+      .recover {
+        case e: Throwable =>
+          log.error(e, "Failed completely while fetching from registry. This means we can't go any further!!")
+          (None, Nil)
+      }
+    safeFuture
+  }
+
+  private def fillStreamSource(nextFuture: () => Future[(Option[String], List[DataSet])]) = {
+
+    tokenCrawl2(nextFuture)
+      .map(results => {
+        tokenOption = results._1
+        val dataSets: Seq[DataSet] = results._2
+        crawledCount.addAndGet(dataSets.size)
+        log.info("Total crawled {} datasets from registry", crawledCount.get())
+        dataSets foreach (dataSet => {
+          dataSet.copy(publisher = dataSet.publisher)
+          ref ! dataSet
+        })
+
+        isCrawling = false
+
+        if (tokenOption.isEmpty)
+          endSource()
+      })
+  }
+
+  private def streamForInterface2(): Source[DataSet, NotUsed] = {
+    val firstPageFuture = () => interface.getDataSetsReturnToken(0, bufferSize)
+    fillStreamSource(firstPageFuture)
+    source
+  }
+
+  private def endSource(): Unit = {
+    log.info("End of crawling.")
+    ref ! PoisonPill
+  }
+
+  def updateSource(pCount: Int): String = {
+
+    if (pCount % bufferSize == 0) {
+      log.info("Total pulled: {}", pCount)
+    }
+
+    if (!isCrawling && tokenOption.nonEmpty && pCount >= newCrawlThreshold){
+      fillStreamSource(() => interface.getDataSetsToken(tokenOption.get, newCrawlThreshold))
+      isCrawling = true
+    }
+
+    "Ok"
   }
 }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -27,8 +27,6 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
   private val streamControllerSourceBufferSize =
     config.getInt("crawler.streamControllerSourceBufferSize")
 
-  private val streamController = new StreamController(interface, streamControllerSourceBufferSize)
-
   def crawlInProgress(): Boolean = lastCrawl.exists(!_.isCompleted)
 
   def crawl(): Future[Unit] = {
@@ -88,6 +86,7 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
   }
 
   private def streamForInterface(): Source[DataSet, NotUsed] = {
+    val streamController = new StreamController(interface, streamControllerSourceBufferSize)
     streamController.start()
     streamController.getSource
   }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -44,8 +44,6 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
 
     val interfaceSource = streamForInterface2()
 
-    ElasticSearchIndexer.setRegistryCrawler(this)
-
     indexer.index(interfaceSource)
       .flatMap { result =>
         log.info("Indexed {} datasets with {} failures", result.successes, result.failures.length)

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -48,9 +48,21 @@ class RegistryCrawler(interface: RegistryExternalInterface, indexer: SearchIndex
       .flatMap { result =>
         log.info("Indexed {} datasets with {} failures", result.successes, result.failures.length)
 
-        val futureOpt = if (result.failures.isEmpty) { // does this need to be tunable?
-          log.info("Trimming datasets indexed before {}", startInstant)
-          Some(indexer.trim(startInstant))
+        val futureOpt: Option[Future[Unit]] = if (result.failures.isEmpty) { // does this need to be tunable?
+          // By default ElasticSearch index is refreshed every second. Let the trimming operation
+          // (delete by query) be delayed by some time interval. Otherwise the operation will report failure.
+          //
+          // index.refresh_interval:
+          // How often to perform a refresh operation, which makes recent changes to the index visible to search.
+          // Defaults to 1s. Can be set to -1 to disable refresh.
+          // Ref: https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index-modules.html#dynamic-index-settings
+
+          Some(Future {
+            val delay = 1000
+            Thread.sleep(delay)
+            log.info("Trimming datasets indexed before {}", startInstant)
+            Some(indexer.trim(startInstant))
+          })
         } else {
           log.warning("Encountered too many failures to trim old datasets")
           None

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
@@ -44,7 +44,8 @@ class WebhookApi(indexer: SearchIndexer)(implicit system: ActorSystem, config: C
   val routes =
     magdaRoute {
       post {
-        entity(as[WebHookPayload]) { payload => withoutSizeLimit
+        withoutSizeLimit
+        entity(as[WebHookPayload]) { payload =>
           val events = payload.events.getOrElse(List())
           getLogger.info(s"Payload size of ${events.size}")
           val idsToDelete = events.filter(_.eventType == EventType.DeleteRecord)

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
@@ -44,7 +44,7 @@ class WebhookApi(indexer: SearchIndexer)(implicit system: ActorSystem, config: C
   val routes =
     magdaRoute {
       post {
-        withoutSizeLimit
+//        withoutSizeLimit
         entity(as[WebHookPayload]) { payload =>
           val events = payload.events.getOrElse(List())
           getLogger.info(s"Payload size of ${events.size}")

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
@@ -1,0 +1,88 @@
+package au.csiro.data61.magda.indexer.helpers
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.actor.{ActorSystem, Scheduler}
+import akka.event.Logging
+import akka.stream.Materializer
+import au.csiro.data61.magda.model.misc.DataSet
+import au.csiro.data61.magda.util.ErrorHandling
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+trait RegistryInterface {
+  def getDataSetsReturnToken(start: Int, size: Int): Future[(Option[String], List[DataSet])]
+  def getDataSetsToken(token: String, size: Int): Future[(Option[String], List[DataSet])]
+}
+
+class StreamController(interface: RegistryInterface, ssc: StreamSourceController)
+                      (implicit val system: ActorSystem,
+                       implicit val config: Config,
+                       implicit val materializer: Materializer) {
+
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  implicit val scheduler: Scheduler = system.scheduler
+
+  val log = Logging(system, getClass)
+  private val crawledCount = new AtomicLong(0)
+  private var tokenOption: Option[String] = None
+
+  def getDataSets(nextFuture: () => Future[(Option[String], List[DataSet])])
+  : Future[(Option[String], List[DataSet])] = {
+
+    val onRetry = (retryCount: Int, e: Throwable) =>
+      log.error(e, "Failed while fetching from registry, retries left: {}", retryCount + 1)
+
+    val safeFuture: Future[(Option[String], List[DataSet])] =
+      ErrorHandling.retry(nextFuture, 30.seconds, 30, onRetry)
+        .recover {
+          case e: Throwable =>
+            log.error(e, "Failed completely while fetching from registry. " +
+              "This means we can't go any further!!")
+            (None, Nil)
+        }
+
+    safeFuture
+  }
+
+  def fillStreamSource(nextFuture: () => Future[(Option[String], List[DataSet])])
+  : Future[Option[String]] = {
+
+    getDataSets(nextFuture)
+      .map(results => {
+        val tokenOption = results._1
+        val dataSets = results._2
+        crawledCount.addAndGet(dataSets.size)
+        log.info("Total crawled {} datasets from registry", crawledCount.get())
+        ssc.fillSource(dataSets)
+        tokenOption
+      })
+  }
+
+  def start(firstPageSize: Int): Future[Option[String]] = {
+    val firstPageF = () => interface.getDataSetsReturnToken(0, firstPageSize)
+    val tokenOptionF = fillStreamSource(firstPageF)
+    tokenOptionF.map(t => {
+      tokenOption = t
+      tokenOption
+    })
+  }
+
+  def next(nextSize: Int): Future[Option[String]] = {
+    if (tokenOption.isEmpty){
+      log.info("No more datasets, terminate the stream.")
+      ssc.terminate()
+      Future.successful(None)
+    }
+    else {
+      val nextPageF = () => interface.getDataSetsToken(tokenOption.get, nextSize)
+      val tokenOptionF = fillStreamSource(nextPageF)
+      tokenOptionF.map(t => {
+        tokenOption = t
+        tokenOption
+      })
+    }
+  }
+}

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
@@ -73,8 +73,8 @@ class StreamController(interface: RegistryInterface, bufferSize: Int)
   }
 
   def start(): Future[Option[String]] = {
-    val firstPageF = () => interface.getDataSetsReturnToken(0, bufferSize)
-    tokenOptionF = fillStreamSource(firstPageF, true)
+    val firstPageF = () => interface.getDataSetsReturnToken(start = 0, size = bufferSize)
+    tokenOptionF = fillStreamSource(firstPageF, isFirst = true)
     tokenOptionF
   }
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamController.scala
@@ -7,17 +7,13 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props, Scheduler}
 import akka.event.Logging
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import au.csiro.data61.magda.client.RegistryInterface
 import au.csiro.data61.magda.model.misc.DataSet
 import au.csiro.data61.magda.util.ErrorHandling
 import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-
-trait RegistryInterface {
-  def getDataSetsReturnToken(start: Int, size: Int): Future[(Option[String], List[DataSet])]
-  def getDataSetsToken(token: String, size: Int): Future[(Option[String], List[DataSet])]
-}
 
 class ControllerActor(controller: StreamController) extends Actor {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -40,6 +40,9 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
 
   private val GET_MORE_DATASETS: String = "Get more datasets"
   private val NO_MORE_DATASETS: String = "No more datasets"
+  /**
+    * It is used to count the total datasets that have been filled into the buffer so far.
+    */
   private val dataSetCount = new AtomicLong(0)
   private val (ref, source) = createStreamSource()
 
@@ -73,7 +76,7 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
           pull(in)
         }
 
-       setHandlers(in, out, this)
+        setHandlers(in, out, this)
       }
 
     override def toString: String = "MessageChecker"
@@ -101,7 +104,6 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
   def fillSource(dataSets: Seq[DataSet], hasNext: Boolean, isFirst: Boolean): Unit = {
     if (isFirst){
       dataSets foreach (dataSet => {
-        dataSet.copy(publisher = dataSet.publisher)
         ref ! dataSet
         if (dataSetCount.incrementAndGet() == bufferSize / 2 && hasNext)
           ref ! GET_MORE_DATASETS
@@ -109,7 +111,6 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
     }
     else {
       dataSets foreach (dataSet => {
-        dataSet.copy(publisher = dataSet.publisher)
         ref ! dataSet
         if (dataSetCount.incrementAndGet() % (bufferSize / 2) == 0 && hasNext)
           ref ! GET_MORE_DATASETS

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -1,5 +1,7 @@
 package au.csiro.data61.magda.indexer.helpers
 
+import java.util.concurrent.atomic.AtomicLong
+
 import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem, Scheduler}
 import akka.event.Logging
@@ -14,28 +16,37 @@ import org.reactivestreams.Publisher
 
 import scala.concurrent.ExecutionContextExecutor
 
-class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
-                                              implicit val config: Config,
-                                              implicit val materializer: Materializer) {
+class StreamSourceController(bufferSize: Int, streamController: StreamController)
+                            (implicit val system: ActorSystem,
+                             implicit val config: Config,
+                             implicit val materializer: Materializer) {
 
   val log = Logging(system, getClass)
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 
+  private val HAS_MORE_DATASETS: String = "Has more"
+  private val NO_MORE_DATASETS: String = "No more"
+  private val dataSetCount = new AtomicLong(0)
   private val (ref, source) = createStreamSource()
-  val NO_MORE_DATASETS: String = "Done"
 
-  final case class CheckEnd[Object]() extends SimpleLinearGraphStage[Object] {
+  final case class MessageChecker[Object]() extends SimpleLinearGraphStage[Object] {
     override def initialAttributes: Attributes = DefaultAttributes.take
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new GraphStageLogic(shape) with InHandler with OutHandler {
         override def onPush(): Unit = {
-          val x = grab(in)
-          if (x == NO_MORE_DATASETS)
+          val message = grab(in)
+          if (message == NO_MORE_DATASETS)
             completeStage()
+          else if (message == HAS_MORE_DATASETS) {
+            if (streamController != None.orNull)
+              streamController.next(bufferSize / 2)
+
+            pull(in)
+          }
           else
-            push(out, x)
+            push(out, message)
         }
 
         override def onPull(): Unit = {
@@ -45,16 +56,16 @@ class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
        setHandlers(in, out, this)
       }
 
-    override def toString: String = "Check"
+    override def toString: String = "MessageChecker"
   }
 
   private def createStreamSource(): (ActorRef, Source[DataSet, NotUsed]) = {
     val (ref: ActorRef, publisher: Publisher[DataSet]) =
-      Source.actorRef[DataSet](bufferSize = bufferSize+1, OverflowStrategy.fail)
+      Source.actorRef[DataSet](bufferSize = bufferSize+3, OverflowStrategy.fail)
         .toMat(Sink.asPublisher(false))(Keep.both).run()
 
     val source: Source[DataSet, NotUsed] = Source.fromPublisher(publisher)
-    val source2: Source[DataSet, NotUsed] = source.via(CheckEnd.apply())
+    val source2: Source[DataSet, NotUsed] = source.via(MessageChecker.apply())
     (ref, source2)
   }
 
@@ -62,11 +73,26 @@ class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
     ref ! NO_MORE_DATASETS
   }
 
-  def fillSource(dataSets: Seq[DataSet]): Unit = {
-    dataSets foreach (dataSet => {
-      dataSet.copy(publisher = dataSet.publisher)
-      ref ! dataSet
-    })
+  def fillSource(dataSets: Seq[DataSet], hasNext: Boolean, isFirst: Boolean): Unit = {
+    if (isFirst){
+      dataSets foreach (dataSet => {
+        dataSet.copy(publisher = dataSet.publisher)
+        ref ! dataSet
+        if (dataSetCount.incrementAndGet() == bufferSize/2)
+          ref ! HAS_MORE_DATASETS
+      })
+    }
+    else {
+      dataSets foreach (dataSet => {
+        dataSet.copy(publisher = dataSet.publisher)
+        ref ! dataSet
+        if (dataSetCount.incrementAndGet() % (bufferSize / 2) == 0)
+          ref ! HAS_MORE_DATASETS
+      })
+    }
+
+    if (!hasNext)
+      ref ! NO_MORE_DATASETS
   }
 
   def refAndSource: (ActorRef, Source[DataSet, NotUsed]) = {

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -80,10 +80,10 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
   }
 
   private def createStreamSource(): (ActorRef, Source[DataSet, NotUsed]) = {
-    // The additional 2 slots in the buffer are for the the control messages GET_MORE_DATASETS
-    // and NO_MORE_DATASETS.
+    // The additional 1 slot in the buffer are for a control message: either GET_MORE_DATASETS
+    // or NO_MORE_DATASETS.
     val (ref: ActorRef, publisher: Publisher[DataSet]) =
-      Source.actorRef[DataSet](bufferSize = bufferSize + 2, OverflowStrategy.fail)
+      Source.actorRef[DataSet](bufferSize = bufferSize + 1, OverflowStrategy.fail)
         .toMat(Sink.asPublisher(true))(Keep.both).run()
 
     val source: Source[DataSet, NotUsed] = Source.fromPublisher(publisher)

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -3,8 +3,11 @@ package au.csiro.data61.magda.indexer.helpers
 import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem, Scheduler}
 import akka.event.Logging
+import akka.stream._
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.stream.{KillSwitches, Materializer, OverflowStrategy}
+import akka.stream.stage.{GraphStageLogic, InHandler, OutHandler}
 import au.csiro.data61.magda.model.misc.DataSet
 import com.typesafe.config.Config
 import org.reactivestreams.Publisher
@@ -19,23 +22,44 @@ class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 
-  private val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
   private val (ref, source) = createStreamSource()
+  val NO_MORE_DATASETS: String = "Done"
+
+  final case class CheckEnd[Object]() extends SimpleLinearGraphStage[Object] {
+    override def initialAttributes: Attributes = DefaultAttributes.take
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+        override def onPush(): Unit = {
+          val x = grab(in)
+          if (x == NO_MORE_DATASETS)
+            completeStage()
+          else
+            push(out, x)
+        }
+
+        override def onPull(): Unit = {
+          pull(in)
+        }
+
+       setHandlers(in, out, this)
+      }
+
+    override def toString: String = "Check"
+  }
 
   private def createStreamSource(): (ActorRef, Source[DataSet, NotUsed]) = {
     val (ref: ActorRef, publisher: Publisher[DataSet]) =
-      Source.actorRef[DataSet](bufferSize = bufferSize, OverflowStrategy.fail)
+      Source.actorRef[DataSet](bufferSize = bufferSize+1, OverflowStrategy.fail)
         .toMat(Sink.asPublisher(false))(Keep.both).run()
 
-    val source = Source.fromPublisher(publisher)
-
-    val source2: Source[DataSet, NotUsed] = source.via(sharedKillSwitch.flow)
-
+    val source: Source[DataSet, NotUsed] = Source.fromPublisher(publisher)
+    val source2: Source[DataSet, NotUsed] = source.via(CheckEnd.apply())
     (ref, source2)
   }
 
   def terminate(): Unit = {
-    sharedKillSwitch.shutdown()
+    ref ! NO_MORE_DATASETS
   }
 
   def fillSource(dataSets: Seq[DataSet]): Unit = {
@@ -48,5 +72,4 @@ class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
   def refAndSource: (ActorRef, Source[DataSet, NotUsed]) = {
     (ref, source)
   }
-
 }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -81,7 +81,7 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
     // and NO_MORE_DATASETS.
     val (ref: ActorRef, publisher: Publisher[DataSet]) =
       Source.actorRef[DataSet](bufferSize = bufferSize + 2, OverflowStrategy.fail)
-        .toMat(Sink.asPublisher(false))(Keep.both).run()
+        .toMat(Sink.asPublisher(true))(Keep.both).run()
 
     val source: Source[DataSet, NotUsed] = Source.fromPublisher(publisher)
     val source2: Source[DataSet, NotUsed] = source.via(MessageChecker.apply())

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -111,7 +111,7 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
       dataSets foreach (dataSet => {
         dataSet.copy(publisher = dataSet.publisher)
         ref ! dataSet
-        if (dataSetCount.incrementAndGet() % (bufferSize / 2) == 0)
+        if (dataSetCount.incrementAndGet() % (bufferSize / 2) == 0 && hasNext)
           ref ! GET_MORE_DATASETS
       })
     }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -11,15 +11,14 @@ import org.reactivestreams.Publisher
 
 import scala.concurrent.ExecutionContextExecutor
 
-class StreamSourceController()(implicit val system: ActorSystem,
-                               implicit val config: Config,
-                               implicit val materializer: Materializer) {
+class StreamSourceController(bufferSize: Int)(implicit val system: ActorSystem,
+                                              implicit val config: Config,
+                                              implicit val materializer: Materializer) {
 
   val log = Logging(system, getClass)
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 
-  private val bufferSize = 1000
   private val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
   private val (ref, source) = createStreamSource()
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -103,7 +103,7 @@ class StreamSourceController(bufferSize: Int, streamController: StreamController
       dataSets foreach (dataSet => {
         dataSet.copy(publisher = dataSet.publisher)
         ref ! dataSet
-        if (dataSetCount.incrementAndGet() == bufferSize / 2)
+        if (dataSetCount.incrementAndGet() == bufferSize / 2 && hasNext)
           ref ! GET_MORE_DATASETS
       })
     }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -1,38 +1,27 @@
 package au.csiro.data61.magda.indexer.helpers
 
-import java.util.concurrent.atomic.AtomicLong
-
 import akka.NotUsed
-import akka.actor.{ActorRef, ActorSystem, PoisonPill, Scheduler}
+import akka.actor.{ActorRef, ActorSystem, Scheduler}
 import akka.event.Logging
-import akka.stream.{KillSwitches, Materializer, OverflowStrategy}
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import au.csiro.data61.magda.client.RegistryExternalInterface
-import au.csiro.data61.magda.indexer.search.SearchIndexer
+import akka.stream.{KillSwitches, Materializer, OverflowStrategy}
 import au.csiro.data61.magda.model.misc.DataSet
-import au.csiro.data61.magda.util.ErrorHandling
 import com.typesafe.config.Config
 import org.reactivestreams.Publisher
 
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.ExecutionContextExecutor
 
-class StreamSourceController(interface: RegistryExternalInterface, indexer: SearchIndexer)
-                            (implicit val system: ActorSystem,
-                             implicit val config: Config,
-                             implicit val materializer: Materializer) {
+class StreamSourceController()(implicit val system: ActorSystem,
+                               implicit val config: Config,
+                               implicit val materializer: Materializer) {
+
   val log = Logging(system, getClass)
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 
   private val bufferSize = 1000
-  private val crawledCount = new AtomicLong(0)
-  private val newCrawlThreshold = 500
   private val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
   private val (ref, source) = createStreamSource()
-  private var tokenOption: Option[String] = None
-  private var isCrawling = false
-
 
   private def createStreamSource(): (ActorRef, Source[DataSet, NotUsed]) = {
     val (ref: ActorRef, publisher: Publisher[DataSet]) =
@@ -50,59 +39,15 @@ class StreamSourceController(interface: RegistryExternalInterface, indexer: Sear
     sharedKillSwitch.shutdown()
   }
 
-  private def tokenCrawl(nextFuture: () => Future[(Option[String], List[DataSet])]): Future[(Option[String], List[DataSet])] = {
-    val onRetry = (retryCount: Int, e: Throwable) => log.error(e, "Failed while fetching from registry, retries left: {}", retryCount + 1)
-
-    val safeFuture: Future[(Option[String], List[DataSet])] = ErrorHandling.retry(nextFuture, 30.seconds, 30, onRetry)
-      .recover {
-        case e: Throwable =>
-          log.error(e, "Failed completely while fetching from registry. This means we can't go any further!!")
-          (None, Nil)
-      }
-    safeFuture
-  }
-
-  private def fillStreamSource(nextFuture: () => Future[(Option[String], List[DataSet])]) = {
-
-    tokenCrawl(nextFuture)
-      .map(results => {
-        tokenOption = results._1
-        val dataSets: Seq[DataSet] = results._2
-        crawledCount.addAndGet(dataSets.size)
-        log.info("Total crawled {} datasets from registry", crawledCount.get())
-        dataSets foreach (dataSet => {
-          dataSet.copy(publisher = dataSet.publisher)
-          ref ! dataSet
-        })
-
-        isCrawling = false
-
-        if (tokenOption.isEmpty)
-          terminate()
-      })
-  }
-
-  def dataSetSource: Source[DataSet, NotUsed] = {
-    val firstPageFuture = () => interface.getDataSetsReturnToken(0, bufferSize)
-    fillStreamSource(firstPageFuture)
-    source
+  def fillSource(dataSets: Seq[DataSet]): Unit = {
+    dataSets foreach (dataSet => {
+      dataSet.copy(publisher = dataSet.publisher)
+      ref ! dataSet
+    })
   }
 
   def refAndSource: (ActorRef, Source[DataSet, NotUsed]) = {
     (ref, source)
   }
 
-  def updateSource(pCount: Int): String = {
-
-    if (pCount % bufferSize == 0 || tokenOption.isEmpty) {
-      log.info("Total pulled: {}", pCount)
-    }
-
-    if (!isCrawling && tokenOption.nonEmpty && pCount >= newCrawlThreshold){
-      fillStreamSource(() => interface.getDataSetsToken(tokenOption.get, newCrawlThreshold))
-      isCrawling = true
-    }
-
-    "Ok"
-  }
 }

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceController.scala
@@ -1,0 +1,108 @@
+package au.csiro.data61.magda.indexer.helpers
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorSystem, PoisonPill, Scheduler}
+import akka.event.Logging
+import akka.stream.{KillSwitches, Materializer, OverflowStrategy}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import au.csiro.data61.magda.client.RegistryExternalInterface
+import au.csiro.data61.magda.indexer.search.SearchIndexer
+import au.csiro.data61.magda.model.misc.DataSet
+import au.csiro.data61.magda.util.ErrorHandling
+import com.typesafe.config.Config
+import org.reactivestreams.Publisher
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class StreamSourceController(interface: RegistryExternalInterface, indexer: SearchIndexer)
+                            (implicit val system: ActorSystem,
+                             implicit val config: Config,
+                             implicit val materializer: Materializer) {
+  val log = Logging(system, getClass)
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  implicit val scheduler: Scheduler = system.scheduler
+
+  private val bufferSize = 1000
+  private val crawledCount = new AtomicLong(0)
+  private val newCrawlThreshold = 500
+  private val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
+  private val (ref, source) = createStreamSource()
+  private var tokenOption: Option[String] = None
+  private var isCrawling = false
+
+
+  private def createStreamSource(): (ActorRef, Source[DataSet, NotUsed]) = {
+    val (ref: ActorRef, publisher: Publisher[DataSet]) =
+      Source.actorRef[DataSet](bufferSize = bufferSize, OverflowStrategy.fail)
+        .toMat(Sink.asPublisher(false))(Keep.both).run()
+
+    val source = Source.fromPublisher(publisher)
+
+    val source2: Source[DataSet, NotUsed] = source.via(sharedKillSwitch.flow)
+
+    (ref, source2)
+  }
+
+  def terminate(): Unit = {
+    sharedKillSwitch.shutdown()
+  }
+
+  private def tokenCrawl(nextFuture: () => Future[(Option[String], List[DataSet])]): Future[(Option[String], List[DataSet])] = {
+    val onRetry = (retryCount: Int, e: Throwable) => log.error(e, "Failed while fetching from registry, retries left: {}", retryCount + 1)
+
+    val safeFuture: Future[(Option[String], List[DataSet])] = ErrorHandling.retry(nextFuture, 30.seconds, 30, onRetry)
+      .recover {
+        case e: Throwable =>
+          log.error(e, "Failed completely while fetching from registry. This means we can't go any further!!")
+          (None, Nil)
+      }
+    safeFuture
+  }
+
+  private def fillStreamSource(nextFuture: () => Future[(Option[String], List[DataSet])]) = {
+
+    tokenCrawl(nextFuture)
+      .map(results => {
+        tokenOption = results._1
+        val dataSets: Seq[DataSet] = results._2
+        crawledCount.addAndGet(dataSets.size)
+        log.info("Total crawled {} datasets from registry", crawledCount.get())
+        dataSets foreach (dataSet => {
+          dataSet.copy(publisher = dataSet.publisher)
+          ref ! dataSet
+        })
+
+        isCrawling = false
+
+        if (tokenOption.isEmpty)
+          terminate()
+      })
+  }
+
+  def dataSetSource: Source[DataSet, NotUsed] = {
+    val firstPageFuture = () => interface.getDataSetsReturnToken(0, bufferSize)
+    fillStreamSource(firstPageFuture)
+    source
+  }
+
+  def refAndSource: (ActorRef, Source[DataSet, NotUsed]) = {
+    (ref, source)
+  }
+
+  def updateSource(pCount: Int): String = {
+
+    if (pCount % bufferSize == 0 || tokenOption.isEmpty) {
+      log.info("Total pulled: {}", pCount)
+    }
+
+    if (!isCrawling && tokenOption.nonEmpty && pCount >= newCrawlThreshold){
+      fillStreamSource(() => interface.getDataSetsToken(tokenOption.get, newCrawlThreshold))
+      isCrawling = true
+    }
+
+    "Ok"
+  }
+}

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
@@ -38,7 +38,7 @@ class ElasticSearchIndexer(
   private val SNAPSHOT_REPO_NAME = "snapshots"
 
   private val indexingBufferSize = config.getInt("indexer.indexingBufferSize")
-  private val indexingQueueBufferSize = config.getInt("indexer.indexingQueueBufferSize")
+  private val indexingQueueBufferSize = Int.MaxValue
   private val indexingMaxBatchSize = config.getInt("indexer.indexingMaxBatchSize")
   private val indexingInitialBatchDelayMs =
     config.getInt("indexer.indexingInitialBatchDelayMs").milliseconds

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
@@ -390,8 +390,6 @@ class ElasticSearchIndexer(
     indexResults.flatMap(identity)
   }
 
-  private val pulledCount = new AtomicInteger(0)
-
   def index(dataSet: DataSet, promise: Promise[Unit] = Promise[Unit]): Future[Unit] = {
 
     indexQueue.offer((dataSet, promise))
@@ -543,7 +541,6 @@ class ElasticSearchIndexer(
 }
 
 object ElasticSearchIndexer {
-  var crawler: RegistryCrawler = None.orNull
   def getYears(from: Option[OffsetDateTime], to: Option[OffsetDateTime]): Option[String] = {
     val newFrom = from.orElse(to).map(_.getYear)
     val newTo = to.orElse(from).map(_.getYear)
@@ -552,9 +549,5 @@ object ElasticSearchIndexer {
       case (Some(newFrom), Some(newTo)) => Some(s"$newFrom-$newTo")
       case _                            => None
     }
-  }
-
-  def setRegistryCrawler(c: RegistryCrawler): Unit = {
-    crawler = c
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/ElasticSearchIndexerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/ElasticSearchIndexerTest.scala
@@ -1,0 +1,5 @@
+package au.csiro.data61.magda.indexer.helpers
+
+class ElasticSearchIndexerTest {
+
+}

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/ElasticSearchIndexerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/ElasticSearchIndexerTest.scala
@@ -1,5 +1,0 @@
-package au.csiro.data61.magda.indexer.helpers
-
-class ElasticSearchIndexerTest {
-
-}

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -23,61 +23,53 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val config: Config = ConfigFactory.load()
 
-  private var ssc: StreamSourceController = None.orNull
   private var sc: StreamController = None.orNull
-
-  private val tokenOption1 = Some("token1")
-  private val dataSet1 =
-    DataSet(identifier = "d1", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
-  private val dataSet2 =
-    DataSet(identifier = "d2", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
-  private val dataSets1: Seq[DataSet] = List(dataSet1, dataSet2)
-
+  private val tokenOption1 = Some("token")
   private val tokenOption2 = None
-  private val dataSet3 =
-    DataSet(identifier = "d3", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
-  private val dataSet4 =
-    DataSet(identifier = "d4", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
-  private val dataSets2: Seq[DataSet] = List(dataSet3, dataSet4)
+  private val batchSize = 2
+  private var dataSets: Seq[DataSet] = Seq()
 
   override def afterEach(): Unit = {
     super.afterEach()
-    val (actorRef, _) = ssc.refAndSource
+    val actorRef = sc.getActorRef
     actorRef ! PoisonPill
   }
 
   class MockRegistryInterface extends RegistryInterface {
     private var callCount = 0
+    private var nextIndex = 0
+
     override def getDataSetsReturnToken(start: Int, size: Int)
     : Future[(Option[String], List[DataSet])] = {
-
+      assert (start == 0)
       callCount += 1
-      Future.successful(tokenOption1, dataSets1.toList)
+      nextIndex = size
+      Future.successful(tokenOption1, dataSets.slice(start, size).toList)
     }
 
     override def getDataSetsToken(token: String, size: Int)
     : Future[(Option[String], List[DataSet])] = {
-      if (callCount == 1){
-        callCount += 1
-        Future.successful(tokenOption2, dataSets2.toList)
+      callCount += 1
+      if (callCount * batchSize < dataSets.size){
+        val startIndex = nextIndex
+        val endIndex = startIndex + size
+        nextIndex = endIndex
+        Future.successful(tokenOption1, dataSets.slice(startIndex, endIndex).toList)
       }
       else {
-        callCount += 1
         Future.successful(tokenOption2, Nil)
       }
     }
   }
 
-  class MockIndexer(streamController: StreamController) extends SearchIndexer{
+  class MockIndexer(streamController: StreamController, batchSize: Int) extends SearchIndexer{
     private var dataSetCount = 0
-    private val batchSize = 2
     private val buffer = new ListBuffer[Promise[Unit]]()
 
     override def index(source: Source[DataSet, NotUsed]): Future[SearchIndexer.IndexResult] = {
-      streamController.start(batchSize)
+      streamController.start()
       val indexResults = source
         .map(dataSet => {
-          println(s"Received: $dataSet")
           (dataSet.uniqueId, index(dataSet))
         })
         .runWith(Sink.fold(Future(SearchIndexer.IndexResult(0, Seq()))) {
@@ -103,8 +95,12 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
       if (dataSetCount % batchSize == 0) {
         buffer.toList.foreach(promise => promise.success())
         buffer.clear()
-        println("Request next batch")
         streamController.next(batchSize)
+      }
+      else if (dataSetCount >= streamController.getTotalDataSetsNum) {
+        buffer.toList.foreach(promise => promise.success())
+        buffer.clear()
+        streamController.terminate()
       }
 
       promise.future
@@ -131,49 +127,38 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  "The stream controller" should "control the simple stream flow" in {
-
-    // Create the stream source.
-    ssc = new StreamSourceController()
-    val (_, source) = ssc.refAndSource
-
-    val mockRegistryInterface = new MockRegistryInterface()
-    sc = new StreamController(mockRegistryInterface, ssc)
-
-    // Start the stream.
-    val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
-
-    // Fill the stream source.
-    val initF = sc.start(2)
-
-    // Fill the stream source, usually caused by feedback from the stream Sink.
-    val nextF = initF.flatMap(_ => sc.next(2))
-
-    // Fill the stream source, may caused by feedback from the stream Sink.
-    // Because tokenOption is None, it will terminate the stream.
-    // Do this after some delay to simulate stream processing.
-    Thread.sleep(500)
-    nextF.map(_ => sc.next( 2))
-
-    nextF.map(tokenOption => tokenOption shouldEqual tokenOption2)
-
-    actualDataSetsF.flatMap(dataSets => dataSets shouldEqual dataSets1 ++ dataSets2)
+  private def createDataSets(num: Int): Seq[DataSet] = {
+    val range = 1 to num
+    range.foldLeft(Seq[DataSet]()){
+      case (acc, e) =>
+        acc ++ Seq(
+          DataSet(identifier = s"d$e", catalog = Some("c"), quality = 1.0D, score = Some(1.0F)))
+    }
   }
 
   "The stream controller" should "support the indexer stream" in {
-
-    // Create the stream source.
-    ssc = new StreamSourceController()
-    val (_, source) = ssc.refAndSource
-
+    val dataSetNum = 8
+    dataSets = createDataSets(dataSetNum)
     val mockRegistryInterface = new MockRegistryInterface()
-    sc = new StreamController(mockRegistryInterface, ssc)
-    val mockIndexer = new MockIndexer(sc)
-
-    // Start the stream.
-    val indexResultF: Future[SearchIndexer.IndexResult] = mockIndexer.index(source)
+    sc = new StreamController(mockRegistryInterface, batchSize)
+    val source = sc.getSource
+    val mockIndexer = new MockIndexer(sc, batchSize)
+    val indexResultF: Future[IndexResult] = mockIndexer.index(source)
 
     indexResultF.map(indexResult =>
-      indexResult shouldEqual IndexResult(dataSets1.size + dataSets2.size, List()))
+      indexResult shouldEqual IndexResult(dataSets.size, List()))
+  }
+
+  "The stream controller" should "support the indexer stream again" in {
+    val dataSetNum = 9
+    dataSets = createDataSets(dataSetNum)
+    val mockRegistryInterface = new MockRegistryInterface()
+    sc = new StreamController(mockRegistryInterface, batchSize)
+    val source = sc.getSource
+    val mockIndexer = new MockIndexer(sc, batchSize)
+    val indexResultF: Future[IndexResult] = mockIndexer.index(source)
+
+    indexResultF.map(indexResult =>
+      indexResult shouldEqual IndexResult(dataSets.size, List()))
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -1,0 +1,179 @@
+package au.csiro.data61.magda.indexer.helpers
+
+import java.time.OffsetDateTime
+
+import akka.NotUsed
+import akka.actor.{ActorSystem, PoisonPill}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import au.csiro.data61.magda.indexer.search.SearchIndexer
+import au.csiro.data61.magda.indexer.search.SearchIndexer.IndexResult
+import au.csiro.data61.magda.model.misc.DataSet
+import au.csiro.data61.magda.search.elasticsearch.Indices
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfterEach, Matchers}
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
+
+class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAfterEach {
+
+  implicit val system: ActorSystem = ActorSystem("StreamControllerTest")
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val config: Config = ConfigFactory.load()
+
+  private var ssc: StreamSourceController = None.orNull
+  private var sc: StreamController = None.orNull
+
+  private val tokenOption1 = Some("token1")
+  private val dataSet1 =
+    DataSet(identifier = "d1", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSet2 =
+    DataSet(identifier = "d2", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSets1: Seq[DataSet] = List(dataSet1, dataSet2)
+
+  private val tokenOption2 = None
+  private val dataSet3 =
+    DataSet(identifier = "d3", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSet4 =
+    DataSet(identifier = "d4", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSets2: Seq[DataSet] = List(dataSet3, dataSet4)
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    val (actorRef, _) = ssc.refAndSource
+    actorRef ! PoisonPill
+  }
+
+  class MockRegistryInterface extends RegistryInterface {
+    private var callCount = 0
+    override def getDataSetsReturnToken(start: Int, size: Int)
+    : Future[(Option[String], List[DataSet])] = {
+
+      callCount += 1
+      Future.successful(tokenOption1, dataSets1.toList)
+    }
+
+    override def getDataSetsToken(token: String, size: Int)
+    : Future[(Option[String], List[DataSet])] = {
+      if (callCount == 1){
+        callCount += 1
+        Future.successful(tokenOption2, dataSets2.toList)
+      }
+      else {
+        callCount += 1
+        Future.successful(tokenOption2, Nil)
+      }
+    }
+  }
+
+  class MockIndexer(streamController: StreamController) extends SearchIndexer{
+    private var dataSetCount = 0
+    private val batchSize = 2
+    private val buffer = new ListBuffer[Promise[Unit]]()
+
+    override def index(source: Source[DataSet, NotUsed]): Future[SearchIndexer.IndexResult] = {
+      streamController.start(batchSize)
+      val indexResults = source
+        .map(dataSet => {
+          println(s"Received: $dataSet")
+          (dataSet.uniqueId, index(dataSet))
+        })
+        .runWith(Sink.fold(Future(SearchIndexer.IndexResult(0, Seq()))) {
+          case (combinedResultFuture, (thisResultIdentifier, thisResultFuture)) =>
+            combinedResultFuture.flatMap { combinedResult =>
+              thisResultFuture.map { _ =>
+                combinedResult.copy(successes = combinedResult.successes + 1)
+              }.recover {
+                case _: Throwable =>
+                  combinedResult.copy(failures = combinedResult.failures :+ thisResultIdentifier)
+              }
+            }
+        })
+
+      indexResults.flatMap(identity)
+    }
+
+    private def index(dataSet: DataSet, promise: Promise[Unit] = Promise[Unit]): Future[Unit] = {
+      dataSetCount += 1
+      buffer.append(promise)
+
+      // Simulate batch processing
+      if (dataSetCount % batchSize == 0) {
+        buffer.toList.foreach(promise => promise.success())
+        buffer.clear()
+        println("Request next batch")
+        streamController.next(batchSize)
+      }
+
+      promise.future
+    }
+
+    override def delete(identifiers: Seq[String]): Future[Unit] = {
+      throw new Exception("delete() not implemented")
+    }
+
+    override def snapshot(): Future[Unit] = {
+      throw new Exception("snapshot() not implemented")
+    }
+
+    override def ready: Future[Unit] = {
+      throw new Exception("ready() not implemented")
+    }
+
+    override def trim(before: OffsetDateTime): Future[Unit] = {
+      throw new Exception("trim() not implemented")
+    }
+
+    override def isEmpty(index: Indices.Index): Future[Boolean] = {
+      throw new Exception("isEmpty() not implemented")
+    }
+  }
+
+  "The stream controller" should "control the simple stream flow" in {
+
+    // Create the stream source.
+    ssc = new StreamSourceController()
+    val (_, source) = ssc.refAndSource
+
+    val mockRegistryInterface = new MockRegistryInterface()
+    sc = new StreamController(mockRegistryInterface, ssc)
+
+    // Start the stream.
+    val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
+
+    // Fill the stream source.
+    val initF = sc.start(2)
+
+    // Fill the stream source, usually caused by feedback from the stream Sink.
+    val nextF = initF.flatMap(_ => sc.next(2))
+
+    // Fill the stream source, may caused by feedback from the stream Sink.
+    // Because tokenOption is None, it will terminate the stream.
+    // Do this after some delay to simulate stream processing.
+    Thread.sleep(500)
+    nextF.map(_ => sc.next( 2))
+
+    nextF.map(tokenOption => tokenOption shouldEqual tokenOption2)
+
+    actualDataSetsF.flatMap(dataSets => dataSets shouldEqual dataSets1 ++ dataSets2)
+  }
+
+  "The stream controller" should "support the indexer stream" in {
+
+    // Create the stream source.
+    ssc = new StreamSourceController()
+    val (_, source) = ssc.refAndSource
+
+    val mockRegistryInterface = new MockRegistryInterface()
+    sc = new StreamController(mockRegistryInterface, ssc)
+    val mockIndexer = new MockIndexer(sc)
+
+    // Start the stream.
+    val indexResultF: Future[SearchIndexer.IndexResult] = mockIndexer.index(source)
+
+    indexResultF.map(indexResult =>
+      indexResult shouldEqual IndexResult(dataSets1.size + dataSets2.size, List()))
+  }
+}

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.{Assertion, AsyncFlatSpec, BeforeAndAfterEach, Matchers}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
 
-class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAfterEach {
+class StreamControllerTest extends AsyncFlatSpec with Matchers {
 
   implicit val system: ActorSystem = ActorSystem("StreamControllerTest")
   implicit val ec: ExecutionContextExecutor = system.dispatcher
@@ -27,11 +27,6 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
 
   private var sc: StreamController = None.orNull
   private var dataSets: Seq[DataSet] = Seq()
-
-  override def afterEach(): Unit = {
-    super.afterEach()
-    sc.getActorRef ! PoisonPill
-  }
 
   class MockRegistryInterface extends RegistryInterface {
     private val nextIndex = new AtomicInteger(0)

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -30,7 +30,6 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
 
   override def afterEach(): Unit = {
     super.afterEach()
-    sc.asActor ! PoisonPill
     sc.getActorRef ! PoisonPill
   }
 
@@ -87,7 +86,6 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     private val batchProcessingSize = 4
 
     override def index(source: Source[DataSet, NotUsed]): Future[SearchIndexer.IndexResult] = {
-//      streamController.start()
       val indexResults = source.buffer(bufferSize, OverflowStrategy.backpressure)
         .map(dataSet => {
           (dataSet.uniqueId, index(dataSet))
@@ -108,7 +106,6 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     }
 
     private def index(dataSet: DataSet, promise: Promise[Unit] = Promise[Unit]): Future[Unit] = {
-      Thread.sleep(1000)
       dataSetCount.incrementAndGet()
       buffer.append(promise)
 
@@ -165,7 +162,7 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     val mockIndexer = new MockIndexer(2)
     val indexResultF: Future[IndexResult] = mockIndexer.index(source)
 
-    sc.asActor ! "start"
+    sc.start()
 
     indexResultF.map(indexResult =>
       indexResult shouldEqual IndexResult(dataSets.size, List()))

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -1,6 +1,7 @@
 package au.csiro.data61.magda.indexer.helpers
 
 import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
 import akka.actor.{ActorSystem, PoisonPill}
@@ -24,53 +25,69 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
   implicit val config: Config = ConfigFactory.load()
 
   private var sc: StreamController = None.orNull
-  private val tokenOption1 = Some("token")
-  private val tokenOption2 = None
-  private val batchSize = 3
   private var dataSets: Seq[DataSet] = Seq()
 
   override def afterEach(): Unit = {
     super.afterEach()
-    val actorRef = sc.getActorRef
-    actorRef ! PoisonPill
+    sc.asActor ! PoisonPill
+    sc.getActorRef ! PoisonPill
   }
 
   class MockRegistryInterface extends RegistryInterface {
-    private var callCount = 0
-    private var nextIndex = 0
+    private val nextIndex = new AtomicInteger(0)
+    private val dataSetCount = new AtomicInteger(0)
 
     override def getDataSetsReturnToken(start: Int, size: Int)
     : Future[(Option[String], List[DataSet])] = {
       assert (start == 0)
-      callCount += 1
-      nextIndex = size
-      Future.successful(tokenOption1, dataSets.slice(start, size).toList)
+      nextIndex.set(size)
+      val batch = dataSets.slice(start, size).toList
+      dataSetCount.addAndGet(batch.size)
+      val token = s"token $size"
+      val tokenOption = if (batch.size < size || batch.size == dataSets.size) None else Some(token)
+//      println(s"* start: $start, end: $size, batch: ${batch.size}, " +
+//        s"fetch: ${dataSetCount.get()}, token: $tokenOption")
+
+      Future.successful(tokenOption, batch)
     }
 
     override def getDataSetsToken(token: String, size: Int)
     : Future[(Option[String], List[DataSet])] = {
       assert (token.nonEmpty)
-      callCount += 1
-      if (callCount * size < dataSets.size){
-        val startIndex = nextIndex
-        val endIndex = startIndex + size
-        nextIndex = endIndex
-        val batch = dataSets.slice(startIndex, endIndex).toList
-        val tokenOption = if (startIndex + batchSize < dataSets.size) tokenOption1 else tokenOption2
-        Future.successful(tokenOption, batch)
-      }
-      else {
-        Future.successful(tokenOption2, Nil)
-      }
+
+      val startIndex = nextIndex.get()
+      var endIndex = startIndex + size
+
+      if (endIndex > dataSets.size)
+        endIndex = dataSets.size
+
+      nextIndex.set(endIndex)
+      val batch = dataSets.slice(startIndex, endIndex).toList
+      dataSetCount.addAndGet(batch.size)
+
+      val tokenOption =
+        if (startIndex >= dataSets.size ||
+          batch.size < size ||
+          batch.size == size && endIndex == dataSets.size)
+          None
+        else
+          Some(s"token ${dataSetCount.get()}")
+
+//      println(s"** start: $startIndex, end: $endIndex, batch: ${batch.size}, " +
+//        s"fetch: ${dataSetCount.get()}, token: $tokenOption")
+
+      Future.successful(tokenOption, batch)
     }
   }
 
-  class MockIndexer(streamController: StreamController, batchSize: Int) extends SearchIndexer{
-    private var dataSetCount = 0
+  class MockIndexer(streamController: StreamController) extends SearchIndexer{
+    private val dataSetCount = new AtomicInteger(0)
     private val buffer = new ListBuffer[Promise[Unit]]()
+    private val batchProcessingSize = 4
 
     override def index(source: Source[DataSet, NotUsed]): Future[SearchIndexer.IndexResult] = {
-      streamController.start()
+//      streamController.start()
+      streamController.asActor ! "start"
       val indexResults = source
         .map(dataSet => {
           (dataSet.uniqueId, index(dataSet))
@@ -91,20 +108,18 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     }
 
     private def index(dataSet: DataSet, promise: Promise[Unit] = Promise[Unit]): Future[Unit] = {
-      dataSetCount += 1
+      dataSetCount.incrementAndGet()
       buffer.append(promise)
 
-      if (dataSetCount % batchSize == 0) {
-        // Simulate batch processing
-        buffer.toList.foreach(promise => promise.success())
-        buffer.clear()
-        streamController.next(batchSize)
-      }
-      else if (dataSetCount == streamController.getTotalDataSetsNum) {
+      if (dataSetCount.get() == dataSets.size) {
         // Simulate non-full batch processing
         buffer.toList.foreach(promise => promise.success())
         buffer.clear()
-        streamController.next(batchSize)
+      }
+      else if (dataSetCount.get() % batchProcessingSize == 0) {
+        // Simulate batch processing
+        buffer.toList.foreach(promise => promise.success())
+        buffer.clear()
       }
 
       promise.future
@@ -140,23 +155,66 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAft
     }
   }
 
+  private val bufferSize = 8
   private def run(dataSetNum: Int): Future[Assertion] = {
     dataSets = createDataSets(dataSetNum)
     val mockRegistryInterface = new MockRegistryInterface()
-    sc = new StreamController(mockRegistryInterface, batchSize)
+    sc = new StreamController(mockRegistryInterface, bufferSize)
     val source = sc.getSource
-    val mockIndexer = new MockIndexer(sc, batchSize)
+    val mockIndexer = new MockIndexer(sc)
     val indexResultF: Future[IndexResult] = mockIndexer.index(source)
 
     indexResultF.map(indexResult =>
       indexResult shouldEqual IndexResult(dataSets.size, List()))
   }
 
-  "The stream controller" should "support the indexer stream" in {
-    run(dataSetNum = 17)
+  "The stream controller" should "support the indexer stream 1" in {
+    val numOfDataSets = 10 * bufferSize - 1
+    run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream again" in {
-    run(dataSetNum = 12)
+  "The stream controller" should "support the indexer stream 2" in {
+    val numOfDataSets = 10 * bufferSize
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 3" in {
+    val numOfDataSets = 10 * bufferSize + 1
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 4" in {
+    val numOfDataSets = bufferSize - 1
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 5" in {
+    val numOfDataSets = bufferSize
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 6" in {
+    val numOfDataSets = bufferSize + 1
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 7" in {
+    val numOfDataSets = bufferSize / 2 - 1
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 8" in {
+    val numOfDataSets = bufferSize / 2
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 9" in {
+    val numOfDataSets = bufferSize / 2 + 1
+    run(numOfDataSets)
+  }
+
+  "The stream controller" should "support the indexer stream 10" in {
+    val numOfDataSets = 1
+    run(numOfDataSets)
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -4,16 +4,16 @@ import java.time.OffsetDateTime
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
-import akka.actor.{ActorSystem, PoisonPill}
-import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{ActorMaterializer, OverflowStrategy}
 import au.csiro.data61.magda.client.RegistryInterface
 import au.csiro.data61.magda.indexer.search.SearchIndexer
 import au.csiro.data61.magda.indexer.search.SearchIndexer.IndexResult
 import au.csiro.data61.magda.model.misc.DataSet
 import au.csiro.data61.magda.search.elasticsearch.Indices
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{Assertion, AsyncFlatSpec, BeforeAndAfterEach, Matchers}
+import org.scalatest.{Assertion, AsyncFlatSpec, Matchers}
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
@@ -163,53 +163,58 @@ class StreamControllerTest extends AsyncFlatSpec with Matchers {
       indexResult shouldEqual IndexResult(dataSets.size, List()))
   }
 
-  "The stream controller" should "support the indexer stream 1" in {
+  "The stream controller" should "support the indexer stream when the dataset number is 1"  in {
+    val numOfDataSets = 1
+    run(numOfDataSets)
+  }
+
+  it should "support the indexer stream when the dataset number is 0"  in {
+    val numOfDataSets = 0
+    run(numOfDataSets)
+  }
+
+  it should "support the indexer stream when the dataset number is 10 * bufferSize - 1" in {
     val numOfDataSets = 10 * bufferSize - 1
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 2" in {
+  it should "support the indexer stream when the dataset number is 10 * bufferSize"  in {
     val numOfDataSets = 10 * bufferSize
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 3" in {
+  it should "support the indexer stream when the dataset number is 10 * bufferSize + 1" in {
     val numOfDataSets = 10 * bufferSize + 1
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 4" in {
+  it should "support the indexer stream when the dataset number is bufferSize - 1" in {
     val numOfDataSets = bufferSize - 1
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 5" in {
+  it should "support the indexer stream when the dataset number is bufferSize"  in {
     val numOfDataSets = bufferSize
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 6" in {
+  it should "support the indexer stream when the dataset number is bufferSize + 1"  in {
     val numOfDataSets = bufferSize + 1
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 7" in {
+  it should "support the indexer stream when the dataset number is bufferSize / 2 - 1"  in {
     val numOfDataSets = bufferSize / 2 - 1
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 8" in {
+  it should "support the indexer stream when the dataset number is bufferSize / 2"  in {
     val numOfDataSets = bufferSize / 2
     run(numOfDataSets)
   }
 
-  "The stream controller" should "support the indexer stream 9" in {
+  it should "support the indexer stream when the dataset number is bufferSize / 2 + 1"  in {
     val numOfDataSets = bufferSize / 2 + 1
-    run(numOfDataSets)
-  }
-
-  "The stream controller" should "support the indexer stream 10" in {
-    val numOfDataSets = 1
     run(numOfDataSets)
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -48,13 +48,11 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
   "The stream source controller" should "fill the source after the stream starts" in {
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     ssc.fillSource(dataSets, false, true)
-//    ssc.terminate()
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before the stream starts" in {
     ssc.fillSource(dataSets, false, true)
-//    ssc.terminate()
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
@@ -63,7 +61,6 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
     ssc.fillSource(dataSets, true, true)
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     ssc.fillSource(dataSets, false, false)
-//    ssc.terminate()
     actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -1,0 +1,89 @@
+package au.csiro.data61.magda.indexer.helpers
+
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorSystem, PoisonPill}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import au.csiro.data61.magda.model.misc.DataSet
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{AsyncFlatSpec, _}
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with BeforeAndAfterEach {
+
+  implicit val system: ActorSystem = ActorSystem("StreamSourceControllerTest")
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val config: Config = ConfigFactory.load()
+
+  private var ssc: StreamSourceController = None.orNull
+  private var actorRef: ActorRef = None.orNull
+  private var source: Source[DataSet, NotUsed] = None.orNull
+
+  private val dataSet1 =
+    DataSet(identifier = "d1", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSet2 =
+    DataSet(identifier = "d2", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+  private val dataSet3 =
+    DataSet(identifier = "d3", catalog = Some("c"), quality = 1.0D, score = Some(1.0F))
+
+  private val dataSets: Seq[DataSet] = List(dataSet1, dataSet2, dataSet3)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ssc = new StreamSourceController(None.orNull, None.orNull)
+    val (ref, src) = ssc.refAndSource
+    actorRef = ref
+    source = src
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    actorRef ! PoisonPill
+  }
+
+  "The stream source controller" should "fill the source after the stream starts" in {
+    // take(dataSets.size) in order to terminate the stream automatically
+    // so that actualDataSetsF can complete.
+    val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
+
+    // Fill the source.
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+
+    actualDataSetsF.map(actual => actual shouldEqual dataSets)
+  }
+
+  it should "fill the source before the stream starts" in {
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+    val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
+    actualDataSetsF.map(actual => actual shouldEqual dataSets)
+  }
+
+  it should "fill the source before and after the stream starts" in {
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+    val actualDataSetsF: Future[Seq[DataSet]] = source.take(2*dataSets.size).runWith(Sink.seq)
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+    actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
+  }
+
+  it should "be able to terminate the stream explicitly" in {
+    // Fill the source.
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+
+    // Run the stream.
+    val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
+
+    // Fill more to the source.
+    dataSets.foreach(dataSet => actorRef ! dataSet)
+
+    // No more data to fill the source, terminate the stream so that actualDataSetsF can complete.
+    // Call terminate() after some delay in order to give some time for actualDataSetsF to run.
+    // If calling terminate() without delay, the future may complete before the stream gets a
+    // chance to run, resulting in an empty actualDataSetsF.
+    Thread.sleep(500)
+    ssc.terminate()
+
+    actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
+  }
+}

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -30,9 +30,11 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
 
   private val dataSets: Seq[DataSet] = List(dataSet1, dataSet2, dataSet3)
 
+  private val sourceBufferSize = 2 * dataSets.size
+
   override def beforeEach(): Unit = {
     super.beforeEach()
-    ssc = new StreamSourceController()
+    ssc = new StreamSourceController(sourceBufferSize)
     val (ref, src) = ssc.refAndSource
     actorRef = ref
     source = src

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -30,11 +30,11 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
 
   private val dataSets: Seq[DataSet] = List(dataSet1, dataSet2, dataSet3)
 
-  private val sourceBufferSize = 2 * dataSets.size
+  private val sourceBufferSize = dataSets.size * 2
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    ssc = new StreamSourceController(sourceBufferSize)
+    ssc = new StreamSourceController(sourceBufferSize, None.orNull)
     val (ref, src) = ssc.refAndSource
     actorRef = ref
     source = src
@@ -47,23 +47,23 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
 
   "The stream source controller" should "fill the source after the stream starts" in {
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
-    ssc.fillSource(dataSets)
-    ssc.terminate()
+    ssc.fillSource(dataSets, false, true)
+//    ssc.terminate()
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before the stream starts" in {
-    ssc.fillSource(dataSets)
-    ssc.terminate()
+    ssc.fillSource(dataSets, false, true)
+//    ssc.terminate()
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before and after the stream starts" in {
-    ssc.fillSource(dataSets)
+    ssc.fillSource(dataSets, true, true)
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
-    ssc.fillSource(dataSets)
-    ssc.terminate()
+    ssc.fillSource(dataSets, false, false)
+//    ssc.terminate()
     actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -46,41 +46,24 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
   }
 
   "The stream source controller" should "fill the source after the stream starts" in {
-    // take(dataSets.size) in order to terminate the stream automatically
-    // so that actualDataSetsF can complete.
-    val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
-
+    val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     ssc.fillSource(dataSets)
-
+    ssc.terminate()
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before the stream starts" in {
     ssc.fillSource(dataSets)
-    val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
+    ssc.terminate()
+    val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before and after the stream starts" in {
     ssc.fillSource(dataSets)
-    val actualDataSetsF: Future[Seq[DataSet]] = source.take(2*dataSets.size).runWith(Sink.seq)
-    ssc.fillSource(dataSets)
-    actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
-  }
-
-  it should "be able to terminate the stream explicitly" in {
-
-    ssc.fillSource(dataSets)
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
     ssc.fillSource(dataSets)
-
-    // No more data to fill the source, terminate the stream so that actualDataSetsF can complete.
-    // Call terminate() after some delay in order to give some time for actualDataSetsF to run.
-    // If calling terminate() without delay, the future may complete before the stream gets a
-    // chance to run, resulting in an empty actualDataSetsF.
-    Thread.sleep(500)
     ssc.terminate()
-
     actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
   }
 }

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamSourceControllerTest.scala
@@ -32,7 +32,7 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    ssc = new StreamSourceController(None.orNull, None.orNull)
+    ssc = new StreamSourceController()
     val (ref, src) = ssc.refAndSource
     actorRef = ref
     source = src
@@ -48,34 +48,29 @@ class StreamSourceControllerTest extends AsyncFlatSpec with Matchers with Before
     // so that actualDataSetsF can complete.
     val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
 
-    // Fill the source.
-    dataSets.foreach(dataSet => actorRef ! dataSet)
+    ssc.fillSource(dataSets)
 
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before the stream starts" in {
-    dataSets.foreach(dataSet => actorRef ! dataSet)
+    ssc.fillSource(dataSets)
     val actualDataSetsF: Future[Seq[DataSet]] = source.take(dataSets.size).runWith(Sink.seq)
     actualDataSetsF.map(actual => actual shouldEqual dataSets)
   }
 
   it should "fill the source before and after the stream starts" in {
-    dataSets.foreach(dataSet => actorRef ! dataSet)
+    ssc.fillSource(dataSets)
     val actualDataSetsF: Future[Seq[DataSet]] = source.take(2*dataSets.size).runWith(Sink.seq)
-    dataSets.foreach(dataSet => actorRef ! dataSet)
+    ssc.fillSource(dataSets)
     actualDataSetsF.map(actual => actual shouldEqual dataSets ++ dataSets)
   }
 
   it should "be able to terminate the stream explicitly" in {
-    // Fill the source.
-    dataSets.foreach(dataSet => actorRef ! dataSet)
 
-    // Run the stream.
+    ssc.fillSource(dataSets)
     val actualDataSetsF: Future[Seq[DataSet]] = source.runWith(Sink.seq)
-
-    // Fill more to the source.
-    dataSets.foreach(dataSet => actorRef ! dataSet)
+    ssc.fillSource(dataSets)
 
     // No more data to fill the source, terminate the stream so that actualDataSetsF can complete.
     // Call terminate() after some delay in order to give some time for actualDataSetsF to run.

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -24,7 +24,17 @@ import com.auth0.jwt.JWT
 import au.csiro.data61.magda.Authentication
 import akka.http.scaladsl.model.headers.RawHeader
 
-class RegistryExternalInterface(httpFetcher: HttpFetcher)(implicit val config: Config, implicit val system: ActorSystem, implicit val executor: ExecutionContext, implicit val materializer: Materializer) extends RegistryConverters {
+trait RegistryInterface {
+  def getDataSetsReturnToken(start: Long, size: Int): Future[(Option[String], List[DataSet])]
+  def getDataSetsToken(token: String, size: Int): Future[(Option[String], List[DataSet])]
+}
+
+class RegistryExternalInterface(httpFetcher: HttpFetcher)
+                               (implicit val config: Config,
+                                implicit val system: ActorSystem,
+                                implicit val executor: ExecutionContext,
+                                implicit val materializer: Materializer)
+  extends RegistryConverters with RegistryInterface{
   def this()(implicit config: Config, system: ActorSystem, executor: ExecutionContext, materializer: Materializer) = {
     this(HttpFetcher(new URL(config.getString("registry.baseUrl"))))(config, system, executor, materializer)
   }


### PR DESCRIPTION
### What this PR does

Fixes #1628

The original design might cause out-of-memory error if the number of datasets is larger than what the memory can hold. The back-pressure was not functioning as expected too. To solve the problems, I designed a new stream source. The source can be filled with datasets even after the stream is running. The number of datasets fetched from the database depends on the indexing speed. Therefore the resource usage is very minimal.

There are some remaining jobs that could be done separately. They are marked as "TODO"s.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
