### PR TITLE
Issue/1880 Mobile Header Not show up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@
 -   Made access notes show up on distribution page with configurable text
 -   Added contact point to distribution page, made title configurable
 -   When `match-part` search strategy is used, a message is shown on UI
+-   Fixed mobile menu not show-up properly
 
 ## 0.0.49
 

--- a/magda-web-client/src/Components/Header/Header.js
+++ b/magda-web-client/src/Components/Header/Header.js
@@ -99,7 +99,7 @@ class Header extends Component {
                                                         <HeaderNav
                                                             isMobile={true}
                                                             headerNavigation={
-                                                                this.state
+                                                                this.props
                                                                     .headerNavigation
                                                             }
                                                         />


### PR DESCRIPTION
### What this PR does

Fixes #1880 

Seems had this issue fixed via https://github.com/magda-io/magda/pull/1819/files But one commit lost somehow.

Probably a good idea to double check relevant merge.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
