### PR TITLE
Fixed empty license responses crashing data.json connector.

### DIFF
--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -215,7 +215,7 @@ connectors:
         name: magda-project-open-data-connector
       id: moretonbay
       name: Moreton Bay Regional Council Data Portal
-      sourceUrl: http://data.moretonbay.qld.gov.au/data.json
+      sourceUrl: http://datahub.moretonbay.qld.gov.au/data.json
     - image:
         name: magda-csw-connector
       id: metoc

--- a/magda-project-open-data-connector/src/ProjectOpenData.ts
+++ b/magda-project-open-data-connector/src/ProjectOpenData.ts
@@ -35,7 +35,7 @@ export default class ProjectOpenData implements ConnectorSource {
                                     console.log(error);
                                     return resolve(dataset);
                                 } else {
-                                    if (body.description) {
+                                    if (body && body.description) {
                                         let foundLink = false;
                                         if (
                                             body.description.match(

--- a/magda-project-open-data-connector/src/ProjectOpenData.ts
+++ b/magda-project-open-data-connector/src/ProjectOpenData.ts
@@ -18,65 +18,69 @@ export default class ProjectOpenData implements ConnectorSource {
     // project open data spec allows URLs for licences
     // ArcGIS creates custom URLs rather than using https://project-open-data.cio.gov/open-licenses/ lookup table
     getDatasetLicence(data: any): Promise<any> {
-        data.dataset = Promise.all(
-            data.dataset.map((dataset: any) => {
-                return new Promise(resolve => {
-                    // don't bother visiting creativecommons urls
-                    if (
-                        dataset.license &&
-                        dataset.license.startsWith("http") &&
-                        !dataset.license.includes("creativecommons")
-                    ) {
-                        request(
-                            dataset.license,
-                            { json: true },
-                            (error, response, body) => {
-                                if (error) {
-                                    console.log(error);
-                                    return resolve(dataset);
-                                } else {
-                                    if (body && body.description) {
-                                        let foundLink = false;
-                                        if (
-                                            body.description.match(
-                                                /https?:\/\/[^ "<]*/g
-                                            )
-                                        ) {
-                                            foundLink = body.description
-                                                .match(/https?:\/\/[^ "<]*/g)
-                                                .some((link: String) => {
-                                                    if (
-                                                        link.includes(
-                                                            "creativecommons.org/licenses"
-                                                        ) ||
-                                                        link.includes(
-                                                            "opendefinition.org/licenses/"
-                                                        )
-                                                    ) {
-                                                        foundLink = true;
-                                                        dataset.license = link;
-                                                        return true;
-                                                    }
-                                                    return false;
-                                                });
-                                        }
-                                        if (!foundLink) {
-                                            dataset.license = this.turndownService.turndown(
-                                                body.description
-                                            );
+        if (data.dataset) {
+            data.dataset = Promise.all(
+                data.dataset.map((dataset: any) => {
+                    return new Promise(resolve => {
+                        // don't bother visiting creativecommons urls
+                        if (
+                            dataset.license &&
+                            dataset.license.startsWith("http") &&
+                            !dataset.license.includes("creativecommons")
+                        ) {
+                            request(
+                                dataset.license,
+                                { json: true },
+                                (error, response, body) => {
+                                    if (error) {
+                                        console.log(error);
+                                        return resolve(dataset);
+                                    } else {
+                                        if (body && body.description) {
+                                            let foundLink = false;
+                                            if (
+                                                body.description.match(
+                                                    /https?:\/\/[^ "<]*/g
+                                                )
+                                            ) {
+                                                foundLink = body.description
+                                                    .match(
+                                                        /https?:\/\/[^ "<]*/g
+                                                    )
+                                                    .some((link: String) => {
+                                                        if (
+                                                            link.includes(
+                                                                "creativecommons.org/licenses"
+                                                            ) ||
+                                                            link.includes(
+                                                                "opendefinition.org/licenses/"
+                                                            )
+                                                        ) {
+                                                            foundLink = true;
+                                                            dataset.license = link;
+                                                            return true;
+                                                        }
+                                                        return false;
+                                                    });
+                                            }
+                                            if (!foundLink) {
+                                                dataset.license = this.turndownService.turndown(
+                                                    body.description
+                                                );
+                                            }
+                                            return resolve(dataset);
                                         }
                                         return resolve(dataset);
                                     }
-                                    return resolve(dataset);
                                 }
-                            }
-                        );
-                    } else {
-                        return resolve(dataset);
-                    }
-                });
-            })
-        );
+                            );
+                        } else {
+                            return resolve(dataset);
+                        }
+                    });
+                })
+            );
+        }
         return data;
     }
 
@@ -115,7 +119,7 @@ export default class ProjectOpenData implements ConnectorSource {
 
     public getJsonDatasets(): AsyncPage<any[]> {
         return AsyncPage.singlePromise<object[]>(
-            this.dataPromise.then((response: any) => response.dataset)
+            this.dataPromise.then((response: any) => response.dataset || [])
         );
     }
 

--- a/magda-project-open-data-connector/src/index.ts
+++ b/magda-project-open-data-connector/src/index.ts
@@ -98,9 +98,15 @@ const connector = new JsonConnector({
 });
 
 if (!argv.interactive) {
-    connector.run().then(result => {
-        console.log(result.summarize());
-    });
+    connector
+        .run()
+        .then(result => {
+            console.log(result.summarize());
+        })
+        .catch(e => {
+            console.error(e);
+            process.exit(1);
+        });
 } else {
     connector.runInteractive({
         timeoutSeconds: argv.timeout,

--- a/magda-project-open-data-connector/src/test/black-box.spec.ts
+++ b/magda-project-open-data-connector/src/test/black-box.spec.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import { runConnectorTest } from "@magda/typescript-common/dist/test/connectors/runConnectorTest";
 
 import { MockOpenDataCatalog } from "./MockOpenDataCatalog";

--- a/magda-project-open-data-connector/src/test/get-license.spec.ts
+++ b/magda-project-open-data-connector/src/test/get-license.spec.ts
@@ -252,4 +252,10 @@ describe("when distributions have a license as a custom URL", function(this: Moc
             );
         });
     });
+
+    it("should not fail if the response returns no datasets", async () => {
+        dataJson.dataset = undefined;
+
+        await connector.run();
+    });
 });

--- a/magda-project-open-data-connector/src/test/get-license.spec.ts
+++ b/magda-project-open-data-connector/src/test/get-license.spec.ts
@@ -1,0 +1,255 @@
+import {} from "mocha";
+import * as nock from "nock";
+import { expect } from "chai";
+
+import Registry from "@magda/typescript-common/dist/registry/AuthorizedRegistryClient";
+import JsonConnector from "@magda/typescript-common/dist/JsonConnector";
+
+import createTransformer from "../createTransformer";
+import ProjectOpenData from "../ProjectOpenData";
+import organizationAspectBuilders from "../organizationAspectBuilders";
+import datasetAspectBuilders from "../datasetAspectBuilders";
+import distributionAspectBuilders from "../distributionAspectBuilders";
+import ProjectOpenDataTransformer from "../ProjectOpenDataTransformer";
+
+describe("when distributions have a license as a custom URL", function(this: Mocha.ISuiteCallbackContext) {
+    let registry: Registry;
+    let source: ProjectOpenData;
+    let transformer: ProjectOpenDataTransformer;
+    let connector: JsonConnector;
+    let dataJson: any;
+    let distributions: any[];
+
+    beforeEach(() => {
+        dataJson = {
+            "@context":
+                "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+            "@type": "dcat:Catalog",
+            conformsTo: "https://project-open-data.cio.gov/v1.1/schema",
+            describedBy:
+                "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+            dataset: [
+                {
+                    "@type": "dcat:Dataset",
+                    identifier:
+                        "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0",
+                    title: "Logan City Council Building Works Applications",
+                    description:
+                        "Building work approval data by application number, application type, description of building work and address. This information is also available on Council’s public PD Online system.",
+                    keyword: [
+                        "Planning Building",
+                        " Building works",
+                        " Logan City Council",
+                        " LCC Open Data",
+                        " Business"
+                    ],
+                    issued: "2017-07-28T01:17:20.000Z",
+                    modified: "2019-01-08T19:04:24.209Z",
+                    publisher: { name: "Logan City Council" },
+                    contactPoint: {
+                        "@type": "vcard:Contact",
+                        fn: "Matthew Maguire",
+                        hasEmail: "mailto:council@logan.qld.gov.au"
+                    },
+                    accessLevel: "public",
+                    distribution: [
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "ArcGIS Open Dataset",
+                            format: "Web page",
+                            mediaType: "text/html",
+                            accessURL:
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0"
+                        },
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "Esri Rest API",
+                            format: "Esri REST",
+                            mediaType: "application/json",
+                            accessURL:
+                                "https://services5.arcgis.com/ZUCWDRj8F77Xo351/arcgis/rest/services/Logan_City_Council_Building_Works_Applications/FeatureServer/0"
+                        },
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "GeoJSON",
+                            format: "GeoJSON",
+                            mediaType: "application/vnd.geo+json",
+                            downloadURL:
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0.geojson"
+                        },
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "CSV",
+                            format: "CSV",
+                            mediaType: "text/csv",
+                            downloadURL:
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0.csv"
+                        },
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "KML",
+                            format: "KML",
+                            mediaType: "application/vnd.google-earth.kml+xml",
+                            downloadURL:
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0.kml"
+                        },
+                        {
+                            "@type": "dcat:Distribution",
+                            title: "Shapefile",
+                            format: "ZIP",
+                            mediaType: "application/zip",
+                            downloadURL:
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0.zip"
+                        }
+                    ],
+                    landingPage:
+                        "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0",
+                    webService:
+                        "https://services5.arcgis.com/ZUCWDRj8F77Xo351/arcgis/rest/services/Logan_City_Council_Building_Works_Applications/FeatureServer/0",
+                    license: "http://license.example.com",
+                    spatial:
+                        "152.8061156622849,-27.936405953929796,153.28713764921812,-27.58739121942008",
+                    theme: ["geospatial"]
+                }
+            ]
+        };
+
+        registry = new Registry({
+            jwtSecret: "secret",
+            userId: "",
+            baseUrl: "http://registry.example.com"
+        });
+
+        source = new ProjectOpenData({
+            id: "id",
+            name: "name",
+            url: "http://source.example.com"
+        });
+
+        transformer = createTransformer({
+            id: "id",
+            name: "name",
+            sourceUrl: "http://source.example.com",
+            datasetAspectBuilders,
+            distributionAspectBuilders,
+            organizationAspectBuilders
+        });
+
+        connector = new JsonConnector({
+            source: source,
+            transformer: transformer,
+            registry: registry
+        });
+
+        nock("http://registry.example.com")
+            .put(
+                path =>
+                    path.startsWith("/aspects") ||
+                    path.startsWith("/records/org") ||
+                    path.startsWith("/records/ds"),
+                () => true
+            )
+            .optionally()
+            .times(1000)
+            .reply(200);
+
+        nock("http://registry.example.com")
+            .delete(
+                path => path.startsWith("/records?sourceTagToPreserve"),
+                () => true
+            )
+            .optionally()
+            .times(1000)
+            .reply(200, JSON.stringify({ count: 0 }));
+
+        nock("http://source.example.com")
+            .get("/")
+            .reply(200, () => JSON.stringify(dataJson));
+
+        distributions = [];
+        nock("http://registry.example.com")
+            .put(
+                path =>
+                    path.startsWith(
+                        "/records/dist-id-" +
+                            encodeURIComponent(
+                                "http://data-logancity.opendata.arcgis.com/datasets/bc07c26cb26d4b4880715f3e55ccdb17_0-"
+                            )
+                    ),
+                (distribution: any) => {
+                    distributions.push(distribution);
+                    return true;
+                }
+            )
+            .times(6)
+            .reply(200);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it("should request license if it's a URL", async () => {
+        nock("http://license.example.com")
+            .get("/")
+            .reply(200, JSON.stringify({ description: "This is a license" }));
+
+        await connector.run();
+
+        expect(distributions).not.to.be.empty;
+        distributions.forEach(dist => {
+            expect(dist.aspects["dcat-distribution-strings"].license).to.equal(
+                "This is a license"
+            );
+        });
+    });
+
+    it("should record license as creative commons if it contains a link to creative commons", async () => {
+        nock("http://license.example.com")
+            .get("/")
+            .reply(
+                200,
+                JSON.stringify({
+                    description:
+                        'Blah blah blah <a href="http://creativecommons.org/licenses/blahlicense">this is the license</a>'
+                })
+            );
+
+        await connector.run();
+
+        expect(distributions).not.to.be.empty;
+        distributions.forEach(dist => {
+            expect(dist.aspects["dcat-distribution-strings"].license).to.equal(
+                "http://creativecommons.org/licenses/blahlicense"
+            );
+        });
+    });
+
+    it("should record license as creative commons if it's a URL with creative commons", async () => {
+        dataJson.dataset[0].license = "https://creativecommons.org/anything";
+
+        await connector.run();
+
+        expect(distributions).not.to.be.empty;
+        distributions.forEach(dist => {
+            expect(dist.aspects["dcat-distribution-strings"].license).to.equal(
+                "https://creativecommons.org/anything"
+            );
+        });
+    });
+
+    it("should not fail if the URL returns no body", async () => {
+        nock("http://license.example.com")
+            .get("/")
+            .reply(200);
+
+        await connector.run();
+
+        expect(distributions).not.to.be.empty;
+        distributions.forEach(dist => {
+            expect(dist.aspects["dcat-distribution-strings"].license).to.equal(
+                "http://license.example.com"
+            );
+        });
+    });
+});


### PR DESCRIPTION
### What this PR does

Fixes #1975 

Essentially this just needed a check for `body` before checking `body.description`, but I added some unit tests too.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   No need for CHANGES, this fixes something introduced this release
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
