### PR TITLE
Made the "Go to Navigation" skiplink go to the first nav item.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 -   Only runtime dependencies will be included by docker image build script
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Fixed an file selector error when current directory & non of its sub directory has \*.json file
+-   Made the "Skip to Navigation" skip link go to the first navigation item rather than trying to target the wrapping `<div>`
 
 ## 0.0.50
 

--- a/magda-web-client/src/Components/Account/AccountNavbar.js
+++ b/magda-web-client/src/Components/Account/AccountNavbar.js
@@ -15,7 +15,7 @@ class AccountNavbar extends React.Component {
             <React.Fragment>
                 {this.props.user ? (
                     [
-                        <li key="/account">
+                        <li key="/account" id={this.props.skipLink && "nav"}>
                             <NavLink to={`/account`}>
                                 <span>{this.props.user.displayName}</span>
                             </NavLink>
@@ -28,7 +28,10 @@ class AccountNavbar extends React.Component {
                     ]
                 ) : (
                     <li key="/account">
-                        <NavLink to={`/account`}>
+                        <NavLink
+                            to={`/account`}
+                            id={this.props.skipLink && "nav"}
+                        >
                             <span>Sign In</span>
                         </NavLink>
                     </li>

--- a/magda-web-client/src/Components/Header/HeaderNav.js
+++ b/magda-web-client/src/Components/Header/HeaderNav.js
@@ -24,6 +24,7 @@ const headerNavigationPlugins = {
                         target={opts.target}
                         rel={opts.rel}
                         title={`Go to ${nav.label}`}
+                        id={i === 0 && "nav"}
                     >
                         <span>{nav.label}</span>
                     </Link>
@@ -35,7 +36,7 @@ const headerNavigationPlugins = {
         config.disableAuthenticationFeatures ? (
             <span key={i} />
         ) : (
-            <AccountNavbar key={i} />
+            <AccountNavbar key={i} skipLink={i === 0} />
         )
 };
 
@@ -50,7 +51,7 @@ function invokeHeaderNavigationPlugin(nav, i) {
 class HeaderNav extends Component {
     render() {
         return (
-            <nav className="navigation header-nav" id="nav">
+            <nav className="navigation header-nav">
                 <ul
                     className={`au-link-list ${
                         this.props.isMobile ? "" : "au-link-list--inline"


### PR DESCRIPTION
### What this PR does

Fixes #1906 

Currently the "Skip to navigation" link doesn't work, because it goes to the `<div>` that wraps the header which can't get focus. This changes it to go to the first link in the nav.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
