### PR TITLE
Provided CKAN migration redirects for datasets where a UUID was used in URL

### DIFF
--- a/magda-gateway/src/createCkanRedirectionRouter.ts
+++ b/magda-gateway/src/createCkanRedirectionRouter.ts
@@ -243,9 +243,8 @@ export default function buildCkanRedirectionRouter({
         retrieveAspects: string[] = [],
         limit: number = 1
     ): Promise<any[]> {
-        const query = `${aspectName}.${
-            uuidRegEx.test(ckanIdOrName) ? "id" : "name"
-        }:${ckanIdOrName}`;
+        const idQuery = `${aspectName}.id:${ckanIdOrName}`;
+        const nameQuery = `${aspectName}.name:${ckanIdOrName}`;
 
         let aspectList: string[] = [];
 
@@ -260,14 +259,26 @@ export default function buildCkanRedirectionRouter({
 
         aspectList = _.uniq(aspectList);
 
-        const resData: any = await queryRegistryRecordApi(
-            [query],
+        let resData: any = await queryRegistryRecordApi(
+            [uuidRegEx.test(ckanIdOrName) ? idQuery : nameQuery],
             retrieveAspects,
             limit
         );
 
-        if (!resData || !resData.records || !resData.records.length)
-            return null;
+        if (!resData || !resData.records || !resData.records.length) {
+            if (uuidRegEx.test(ckanIdOrName)) {
+                resData = await queryRegistryRecordApi(
+                    [nameQuery],
+                    retrieveAspects,
+                    limit
+                );
+                if (!resData || !resData.records || !resData.records.length) {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
         return resData.records;
     }
 


### PR DESCRIPTION
### What this PR does

Some data that was migrated into CKAN incorrectly with UUIDs as URLs. Rather than 404 these, double check that a UUID isn't a URL "name" or slug.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
