### PR TITLE
Increase Travis scala test time limit to 30 mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           - REACT_APP_SHA1=$TRAVIS_COMMIT
       addons:
         postgresql: "9.6"
-      script: travis_retry travis_wait 30 sbt test
+      script: travis_wait 30 sbt test
     - language: node_js
       node_js: "8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           - REACT_APP_SHA1=$TRAVIS_COMMIT
       addons:
         postgresql: "9.6"
-      script: travis_wait 30 sbt test
+      script: travis_retry travis_wait 30 sbt test
     - language: node_js
       node_js: "8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           - REACT_APP_SHA1=$TRAVIS_COMMIT
       addons:
         postgresql: "9.6"
-      script: travis_retry sbt test
+      script: travis_retry travis_wait 30 sbt test
     - language: node_js
       node_js: "8"
       cache:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Ops:
 -   `create-secrets` tool can create secret for `Australian Access Federation` Rapid Connect
 -   Allows gateway routes to be overiden from top level values file
 -   Added `enableCkanRedirection` switch to turn on or off Ckan redirection feature from gateway
+-   Increase travis scala test time limit to 30 mins
 
 Search:
 


### PR DESCRIPTION
### What this PR does

This PR Increase Travis scala test time limit to 30 mins (as a quick fix) to avoid failure due to test cases timeout .

Tested with this PR seems work alright.

Now if you check the log before the test completes, you'd see something like:
```
$ javac -J-Xmx32m -version
javac 1.8.0_151
Using Scala 2.11.8
travis_time:start:1380adc3
[0K$ travis_retry travis_wait 30 sbt test


Still running (1 of 30): sbt test
Still running (2 of 30): sbt test
Still running (3 of 30): sbt test
```

But once the test is full completed, the log output will be back to the normal and with all detailed output like now.

### Notes:

Even with the help of `travis_retry` & `travis_wait`, we can't go over travis's hard total running time limit --- which is 50 mins.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
