### PR TITLE
Issue/1896 Fixed an issue that static page content won't be loaded if switch between static pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@
 -   Added contact point to distribution page, made title configurable
 -   When `match-part` search strategy is used, a message is shown on UI
 -   Fixed mobile menu not show-up properly
+-   Fixed an issue that static page content won't be loaded if switch between static pages
 
 ## 0.0.49
 


### PR DESCRIPTION
### What this PR does

Fixes #1896 

Fixed an issue that static page content won't be loaded if switch between static pages

Based on branch release/0.0.50 as it's a release blocker

### Checklist

-   [ ] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
