### PR TITLE
Upgrade JDK version & install NSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## 0.0.55
 
+Others:
+
+-   Upgraded JDK version for magda-builder-scala to 8u201
+
 ## 0.0.54
 
 Connectors:

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -20,8 +20,8 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u191
-ENV JAVA_ALPINE_VERSION 8.191.12-r0
+ENV JAVA_VERSION 8u201
+ENV JAVA_ALPINE_VERSION 8.201.08-r0
 
 RUN set -x \
 	&& apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -36,6 +36,7 @@ ENV PATH ${PATH}:${SBT_HOME}/bin
 # Install sbt
 RUN mkdir -p "$SBT_HOME" && \
     apk add --no-cache --update wget bash && \
+    apk add nss && \
     wget -qO - --no-check-certificate "http://dl.bintray.com/sbt/native-packages/sbt/$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar xz -C $SBT_HOME --strip-components=1 && \
     apk del wget && \
 	sbt sbtVersion

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -35,8 +35,7 @@ ENV PATH ${PATH}:${SBT_HOME}/bin
 
 # Install sbt
 RUN mkdir -p "$SBT_HOME" && \
-    apk add --no-cache --update wget bash && \
-    apk add nss && \
+    apk add --no-cache --update wget bash nss && \
     wget -qO - --no-check-certificate "http://dl.bintray.com/sbt/native-packages/sbt/$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar xz -C $SBT_HOME --strip-components=1 && \
     apk del wget && \
 	sbt sbtVersion


### PR DESCRIPTION
### What this PR does

Fixed the following:
```
@magda/builder-scala: + apk add --no-cache openjdk8=8.191.12-r0
@magda/builder-scala: fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
@magda/builder-scala: fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
@magda/builder-scala: ERROR: unsatisfiable constraints:
@magda/builder-scala:   openjdk8-8.201.08-r0:
@magda/builder-scala:     breaks: world[openjdk8=8.191.12-r0]
@magda/builder-scala: The command '/bin/sh -c set -x     && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION"     && [ "$JAVA_HOME" = "$(docker-java-home)" ]' returned a non-zero code: 1
```

Also, install NSS to avoid:
```
Caused by: java.security.ProviderException: Could not initialize NSS
	at sun.security.pkcs11.SunPKCS11.<init>(SunPKCS11.java:223)
	at sun.security.pkcs11.SunPKCS11.<init>(SunPKCS11.java:103)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at sun.security.jca.ProviderConfig$2.run(ProviderConfig.java:224)
	at sun.security.jca.ProviderConfig$2.run(ProviderConfig.java:206)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.security.jca.ProviderConfig.doLoadProvider(ProviderConfig.java:206)
	at sun.security.jca.ProviderConfig.getProvider(ProviderConfig.java:187)
	at sun.security.jca.ProviderList.getProvider(ProviderList.java:233)
	at sun.security.jca.ProviderList.getIndex(ProviderList.java:263)
	at sun.security.jca.ProviderList.getProviderConfig(ProviderList.java:247)
	at sun.security.jca.ProviderList.getProvider(ProviderList.java:253)
	at java.security.Security.getProvider(Security.java:503)
	at sun.security.ssl.SignatureAndHashAlgorithm.<clinit>(SignatureAndHashAlgorithm.java:415)
	... 75 more
Caused by: java.io.FileNotFoundException: /usr/lib/libnss3.so
	at sun.security.pkcs11.Secmod.initialize(Secmod.java:193)
	at sun.security.pkcs11.SunPKCS11.<init>(SunPKCS11.java:218)
```

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
