### PR TITLE
Remove HTTPS upgrade from new Gateway Health Checks

### DIFF
--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: "magda"
 description: "A complete solution for managing, publishing and discovering government data, private and open."
-version: "0.0.51-0"
+version: "0.0.51-RC1"
 home: "https://github.com/TerriaJS/magda"
 sources: ["https://github.com/TerriaJS/magda"]

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -52,7 +52,7 @@ spec:
           httpGet:
             path: /_cluster/health
             port: http
-          initialDelaySeconds: 20
+          initialDelaySeconds: 120
           timeoutSeconds: 5
 {{- if .Values.global.enableLivenessProbes }}
         livenessProbe:

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -6,7 +6,7 @@ global:
     maxUnavailable: 0
   exposeNodePorts: false
   image:
-    tag: 0.0.51-0
+    tag: 0.0.51-RC1
     repository: "data61"
     pullPolicy: IfNotPresent
   defaultAdminUserId: "00000000-0000-4000-8000-000000000000"

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/deploy",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "MAGDA deployment configuration.",
   "scripts": {
     "create-connector-configmap": "kubectl delete configmap connector-config --ignore-not-found && kubectl create configmap connector-config --from-file ./connector-config/",
@@ -13,7 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "fs-extra": "^2.1.2",
     "klaw-sync": "^2.1.0",
     "tmp": "0.0.31",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["deploy/", "magda-*", "scripts/"],
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "hoist": [
     "tsmonad",
     "urijs",
@@ -22,7 +22,7 @@
     "eslint-config-react-app",
     "babel-eslint"
   ],
-  "commands": {
+  "command": {
     "docker-build-prod": {
       "ignore": ["magda-authorization-db", "magda-authorization-api"]
     }

--- a/magda-admin-api/package.json
+++ b/magda-admin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/admin-api",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -13,19 +13,19 @@
     "retag-and-push": "retag-and-push"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.13.2",
     "express": "^4.13.1",
     "http-proxy": "^1.16.2",
     "isomorphic-fetch": "^2.2.1",
     "kubernetes-client": "3.17.2",
     "lodash": "^4.17.4",
+    "nyc": "^13.1.0",
     "util.promisify": "^1.0.0",
-    "yargs": "^8.0.2",
-    "nyc": "^13.1.0"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.4",
     "@types/config": "0.0.32",
     "@types/express": "^4.0.35",

--- a/magda-apidocs-server/package.json
+++ b/magda-apidocs-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/apidocs-server",
   "description": "The MAGDA in-browser api documentation.",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "generate-api-documentation --config ./apidoc.json --output ./build",
@@ -10,7 +10,7 @@
     "retag-and-push": "retag-and-push"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "config": {
     "docker": {

--- a/magda-authorization-api/package.json
+++ b/magda-authorization-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/authorization-api",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -13,17 +13,17 @@
     "retag-and-push": "retag-and-push"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.13.2",
     "express": "^4.13.1",
     "jsonwebtoken": "^7.4.1",
+    "lodash": "^4.17.4",
     "pg": "^6.4.0",
     "tsmonad": "^0.7.2",
-    "yargs": "^8.0.2",
-    "lodash": "^4.17.4"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.1.2",
     "@types/express": "^4.0.35",
     "@types/lodash": "^4.14.96",

--- a/magda-builder-docker/package.json
+++ b/magda-builder-docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/builder-docker",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Builder image for nodejs magda projects",
   "scripts": {
     "docker-build-prod": "create-docker-context-for-node-component --build --push",
@@ -16,8 +16,8 @@
     }
   },
   "devDependencies": {
-    "@magda/builder-nodejs": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/builder-nodejs": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-builder-nodejs/package.json
+++ b/magda-builder-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/builder-nodejs",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Builder image for nodejs magda projects",
   "scripts": {
     "docker-build-prod": "create-docker-context-for-node-component --build --push",
@@ -16,7 +16,7 @@
     }
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-builder-scala/package.json
+++ b/magda-builder-scala/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/builder-scala",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Builder image for scala magda projects",
   "scripts": {
     "docker-build-prod": "create-docker-context-for-node-component --build --push",
@@ -16,8 +16,8 @@
     }
   },
   "devDependencies": {
-    "@magda/builder-docker": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/builder-docker": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-ckan-connector/package.json
+++ b/magda-ckan-connector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/ckan-connector",
   "description": "MAGDA CKAN Connector",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "yarn run compile-node && yarn run compile-browser",
@@ -18,7 +18,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/express": "^4.0.37",
     "@types/node": "^8.0.14",
     "@types/read-pkg-up": "^3.0.1",
@@ -33,16 +33,16 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.18.1",
     "express": "^4.15.4",
+    "isomorphic-fetch": "^2.2.1",
     "moment": "^2.17.1",
     "read-pkg-up": "^3.0.0",
     "request": "^2.79.0",
     "urijs": "^1.18.12",
-    "yargs": "^8.0.1",
-    "isomorphic-fetch": "^2.2.1"
+    "yargs": "^8.0.1"
   },
   "config": {
     "registryUrl": "http://localhost:6101/v0",

--- a/magda-content-api/package.json
+++ b/magda-content-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/content-api",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -13,7 +13,7 @@
     "retag-and-push": "retag-and-push"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.13.2",
     "djv": "^2.1.1",
     "express": "^4.13.1",
@@ -25,7 +25,7 @@
     "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.1.2",
     "@types/express": "^4.0.35",
     "@types/lodash": "^4.14.96",
@@ -38,15 +38,13 @@
     "@types/supertest": "^2.0.4",
     "@types/urijs": "^1.15.38",
     "@types/yargs": "^8.0.2",
-    "@types/mime-types": "^2.1.0",
-    "@types/urijs": "^1.15.38",
     "chai": "^4.1.2",
     "mocha": "^3.5.3",
     "nock": "^9.1.6",
+    "nyc": "^13.1.0",
     "sinon": "^4.2.1",
     "supertest": "^3.0.0",
-    "typescript": "~2.5.0",
-    "nyc": "^13.1.0"
+    "typescript": "~2.5.0"
   },
   "config": {
     "docker": {

--- a/magda-correspondence-api/package.json
+++ b/magda-correspondence-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/correspondence-api",
   "description": "MAGDA correspondence API",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -15,7 +15,7 @@
     "retag-and-push": "retag-and-push"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.13.2",
     "email-validator": "^2.0.3",
     "express": "^4.13.1",
@@ -36,7 +36,7 @@
     "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.1.3",
     "@types/email-validator": "^1.0.6",
     "@types/express": "^4.0.35",

--- a/magda-csv-connector/package.json
+++ b/magda-csv-connector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/csv-connector",
   "description": "MAGDA Csv/Xlsx/Ods etc data catalog Connector",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "yarn run compile-node && yarn run compile-browser",
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/jsonpath": "^0.1.29",
     "@types/lodash": "^4.14.66",
     "@types/node": "^8.0.14",
@@ -32,8 +32,8 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "escape-html": "^1.0.3",
     "jsonpath": "^0.2.11",
     "read-pkg-up": "^3.0.0",

--- a/magda-csw-connector/package.json
+++ b/magda-csw-connector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/csw-connector",
   "description": "MAGDA OGC Catalogue Service for the Web (CSW) Connector",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "yarn run compile-node && yarn run compile-browser",
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/jsonpath": "^0.1.29",
     "@types/lodash": "^4.14.66",
     "@types/nock": "^9.3.0",
@@ -34,8 +34,8 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "jsonpath": "^0.2.11",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/magda-dap-connector/package.json
+++ b/magda-dap-connector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/dap-connector",
   "description": "MAGDA DAP Connector",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "yarn run compile-node && yarn run compile-browser",
@@ -17,7 +17,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/express": "^4.0.37",
     "@types/node": "^8.0.14",
     "@types/read-pkg-up": "^3.0.1",
@@ -32,11 +32,11 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
-    "isomorphic-fetch": "^2.2.1",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.18.1",
     "express": "^4.15.4",
+    "isomorphic-fetch": "^2.2.1",
     "moment": "^2.17.1",
     "read-pkg-up": "^3.0.0",
     "request": "^2.79.0",

--- a/magda-db-migrator/package.json
+++ b/magda-db-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/db-migrator",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "A base Docker image for PostgreSQL with Flyway for schema migrations.",
   "scripts": {
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
@@ -17,7 +17,7 @@
     }
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-elastic-search/package.json
+++ b/magda-elastic-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/elastic-search",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "MAGDA's custom elasticsearch docker image.",
   "scripts": {
     "dev": "create-pod-and-forward --configuration ../deploy/kubernetes/local/base/elasticsearch.yml --selector component=elasticsearch --port 9300",
@@ -57,7 +57,7 @@
     }
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/gateway",
   "description": "The public gateway to all of MAGDA, including the API and web front end.",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -15,7 +15,7 @@
     "test": "mocha --compilers ts:ts-node/register,tsx:ts-node/register --require tsconfig-paths/register \"src/test/**/*.spec.ts\""
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.13.2",
     "cheerio": "^0.22.0",
     "compression": "^1.7.2",
@@ -43,13 +43,13 @@
     "passport-local": "^1.0.0",
     "pg": "^6.4.0",
     "read-pkg-up": "^3.0.0",
+    "request": "^2.79.0",
     "tsmonad": "^0.7.2",
     "urijs": "^1.18.12",
-    "yargs": "^8.0.2",
-    "request": "^2.79.0"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.1",
     "@types/compression": "^0.0.36",
     "@types/cors": "^2.8.1",

--- a/magda-gateway/src/createApiRouter.ts
+++ b/magda-gateway/src/createApiRouter.ts
@@ -8,11 +8,6 @@ import buildJwt from "@magda/typescript-common/dist/session/buildJwt";
 import createBaseProxy from "./createBaseProxy";
 import Authenticator from "./Authenticator";
 
-import {
-    installStatusRouter,
-    createServiceProbe
-} from "@magda/typescript-common/dist/express/status";
-
 export interface ProxyTarget {
     to: string;
     methods?: string[];
@@ -35,14 +30,6 @@ export default function createApiRouter(options: ApiRouterOptions): Router {
     const jwtSecret = options.jwtSecret;
 
     const router: Router = express.Router();
-
-    const probes: any = {};
-
-    _.forEach(options.routes, (value: ProxyTarget, key: string) => {
-        probes[key] = createServiceProbe(value.to);
-    });
-
-    installStatusRouter(router, { probes });
 
     proxy.on("proxyReq", (proxyReq, req: any, res, options) => {
         if (jwtSecret && req.user) {

--- a/magda-gateway/src/createHttpsRedirectionMiddleware.ts
+++ b/magda-gateway/src/createHttpsRedirectionMiddleware.ts
@@ -1,17 +1,10 @@
 import { NextFunction, Response, Request, RequestHandler } from "express";
-import * as URI from "urijs";
 
 export default function createHttpsRedirectionMiddleware(
     enableHttpsRedirection: boolean
 ): RequestHandler {
     return function(req: Request, res: Response, next: NextFunction) {
         if (!enableHttpsRedirection) {
-            next();
-            return;
-        }
-
-        const uri = new URI(req.originalUrl);
-        if (uri.pathname() === "/v0/healthz") {
             next();
             return;
         }

--- a/magda-gateway/src/test/createHttpsRedirectionMiddleware.spec.ts
+++ b/magda-gateway/src/test/createHttpsRedirectionMiddleware.spec.ts
@@ -119,30 +119,4 @@ describe("Test createHttpsRedirectionMiddleware", () => {
             });
         });
     });
-
-    describe("should forward request to next request handler if request url is `/v0/healthz`", () => {
-        it("when `enableHttpsRedirection` parameter is true and `X-Forwarded-Proto` = 'http'", () => {
-            const testRequest = setupTest(true, "http", "/v0/healthz");
-
-            return testRequest.expect(200).then(() => {
-                expect(isNextHandlerCalled).to.equal(true);
-            });
-        });
-
-        it("when `enableHttpsRedirection` parameter is true and `X-Forwarded-Proto` = 'https'", () => {
-            const testRequest = setupTest(true, "https", "/v0/healthz");
-
-            return testRequest.expect(200).then(() => {
-                expect(isNextHandlerCalled).to.equal(true);
-            });
-        });
-
-        it("when `enableHttpsRedirection` parameter is true and `X-Forwarded-Proto` not set", () => {
-            const testRequest = setupTest(true, null, "/v0/healthz");
-
-            return testRequest.expect(200).then(() => {
-                expect(isNextHandlerCalled).to.equal(true);
-            });
-        });
-    });
 });

--- a/magda-gateway/tsconfig-build.json
+++ b/magda-gateway/tsconfig-build.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "declaration": true,
         "outDir": "dist",
-        "baseUrl": "."
+        "baseUrl": ".",
+        "lib": ["es2017", "dom"]
     },
     "include": ["src"]
 }

--- a/magda-indexer/package.json
+++ b/magda-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/indexer",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Indexes the registry for searching.",
   "scripts": {
     "build": "yarn run compile",

--- a/magda-int-test/package.json
+++ b/magda-int-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/int-test",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Integration tests",
   "scripts": {
     "build": "yarn run compile",

--- a/magda-migrator-authorization-db/package.json
+++ b/magda-migrator-authorization-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/migrator-authorization-db",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The MAGDA database for storing users and other authorization data.",
   "license": "Apache-2.0",
   "scripts": {
@@ -16,8 +16,8 @@
     }
   },
   "devDependencies": {
-    "@magda/db-migrator": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/db-migrator": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-migrator-content-db/package.json
+++ b/magda-migrator-content-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/migrator-content-db",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The MAGDA database for storing content data.",
   "license": "Apache-2.0",
   "scripts": {
@@ -16,8 +16,8 @@
     }
   },
   "devDependencies": {
-    "@magda/db-migrator": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/db-migrator": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-migrator-registry-db/package.json
+++ b/magda-migrator-registry-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/migrator-registry-db",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The registry's PostgreSQL database.",
   "scripts": {
     "dev": "echo \"No dev mode available, use helm instead.\"",
@@ -17,8 +17,8 @@
     }
   },
   "devDependencies": {
-    "@magda/db-migrator": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/db-migrator": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-migrator-session-db/package.json
+++ b/magda-migrator-session-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/migrator-session-db",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The database storing session information.",
   "scripts": {
     "dev": "echo \"No dev mode available, use helm instead.\"",
@@ -16,8 +16,8 @@
     }
   },
   "devDependencies": {
-    "@magda/db-migrator": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/db-migrator": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-minion-broken-link/package.json
+++ b/magda-minion-broken-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/minion-broken-link",
   "description": "MAGDA Broken Link Minion",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -16,7 +16,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.2",
     "@types/ftp": "^0.3.29",
     "@types/lodash": "^4.14.71",
@@ -37,9 +37,9 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/minion-framework": "^0.0.51-0",
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/minion-framework": "^0.0.51-RC1",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "ftp": "^0.3.10",
     "lodash": "^4.17.4",
     "lru-cache": "4.0.2",

--- a/magda-minion-format/package.json
+++ b/magda-minion-format/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/minion-format",
   "description": "MAGDA Layering Minion",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -16,7 +16,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.2",
     "@types/ftp": "^0.3.29",
     "@types/lodash": "^4.14.88",
@@ -37,9 +37,9 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/minion-framework": "^0.0.51-0",
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/minion-framework": "^0.0.51-RC1",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "@types/escape-string-regexp": "^0.0.32",
     "@types/lodash": "^4.14.88",
     "escape-string-regexp": "^1.0.5",

--- a/magda-minion-framework/package.json
+++ b/magda-minion-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/minion-framework",
   "description": "MAGDA Minion Framework",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "main": "dist",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.1",
     "@types/express": "^4.0.36",
     "@types/isomorphic-fetch": "0.0.34",
@@ -36,8 +36,8 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "isomorphic-fetch": "^2.2.1",

--- a/magda-minion-linked-data-rating/package.json
+++ b/magda-minion-linked-data-rating/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/minion-linked-data-rating",
   "description": "MAGDA Linked Data Rating Minion",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -16,7 +16,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.4",
     "@types/lodash": "^4.14.74",
     "@types/mocha": "^2.2.42",
@@ -31,9 +31,9 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/minion-framework": "^0.0.51-0",
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/minion-framework": "^0.0.51-RC1",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "lodash": "^4.17.4"
   },
   "config": {

--- a/magda-minion-visualization/package.json
+++ b/magda-minion-visualization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/minion-visualization",
   "description": "MAGDA visualization Minion",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "scripts": {
     "build": "yarn run compile",
     "compile": "tsc -p tsconfig-build.json",
@@ -15,7 +15,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/node": "^7.0.5",
     "@types/papaparse": "^4.1.31",
     "@types/read-pkg-up": "^3.0.1",
@@ -24,9 +24,9 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/minion-framework": "^0.0.51-0",
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/minion-framework": "^0.0.51-RC1",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "moment": "^2.19.1",
     "papaparse": "^4.3.6",
     "read-pkg-up": "^3.0.0",

--- a/magda-postgres/package.json
+++ b/magda-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/postgres",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "A base Docker image for PostgreSQL with Flyway for schema migrations.",
   "scripts": {
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
@@ -17,7 +17,7 @@
     }
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0"
+    "@magda/scripts": "^0.0.51-RC1"
   },
   "magda": {
     "categories": {

--- a/magda-preview-map/package.json
+++ b/magda-preview-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/preview-map",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Geospatial preview based on TerriaJS.",
   "license": "Apache-2.0",
   "engines": {
@@ -29,7 +29,7 @@
     }
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "babel-core": "^6.7.4",
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.0.0",

--- a/magda-project-open-data-connector/package.json
+++ b/magda-project-open-data-connector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/project-open-data-connector",
   "description": "MAGDA Project Open Data (data.json) Connector",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -17,7 +17,7 @@
     "test": "mocha --compilers ts:ts-node/register,tsx:ts-node/register --require tsconfig-paths/register \"src/test/**/*.spec.ts\""
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/node": "^8.0.14",
     "@types/read-pkg-up": "^3.0.1",
     "@types/request": "^2.0.0",
@@ -28,8 +28,8 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/typescript-common": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/typescript-common": "^0.0.51-RC1",
     "@types/to-markdown": "^3.0.0",
     "jsonpath": "^1.0.0",
     "lodash": "^4.17.4",

--- a/magda-registry-api/package.json
+++ b/magda-registry-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/registry-api",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The registry API.",
   "license": "Apache-2.0",
   "scripts": {

--- a/magda-registry-aspects/package.json
+++ b/magda-registry-aspects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/registry-aspects",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Common aspects for use with the registry.",
   "scripts": {},
   "author": "",

--- a/magda-scala-common/package.json
+++ b/magda-scala-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/scala-common",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Common Scala code shared between components.",
   "scripts": {
     "test": "cd .. && sbt common/test",

--- a/magda-scss-compiler/package.json
+++ b/magda-scss-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/magda-scss-compiler",
   "description": "The web-client SCSS compiler pod",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -14,7 +14,7 @@
     "test": "mocha --compilers ts:ts-node/register,tsx:ts-node/register --require tsconfig-paths/register \"src/test/**/*.spec.ts\""
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/autoprefixer": "^9.1.0",
     "@types/chai": "^4.0.1",
     "@types/clean-css": "^3.4.30",
@@ -39,8 +39,8 @@
     "typescript": "~2.5.0"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
-    "@magda/web-client": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
+    "@magda/web-client": "^0.0.51-RC1",
     "autoprefixer": "^9.2.1",
     "clean-css": "^4.2.1",
     "escape-string-regexp": "^1.0.5",

--- a/magda-search-api/package.json
+++ b/magda-search-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/search-api",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "The search API.",
   "license": "Apache-2.0",
   "scripts": {

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/typescript-common",
   "description": "Common TypeScript code shared between components.",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -12,8 +12,8 @@
     "dev": "yarn run watch"
   },
   "devDependencies": {
-    "@magda/registry-aspects": "^0.0.51-0",
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/registry-aspects": "^0.0.51-RC1",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.0",
     "@types/chai-as-promised": "^7.1.0",
     "@types/express": "^4.0.35",
@@ -21,13 +21,13 @@
     "@types/mocha": "^2.2.41",
     "@types/nock": "^8.2.1",
     "@types/node": "^8.0.14",
+    "@types/read-pkg-up": "^3.0.1",
     "@types/sinon": "^4.1.3",
     "@types/superagent": "^3.5.5",
     "@types/supertest": "^2.0.3",
     "@types/urijs": "^1.15.34",
     "@types/uuid": "^3.4.0",
     "@types/yargs": "^8.0.2",
-    "@types/read-pkg-up": "^3.0.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "djv": "^2.1.1",
@@ -35,9 +35,9 @@
     "lazy-seq": "^1.0.0",
     "mocha": "^3.4.2",
     "nock": "^9.0.14",
+    "nyc": "^13.1.0",
     "sinon": "^4.2.1",
-    "typescript": "~2.5.0",
-    "nyc": "^13.1.0"
+    "typescript": "~2.5.0"
   },
   "dependencies": {
     "@types/request": "^2.0.0",
@@ -47,12 +47,12 @@
     "jsonwebtoken": "^7.4.1",
     "load-json-file": "^1.0.0",
     "moment": "^2.17.1",
+    "read-pkg-up": "^3.0.0",
     "request": "^2.79.0",
     "tsmonad": "^0.7.2",
     "urijs": "^1.18.12",
     "uuid": "^3.1.0",
-    "yargs": "^10.1.1",
-    "read-pkg-up": "^3.0.0"
+    "yargs": "^10.1.1"
   },
   "config": {
     "docker": {

--- a/magda-typescript-common/src/express/status.ts
+++ b/magda-typescript-common/src/express/status.ts
@@ -15,7 +15,7 @@ export interface OptionsIO {
     // outputs
     ready?: boolean;
     _installed?: any;
-    _probes?: any;
+    _probes?: { [key: string]: () => any };
     since?: string;
     last?: string;
     details?: any;

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/web-client",
   "description": "The MAGDA in-browser web front end.",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "storybook": "start-storybook -p 9001 -c .storybook -s ./public",
@@ -50,7 +50,7 @@
     "urijs": "^1.19.1"
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@storybook/addon-actions": "^3.3.3",
     "@storybook/addon-links": "^3.3.3",
     "@storybook/addons": "^3.3.3",

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/web-server",
   "description": "The server that serves the MAGDA web front end.",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run compile",
@@ -15,7 +15,7 @@
     "test": "mocha --compilers ts:ts-node/register,tsx:ts-node/register --require tsconfig-paths/register \"src/test/**/*.spec.ts\""
   },
   "devDependencies": {
-    "@magda/scripts": "^0.0.51-0",
+    "@magda/scripts": "^0.0.51-RC1",
     "@types/chai": "^4.0.1",
     "@types/config": "0.0.32",
     "@types/express": "^4.0.39",
@@ -41,8 +41,8 @@
     "xml2js": "^0.4.19"
   },
   "dependencies": {
-    "@magda/typescript-common": "^0.0.51-0",
-    "@magda/web-client": "^0.0.51-0",
+    "@magda/typescript-common": "^0.0.51-RC1",
+    "@magda/web-client": "^0.0.51-RC1",
     "express": "^4.15.3",
     "morgan": "^1.9.0",
     "read-pkg-up": "^3.0.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magda/scripts",
-  "version": "0.0.51-0",
+  "version": "0.0.51-RC1",
   "description": "Scripts for building, running, and deploying MAGDA",
   "license": "Apache-2.0",
   "bin": {
@@ -26,9 +26,6 @@
     }
   },
   "dependencies": {
-    "is-subdir": "^1.0.2",
-    "request": "^2.88.0",
-    "stream-json": "^1.1.3",
     "ansi-styles": "^3.2.1",
     "apidoc": "https://github.com/magda-io/apidoc",
     "chalk": "^2.4.1",
@@ -39,6 +36,7 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^6.0.0",
     "inquirer-autocomplete-prompt": "^1.0.1",
+    "is-subdir": "^1.0.2",
     "js-base64": "^2.4.8",
     "klaw-sync": "^2.1.0",
     "lodash": "^4.17.5",
@@ -46,6 +44,8 @@
     "nodemon": "^1.11.0",
     "pkg": "^4.3.4",
     "pwgen": "^0.1.6",
+    "request": "^2.88.0",
+    "stream-json": "^1.1.3",
     "strip-ansi": "^4.0.0",
     "strip-json-comments": "^2.0.1",
     "tmp": "0.0.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,12 +472,35 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
   integrity sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==
 
+"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
+  dependencies:
+    type-detect "4.0.8"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
   integrity sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==
   dependencies:
     samsam "1.3.0"
+
+"@sinonjs/formatio@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
+  integrity sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==
+  dependencies:
+    "@sinonjs/samsam" "^2 || ^3"
+
+"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
+  integrity sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash.get "^4.4.2"
 
 "@storybook/addon-actions@3.4.7", "@storybook/addon-actions@^3.3.3":
   version "3.4.7"
@@ -1088,6 +1111,16 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
 
+"@types/request@^2.48.1":
+  version "2.48.1"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.1.tgz#e402d691aa6670fbbff1957b15f1270230ab42fa"
+  integrity sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/form-data" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -1663,6 +1696,11 @@ array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
   integrity sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -9730,6 +9768,13 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-subdir@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-subdir/-/is-subdir-1.0.2.tgz#28cd419f66d91403ca8181ab55257687d99562de"
+  integrity sha512-2H3vM92ez7TjW6T2e4G7AQVm/1/UA/qikNO0/aIi2SkouUU2wXW2CQ5Owiz8oaaFQpjNl74B5LIjTcM1htr2mQ==
+  dependencies:
+    is-windows "^1.0.0"
+
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
@@ -9776,7 +9821,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -10695,6 +10740,11 @@ just-extend@^1.1.27:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
   integrity sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 jwa@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
@@ -11427,6 +11477,11 @@ lolex@^2.1.2, lolex@^2.2.0, lolex@^2.3.2, lolex@^2.4.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.0.tgz#9c087a69ec440e39d3f796767cf1b2cdc43d5ea5"
   integrity sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
 longest@^1.0.1:
   version "1.0.1"
@@ -12260,6 +12315,17 @@ nise@^1.0.1, nise@^1.2.0, nise@^1.3.3:
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
     just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
+nise@^1.4.7:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.8.tgz#ce91c31e86cf9b2c4cac49d7fcd7f56779bfd6b0"
+  integrity sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    just-extend "^4.0.2"
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
@@ -16507,6 +16573,19 @@ sinon@^5.0.7:
     supports-color "^5.4.0"
     type-detect "^4.0.8"
 
+sinon@^7.0.0:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.2.tgz#388ecabd42fa93c592bfc71d35a70894d5a0ca07"
+  integrity sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==
+  dependencies:
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/samsam" "^3.0.2"
+    diff "^3.5.0"
+    lolex "^3.0.0"
+    nise "^1.4.7"
+    supports-color "^5.5.0"
+
 sitemap@^1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-1.13.0.tgz#569cbe2180202926a62a266cd3de09c9ceb43f83"
@@ -16955,6 +17034,11 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-chain@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.1.0.tgz#a058a7104d7261a71bf7eb4c5f496f13dc665320"
+  integrity sha512-PAUXdRGm0G8P0+/+JEd3O9kfmB9kwmr2nKIc5zhcsHn0KdBByD5PJ2po21iDzc+TZsOSEbU8j4JbAevJsZkLyQ==
+
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
@@ -16992,6 +17076,13 @@ stream-http@^2.7.2:
     readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-json@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.1.4.tgz#95817dc3f3e4b68d5f8e74aec43a73142b6643a6"
+  integrity sha512-NAgE3JS4qULiptmr80utUSHTGLOkgiy1wJJJeJEC+4ZL+TaqdgBCoxYriq/wjIsE2pf5r4TRuW/DbZ8GFtWFeQ==
+  dependencies:
+    stream-chain "^2.0.3"
 
 stream-meter@1.0.4:
   version "1.0.4"
@@ -18094,7 +18185,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
### What this PR does

Fixes #1972 

Currently in staging the gateway is continually going up and down because the new liveness check is in the wrong place (`/api/v0/status/live` instead of `/status/live` where the readiness/health check looks), and is affected by the HTTPS upgrade, which stops it from being called by kubernetes via HTTP.

This moves it to where it's supposed to be, and declares it before the HTTPS upgrade so it's not affected.

This also tweaks the readiness check for elasticsearch, because the staging upgrade to 0.0.50-RC1 went pretty badly as a result of the data nodes coming up too fast.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] No CHANGES.md, this fixes something that was broken this release.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
