### PR TITLE
Removed .bin extensions from logo headers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 -   Only runtime dependencies will be included by docker image build script
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Fixed an file selector error when current directory & non of its sub directory has \*.json file
+-   Removed the .bin extension from the logo
 
 ## 0.0.50
 

--- a/magda-web-client/src/config.js
+++ b/magda-web-client/src/config.js
@@ -87,8 +87,8 @@ export const config = {
         { id: "temporal", component: Temporal },
         { id: "format", component: Format }
     ],
-    headerLogoUrl: `${contentApiURL}header/logo.bin`,
-    headerMobileLogoUrl: `${contentApiURL}header/logo-mobile.bin`,
+    headerLogoUrl: `${contentApiURL}header/logo`,
+    headerMobileLogoUrl: `${contentApiURL}header/logo-mobile`,
     contentUrl: `${contentApiURL}all?id=home/*&id=footer/*&id=config/*&id=header/*&inline=true`,
     fallbackUrl: serverConfig.fallbackUrl,
     months: [


### PR DESCRIPTION
### What this PR does

Fixes #1946 

Right now the .bin extension on the logo is being blocked on the agriculture network. Turns out everything works fine if you just trim the .bin off. Wish every issue was this easy.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
