### PR TITLE
Made url for CKAN authentication configurable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Others:
 
 -   Changed terminology for data rating to `Linked Data Rating`
 -   Fixed: Empty source link shows as a working link on dataset page
+-   Removed hard-coded URL for CKAN authentication, made it configurable.
 
 ## 0.0.51
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -40,28 +40,11 @@ gateway:
     directives:
       scriptSrc:
       - "''self''"
-      - "''unsafe-inline''" # For VWO, hopefully we can remove this soon
-      - "data:" # Also for VWO
       - browser-update.org
-      - dev.visualwebsiteoptimizer.com
-      - platform.twitter.com
-      - www.googletagmanager.com
-      - www.google-analytics.com
-      - rum-static.pingdom.net
-      - https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/2.4.1/rollbar.min.js
-      - https://tagmanager.google.com/debug
-      - assets.zendesk.com
-      - static.zdassets.com
-      - ekr.zdassets.com
       objectSrc:
       - "''none''"
-      sandbox: # We run the sandbox because we have to have unsafe-inline, when we remove unsafe inline we should remove this
-      - allow-scripts
-      - allow-same-origin
-      - allow-popups
-      - allow-forms
-      - allow-popups-to-escape-sandbox
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
+  ckanAuthenticationUrl: https://data.gov.au/data
 
 combined-db:
   waleBackup:

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -31,6 +31,7 @@ gateway:
   auth:
     facebookClientId: "173073926555600"
     googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
+    ckanAuthenticationUrl: https://data.gov.au/data
   cors:
     credentials: true
     origin: true
@@ -41,10 +42,10 @@ gateway:
       scriptSrc:
       - "''self''"
       - browser-update.org
+      - "''unsafe-inline''"
       objectSrc:
       - "''none''"
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
-  ckanAuthenticationUrl: https://data.gov.au/data
 
 combined-db:
   waleBackup:

--- a/deploy/helm/magda/charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
 {{- if .Values.enableCkanRedirection }}
             "--enableCkanRedirection", {{ .Values.enableCkanRedirection | quote }},
 {{- end }}
+{{- if .Values.ckanAuthenticationUrl }}
+            "--ckanUrl", {{ .Values.ckanAuthenticationUrl | quote }},
+{{- end }}
             "--proxyRoutesJson", "/etc/config/routes.json",
             "--helmetJson", "/etc/config/helmet.json",
             "--cspJson", "/etc/config/csp.json",
@@ -61,7 +64,6 @@ spec:
             "--web", "http://web",
             "--authorizationApi", "http://authorization-api/v0",
             "--previewMap", "http://preview-map:6110",
-            "--ckanUrl", "https://data.gov.au"
         ]
         volumeMounts:
           - name: config

--- a/deploy/helm/magda/charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/deployment.yaml
@@ -54,8 +54,8 @@ spec:
 {{- if .Values.enableCkanRedirection }}
             "--enableCkanRedirection", {{ .Values.enableCkanRedirection | quote }},
 {{- end }}
-{{- if .Values.ckanAuthenticationUrl }}
-            "--ckanUrl", {{ .Values.ckanAuthenticationUrl | quote }},
+{{- if .Values.auth.ckanAuthenticationUrl }}
+            "--ckanUrl", {{ .Values.auth.ckanAuthenticationUrl | quote }},
 {{- end }}
             "--proxyRoutesJson", "/etc/config/routes.json",
             "--helmetJson", "/etc/config/helmet.json",

--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -54,6 +54,8 @@ csp:
   directives:
     scriptSrc:
     - "''self''"
+    - "''unsafe-inline''"
+    - browser-update.org
     objectSrc:
     - "''none''"
 

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -23,6 +23,7 @@ gateway:
   auth:
     facebookClientId: "173073926555600"
     googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
+    ckanAuthenticationUrl: https://data.gov.au/data
 
 registry-api:
   skipAuthorization: true

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -36,28 +36,11 @@ gateway:
     directives:
       scriptSrc:
       - "''self''"
-      - "''unsafe-inline''" # For VWO, hopefully we can remove this soon
-      - "data:" # Also for VWO
       - browser-update.org
-      - dev.visualwebsiteoptimizer.com
-      - platform.twitter.com
-      - www.googletagmanager.com
-      - www.google-analytics.com
-      - rum-static.pingdom.net
-      - https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/2.4.1/rollbar.min.js
-      - https://tagmanager.google.com/debug
-      - assets.zendesk.com
-      - static.zdassets.com
-      - ekr.zdassets.com
       objectSrc:
       - "''none''"
-      sandbox: # We run the sandbox because we have to have unsafe-inline, when we remove unsafe inline we should remove this
-      - allow-scripts
-      - allow-same-origin
-      - allow-popups
-      - allow-forms
-      - allow-popups-to-escape-sandbox
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
+  ckanAuthenticationUrl: https://data.gov.au/data
       
 combined-db:
   waleBackup:

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -24,9 +24,7 @@ gateway:
     enabled: false
   enableAuthEndpoint: true
   enableHttpsRedirection: true
-  enableCkanRedirection: true
-  ckanRedirectionDomain: "ckan.data.gov.au"
-  ckanRedirectionPath: ""
+  enableCkanRedirection: false
   helmet:
     frameguard: false
   cors:
@@ -36,11 +34,13 @@ gateway:
     directives:
       scriptSrc:
       - "''self''"
+      - "''unsafe-inline''"
       - browser-update.org
       objectSrc:
       - "''none''"
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
-  ckanAuthenticationUrl: https://data.gov.au/data
+  auth:
+    ckanAuthenticationUrl: https://data.gov.au/data
       
 combined-db:
   waleBackup:

--- a/magda-gateway/src/createAuthRouter.ts
+++ b/magda-gateway/src/createAuthRouter.ts
@@ -61,7 +61,8 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
             authRouter: require("./oauth2/ckan").default({
                 authorizationApi: authApi,
                 passport: passport,
-                externalAuthHome: `${options.externalUrl}/auth`
+                externalAuthHome: `${options.externalUrl}/auth`,
+                ckanUrl: options.ckanUrl
             })
         },
         {

--- a/magda-gateway/src/oauth2/ckan.ts
+++ b/magda-gateway/src/oauth2/ckan.ts
@@ -12,12 +12,14 @@ export interface CkanOptions {
     authorizationApi: ApiClient;
     passport: Authenticator;
     externalAuthHome: string;
+    ckanUrl: string;
 }
 
 export default function ckan(options: CkanOptions) {
     const authorizationApi = options.authorizationApi;
     const passport = options.passport;
     const externalAuthHome = options.externalAuthHome;
+    const ckanUrl = options.ckanUrl;
 
     passport.use(
         new LocalStrategy(function(
@@ -25,7 +27,7 @@ export default function ckan(options: CkanOptions) {
             password: string,
             cb: (error: any, user?: any, info?: any) => void
         ) {
-            loginToCkan(username, password).then(result => {
+            loginToCkan(username, password, ckanUrl).then(result => {
                 result.caseOf({
                     left: error => cb(error),
                     right: profile => {

--- a/magda-gateway/src/oauth2/loginToCkan.ts
+++ b/magda-gateway/src/oauth2/loginToCkan.ts
@@ -14,19 +14,17 @@ namespace loginToCkan {
 
 function loginToCkan(
     username: string,
-    password: string
+    password: string,
+    ckanUrl: string
 ): Promise<Either<loginToCkan.Failure, loginToCkan.Success>> {
-    return fetch(
-        "https://data.gov.au/login_generic?came_from=/user/logged_in",
-        {
-            method: "POST",
-            redirect: "manual",
-            headers: {
-                "Content-Type": "application/x-www-form-urlencoded"
-            },
-            body: `login=${username}&password=${password}`
-        }
-    ).then(res => {
+    return fetch(ckanUrl + "/data/login_generic?came_from=/user/logged_in", {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: `login=${username}&password=${password}`
+    }).then(res => {
         const cookies = res.headers.get("set-cookie");
 
         if (!cookies) {
@@ -39,15 +37,16 @@ function loginToCkan(
 
         const relevantCookie = cookies.split(";")[0];
 
-        return afterLoginSuccess(relevantCookie, username);
+        return afterLoginSuccess(relevantCookie, username, ckanUrl);
     });
 }
 
 function afterLoginSuccess(
     cookies: string,
-    username: string
+    username: string,
+    ckanUrl: string
 ): Promise<Either<loginToCkan.Failure, loginToCkan.Success>> {
-    return fetch("https://data.gov.au/user/edit/" + username, {
+    return fetch(ckanUrl + "/user/edit/" + username, {
         headers: {
             cookie: cookies
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10762,6 +10762,11 @@ jws@^3.1.4:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
 
+jwt-simple@^0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/jwt-simple/-/jwt-simple-0.5.5.tgz#53f60ceab266708450a22cafa6fd93cfa2ccfa3a"
+  integrity sha512-KEyanRIDHooo8KuBxY3CC019NbwHtxdsxzRJUfaGqcxMrvBPBkosN+RUxx1nZFI6yrErq3KTW8HI/qrNIxHe0g==
+
 jxLoader@*:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jxLoader/-/jxLoader-0.1.1.tgz#0134ea5144e533b594fc1ff25ff194e235c53ecd"
@@ -13306,6 +13311,13 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+passport-custom@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/passport-custom/-/passport-custom-1.0.5.tgz#2d1d9c174a6a4685bf0289bce61091cd5ec7b0f4"
+  integrity sha1-LR2cF0pqRoW/Aom85hCRzV7HsPQ=
+  dependencies:
+    passport-strategy "1.x.x"
 
 passport-facebook@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
### What this PR does

Fixes #2029 

The hard-coded old data.gov.au location we had in the CKAN auth provider is now out of date - this makes it configurable.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
