### PR TITLE
Issue/2092 Fixed clicking out of search filter causes the results to refetch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Others:
 
 -   Upgraded JDK version for magda-builder-scala to 8u201
 -   Added craco to allow for some Create React App overrides for a faster build and to allow use of PDFjs without warnings.
+-   Fixed clicking out of search filter causes the results to refetch
+-   Fixed warnings: `as` props is compulsory for AUpageAlert & boolean value was sent to `id` props
 
 ## 0.0.54
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,12 @@ UI:
 -   Updated design system components
 -   Integrate sentry release notification and source map upload
 -   Added "role" to account page
+-   Fixed clicking out of search filter causes the results to refetch
 
 Others:
 
 -   Upgraded JDK version for magda-builder-scala to 8u201
 -   Added craco to allow for some Create React App overrides for a faster build and to allow use of PDFjs without warnings.
--   Fixed clicking out of search filter causes the results to refetch
 -   Fixed warnings: `as` props is compulsory for AUpageAlert & boolean value was sent to `id` props
 
 ## 0.0.54

--- a/magda-web-client/src/Components/Account/AccountNavbar.js
+++ b/magda-web-client/src/Components/Account/AccountNavbar.js
@@ -15,7 +15,10 @@ class AccountNavbar extends React.Component {
             <React.Fragment>
                 {this.props.user ? (
                     [
-                        <li key="/account" id={this.props.skipLink && "nav"}>
+                        <li
+                            key="/account"
+                            id={this.props.skipLink ? "nav" : undefined}
+                        >
                             <NavLink to={`/account`}>
                                 <span>{this.props.user.displayName}</span>
                             </NavLink>
@@ -34,7 +37,7 @@ class AccountNavbar extends React.Component {
                     <li key="/account">
                         <NavLink
                             to={`/account`}
-                            id={this.props.skipLink && "nav"}
+                            id={this.props.skipLink ? "nav" : undefined}
                         >
                             <span>Sign In</span>
                         </NavLink>

--- a/magda-web-client/src/Components/Search/MatchingStatus.tsx
+++ b/magda-web-client/src/Components/Search/MatchingStatus.tsx
@@ -23,7 +23,7 @@ export default function MatchingStatus(props: {
         return (
             <div>
                 <div className="no-matching">
-                    <AUpageAlert>
+                    <AUpageAlert as="info">
                         <p>
                             <strong>
                                 Sorry, we couldn't find any datasets that match

--- a/magda-web-client/src/Pages/withHeader.tsx
+++ b/magda-web-client/src/Pages/withHeader.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentType } from "react";
 import { connect } from "react-redux";
+import { memoize } from "lodash";
 
 import Header from "../Components/Header/Header";
 import SearchBoxSwitcher from "../Components/SearchBox/SearchBoxSwitcher";
@@ -59,4 +60,4 @@ const withHeader = <P extends {}>(
     return connect(mapStateToProps)(NewComponent);
 };
 
-export default withHeader;
+export default memoize(withHeader);


### PR DESCRIPTION
### What this PR does

Fixes #2092 

- Fixed clicking out of search filter causes the results to refetch

It was caused by:
```javasc
<Route exact path="/search" component={withHeader(Search, true)} />
```
`withHeader` create a new Component on every call --- this cause wrapped components are considered as new components during react reconciliation and lead to always re-render.
Consequently, `componentWillUnmount` will be called when any state (in the component tree) is changed.

Make  `withHeader` memorise the result seems fixed the issue.

Also, fixed the following warnings under development mode:
- `as` props is compulsory for AUpageAlert 
- boolean value was sent to `id` props

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
