### PR TITLE
Change search selection color for non-home pages Fixes #1948

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.0.51
 
+-   Change search selection color for non-home pages
 -   Changed the migrators to look for "password" instead of "postgres-password" in the cloudsql-db-credentials secret.
 -   Add readiness and liveness probes to all services
 -   Got screen reader to say "Open Data Quality: 3/5 stars" instead of repeating star rating text

--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -191,3 +191,12 @@
         color: rgba($AU-color-foreground-action, 0.6);
     }
 }
+
+.other-page {
+    .searchBox {
+        ::selection {
+            background: rgba(#ffffff, 0.4) !important;
+            color: #ffffff !important;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does

Fixes #1948

Change search selection color for non-home page

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
