### PR TITLE
Issue/2071 Unable to use Google / Facebook Login on Preview Site

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Others:
 
 -   Upgraded JDK version for magda-builder-scala to 8u201
 -   Added craco to allow for some Create React App overrides for a faster build and to allow use of PDFjs without warnings.
+-   Fixed Unable to use Google / Facebook Login on Preview Site
 
 ## 0.0.54
 

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -17,14 +17,17 @@ ingress:
   enableTls: true
   useDefaultCertificate: true
 gateway:
+  ckanRedirectionDomain: "ckan.data.gov.au"
+  ckanRedirectionPath: ""
+  enableCkanRedirection: true
+  enableAuthEndpoint: true
+  enableHttpsRedirection: true
   auth:
     facebookClientId: "173073926555600"
     googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
+    ckanAuthenticationUrl: https://data.gov.au/data
   autoscaler:
     enabled: false
-  enableAuthEndpoint: true
-  enableHttpsRedirection: true
-  enableCkanRedirection: false
   helmet:
     frameguard: false
   cors:
@@ -39,8 +42,6 @@ gateway:
       objectSrc:
       - "''none''"
       reportUri: https://sdga.report-uri.com/r/d/csp/enforce
-  auth:
-    ckanAuthenticationUrl: https://data.gov.au/data
       
 combined-db:
   waleBackup:


### PR DESCRIPTION
### What this PR does

Fixed #2071 Unable to use Google / Facebook Login on Preview Site

Changes: 
- Remove the duplicated `auth` section in preview.yml that resets the values of `googleClientId` & `facebookClientId`

### Test Site:

https://issue-2071.dev.magda.io

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
