### PR TITLE
Made statefulsets end up on non-preemptible node in dev

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 -   Fixed: Error messages are not associated with their form fields on suggest dataset form
 -   Added shortcut to build create secrets script for magda-config repo
 -   Added preemption priority classes
+-   Added ability to add fully customised affinity to statefulsets in helm
 
 ## 0.0.50
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -71,7 +71,12 @@ combined-db:
       fileName: TerriaJS-5e042b649f8a.json
   data:
     storage: 250Gi
-  antiPreemptibleAffinity: 100
+  affinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: cloud.google.com/gke-preemptible
+            operator: DoesNotExist
 
 elasticsearch:
   data:
@@ -80,7 +85,12 @@ elasticsearch:
     googleApplicationCreds:
       secretName: storage-account-credentials
       fileName: db-service-account-private-key.json
-  antiPreemptibleAffinity: 99
+  affinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: cloud.google.com/gke-preemptible
+            operator: DoesNotExist
 
 indexer:
   readSnapshots: false

--- a/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: authorization-db
         resources:

--- a/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: authorization-db
         resources:

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: combined-db
         resources:

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: combined-db
         resources:

--- a/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: content-db
         resources:

--- a/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/content-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: content-db
         resources:

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -21,7 +21,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50

--- a/deploy/helm/magda/charts/priorities/templates/magda-0.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-0.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 0
 globalDefault: true
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-1.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-1.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 10000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-10.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-10.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 100000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-2.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-2.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 20000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-3.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-3.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 30000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-4.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-4.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 40000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-5.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-5.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 50000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-6.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-6.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 60000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-7.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-7.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 70000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-8.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-8.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 80000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/priorities/templates/magda-9.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-9.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1" }}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 90000000
 globalDefault: false
 description: "Ordered importance class 1-10"
+{{- end }}

--- a/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: registry-db
         resources:

--- a/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: registry-db
         resources:

--- a/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
+{{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: session-db
         resources:

--- a/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/session-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 60
       affinity:
-        {{ include "magda.antiPreemptibleAffinity" . }}
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: session-db
         resources:

--- a/deploy/helm/magda/requirements.yaml
+++ b/deploy/helm/magda/requirements.yaml
@@ -86,6 +86,11 @@ dependencies:
     tags:
       - minion-visualization
 
+# K8s misc
+  - name: priorities
+    tags:
+      - all
+      - priorities
   - name: ingress
     tags:
       - ingress

--- a/deploy/helm/magda/templates/_helpers.tpl
+++ b/deploy/helm/magda/templates/_helpers.tpl
@@ -216,16 +216,3 @@ spec:
               - key: "{{ .jobConfig.id }}.json"
                 path: "connector.json"
 {{- end }}
-
-
-{{- define "magda.antiPreemptibleAffinity" }}
-        {{- if .Values.antiPreemptibleAffinity }}
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: cloud.google.com/gke-preemptible
-                operator: DoesNotExist
-            weight: {{ .Values.antiPreemptibleAffinity }}
-        {{- end }}
-{{- end }}

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -40,4 +40,4 @@ tags:
   web-server: false
   ingress: false
   connectors: false
-  priorities: true
+  priorities: false


### PR DESCRIPTION
### What this PR does

Right now despite node affinity and node priority, the statefulsets in dev are still ending up on preemptible nodes and getting shut down and started back up all the time, which is super annoying.

Turns out that this is because preferred affinity isn't enough to actually combined with node priority and preemption - in order to kick less important pods off the single expensive non-preemptible instance in dev, a pod has to be unschedulable. So this changes the affinity to required, meaning that the es and postgres pods won't be scheduled in dev unless they're on the non-preemptible node.

In order to make this easier to customise, I've just allowed additions to the affinity to be added as yaml instead of as preference weight. 

I've also added priorities to `tags.all` because it stops pods from deploying successfully without it.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
(no issue, this is more an ops thing)
