### PR TITLE
Fixed: indexer throws an error when processes spatial data number with more than one decimal places

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 -   Fixed chart won't displayed correctly under IE11
 -   Fixed stream processing issue when re-indexing, mitigating out-of-memory risk too
 -   Fixed index trimming failure issue when re-indexing
+-   Fixed: indexer throws an error when processes spatial data number with more than one decimal places
 
 ## 0.0.50
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/WebhookApi.scala
@@ -27,7 +27,7 @@ class WebhookApi(indexer: SearchIndexer)(implicit system: ActorSystem, config: C
   /**
   * @apiGroup Indexer
   * @api {post} http://indexer/v0/registry-hook Hook endpoint (internal)
-  * 
+  *
   * @apiDescription Registry webhook endpoint - accepts webhook payloads from the registry.
   *   This generally means datasets from the registry as they're updated. This shouldn't
   *   be called manually, it's purely for registry use.
@@ -62,13 +62,13 @@ class WebhookApi(indexer: SearchIndexer)(implicit system: ActorSystem, config: C
             case None | Some(Nil) => Future.successful(Unit)
             case Some(list) =>
               val dataSets = list.map(record => try {
-                Some(convertRegistryDataSet(record))
+                Some(convertRegistryDataSet(record, Some(system.log)))
               } catch {
                 case CausedBy(e: spray.json.DeserializationException) =>
                   system.log.error(e, "When converting {}", record.id)
                   None
               })
-              
+
               indexer.index(Source(dataSets.flatten))
           }
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -286,16 +286,20 @@ object Generators {
     geoJson <- someBiasedOption(geometryGen)
     shouldGenerateInvalidDecimals <- arbitrary[Boolean]
   } yield {
-    val text = geoJson.map(_.toJson.toString).map { jsonString =>
-      if (!shouldGenerateInvalidDecimals) {
-        jsonString
-      } else {
-        /**
-          * Add extra invalid decimal places to simulate the possible poor geoJson data
-          * e.g. 123.34.22
-          * */
-        jsonString.replaceAll("(\\d+\\.\\d)(\\d+)", "$1.$2")
-      }
+    val text = geoJson.map(_.toJson.toString)
+      .map { jsonString =>
+        if (!shouldGenerateInvalidDecimals) {
+          jsonString
+        } else {
+          /**
+            * Add extra invalid decimal places to simulate the possible poor geoJson data
+            * e.g. 123.34.22
+            * */
+          jsonString
+            // --- add extra decimal places
+            // --- please note: this will not be valid json anymore
+            .replaceAll("(\\d+\\.\\d)(\\d+)", "$1.$2")
+        }
     }
     new Location(text, geoJson)
   }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -61,7 +61,7 @@ class RegistryExternalInterface(httpFetcher: HttpFetcher)
       response.status match {
         case OK => Unmarshal(response.entity).to[RegistryRecordsResponse].map { registryResponse =>
           (registryResponse.nextPageToken, mapCatching[Record, DataSet](registryResponse.records,
-            { hit => convertRegistryDataSet(hit) },
+            { hit => convertRegistryDataSet(hit, Some(logger)) },
             { (e, item) => logger.error(e, "Could not parse item: {}", item.toString) }))
         }
         case _ => Unmarshal(response.entity).to[String].flatMap(onError(response))
@@ -74,7 +74,7 @@ class RegistryExternalInterface(httpFetcher: HttpFetcher)
       response.status match {
         case OK => Unmarshal(response.entity).to[RegistryRecordsResponse].map { registryResponse =>
           (registryResponse.nextPageToken, mapCatching[Record, DataSet](registryResponse.records,
-            { hit => convertRegistryDataSet(hit) },
+            { hit => convertRegistryDataSet(hit, Some(logger)) },
             { (e, item) => logger.error(e, "Could not parse item: {}", item.toString) }))
         }
         case _ => Unmarshal(response.entity).to[String].flatMap(onError(response))

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -10,6 +10,7 @@ import au.csiro.data61.magda.model.GeoJsonFormats._
 import au.csiro.data61.magda.model.Temporal._
 import spray.json._
 import scala.runtime.ScalaRunTime
+import scala.util.{ Failure, Success, Try }
 
 package misc {
   sealed trait FacetType {
@@ -128,25 +129,24 @@ package misc {
       val string = stringWithNewLines.replaceAll("[\\n\\r]", " ")
       Location.applySanitised(string, string match {
         case geoJsonPattern() => {
-          Some(Protocols.GeometryFormat.read(string.parseJson))
+          val json = Try(string.parseJson) match {
+            case Success(json) => json
+            case Failure(e) =>
+              CoordinateFormat.quoteNumbersInJson(string).parseJson
+          }
+          Some(Protocols.GeometryFormat.read(json))
         }
         case emptyPolygonPattern() => None
         case csvPattern(a) =>
-          val latLongs = string.split(",").map(BigDecimal.apply)
+          val latLongs = string.split(",").map(str => CoordinateFormat.convertStringToBigDecimal(str))
           fromBoundingBox(Seq(BoundingBox(latLongs(0), latLongs(1), latLongs(2), latLongs(3))))
         case polygonPattern(polygonCoords, _) =>
           val coords = polygonCoords.split(",")
             .map { stringCoords =>
-              val Array(x, y) = stringCoords.trim.split("\\s").map { str =>
-                // --- remove possible redundant dot in number string
-                val parts = str.split("\\.")
-                if (parts.length > 2) {
-                  // --- drop all dots except the first one
-                  parts.take(2).mkString(".") + parts.drop(2).mkString
-                } else {
-                  str
-                }
-              }.map(_.toDouble)
+              val Array(x, y) = stringCoords
+                                  .trim
+                                  .split("\\s")
+                                  .map(str => CoordinateFormat.convertStringToBigDecimal(str))
               Coordinate(x, y)
             }.toSeq
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -137,7 +137,16 @@ package misc {
         case polygonPattern(polygonCoords, _) =>
           val coords = polygonCoords.split(",")
             .map { stringCoords =>
-              val Array(x, y) = stringCoords.trim.split("\\s").map(_.toDouble)
+              val Array(x, y) = stringCoords.trim.split("\\s").map { str =>
+                // --- remove possible redundant dot in number string
+                val parts = str.split("\\.")
+                if (parts.length > 2) {
+                  // --- drop all dots except the first one
+                  parts.take(2).mkString(".") + parts.drop(2).mkString
+                } else {
+                  str
+                }
+              }.map(_.toDouble)
               Coordinate(x, y)
             }.toSeq
 


### PR DESCRIPTION
### What this PR does

Fixes #1918 

Fixed: indexer throws an error when processes spatial data number with more than one decimal places

More details see issue description.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
