### PR TITLE
Issue/1942 added `cloudsql-db-credentials` to create-secrets tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 -   Fixed: Error messages are not associated with their form fields on suggest dataset form
 -   Added shortcut to build create secrets script for magda-config repo
 -   Added preemption priority classes
+-   Added `cloudsql-db-credentials` to create-secrets tool
+-   Fixed an file selector error when current directory & non of its sub directory has \*.json file
 
 ## 0.0.50
 

--- a/scripts/create-secrets/askQuestions.js
+++ b/scripts/create-secrets/askQuestions.js
@@ -52,6 +52,14 @@ const questions = [
         when: onlyAvailableForGoogleCloud
     },
     {
+        type: "input",
+        name: "cloudsql-db-credentials",
+        message: "Please provide default google cloud SQL service DB password:",
+        when: onlyWhenQuestion("use-cloudsql-instance-credentials", true),
+        validate: input =>
+            trim(input).length ? true : "Default password cannot be empty!"
+    },
+    {
         type: "list",
         dataType: "boolean",
         name: "reselect-cloudsql-instance-credentials",

--- a/scripts/create-secrets/k8sExecution.js
+++ b/scripts/create-secrets/k8sExecution.js
@@ -98,6 +98,9 @@ function doK8sExecution(config, shouldNotAsk = false) {
                 "credentials.json",
                 configData["cloudsql-instance-credentials"]["data"]
             );
+            createSecret(env, namespace, "cloudsql-db-credentials", {
+                password: configData["cloudsql-db-credentials"]
+            });
         }
 
         if (configData["use-storage-account-credentials"] === true) {

--- a/scripts/create-secrets/prompts/inquirer-fuzzy-path.js
+++ b/scripts/create-secrets/prompts/inquirer-fuzzy-path.js
@@ -36,6 +36,9 @@ class InquirerFuzzyPath extends InquirerAutocomplete {
                     this.currentChoices,
                     choiceIndex
                 );
+                if (!choice) {
+                    return null;
+                }
                 return {
                     value: stripAnsi(choice.value),
                     name: stripAnsi(choice.name),
@@ -47,13 +50,18 @@ class InquirerFuzzyPath extends InquirerAutocomplete {
 
     onSubmit(line) {
         if (typeof this.opt.validate === "function") {
+            const choice = this.currentChoices.getChoice(this.selected);
+            if (!choice) {
+                this.render(
+                    "You need to select a file. Make sure the json file is in current directory or its sub-directory"
+                );
+                return;
+            }
             var validationResult = this.opt.validate(
                 this.currentChoices.getChoice(this.selected)
             );
             if (validationResult !== true) {
-                this.render(
-                    validationResult || "Enter something, tab to autocomplete!"
-                );
+                this.render(validationResult || "You need to select a file");
                 return;
             }
         }

--- a/scripts/create-secrets/prompts/inquirer-fuzzy-path.js
+++ b/scripts/create-secrets/prompts/inquirer-fuzzy-path.js
@@ -53,11 +53,11 @@ class InquirerFuzzyPath extends InquirerAutocomplete {
             const choice = this.currentChoices.getChoice(this.selected);
             if (!choice) {
                 this.render(
-                    "You need to select a file. Make sure the json file is in current directory or its sub-directory"
+                    "You need to select a file. Make sure the json file is in the current directory or its sub-directory"
                 );
                 return;
             }
-            var validationResult = this.opt.validate(
+            const validationResult = this.opt.validate(
                 this.currentChoices.getChoice(this.selected)
             );
             if (validationResult !== true) {


### PR DESCRIPTION
### What this PR does

Fixes #1942 

Changes Summary:
- added `cloudsql-db-credentials` to create-secrets tool
- Currently, if there is no *.json in current directory or any its sub directory, the file selector will report an error:
```
>> TypeError: Cannot read property 'value' of null
```
I've changed this to make sure a proper error message will be displayed:
```
>> You need to select a file. Make sure the json file is in the current directory or its sub-directory
```

Tested on local `minikube` cluster

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
