### PR TITLE
Support dev node taint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Dataset Page:
 Others:
 
 -   Upgraded dependencies with snyk.io vulnerabilities.
+-   Added `magda.reservedFor=statefulsets:NoSchedule` toleration to statefulsets.
 
 ## 0.0.52
 

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
       tolerations:
-      - key: "reservedFor"
+      - key: "magda.reservedFor"
         operator: "Equal"
         value: "statefulsets"
         effect: "NoSchedule"

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -22,6 +22,11 @@ spec:
 {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
+      tolerations:
+      - key: "reservedFor"
+        operator: "Equal"
+        value: "statefulsets"
+        effect: "NoSchedule"
       containers:
       - name: combined-db
         resources:

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -41,6 +41,11 @@ spec:
                   values:
                   - data
               topologyKey: kubernetes.io/hostname
+      tolerations:
+      - key: "reservedFor"
+        operator: "Equal"
+        value: "statefulsets"
+        effect: "NoSchedule"
       containers:
       - name: es-data
         securityContext:

--- a/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
+++ b/deploy/helm/magda/charts/elasticsearch/templates/data-statefulset.yml
@@ -42,7 +42,7 @@ spec:
                   - data
               topologyKey: kubernetes.io/hostname
       tolerations:
-      - key: "reservedFor"
+      - key: "magda.reservedFor"
         operator: "Equal"
         value: "statefulsets"
         effect: "NoSchedule"


### PR DESCRIPTION
### What this PR does
This is the config change I made to dev to stop combined-db-0 being unschedulable.

Essentially in dev there's a taint on the non-preemptible node - `magda.reservedFor=statefulsets:NoSchedule`. This toleration allows the es-data and combined-db pods to get scheduled on it anyway.