### PR TITLE
Made CSV Connector Fill Distribution Descriptions from Dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,15 +11,23 @@ Ops:
 -   Added `enableCkanRedirection` switch to turn on or off Ckan redirection feature from gateway
 -   Added `global.enablePriorityClass` switch to turn on or off `priorityClassName` on deployment templates
 -   Improved responsiveness of registry-api when it's under load
+-   Made the content-api accept authentication by default
 
 Search:
 
 -   Made the lowest quality rating for a dataset in the search index 0.01, so that 0-quality datasets rank properly relative to each other.
-    Others:
 
-Interoperability
+Connectors:
+
+-   Made the CSV connector put the description column in the distribution description, not just the dataset one
+
+Interoperability:
 
 -   Fixed /dashboard and /dataset?q=keyword redirects for migrating easily from CKAN sites
+
+Development:
+
+-   Made connector tests use the typescript of the code under test through ts-node, instead of the `/dist` directory.
 
 Others:
 

--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -41,6 +41,7 @@ defaultRoutes:
     auth: true
   content:
     to: http://content-api/v0
+    auth: true
   correspondence:
     to: http://correspondence-api/v0/public
   apidocs:

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -5,7 +5,7 @@ global:
     imagePullSecret: "regcred"
     pullPolicy: Always
   exposeNodePorts: false
-  enablePriorityClass: true
+  enablePriorityClass: false
 
 tags:
   all: true

--- a/magda-csv-connector/aspect-templates/dcat-distribution-strings.js
+++ b/magda-csv-connector/aspect-templates/dcat-distribution-strings.js
@@ -34,6 +34,12 @@ let downloadURL = fuzzy.findClosestFieldThreshold(
     "internal location"
 );
 
+let description = fuzzy.findClosestField(
+    dataset,
+    "description",
+    "short description"
+);
+
 let format = fuzzy.findClosestFieldThreshold(distribution, 0.5, "format");
 
 return {
@@ -43,5 +49,6 @@ return {
     accessURL,
     accessNotes,
     downloadURL,
-    format
+    format,
+    description
 };

--- a/magda-csv-connector/src/test/csv1.json
+++ b/magda-csv-connector/src/test/csv1.json
@@ -8,7 +8,8 @@
                 "license": "Copyright",
                 "rights": "RFC",
                 "accessNotes": "LOCATION1",
-                "format": "MS Access"
+                "format": "MS Access",
+                "description": "D1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -90,7 +91,8 @@
                 "title": "T2",
                 "rights": "Internal",
                 "accessNotes": "METADATA LOCATION",
-                "format": "PDF"
+                "format": "PDF",
+                "description": "D2"
             },
             "source": {
                 "type": "csv-distribution",
@@ -164,7 +166,8 @@
             "dcat-distribution-strings": {
                 "title": "T3",
                 "license": "Copyright",
-                "accessNotes": "LOCATION3"
+                "accessNotes": "LOCATION3",
+                "description": "D3"
             },
             "source": {
                 "type": "csv-distribution",

--- a/magda-csv-connector/src/test/csv2.json
+++ b/magda-csv-connector/src/test/csv2.json
@@ -9,7 +9,8 @@
                 "accessURL": "LOCATION 3",
                 "accessNotes": "PATH/2",
                 "downloadURL": "http://internal-1",
-                "format": "CSV"
+                "format": "CSV",
+                "description": "DATASET\n\nDESCRIPTION 1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -30,7 +31,8 @@
                 "accessURL": "LOCATION 3",
                 "accessNotes": "PATH/2",
                 "downloadURL": "http://internal-1",
-                "format": "JSON"
+                "format": "JSON",
+                "description": "DATASET\n\nDESCRIPTION 1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -51,7 +53,8 @@
                 "accessURL": "LOCATION 3",
                 "accessNotes": "PATH/2",
                 "downloadURL": "http://internal-1",
-                "format": "Excel"
+                "format": "Excel",
+                "description": "DATASET\n\nDESCRIPTION 1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -72,7 +75,8 @@
                 "accessURL": "LOCATION 3",
                 "accessNotes": "PATH/2",
                 "downloadURL": "http://internal-1",
-                "format": "Other"
+                "format": "Other",
+                "description": "DATASET\n\nDESCRIPTION 1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -154,7 +158,9 @@
                 "accessURL": "LOCATION 2",
                 "accessNotes": "PATH/1",
                 "downloadURL": "INTERNAL DATABASE 2",
-                "format": "Shape File"
+                "format": "Shape File",
+                "description":
+                    "&lt;script&gt;alert(âDATASET DESCRIPTION 2â)&lt;/script&gt;"
             },
             "source": {
                 "type": "csv-distribution",
@@ -175,7 +181,9 @@
                 "accessURL": "LOCATION 2",
                 "accessNotes": "PATH/1",
                 "downloadURL": "INTERNAL DATABASE 2",
-                "format": "Other"
+                "format": "Other",
+                "description":
+                    "&lt;script&gt;alert(âDATASET DESCRIPTION 2â)&lt;/script&gt;"
             },
             "source": {
                 "type": "csv-distribution",
@@ -257,7 +265,8 @@
                 "accessURL": "LOCATION 1",
                 "accessNotes": "PATH/3",
                 "downloadURL": "file://external-3",
-                "format": "CSV"
+                "format": "CSV",
+                "description": "DATASET &lt;b&gt;DESCRIPTION&lt;/b&gt; 3"
             },
             "source": {
                 "type": "csv-distribution",
@@ -280,7 +289,8 @@
                 "accessURL": "LOCATION 1",
                 "accessNotes": "PATH/3",
                 "downloadURL": "file://external-3",
-                "format": "Other"
+                "format": "Other",
+                "description": "DATASET &lt;b&gt;DESCRIPTION&lt;/b&gt; 3"
             },
             "source": {
                 "type": "csv-distribution",

--- a/magda-csv-connector/src/test/csv3.json
+++ b/magda-csv-connector/src/test/csv3.json
@@ -8,7 +8,8 @@
                 "license": "Copyright",
                 "rights": "RFC",
                 "accessNotes": "LOCATION1",
-                "format": "MS Access"
+                "format": "MS Access",
+                "description": "D1"
             },
             "source": {
                 "type": "csv-distribution",
@@ -90,7 +91,8 @@
                 "title": "T2",
                 "rights": "Internal",
                 "accessNotes": "METADATA LOCATION",
-                "format": "PDF"
+                "format": "PDF",
+                "description": "D2"
             },
             "source": {
                 "type": "csv-distribution",
@@ -164,7 +166,8 @@
             "dcat-distribution-strings": {
                 "title": "T3",
                 "license": "Copyright",
-                "accessNotes": "LOCATION3"
+                "accessNotes": "LOCATION3",
+                "description": "D3"
             },
             "source": {
                 "type": "csv-distribution",

--- a/magda-typescript-common/src/test/connectors/runConnectorTest.ts
+++ b/magda-typescript-common/src/test/connectors/runConnectorTest.ts
@@ -20,6 +20,7 @@ export function runConnectorTest(
 
         function run(done: any) {
             const command = [
+                "--require=tsconfig-paths/register",
                 "src",
                 "--id=connector",
                 "--name=Connector",


### PR DESCRIPTION
### What this PR does

Fixes #1996 

Because we only have one description per row in the CSV, we're currently putting that description against the dataset and leaving the distribution desc blank. This makes it so that the distribution gets the same desc as the dataset.

Testing instance is at https://issue-1996-csv-connector-dist-desc.dev.magda.io. Username/password are the same as the usual agriculture instance.

Example of agriculture distribution with description: https://issue-1996-csv-connector-dist-desc.dev.magda.io/dataset/ds-csv-ag2-507/distribution/dist-csv-ag2-507-0-msexcel/details?q= is an example of an ag dataset distribution.

Example of environment distribution with description: https://issue-1996-csv-connector-dist-desc.dev.magda.io/dataset/ds-csv-ag-row-9/distribution/dist-csv-ag-row-9-0-databasetable/details?q=

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
