### PR TITLE
Stopped focus going back to the top of the page after the search box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 -   Only runtime dependencies will be included by docker image build script
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Fixed an file selector error when current directory & non of its sub directory has \*.json file
+-   Stopped tab order reverting to body after tabbing through the search box
 
 ## 0.0.50
 

--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -108,7 +108,6 @@
         cursor: pointer;
         text-decoration: none;
         margin: 0px;
-        outline: none;
         font-size: 0px;
         font-weight: inherit;
         overflow: visible;

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -294,7 +294,6 @@ class SearchSuggestionBox extends Component {
             <div
                 className="search-suggestion-box"
                 ref={el => (this.containerRef = el)}
-                tabIndex={999}
             >
                 <div className="search-suggestion-box-position-adjust" />
                 <div
@@ -324,6 +323,7 @@ class SearchSuggestionBox extends Component {
                             <button
                                 className="au-btn au-btn--tertiary search-item-main-button"
                                 onClick={e => this.onSearchItemClick(e, item)}
+                                tabIndex={-1}
                             >
                                 <Medium>
                                     <MarkdownViewer
@@ -342,6 +342,7 @@ class SearchSuggestionBox extends Component {
                             <button
                                 className="au-btn au-btn--tertiary search-item-delete-button"
                                 onClick={e => this.onDeleteItemClick(e, idx)}
+                                tabIndex={-1}
                             >
                                 <img alt="delete search item" src={closeIcon} />
                             </button>


### PR DESCRIPTION
### What this PR does

Fixes #1910 

Right now when you tab past the search box, the focus returns to `<body>`. This is because the next element in the tab order is inside the recent searches dropdown, but that's removed from the DOM when the searchbox `<input>` is blurred, hence forcing the browser to go back to the `<body>`. Modern browsers handle this gracefully, but once the body is focused on ie it restarts the tab order, meaning that focus can't ever go past the search box if there's recent searches.

This sets `taborder="-1"` on all the focusable elements in the recent searches dropdown, so that tabbing out of the searchbox doesn't try to focus any of them. It also reinstates the `outline` on the search button so that it can be easily seen when tabbed to.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
