### PR TITLE
Issue/2010 Improvements on CSW connector license info retrieve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Connectors:
 
 -   Allowed Ckan connector to pull datasets belongs to a specified organisation
 -   Added `presetRecordAspects` & `extra` parameters supports to all connectors
+-   Improvements on CSW connector license info retrieve
 
 Dataset Page:
 

--- a/magda-csw-connector/src/test/env.json
+++ b/magda-csw-connector/src/test/env.json
@@ -9,8 +9,7 @@
                 "issued": "2019-01-07",
                 "accessURL": "http://www.environment.gov.au",
                 "format": "ArcGIS File geodatabase",
-                "license":
-                    "Spatial data for Threatened Ecological Communities  has no legal status and must always defer to the Conservation Advice. It is unsafe to use the spatial data only to decide if an ecological community of national environmental significance occurs at a particular location."
+                "license": "CC - Attribution (CC BY)"
             },
             "source": {
                 "type": "csw-distribution",
@@ -134,7 +133,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "ArcGIS File geodatabase",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons. Referral spatial boundaries are indicative only and should not be used to define the totality of onground works including being used as a substitute for an onground development footprint. Through the assessment and approval process, boundaries may be updated by a proponent to reflect improved understanding of the extent of a development. Where advised ERIN update the EPBC Act Referrals Spatial Database to reflect these changes however no guarantee is given to this."
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons."
             },
             "source": {
                 "type": "csw-distribution",
@@ -159,7 +158,7 @@
                     "http://www.environment.gov.au/mapping/services/ogc_services/EPBC_Referrals/MapServer/WMSServer",
                 "format": "OGC:WMS",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons. Referral spatial boundaries are indicative only and should not be used to define the totality of onground works including being used as a substitute for an onground development footprint. Through the assessment and approval process, boundaries may be updated by a proponent to reflect improved understanding of the extent of a development. Where advised ERIN update the EPBC Act Referrals Spatial Database to reflect these changes however no guarantee is given to this."
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons."
             },
             "source": {
                 "type": "csw-distribution",
@@ -184,7 +183,7 @@
                     "http://www.environment.gov.au/mapping/services/ogc_services/EPBC_Referrals/MapServer/WFSServer",
                 "format": "OGC:WFS",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons. Referral spatial boundaries are indicative only and should not be used to define the totality of onground works including being used as a substitute for an onground development footprint. Through the assessment and approval process, boundaries may be updated by a proponent to reflect improved understanding of the extent of a development. Where advised ERIN update the EPBC Act Referrals Spatial Database to reflect these changes however no guarantee is given to this."
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons."
             },
             "source": {
                 "type": "csw-distribution",
@@ -209,7 +208,7 @@
                     "http://www.environment.gov.au/about-us/environmental-information-data",
                 "format": "WWW:LINK-1.0-http--link",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons. Referral spatial boundaries are indicative only and should not be used to define the totality of onground works including being used as a substitute for an onground development footprint. Through the assessment and approval process, boundaries may be updated by a proponent to reflect improved understanding of the extent of a development. Where advised ERIN update the EPBC Act Referrals Spatial Database to reflect these changes however no guarantee is given to this."
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons."
             },
             "source": {
                 "type": "csw-distribution",
@@ -286,7 +285,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "Shapefile",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 4.0 International Licence. More information can be found at https://creativecommons.org/licenses/by/4.0/. Indicative only"
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 4.0 International Licence. More information can be found at https://creativecommons.org/licenses/by/4.0/."
             },
             "source": {
                 "type": "csw-distribution",
@@ -355,7 +354,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "Shapefile",
                 "license":
-                    "Data is licenced under the department's restrictive Data Licence Deed Data is in draft format only Departmental Deed"
+                    "Departmental Deed\nData is in draft format only\nData is licenced under the department's restrictive Data Licence Deed"
             },
             "source": {
                 "type": "csw-distribution",
@@ -424,7 +423,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "Shapefile",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 4.0 International Licence. "
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 4.0 International Licence. "
             },
             "source": {
                 "type": "csw-distribution",
@@ -493,7 +492,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "Shapefile",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 4.0 International Licence. "
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 4.0 International Licence. "
             },
             "source": {
                 "type": "csw-distribution",
@@ -661,7 +660,7 @@
                 "accessURL": "http://www.environment.gov.au",
                 "format": "Shapefile",
                 "license":
-                    "This data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons. The generalised maps and data are indicative products only and are not intended for use at a local or regional level."
+                    "CC - Attribution (CC BY)\nThis data has been licensed under the Creative Commons Attribution 3.0 Australia Licence. More information can be found at http://www.ausgoal.gov.au/creative-commons."
             },
             "source": {
                 "type": "csw-distribution",

--- a/magda-web-client/src/Components/DistributionRow.scss
+++ b/magda-web-client/src/Components/DistributionRow.scss
@@ -26,6 +26,7 @@
 
     .distribution-row-link-license {
         @include AU-fontgrid(xs);
+        white-space: pre;
     }
 
     .download-button {


### PR DESCRIPTION
### What this PR does

Fixes #2010 

Changes Summary:
- Altered regex for matching CC license & Compare search method result with -1 (avoid 0 to be treated as not found)
  - this fixed a few missed CC license lookup
- Sort by license string length
  - If more than one license description is found, the shorter one (e.g. `CC - Attribution (CC BY)`) normally is the license title and the longer string is the description. The sort func makes sure the license title always be shown in front of the long description block.
- join license text block by \n (instead of space)
  - Make it easier for possible future processing and visual improvement
- Make \n displayed as newline on dataset page
- Updated test cases

![image](https://user-images.githubusercontent.com/674387/52927253-b1ecc400-338d-11e9-94b9-2fc674e5136d.png)

#### Test:

Test Site (crawled env ): https://issue-2010.dev.magda.io

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
