### PR TITLE
Made client send a GA event when chart fails to render.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 -   Only runtime dependencies will be included by docker image build script
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Fixed an file selector error when current directory & non of its sub directory has \*.json file
+-   Added google analytics event when chart fails to load
 
 ## 0.0.50
 

--- a/magda-web-client/src/UI/DataPreviewChart.js
+++ b/magda-web-client/src/UI/DataPreviewChart.js
@@ -7,6 +7,8 @@ import downArrowIcon from "../assets/downArrow.svg";
 import upArrowIcon from "../assets/upArrow.svg";
 import AUpageAlert from "../pancake/react/page-alerts";
 import memoize from "memoize-one";
+import { gapi } from "../analytics/ga";
+
 import "./DataPreviewChart.css";
 
 let ReactEcharts = null;
@@ -113,6 +115,16 @@ class DataPreviewChart extends Component {
                         error: e
                     })
                 );
+
+                gapi.event({
+                    category: "Error",
+                    action: `Failed to display chart for ${
+                        window.location.href
+                    }: ${e.message}`,
+                    label: "Chart Display Failure",
+                    nonInteraction: true
+                });
+
                 // if there is error, automatically switch to table view
                 switchTabOnFirstGo(this.props);
             }


### PR DESCRIPTION
### What this PR does

Fixes #1936 

Adds a GA event that triggers when the chart fails to load, with details of the error and where it happened.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
