### PR TITLE
Issue/2006 Fixed: Empty source link shows as a working link on dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Development:
 Others:
 
 -   Changed terminology for data rating to `Linked Data Rating`
+-   Fixed: Empty source link shows as a working link on dataset page
 
 ## 0.0.51
 

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -17,9 +17,11 @@ class DatasetDetails extends Component {
         const searchText =
             queryString.parse(this.props.location.search).q || "";
         const source = this.props.dataset.source
-            ? `This dataset was originally found on [${
-                  this.props.dataset.source
-              }](${dataset.landingPage})`
+            ? `This dataset was originally found on ${
+                  dataset.landingPage
+                      ? `[${this.props.dataset.source}](${dataset.landingPage})`
+                      : this.props.dataset.source
+              }`
             : "";
         return (
             <div className="dataset-details">


### PR DESCRIPTION
### What this PR does

Fixes #2006 

Fixed: Empty source link shows as a working link on dataset page

Test Link:

No link:
https://issue-2006.dev.magda.io/dataset/ds-listtas-f7122469-cf06-4a69-a446-8e28f2c65d16/details

Has link:
https://issue-2006.dev.magda.io/dataset/ds-sa-996ec2ae-d52c-4d7e-be9c-d4dab1c1aa45/details

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
