### PR TITLE
Added role to user page.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 UI:
 
 -   Integrate sentry release notification and source map upload
+-   Added "role" to account page
 
 Others:
 

--- a/magda-web-client/src/Components/Account/Account.js
+++ b/magda-web-client/src/Components/Account/Account.js
@@ -53,6 +53,12 @@ class Account extends React.Component {
                             <h1>Account</h1>
                             <p>Display Name: {this.props.user.displayName}</p>
                             <p>Email: {this.props.user.email}</p>
+                            <p>
+                                Role:{" "}
+                                {this.props.user.isAdmin
+                                    ? "Admin"
+                                    : "Data User"}
+                            </p>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
### What this PR does

Fixes #2102.

Simply adds an extra line to the account page that says whether you're an admin or not.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
