### PR TITLE
Fix /dashboard and /dataset?q=keyword redirects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ Ops:
 -   Allows gateway routes to be overiden from top level values file
 -   Added `enableCkanRedirection` switch to turn on or off Ckan redirection feature from gateway
 
+Others:
+
+-   Fixed /dashboard and /dataset?q=keyword redirects for migrating easily from CKAN sites
+
 ## 0.0.51
 
 Accessibility:

--- a/magda-gateway/src/createCkanRedirectionRouter.ts
+++ b/magda-gateway/src/createCkanRedirectionRouter.ts
@@ -27,6 +27,8 @@ export const genericUrlRedirectConfigs: genericUrlRedirectConfig[] = [
     },
     "/dataset/edit",
     "/dataset/new",
+    "/datastore",
+    "/dashboard",
     {
         path: "/fanstatic",
         requireExtraSeqment: true

--- a/magda-web-client/src/Pages/OtherPages.js
+++ b/magda-web-client/src/Pages/OtherPages.js
@@ -22,6 +22,18 @@ const renderBody = (loading, pages) => {
     return (
         <Switch>
             <Route exact path="/search" component={Search} />
+            <Route
+                exact
+                path="/dataset"
+                render={({ location }) => (
+                    <Redirect
+                        to={{
+                            pathname: "/search",
+                            search: location.search
+                        }}
+                    />
+                )}
+            />
             <Route exact path="/account" component={Account} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/sign-in-redirect" component={SignInRedirect} />


### PR DESCRIPTION
### What this PR does

Fixes #1961 and another redirect that was discovered post launch /dataset and /dataset?q=keyword 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
