### PR TITLE
Added nodeAffinity prefix to dev affinity declarations.

### DIFF
--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -72,25 +72,27 @@ combined-db:
   data:
     storage: 250Gi
   affinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-          - key: cloud.google.com/gke-preemptible
-            operator: DoesNotExist
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: DoesNotExist
 
 elasticsearch:
   data:
     heapSize: 500m
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: DoesNotExist
   backup:
     googleApplicationCreds:
       secretName: storage-account-credentials
       fileName: db-service-account-private-key.json
-  affinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-          - key: cloud.google.com/gke-preemptible
-            operator: DoesNotExist
 
 indexer:
   readSnapshots: false

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -21,8 +21,8 @@ spec:
       priorityClassName: magda-9
       terminationGracePeriodSeconds: 10
       affinity:
-{{- if .Values.affinity }}
-{{ toYaml .Values.affinity | indent 8 }}
+{{- if .Values.data.affinity }}
+{{ toYaml .Values.data.affinity | indent 8 }}
 {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/helm/magda/charts/priorities/templates/magda-0.yaml
+++ b/deploy/helm/magda/charts/priorities/templates/magda-0.yaml
@@ -4,6 +4,5 @@ kind: PriorityClass
 metadata:
   name: magda-0
 value: 0
-globalDefault: true
 description: "Ordered importance class 1-10"
 {{- end }}


### PR DESCRIPTION
### What this PR does
So these failed when they got to dev, turns out I somehow messed up the k8s declaration for node affinity (by leaving out `nodeAffinity` at the last moment and kubernetes didn't throw a proper error for it for some reason (it just resolved to `{}`). This makes it work properly.