### PR TITLE
Add value attribute to "Search and Result Clicked" events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.0.54
+
+Others:
+
+-   Added value to the "Search result and click" Google Analytics event that will show averages and other numeric aggregates in Google Analytics.
+
 ## 0.0.53
 
 Connectors:
@@ -63,7 +69,6 @@ Others:
 -   Changed terminology for data rating to `Linked Data Rating`
 -   Fixed: Empty source link shows as a working link on dataset page
 -   Removed hard-coded URL for CKAN authentication, made it configurable.
--   Added value to the "Search result and click" Google Analytics event that will show averages and other numeric aggregates in Google Analytics.
 
 ## 0.0.51
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Others:
 -   Changed terminology for data rating to `Linked Data Rating`
 -   Fixed: Empty source link shows as a working link on dataset page
 -   Removed hard-coded URL for CKAN authentication, made it configurable.
+-   Added value to the "Search result and click" Google Analytics event that will show averages and other numeric aggregates in Google Analytics.
 
 ## 0.0.51
 

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.js
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.js
@@ -101,7 +101,8 @@ export default class DatasetSummary extends Component {
                                 gapi.event({
                                     category: "Search and Result Clicked",
                                     action: this.props.searchText,
-                                    label: (searchResultNumber + 1).toString()
+                                    label: (searchResultNumber + 1).toString(),
+                                    value: (searchResultNumber + 1).toString()
                                 });
                             }
                         }}


### PR DESCRIPTION
### What this PR does

By adding a value to the "Search and Result Clicked" event, we can get averages, totals and other aggregates in the GA interface.
The value used is the ranking of the search result that was clicked. By adding it to the numeric field, we can look at things like totals and averages for different datasets, and totals/averages for different queries.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
