### PR TITLE
Made the query for getting aspects by path able to use indices.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Ops:
 -   Added `cloudsql-db-credentials` to create-secrets tool
 -   Only runtime dependencies will be included by docker image build script
 -   Fixed an file selector error in create-secrets script when current directory & non of its sub directory has \*.json file
+-   Changed SQL for querying aspects by path/value so that it could take advantage of JSONB indices.
 
 Security:
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -781,7 +781,6 @@ object DefaultRecordPersistence extends Protocols with DiffsonProtocol with Reco
   }
 
   private def aspectQueryToWhereClause(query: AspectQuery) = {
-    val path = query.path.map(pathElement => sqls"->>$pathElement").reduce((a, b) => a.append(b))
-    sqls"EXISTS (SELECT 1 FROM recordaspects WHERE recordaspects.recordid=records.recordid AND aspectId = ${query.aspectId} AND data #>> ${"{" + query.path.mkString(",") + "}"}::varchar[] = ${query.value})"
+    sqls"EXISTS (SELECT 1 FROM recordaspects WHERE recordaspects.recordid=records.recordid AND aspectId = ${query.aspectId} AND data #>> string_to_array(${query.path.mkString(",")}, ',') = ${query.value})"
   }
 }


### PR DESCRIPTION
### What this PR does

Fixes #1993 

So what ambushed us on the DGA launch was that there's a lot of traffic that comes in on old CKAN addresses and uses the CKAN direction module in the gateway. That module looks up CKAN dataset/org/resource names and ids in the JSON, which is fine as long as we have an index for those paths in the `data` column.

BUT you need the path to be a `varchar[]` in order for it to use the index. If it's not, it'll still work exactly the same, but won't use the index. Which is the difference between a 6ms call and a 6000ms call, 100% utilisation across 6 CPUs vs 3% utilisation, and (importantly) the database not responding at 11:36 every evening when some external scraping job hits us, or the database performing perfectly at that time.

Casting the path to a `varchar[]` doesn't count for some reason, but `string_to_array` does. 🤷‍♂️ 

I actually cheated and manually put this into prod already because I didn't want to get paged at 11:30 again, this is the result:

![image](https://user-images.githubusercontent.com/900555/51359412-b702ed00-1b1b-11e9-8892-76eb00ba9b64.png)

o_0

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
