### PR TITLE
Issue/1913 Improve the accessibility of the Recent Searches dropdown

### DIFF
--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -12,7 +12,7 @@ import searchDark from "../../assets/search-purple.svg";
 import PropTypes from "prop-types";
 import queryString from "query-string";
 import SearchSuggestionBox from "./SearchSuggestionBox";
-import { Small, Medium } from "../../UI/Responsive";
+import { Small } from "../../UI/Responsive";
 import stripFiltersFromQuery from "./stripFiltersFromQuery";
 import { withRouter } from "react-router-dom";
 import MagdaNamespacesConsumer from "../../Components/i18n/MagdaNamespacesConsumer";
@@ -168,6 +168,7 @@ class SearchBox extends Component {
                 aria-owns="search-history-items"
                 aria-activedescendant={this.state.selectedId}
                 aria-expanded={this.state.isFocus}
+                aria-controls="search-suggestion-box"
             />
         );
     }

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -36,7 +36,8 @@ class SearchBox extends Component {
             searchText: null,
             width: 0,
             height: 0,
-            isFocus: false
+            isFocus: false,
+            selectedId: null
         };
         this.searchInputFieldRef = null;
         props.history.listen(location => {
@@ -151,9 +152,19 @@ class SearchBox extends Component {
                         isFocus: false
                     })
                 }
+                role="combobox"
+                aria-autocomplete="list"
+                aria-owns="search-history-items"
+                aria-activedescendant={this.state.selectedId}
             />
         );
     }
+
+    onSelectedIdChange = newId => {
+        this.setState({
+            selectedId: newId
+        });
+    };
 
     render() {
         const suggestionBox = (
@@ -161,6 +172,7 @@ class SearchBox extends Component {
                 searchText={this.getSearchBoxValue()}
                 isSearchInputFocus={this.state.isFocus}
                 inputRef={this.searchInputFieldRef}
+                onSelectedIdChange={this.onSelectedIdChange}
             />
         );
 
@@ -171,7 +183,9 @@ class SearchBox extends Component {
                     <div className="searchBox">
                         <label htmlFor="search">
                             <span className="sr-only">
-                                {"Search " + translate(["appName", ""])}
+                                {"Search " +
+                                    translate(["appName", ""]) +
+                                    ", use arrow keys to browse search history"}
                             </span>
                             <Medium>
                                 <div style={{ position: "relative" }}>

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -160,7 +160,8 @@ class SearchSuggestionBox extends Component {
         ) {
             this.props.onSelectedIdChange &&
                 this.props.onSelectedIdChange(
-                    this.state.selectedItemIdx
+                    this.state.selectedItemIdx ||
+                    this.state.selectedItemIdx === 0
                         ? this.buildOptionId(
                               this.state.selectedItemIdx,
                               this.state.deleteSelected
@@ -314,6 +315,8 @@ class SearchSuggestionBox extends Component {
                     manuallyHidden: true
                 });
                 break;
+            default:
+                break;
         }
     }
 
@@ -358,6 +361,7 @@ class SearchSuggestionBox extends Component {
             <div
                 className="search-suggestion-box"
                 ref={el => (this.containerRef = el)}
+                id="search-suggestion-box"
             >
                 <div className="search-suggestion-box-position-adjust" />
                 <div
@@ -370,7 +374,11 @@ class SearchSuggestionBox extends Component {
                             Recent Searches
                         </h5>
                     </Medium>
-                    <ul id="search-history-items" role="listbox">
+                    <ul
+                        id="search-history-items"
+                        role="listbox"
+                        className="search-history-items"
+                    >
                         {recentSearchItems.map((item, idx) => (
                             <li
                                 key={idx}
@@ -388,12 +396,19 @@ class SearchSuggestionBox extends Component {
                                 />
                                 <button
                                     role="option"
+                                    aria-selected={
+                                        this.state.selectedItemIdx === idx &&
+                                        !this.state.deleteSelected
+                                    }
                                     id={this.buildOptionId(idx)}
                                     className="au-btn au-btn--tertiary search-item-main-button"
                                     onClick={e =>
                                         this.onSearchItemClick(e, item)
                                     }
                                 >
+                                    <span className="sr-only">
+                                        Recent search item
+                                    </span>
                                     <Medium>
                                         <MarkdownViewer
                                             markdown={this.createSearchItemLabelText(
@@ -412,6 +427,11 @@ class SearchSuggestionBox extends Component {
                                 </button>
                                 <button
                                     id={this.buildOptionId(idx, true)}
+                                    role="option"
+                                    aria-selected={
+                                        this.state.deleteSelected &&
+                                        this.state.selectedItemIdx === idx
+                                    }
                                     className={`au-btn au-btn--tertiary search-item-delete-button ${
                                         this.state.deleteSelected &&
                                         this.state.selectedItemIdx === idx
@@ -423,7 +443,9 @@ class SearchSuggestionBox extends Component {
                                     }
                                 >
                                     <img
-                                        alt="delete search item"
+                                        alt={`delete recent search item ${this.createSearchItemLabelText(
+                                            item
+                                        )}`}
                                         src={closeIcon}
                                     />
                                 </button>

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
@@ -52,6 +52,10 @@
                 height: 13px;
                 opacity: 0.5;
             }
+
+            &--selected.search-item-delete-button {
+                background: #f2f2f2 !important;
+            }
         }
         .search-item-container {
             position: relative;

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
@@ -68,6 +68,11 @@
         .recent-item-icon {
             padding: 8px;
         }
+
+        .search-history-items {
+            list-style: none;
+            padding: 0;
+        }
     }
 
     .selected {

--- a/magda-web-client/src/storage/localStorage.js
+++ b/magda-web-client/src/storage/localStorage.js
@@ -87,7 +87,7 @@ export function prependToLocalStorageArray(
  * @param {*} defaultValue Returned if localStorage isn't available on window
  */
 export function deleteFromLocalStorageArray(key, index, defaultValue = []) {
-    if (!noLocalStorage) return defaultValue;
+    if (noLocalStorage) return defaultValue;
     let items = retrieveLocalData(key);
     items.splice(index, 1);
     try {


### PR DESCRIPTION
### What this PR does

Fixes #1913 

- Makes the search box into an aria combobox and lets a screen reader user know to use the arrow keys to flip through them
- Puts all the aria stuff in place so that the screen reader reads out the choices as they move the arrow keys
- Makes it so you can use the right/left keys to toggle between deleting recent searches and searching them
- Makes the ESC key close the recent searches dialog
- Stops the search from auto-submitting if it's still blank

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
