### PR TITLE
Issue/1928 Fixed Search WA timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,10 @@ Indexer:
 
 -   Fixed issues of snapshot creation & restore
 -   Indexer will auto reopen index if it's closed
+-   Added Geo Spatial Data Validation to Indexer
+-   Added `simplifyToleranceRatio` & `requireSimplify` Parameters to Indexer & Allow them to be configured per file & per data
+-   Used manual simplified STE region data
+-   Fixed timeout issue when filter by WA state
 
 Others:
 
@@ -38,7 +42,6 @@ Others:
 -   Upgraded Elasticsearch to v6.5.4 Elastic4s to v6.5.1
 -   Elasticsearch related test cases run on Docker container than than local node
 -   Fixed: datasets with null description could lead to blank search result page
--   Added Geo Spatial Data Validation to Indexer
 
 ## 0.0.53
 

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -10,7 +10,7 @@ elasticSearch {
 
   indices {
     regions {
-      version = 22
+      version = 23
     }
 
     datasets {

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -81,7 +81,7 @@ regionSources = {
 		order = 80
 	}
 	STE {
-		url = "https://s3-ap-southeast-2.amazonaws.com/magda-files/STE.geojson"
+		url = "https://s3-ap-southeast-2.amazonaws.com/magda-files/STE.simplified.geojson"
 		idField = "STE_CODE11"
 		nameField = "STE_NAME11"
         shortNameField = "STE_ABBREV"

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -255,7 +255,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val regions: IndexDefinition =
     new IndexDefinition(
       name = "regions",
-      version = 22,
+      version = 23,
       indicesIndex = Indices.RegionsIndex,
       definition = (indices, config) =>
       createIndex(indices.getIndex(config, Indices.RegionsIndex))

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -411,44 +411,63 @@ object IndexDefinition extends DefaultJsonProtocol {
           val shortName = regionSource.shortNameProperty.map(shortNameProp =>
             properties.fields(shortNameProp).convertTo[String])
 
+          // --- allow simplifyToleranceRatio to be specified per file or per region
+          val simplifyToleranceRatio:Double = properties
+            .getFields("simplifyToleranceRatio")
+            .headOption.map(_.convertTo[Double])
+            .getOrElse(regionSource.simplifyToleranceRatio)
+
+          // --- allow requireSimplify to be specified per file or per region
+          val requireSimplify:Boolean = properties
+            .getFields("requireSimplify")
+            .headOption.map(_.convertTo[Boolean])
+            .getOrElse(regionSource.requireSimplify)
+
           val geometryOpt = jsonRegion.fields("geometry") match {
             case (jsGeometry: JsObject) =>
               val geometry = jsGeometry.convertTo[GeoJson.Geometry]
-              val jtsGeo = GeometryConverter.toJTSGeo(geometry, geometryFactory)
 
-              val shortestSide = {
-                val env = jtsGeo.getEnvelopeInternal
-                Math.min(env.getWidth, env.getHeight)
+              if (!requireSimplify) {
+                logger.info("Skipped simplifying GeoData {}/{}/{}", regionSource.idProperty, id, name)
+                Some(geometry)
+              } else {
+
+                val jtsGeo = GeometryConverter.toJTSGeo(geometry, geometryFactory)
+
+                val shortestSide = {
+                  val env = jtsGeo.getEnvelopeInternal
+                  Math.min(env.getWidth, env.getHeight)
+                }
+                val simplified =
+                  TopologyPreservingSimplifier.simplify(
+                    jtsGeo,
+                    shortestSide * simplifyToleranceRatio
+                  )
+
+                def removeInvalidHoles(polygon: Polygon): Polygon = {
+                  val holes = for { i <- 0 to polygon.getNumInteriorRing - 1 } yield polygon.getInteriorRingN(i).asInstanceOf[LinearRing]
+                  val filteredHoles = holes.filter(_.within(simplified))
+                  new Polygon(
+                    polygon.getExteriorRing.asInstanceOf[LinearRing],
+                    filteredHoles.toArray,
+                    geometryFactory
+                  )
+                }
+
+                // Remove holes that intersect the edge of the shape - TODO: Can we do something clever like use an intersection to trim the hole?
+                val simplifiedFixed: Geometry = simplified.getGeometryType match {
+                  case "Polygon" =>
+                    val x = simplified.asInstanceOf[Polygon]
+                    removeInvalidHoles(x)
+                  case "MultiPolygon" =>
+                    val x = simplified.asInstanceOf[MultiPolygon]
+                    val geometries = for { i <- 0 to x.getNumGeometries - 1 } yield removeInvalidHoles(x.getGeometryN(i).asInstanceOf[Polygon])
+                    new MultiPolygon(geometries.toArray, geometryFactory)
+                  case _ => simplified
+                }
+
+                Some(GeometryConverter.fromJTSGeo(simplifiedFixed))
               }
-              val simplified =
-                TopologyPreservingSimplifier.simplify(
-                  jtsGeo,
-                  shortestSide / 100
-                )
-
-              def removeInvalidHoles(polygon: Polygon): Polygon = {
-                val holes = for { i <- 0 to polygon.getNumInteriorRing - 1 } yield polygon.getInteriorRingN(i).asInstanceOf[LinearRing]
-                val filteredHoles = holes.filter(_.within(simplified))
-                new Polygon(
-                  polygon.getExteriorRing.asInstanceOf[LinearRing],
-                  filteredHoles.toArray,
-                  geometryFactory
-                )
-              }
-
-              // Remove holes that intersect the edge of the shape - TODO: Can we do something clever like use an intersection to trim the hole?
-              val simplifiedFixed: Geometry = simplified.getGeometryType match {
-                case "Polygon" =>
-                  val x = simplified.asInstanceOf[Polygon]
-                  removeInvalidHoles(x)
-                case "MultiPolygon" =>
-                  val x = simplified.asInstanceOf[MultiPolygon]
-                  val geometries = for { i <- 0 to x.getNumGeometries - 1 } yield removeInvalidHoles(x.getGeometryN(i).asInstanceOf[Polygon])
-                  new MultiPolygon(geometries.toArray, geometryFactory)
-                case _ => simplified
-              }
-
-              Some(GeometryConverter.fromJTSGeo(simplifiedFixed))
             case _ => None
           }
 
@@ -490,13 +509,20 @@ object IndexDefinition extends DefaultJsonProtocol {
       }
       .map { result =>
         result match {
-          case failure:RequestFailure => logger.error("Failure: {}", failure.error)
+          case failure:RequestFailure =>
+            logger.error("Failure: {}", failure.error)
+            0
           case results:RequestSuccess[BulkResponse] =>
-            logger.debug(
-              "Took {} seconds to execute request.",
-              results.result.took
-            )
-            results.result.successes.size
+            if(result.result.errors) {
+              logger.error("Failure: {}", result.body)
+              0
+            } else {
+              logger.debug(
+                "Took {} seconds to execute request.",
+                results.result.took
+              )
+              results.result.successes.size
+            }
         }
       }
       .recover {

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/RegionSource.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/RegionSource.scala
@@ -15,7 +15,9 @@ case class RegionSource(
   shortNameProperty: Option[String],
   includeIdInName: Boolean,
   disabled: Boolean,
-  order: Int)
+  order: Int,
+  simplifyToleranceRatio: Double = 0.01,
+  requireSimplify: Boolean = true)
 
 object RegionSource {
   def generateRegionId(regionType: String, id: String) = s"${regionType}/$id".toLowerCase
@@ -40,7 +42,16 @@ class RegionSources(config: Config) {
           shortNameProperty = if (regionSourceConfig.hasPath("shortNameField")) Some(regionSourceConfig.getString("shortNameField")) else None,
           includeIdInName = if (regionSourceConfig.hasPath("includeIdInName")) regionSourceConfig.getBoolean("includeIdInName") else false,
           disabled = regionSourceConfig.hasPath("disabled") && regionSourceConfig.getBoolean("disabled"),
-          order = regionSourceConfig.getInt("order"))
+          order = regionSourceConfig.getInt("order"),
+          simplifyToleranceRatio =
+            if (regionSourceConfig.hasPath("simplifyToleranceRatio"))
+              regionSourceConfig.getDouble("simplifyToleranceRatio")
+            else 0.01,
+          requireSimplify =
+            if (regionSourceConfig.hasPath("requireSimplify"))
+              regionSourceConfig.getBoolean("requireSimplify")
+            else true
+        )
     }.toSeq.filterNot(_.disabled)
   }
 }


### PR DESCRIPTION
### What this PR does

Fixes #1928 

-   Added `simplifyToleranceRatio` & `requireSimplify` Parameters to Indexer & Allow them to be configured per file & per data
  - Can set those two parameters in `common.conf` region data section or on region geojson data `properties` field. 
  - If not specified, default value will be used. `simplifyToleranceRatio`=0.01 `requireSimplify`=true
  - `simplifyToleranceRatio`: e.g. if 0.01, the actual simplify Tolerance distance will be 1% of shortest side. Current default value is same as before
-   Used manual simplified STE region data
  - All manual simplified STE region data will skip the simplify
  - no.9 Other Australian Territory are not manual simplified and will still be simplified by existing program 
-   Fixed timeout issue when filter by WA state
-   Fixed a bug that indexer will not report error when indexing region data as bulk request error response comes with 200 status code.

### Example of Configuring `simplifyToleranceRatio` OR `requireSimplify`
- in `common.conf`
```conf
regionSources = {
	STE {
		url = "https://s3-ap-southeast-2.amazonaws.com/magda-files/STE.simplified.geojson"
		idField = "STE_CODE11"
		nameField = "STE_NAME11"
                 shortNameField = "STE_ABBREV"
                 simplifyToleranceRatio = 0.01
                 requireSimplify = true
		order = 10
	}
}
```
- in GeoJson Data
```json
{
  "type": "Feature",
  "properties": {
    "FID": 0,
    "STE_CODE11": "1",
    "STE_NAME11": "New South Wales",
    "ALBERS_SQM": 800808771946.097,
    "STE_ABBREV": "NSW",
    "requireSimplify": false,
    "simplifyToleranceRatio": 0.01
  },
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      ...
    ]
  }
}
```

### Test Site:

https://issue-1928-alt-simplify-manual.dev.magda.io

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
