### PR TITLE
Issue/1916 Fixed: Error messages are not associated with their form fields on suggest dataset form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 -   Fixed chart won't displayed correctly under IE11
 -   Fixed stream processing issue when re-indexing, mitigating out-of-memory risk too
 -   Fixed index trimming failure issue when re-indexing
+-   Fixed: Error messages are not associated with their form fields on suggest dataset form
 
 ## 0.0.50
 

--- a/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
+++ b/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
@@ -156,9 +156,17 @@ export default class RequestFormTemplate extends React.Component {
                     onChange={this.handleInputChange}
                     type="text"
                     placeholder={this.props.textAreaPlaceHolder}
+                    {...(this.state.messageValid
+                        ? {}
+                        : {
+                              "aria-describedby": "messageFieldDescription"
+                          })}
                 />
                 {!this.state.messageValid && (
-                    <label className="correspondence-field-error">
+                    <label
+                        id="messageFieldDescription"
+                        className="correspondence-field-error"
+                    >
                         Please enter a valid message
                     </label>
                 )}
@@ -177,9 +185,17 @@ export default class RequestFormTemplate extends React.Component {
                             : "au-text-input--invalid")
                     }
                     placeholder={this.props.namePlaceHolder}
+                    {...(this.state.senderNameValid
+                        ? {}
+                        : {
+                              "aria-describedby": "senderNameFieldDescription"
+                          })}
                 />
                 {!this.state.senderNameValid && (
-                    <label className="correspondence-field-error">
+                    <label
+                        id="senderNameFieldDescription"
+                        className="correspondence-field-error"
+                    >
                         Please enter a name
                     </label>
                 )}
@@ -197,9 +213,18 @@ export default class RequestFormTemplate extends React.Component {
                             : "au-text-input--invalid")
                     }
                     placeholder={this.props.emailPlaceHolder}
+                    {...(this.state.senderEmailValid
+                        ? {}
+                        : {
+                              "aria-describedby": "senderEmailFieldDescription"
+                          })}
                 />
                 {!this.state.senderEmailValid && (
-                    <label className="correspondence-field-error">
+                    <label
+                        id="senderEmailFieldDescription"
+                        className="correspondence-field-error"
+                        aria-describedby="senderEmail"
+                    >
                         Email is invalid
                     </label>
                 )}

--- a/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
+++ b/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
@@ -159,12 +159,12 @@ export default class RequestFormTemplate extends React.Component {
                     {...(this.state.messageValid
                         ? {}
                         : {
-                              "aria-describedby": "messageFieldDescription"
+                              "aria-describedby": "messageFieldError"
                           })}
                 />
                 {!this.state.messageValid && (
                     <label
-                        id="messageFieldDescription"
+                        id="messageFieldError"
                         className="correspondence-field-error"
                     >
                         Please enter a valid message
@@ -188,12 +188,12 @@ export default class RequestFormTemplate extends React.Component {
                     {...(this.state.senderNameValid
                         ? {}
                         : {
-                              "aria-describedby": "senderNameFieldDescription"
+                              "aria-describedby": "senderNameFieldError"
                           })}
                 />
                 {!this.state.senderNameValid && (
                     <label
-                        id="senderNameFieldDescription"
+                        id="senderNameFieldError"
                         className="correspondence-field-error"
                     >
                         Please enter a name
@@ -216,12 +216,12 @@ export default class RequestFormTemplate extends React.Component {
                     {...(this.state.senderEmailValid
                         ? {}
                         : {
-                              "aria-describedby": "senderEmailFieldDescription"
+                              "aria-describedby": "senderEmailFieldError"
                           })}
                 />
                 {!this.state.senderEmailValid && (
                     <label
-                        id="senderEmailFieldDescription"
+                        id="senderEmailFieldError"
                         className="correspondence-field-error"
                         aria-describedby="senderEmail"
                     >


### PR DESCRIPTION
### What this PR does

Fixes #1916 

Fixed: Error messages are not associated with their form fields on suggest dataset form

The recommendation solution seems not right --- `aria-describedby` should be on input field to have error message label to describe the input field rather than the other way round. 

Tested on mac voiceover mode (turn on using Command + F5)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
