### PR TITLE
Issue/2104 Fixed: datasets with null description could lead to blank search result page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Others:
 -   Change content api delete response status code from to 204 to 200 so its content can be read.
 -   Upgraded Elasticsearch to v6.5.4 Elastic4s to v6.5.1
 -   Elasticsearch related test cases run on Docker container than than local node
+-   Fixed: datasets with null description could lead to blank search result page
 
 ## 0.0.53
 

--- a/magda-web-client/src/UI/MarkdownViewer.js
+++ b/magda-web-client/src/UI/MarkdownViewer.js
@@ -8,6 +8,7 @@ var DOMPurify = require("dompurify/dist/purify");
 class MarkdownViewer extends React.Component {
     render() {
         let html = markdownToHtml(this.props.markdown);
+        html = html ? html : "";
         if (this.props.truncate === true) {
             html = truncate(
                 html,


### PR DESCRIPTION
### What this PR does

Fixes #2104 

Fixed: datasets with null description could lead to blank search result page

Here is the dataset actually causes the issue (null description):

https://data.gov.au/dataset/ds-qld-1a7aff41-625d-4b35-901a-654ff071ba82/details?q=finance

This issue only happens to search result page.

How it looks like now:

![image](https://user-images.githubusercontent.com/674387/54173618-d3495780-44d6-11e9-8864-fd0b7e11a47b.png)


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
