### PR TITLE
Issue/2061 Added Geo Spatial Data Validation to Indexer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Others:
 -   Upgraded Elasticsearch to v6.5.4 Elastic4s to v6.5.1
 -   Elasticsearch related test cases run on Docker container than than local node
 -   Fixed: datasets with null description could lead to blank search result page
+-   Added Geo Spatial Data Validation to Indexer
 
 ## 0.0.53
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/spatial/GeoJsonValidationTest.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/spatial/GeoJsonValidationTest.scala
@@ -1,0 +1,57 @@
+package au.csiro.data61.magda.spatial
+import au.csiro.data61.magda.model.misc.Location
+import org.scalatest.{Assertion, FlatSpec, FunSpec, Matchers}
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success, Try}
+
+
+class GeoJsonValidationTest extends FunSpec with Matchers {
+
+  val logger = LoggerFactory.getLogger(getClass)
+
+  describe("GeoJson Data Validation") {
+    it("should detect invalidation data with invalid Longitude"){
+      val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[20106.11903, -31.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
+      withClue(){
+        Try(Location(geoJson)) match {
+          case Failure(e) =>
+            logger.info("Detected invalid GeoJson data: {}", e.toString)
+            succeed
+          case Success(v) =>
+            val g = v.geoJson
+            fail("Failed to detect invalid geoJson Data")
+        }
+      }
+    }
+
+    it("should detect invalidation data with invalid latitude"){
+      val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[152.11903, -91.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
+      withClue(){
+        Try(Location(geoJson)) match {
+          case Failure(e) =>
+            logger.info("Detected invalid GeoJson data: {}", e.toString)
+            succeed
+          case Success(v) =>
+            val g = v.geoJson
+            fail("Failed to detect invalid geoJson Data")
+        }
+      }
+    }
+
+    it("should return `Location` if it comes with valid coordinates"){
+      val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[152.11903, -31.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
+      withClue(){
+        Try(Location(geoJson)) match {
+          case Failure(e) =>
+            logger.info("Detected invalid GeoJson data: {}", e.toString)
+            succeed
+          case Success(v) =>
+            v.geoJson.isEmpty should be(false)
+        }
+      }
+    }
+
+  }
+}
+

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/spatial/GeoJsonValidationTest.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/spatial/GeoJsonValidationTest.scala
@@ -13,42 +13,36 @@ class GeoJsonValidationTest extends FunSpec with Matchers {
   describe("GeoJson Data Validation") {
     it("should detect invalidation data with invalid Longitude"){
       val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[20106.11903, -31.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
-      withClue(){
-        Try(Location(geoJson)) match {
-          case Failure(e) =>
-            logger.info("Detected invalid GeoJson data: {}", e.toString)
-            succeed
-          case Success(v) =>
-            val g = v.geoJson
-            fail("Failed to detect invalid geoJson Data")
-        }
+      Try(Location(geoJson)) match {
+        case Failure(e) =>
+          logger.info("Detected invalid GeoJson data: {}", e.toString)
+          succeed
+        case Success(v) =>
+          val g = v.geoJson
+          fail("Failed to detect invalid geoJson Data")
       }
     }
 
     it("should detect invalidation data with invalid latitude"){
       val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[152.11903, -91.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
-      withClue(){
-        Try(Location(geoJson)) match {
-          case Failure(e) =>
-            logger.info("Detected invalid GeoJson data: {}", e.toString)
-            succeed
-          case Success(v) =>
-            val g = v.geoJson
-            fail("Failed to detect invalid geoJson Data")
-        }
+      Try(Location(geoJson)) match {
+        case Failure(e) =>
+          logger.info("Detected invalid GeoJson data: {}", e.toString)
+          succeed
+        case Success(v) =>
+          val g = v.geoJson
+          fail("Failed to detect invalid geoJson Data")
       }
     }
 
     it("should return `Location` if it comes with valid coordinates"){
       val geoJson = "{\"type\": \"Polygon\", \"coordinates\": [[[152.11903, -31.85658], [152.11903, -28.53715], [147.39402, -28.53715], [147.39402, -31.85658], [152.11903, -31.85658]]]}"
-      withClue(){
-        Try(Location(geoJson)) match {
-          case Failure(e) =>
-            logger.info("Detected invalid GeoJson data: {}", e.toString)
-            succeed
-          case Success(v) =>
-            v.geoJson.isEmpty should be(false)
-        }
+      Try(Location(geoJson)) match {
+        case Failure(e) =>
+          logger.info("Detected invalid GeoJson data: {}", e.toString)
+          succeed
+        case Success(v) =>
+          v.geoJson.isEmpty should be(false)
       }
     }
 

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -9,29 +9,30 @@ libraryDependencies ++= {
   val akkaHttpV   = "10.1.7"
   val scalaTestV  = "3.0.1"
   Seq(
-       "com.typesafe.akka" %% "akka-actor" % akkaV,
-       "com.typesafe.akka" %% "akka-stream" % akkaV,
-       "com.typesafe.akka" %% "akka-contrib" % akkaV,
-       "com.typesafe.akka" %% "akka-http" % akkaHttpV,
-       "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
-       "com.typesafe.akka" %% "akka-slf4j" % akkaV,
-       "ch.qos.logback" % "logback-classic" % "1.2.3",
-       "com.monsanto.labs" %% "mwundo" % "0.1.0" exclude("xerces", "xercesImpl"),
-       "org.scalaz" %% "scalaz-core" % "7.2.8",
+    "com.typesafe.akka" %% "akka-actor" % akkaV,
+    "com.typesafe.akka" %% "akka-stream" % akkaV,
+    "com.typesafe.akka" %% "akka-contrib" % akkaV,
+    "com.typesafe.akka" %% "akka-http" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-slf4j" % akkaV,
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.monsanto.labs" %% "mwundo" % "0.1.0" exclude("xerces", "xercesImpl"),
+    "org.scalaz" %% "scalaz-core" % "7.2.8",
 
-       "org.locationtech.spatial4j" % "spatial4j" % "0.7",
-       "org.locationtech.jts" % "jts-core" % "1.15.0",
-       "org.elasticsearch" % "elasticsearch" % "6.5.1",
+    "org.locationtech.spatial4j" % "spatial4j" % "0.7",
+    "org.locationtech.jts" % "jts-core" % "1.15.0",
+    "org.elasticsearch" % "elasticsearch" % "6.5.1",
 
-       "com.sksamuel.elastic4s" %% "elastic4s-core" % "6.5.1",
-       "com.sksamuel.elastic4s" %% "elastic4s-http" % "6.5.1",
-       "org.apache.logging.log4j" % "log4j-core" % "2.9.1",
-       "org.apache.logging.log4j" % "log4j-api" % "2.9.1",
+    "com.sksamuel.elastic4s" %% "elastic4s-core" % "6.5.1",
+    "com.sksamuel.elastic4s" %% "elastic4s-http" % "6.5.1",
+    "org.apache.logging.log4j" % "log4j-core" % "2.9.1",
+    "org.apache.logging.log4j" % "log4j-api" % "2.9.1",
 
-       "com.mchange" %% "leftright" % "0.0.1",
-       "com.beachape" %% "enumeratum" % "1.5.10",
-       "com.github.swagger-akka-http" %% "swagger-akka-http" % "0.14.1",
-       "com.auth0" % "java-jwt" % "3.7.0",
-       "net.virtual-void" %%  "json-lenses" % "0.6.2"
-     )
+    "com.mchange" %% "leftright" % "0.0.1",
+    "com.beachape" %% "enumeratum" % "1.5.10",
+    "com.github.swagger-akka-http" %% "swagger-akka-http" % "0.14.1",
+    "com.auth0" % "java-jwt" % "3.7.0",
+    "net.virtual-void" %%  "json-lenses" % "0.6.2",
+    "com.mapbox.mapboxsdk" % "mapbox-sdk-geojson" % "4.5.0"
+  )
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -3,14 +3,15 @@ package au.csiro.data61.magda.model
 import java.time.OffsetDateTime
 
 import com.monsanto.labs.mwundo.GeoJson._
-
 import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes
 import au.csiro.data61.magda.model.GeoJsonFormats._
 import au.csiro.data61.magda.model.Temporal._
+import au.csiro.data61.magda.spatial.GeoJsonValidator
 import spray.json._
+
 import scala.runtime.ScalaRunTime
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 package misc {
   sealed trait FacetType {
@@ -137,6 +138,8 @@ package misc {
           }
         case x => x
       }
+
+      processedGeoJson.foreach(geoJson => GeoJsonValidator.validate(geoJson))
 
       new Location(Some(text), processedGeoJson)
     }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
@@ -35,8 +35,8 @@ object GeoJsonValidator {
     * A Longitude (x) can be -180 to +180 & A latitude (y) can only be in the range of -90 to +90.
     */
   def validateCoordinate(c:GeoJson.Coordinate): Boolean = {
-    if(c.x > 180 || c.x < -180) throw new Exception(s"Invalid Longitude (x) range: ${c.x}. Should be within -180 to +180")
-    if(c.y > 90 || c.y < -90) throw new Exception(s"Invalid latitude (x) range: ${c.x}. Should be within -90 to +90")
+    if(c.x.abs > BigDecimal(180)) throw new Exception(s"Invalid Longitude (x) range: ${c.x}. Should be within -180 to +180")
+    if(c.y.abs > BigDecimal(90)) throw new Exception(s"Invalid latitude (y) range: ${c.y}. Should be within -90 to +90")
     true
   }
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
@@ -8,16 +8,42 @@ import spray.json._
 object GeoJsonValidator {
 
   def validate(geoJson:GeoJson.Typed):GeoJson = geoJson match {
-    case geoJson:GeoJson.Point => Point.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.MultiPoint => MultiPoint.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.LineString => LineString.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.MultiLineString => MultiLineString.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.Polygon => Polygon.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.MultiPolygon => MultiPolygon.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.GeometryCollection[_] => GeometryCollection.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.Feature[_,_] => Feature.fromJson(geoJson.toJson.toString)
-    case geoJson:GeoJson.FeatureCollection[_,_] => FeatureCollection.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.Point =>
+      validateCoordinate(geoJson.coordinates)
+      Point.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiPoint =>
+      validateCoordinates(geoJson.coordinates)
+      MultiPoint.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.LineString =>
+      validateCoordinates(geoJson.coordinates)
+      LineString.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiLineString =>
+      validateCoordinatesCollection(geoJson.coordinates)
+      MultiLineString.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.Polygon =>
+      validateCoordinatesCollection(geoJson.coordinates)
+      Polygon.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiPolygon =>
+      validateCoordinatesCollections(geoJson.coordinates)
+      MultiPolygon.fromJson(geoJson.toJson.toString)
     case _ => throw new Exception(s"Invalid GeoJson object: ${geoJson.getClass.toString}")
   }
+
+  /**
+    * In GeoJSON and WKT, and therefore Elasticsearch, the correct coordinate order is longitude, latitude (X, Y) within coordinate arrays.
+    * This differs from many Geospatial APIs (e.g., Google Maps) that generally use the colloquial latitude, longitude (Y, X).
+    * A Longitude (x) can be -180 to +180 & A latitude (y) can only be in the range of -90 to +90.
+    */
+  def validateCoordinate(c:GeoJson.Coordinate): Boolean = {
+    if(c.x > 180 || c.x < -180) throw new Exception(s"Invalid Longitude (x) range: ${c.x}. Should be within -180 to +180")
+    if(c.y > 90 || c.y < -90) throw new Exception(s"Invalid latitude (x) range: ${c.x}. Should be within -90 to +90")
+    true
+  }
+
+  def validateCoordinates(cs:Seq[GeoJson.Coordinate]): Boolean = !cs.exists{c:GeoJson.Coordinate => !validateCoordinate(c)}
+
+  def validateCoordinatesCollection(col:Seq[Seq[GeoJson.Coordinate]]): Boolean = !col.exists{cs:Seq[GeoJson.Coordinate] => !validateCoordinates(cs)}
+
+  def validateCoordinatesCollections(cols:Seq[Seq[Seq[GeoJson.Coordinate]]]): Boolean = !cols.exists{col:Seq[Seq[GeoJson.Coordinate]] => !validateCoordinatesCollection(col)}
 
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeoJsonValidator.scala
@@ -1,0 +1,23 @@
+package au.csiro.data61.magda.spatial
+
+import au.csiro.data61.magda.model.GeoJsonFormats._
+import com.mapbox.geojson._
+import com.monsanto.labs.mwundo.GeoJson
+import spray.json._
+
+object GeoJsonValidator {
+
+  def validate(geoJson:GeoJson.Typed):GeoJson = geoJson match {
+    case geoJson:GeoJson.Point => Point.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiPoint => MultiPoint.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.LineString => LineString.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiLineString => MultiLineString.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.Polygon => Polygon.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.MultiPolygon => MultiPolygon.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.GeometryCollection[_] => GeometryCollection.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.Feature[_,_] => Feature.fromJson(geoJson.toJson.toString)
+    case geoJson:GeoJson.FeatureCollection[_,_] => FeatureCollection.fromJson(geoJson.toJson.toString)
+    case _ => throw new Exception(s"Invalid GeoJson object: ${geoJson.getClass.toString}")
+  }
+
+}


### PR DESCRIPTION
### What this PR does

Fixes #2061 

Added Geo Spatial Data Validation to Indexer
- Mainly filtered out (set Spatial field to None before indexing) coordinates that 
  - Longitude (x) out of the range of `-180 to +180`
  - latitude (y) out of the range of `-90 to +90`
- Included `mapbox-sdk-geojson` for overall geoJson validation
- Right hand rule are not checked as per document:
>Elasticsearch accepts both clockwise and counterclockwise polygons if they appear not to cross the dateline (i.e. they cross less than 180° of longitude), but for polygons that do cross the dateline (or for other polygons wider than 180°) Elasticsearch requires the vertex ordering to comply with the OGC and GeoJSON specifications. Otherwise, an unintended polygon may be created and unexpected query/filter results will be returned.

### Testing

1> Done manual triggered full indexing and works fine. 

Here is log:

[idx.log.txt](https://github.com/magda-io/magda/files/2976138/idx.log.txt)
 
There are around 500 geoSpatial data are filtered out:

[lines.idx.log.txt](https://github.com/magda-io/magda/files/2976139/lines.idx.log.txt)

2> Set last event id to `13992910`

And it works fine:
```
[INFO] [03/18/2019 02:16:40.782] [indexer-akka.actor.default-dispatcher-6] [RegisterWebhook$(akka://indexer)] Successfully resumed webhook
[INFO] [03/18/2019 02:16:40.793] [indexer-akka.actor.default-dispatcher-6] [IndexerApp$(akka://indexer)] Checking to see if datasets index is empty
[INFO] [03/18/2019 02:16:41.171] [indexer-akka.actor.default-dispatcher-6] [IndexerApp$(akka://indexer)] Datasets index is NOT empty. No need to recrawl.
[ERROR] [03/18/2019 02:17:55.178] [indexer-akka.actor.default-dispatcher-8] [akka.actor.ActorSystemImpl(indexer)] Failed to parse spatial data for dataset ds-sdinsw-{02E30FD2-D967-4F25-BEEB-E2D9B025C5E2}: Invalid latitude (y) range: 20106.198. Should be within -90 to +90
[INFO] [03/18/2019 02:17:56.479] [indexer-akka.actor.default-dispatcher-8] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 2 datasets
[INFO] [03/18/2019 02:18:07.297] [indexer-akka.actor.default-dispatcher-20] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 2 datasets
[INFO] [03/18/2019 02:18:23.490] [indexer-akka.actor.default-dispatcher-8] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 101 datasets
[INFO] [03/18/2019 02:18:30.766] [indexer-akka.actor.default-dispatcher-22] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 101 datasets
[INFO] [03/18/2019 02:18:40.290] [indexer-akka.actor.default-dispatcher-22] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 2 datasets
```

#### test site: 
https://issue-2061.dev.magda.io



### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
