### PR TITLE
Made the data quality tooltip read itself out for screen readers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 -   Only runtime dependencies will be included by docker image build script
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Fixed an file selector error when current directory & non of its sub directory has \*.json file
+-   Made the data quality tooltip read its contents out, and link to the data quality page.
 
 ## 0.0.50
 

--- a/magda-web-client/src/UI/DataQualityTooltip.js
+++ b/magda-web-client/src/UI/DataQualityTooltip.js
@@ -12,11 +12,13 @@ export default function DataQualityTooltip(props) {
         <Tooltip
             className="data-quality-tooltip"
             launcher={() => (
-                <img
-                    className="data-quality-tooltip-launcher"
-                    src={helpIcon}
-                    alt="Help Link"
-                />
+                <Link to="/page/dataset-quality">
+                    <img
+                        className="data-quality-tooltip-launcher"
+                        src={helpIcon}
+                        alt="Calculated using the open data scale, click for more information"
+                    />
+                </Link>
             )}
             innerElementClassName="data-quality-tooltip-inner"
         >


### PR DESCRIPTION
### What this PR does

Fixes #1909 

In order to make the tooltip (effectively) work for screen readers, I've made the contents of the tooltip automatically get read out when it's focused, and clicking will take you to the quality page just like if a sighted user clicked the link.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
