### PR TITLE
Stopped passing auth headers through the gateway

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ Others:
 -   Upgraded Elasticsearch to v6.5.4 Elastic4s to v6.5.1
 -   Elasticsearch related test cases run on Docker container than than local node
 -   Fixed: datasets with null description could lead to blank search result page
+-   Stopped gateway from passing auth and single-hop headers through to other services
 
 ## 0.0.53
 

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -74,7 +74,7 @@
     "@types/yargs": "^12.0.8",
     "chai": "^4.1.0",
     "mocha": "^3.4.2",
-    "nock": "^9.0.14",
+    "nock": "git://github.com/magda-io/nock.git#master",
     "randomstring": "^1.1.5",
     "sinon": "^2.4.1",
     "supertest": "^3.0.0",

--- a/magda-gateway/src/buildApp.ts
+++ b/magda-gateway/src/buildApp.ts
@@ -18,6 +18,12 @@ import createCkanRedirectionRouter from "./createCkanRedirectionRouter";
 import createHttpsRedirectionMiddleware from "./createHttpsRedirectionMiddleware";
 import Authenticator from "./Authenticator";
 import defaultConfig from "./defaultConfig";
+import { ProxyTarget } from "./createApiRouter";
+
+// Tell typescript about the semi-private __express field of ejs.
+declare module "ejs" {
+    var __express: any;
+}
 
 type Route = {
     to: string;
@@ -33,7 +39,9 @@ type Config = {
     externalUrl: string;
     dbHost: string;
     dbPort: number;
-    proxyRoutesJson: string;
+    proxyRoutesJson: {
+        [localRoute: string]: ProxyTarget;
+    };
     helmetJson: string;
     cspJson: string;
     corsJson: string;
@@ -101,7 +109,6 @@ export default function buildApp(config: Config) {
     // Set sensible secure headers
     app.disable("x-powered-by");
     app.use(helmet(_.merge({}, defaultConfig.helmet, config.helmetJson as {})));
-    console.log(_.merge({}, defaultConfig.csp, config.cspJson));
     app.use(
         helmet.contentSecurityPolicy(
             _.merge({}, defaultConfig.csp, config.cspJson)

--- a/magda-gateway/src/buildApp.ts
+++ b/magda-gateway/src/buildApp.ts
@@ -1,0 +1,186 @@
+import * as cors from "cors";
+import * as express from "express";
+import * as path from "path";
+import * as ejs from "ejs";
+import * as helmet from "helmet";
+import * as compression from "compression";
+import * as basicAuth from "express-basic-auth";
+import * as _ from "lodash";
+
+import {
+    installStatusRouter,
+    createServiceProbe
+} from "@magda/typescript-common/dist/express/status";
+import createApiRouter from "./createApiRouter";
+import createAuthRouter from "./createAuthRouter";
+import createGenericProxy from "./createGenericProxy";
+import createCkanRedirectionRouter from "./createCkanRedirectionRouter";
+import createHttpsRedirectionMiddleware from "./createHttpsRedirectionMiddleware";
+import Authenticator from "./Authenticator";
+import defaultConfig from "./defaultConfig";
+
+type Route = {
+    to: string;
+    auth?: boolean;
+};
+
+type Routes = {
+    [host: string]: Route;
+};
+
+type Config = {
+    listenPort: number;
+    externalUrl: string;
+    dbHost: string;
+    dbPort: number;
+    proxyRoutesJson: string;
+    helmetJson: string;
+    cspJson: string;
+    corsJson: string;
+    authorizationApi: string;
+    sessionSecret: string;
+    jwtSecret: string;
+    userId: string;
+    web: string;
+    previewMap?: string;
+    enableHttpsRedirection?: boolean;
+    enableWebAccessControl?: boolean;
+    webAccessUsername?: string;
+    webAccessPassword?: string;
+    enableAuthEndpoint?: boolean;
+    facebookClientId?: string;
+    facebookClientSecret?: string;
+    googleClientId?: string;
+    googleClientSecret?: string;
+    aafClientUri?: string;
+    aafClientSecret?: string;
+    ckanUrl?: string;
+    enableCkanRedirection?: boolean;
+    ckanRedirectionDomain?: string;
+    ckanRedirectionPath?: string;
+};
+
+export default function buildApp(config: Config) {
+    const routes = _.isEmpty(config.proxyRoutesJson)
+        ? defaultConfig.proxyRoutes
+        : ((config.proxyRoutesJson as unknown) as Routes);
+
+    const authenticator = new Authenticator({
+        sessionSecret: config.sessionSecret,
+        dbHost: config.dbHost,
+        dbPort: config.dbPort
+    });
+
+    // Create a new Express application.
+    var app = express();
+
+    // Log everything
+    app.use(require("morgan")("combined"));
+
+    const probes: any = {};
+
+    /**
+     * Should use config.routes to setup probes
+     * so that no prob will be setup when run locally for testing
+     */
+    _.forEach(
+        (config.proxyRoutesJson as unknown) as Routes,
+        (value: any, key: string) => {
+            probes[key] = createServiceProbe(value.to);
+        }
+    );
+    installStatusRouter(app, { probes });
+
+    // Redirect http url to https
+    app.set("trust proxy", true);
+    app.use(createHttpsRedirectionMiddleware(config.enableHttpsRedirection));
+
+    // GZIP responses where appropriate
+    app.use(compression());
+
+    // Set sensible secure headers
+    app.disable("x-powered-by");
+    app.use(helmet(_.merge({}, defaultConfig.helmet, config.helmetJson as {})));
+    console.log(_.merge({}, defaultConfig.csp, config.cspJson));
+    app.use(
+        helmet.contentSecurityPolicy(
+            _.merge({}, defaultConfig.csp, config.cspJson)
+        )
+    );
+
+    // Set up CORS headers for all requests
+    const configuredCors = cors(
+        _.merge({}, defaultConfig.cors, config.corsJson as {})
+    );
+    app.options("*", configuredCors);
+    app.use(configuredCors);
+
+    // Configure view engine to render EJS templates.
+    app.set("views", path.join(__dirname, "..", "views"));
+    app.set("view engine", "ejs");
+    app.engine(".ejs", ejs.__express); // This stops express trying to do its own require of 'ejs'
+
+    // --- enable http basic authentication for all users
+    if (config.enableWebAccessControl) {
+        app.use(
+            basicAuth({
+                users: {
+                    [config.webAccessUsername]: config.webAccessPassword
+                },
+                challenge: true,
+                unauthorizedResponse: `You cannot access the system unless provide correct username & password.`
+            })
+        );
+    }
+
+    if (config.enableAuthEndpoint) {
+        app.use(
+            "/auth",
+            createAuthRouter({
+                authenticator: authenticator,
+                jwtSecret: config.jwtSecret,
+                facebookClientId: config.facebookClientId,
+                facebookClientSecret: config.facebookClientSecret,
+                googleClientId: config.googleClientId,
+                googleClientSecret: config.googleClientSecret,
+                aafClientUri: config.aafClientUri,
+                aafClientSecret: config.aafClientSecret,
+                ckanUrl: config.ckanUrl,
+                authorizationApi: config.authorizationApi,
+                externalUrl: config.externalUrl,
+                userId: config.userId
+            })
+        );
+    }
+
+    app.use(
+        "/api/v0",
+        createApiRouter({
+            authenticator: authenticator,
+            jwtSecret: config.jwtSecret,
+            routes
+        })
+    );
+    app.use("/preview-map", createGenericProxy(config.previewMap));
+
+    if (config.enableCkanRedirection) {
+        if (!routes.registry) {
+            console.error(
+                "Cannot locate routes.registry for ckan redirection!"
+            );
+        } else {
+            app.use(
+                createCkanRedirectionRouter({
+                    ckanRedirectionDomain: config.ckanRedirectionDomain,
+                    ckanRedirectionPath: config.ckanRedirectionPath,
+                    registryApiBaseUrlInternal: routes.registry.to
+                })
+            );
+        }
+    }
+
+    // Proxy any other URL to magda-web
+    app.use("/", createGenericProxy(config.web));
+
+    return app;
+}

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -2,22 +2,20 @@ import * as httpProxy from "http-proxy";
 import groupBy = require("lodash/groupBy");
 
 const DO_NOT_PROXY_HEADERS = [
-    "Host",
-    "X-Forwarded-Host",
-    "Proxy-Connection",
     "Connection",
+    "Proxy-Connection",
     "Keep-Alive",
-    "Transfer-Encoding",
-    "TE",
-    "Trailer",
     "Proxy-Authorization",
     "Proxy-Authenticate",
+    "TE",
+    "Trailer",
+    "Transfer-Encoding",
     "Upgrade",
-    "Expires",
-    "pragma",
-    "Strict-Transport-Security",
     "Authorization",
-    "Cookie"
+    "Cookie",
+    "Cookie2",
+    "Set-Cookie",
+    "Set-Cookie2"
 ];
 
 const doNotProxyHeaderLookup = groupBy(
@@ -27,7 +25,8 @@ const doNotProxyHeaderLookup = groupBy(
 
 export default function createBaseProxy(): httpProxy {
     const proxy = httpProxy.createProxyServer({
-        prependUrl: false
+        prependUrl: false,
+        changeOrigin: true
     } as httpProxy.ServerOptions);
 
     proxy.on("error", function(err: any, req: any, res: any) {
@@ -64,6 +63,7 @@ export default function createBaseProxy(): httpProxy {
         ) {
             proxyRes.headers["Cache-Control"] = "public, max-age=60";
         }
+
         /**
          * Remove security sensitive headers
          * `server` header is from scala APIs

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -20,7 +20,7 @@ const DO_NOT_PROXY_HEADERS = [
     "Cookie"
 ];
 
-const headerLookup = groupBy(
+const doNotProxyHeaderLookup = groupBy(
     DO_NOT_PROXY_HEADERS.map(x => x.toLowerCase()),
     (x: string) => x
 );
@@ -44,8 +44,10 @@ export default function createBaseProxy(): httpProxy {
         // Presume that we've already got whatever auth details we need out of the request and so remove it now.
         // If we keep it it causes scariness upstream - like anything that goes through the TerriaJS proxy will
         // be leaking auth details to wherever it proxies to.
-        for (let headerName of proxyReq.getHeaderNames()) {
-            if (!!headerLookup[headerName.toLowerCase()]) {
+        const headerNames = proxyReq.getHeaderNames();
+        for (let i = 0; i < headerNames.length; i++) {
+            const headerName = headerNames[i];
+            if (!!doNotProxyHeaderLookup[headerName]) {
                 proxyReq.removeHeader(headerName);
             }
         }

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -2,15 +2,8 @@ import * as httpProxy from "http-proxy";
 import groupBy = require("lodash/groupBy");
 
 const DO_NOT_PROXY_HEADERS = [
-    "Connection",
-    "Proxy-Connection",
-    "Keep-Alive",
     "Proxy-Authorization",
     "Proxy-Authenticate",
-    "TE",
-    "Trailer",
-    "Transfer-Encoding",
-    "Upgrade",
     "Authorization",
     "Cookie",
     "Cookie2",

--- a/magda-gateway/src/index.ts
+++ b/magda-gateway/src/index.ts
@@ -4,11 +4,6 @@ import * as _ from "lodash";
 import buildApp from "./buildApp";
 import addJwtSecretFromEnvVar from "@magda/typescript-common/dist/session/addJwtSecretFromEnvVar";
 
-// Tell typescript about the semi-private __express field of ejs.
-declare module "ejs" {
-    var __express: any;
-}
-
 const coerceJson = (path?: string) => path && require(path);
 
 const argv = addJwtSecretFromEnvVar(
@@ -200,7 +195,7 @@ const argv = addJwtSecretFromEnvVar(
         }).argv
 );
 
-const app = buildApp(argv);
+const app = buildApp(argv as any);
 
 app.listen(argv.listenPort);
 console.log("Listening on port " + argv.listenPort);

--- a/magda-gateway/src/test/proxy.spec.ts
+++ b/magda-gateway/src/test/proxy.spec.ts
@@ -1,0 +1,70 @@
+import {} from "mocha";
+import * as sinon from "sinon";
+import * as express from "express";
+// import { expect } from "chai";
+import * as nock from "nock";
+import * as _ from "lodash";
+import * as supertest from "supertest";
+// import * as URI from "urijs";
+
+import buildApp from "../buildApp";
+
+const PROXY_ROOTS = {
+    "/v0/api/registry": "http://registry.example.com/",
+    "/preview-map": "http://preview-map.example.com"
+};
+
+describe("proxying", () => {
+    let app: express.Application;
+
+    before(() => {
+        // registryScope = nock(registryUrl);
+    });
+
+    after(() => {
+        nock.cleanAll();
+    });
+
+    beforeEach(() => {
+        app = buildApp({
+            listenPort: 80,
+            externalUrl: "https://example.com",
+            dbHost: "localhost",
+            dbPort: 5432,
+            proxyRoutesJson: "{}",
+            helmetJson: "{}",
+            cspJson: "{}",
+            corsJson: "{}",
+            authorizationApi: "https://example.com",
+            sessionSecret: "secret",
+            jwtSecret: "othersecret",
+            userId: "123",
+            web: "https://example.com",
+            previewMap: "https://preview-map"
+        });
+    });
+
+    afterEach(() => {
+        if ((<sinon.SinonStub>console.error).restore) {
+            (<sinon.SinonStub>console.error).restore();
+        }
+    });
+
+    _.map(PROXY_ROOTS, (key, value) => {
+        describe(`when proxying ${key} to ${value}`, () => {
+            it("doesn't pass auth headers through", () => {
+                nock(value)
+                    .get("/", null, {
+                        badheaders: ["Authorization"]
+                    })
+                    .reply((uri, body, cb) => {
+                        return 200;
+                    });
+
+                supertest(app)
+                    .get(key)
+                    .expect(200);
+            });
+        });
+    });
+});

--- a/magda-gateway/src/test/proxy.spec.ts
+++ b/magda-gateway/src/test/proxy.spec.ts
@@ -1,11 +1,10 @@
 import {} from "mocha";
 import * as sinon from "sinon";
 import * as express from "express";
-// import { expect } from "chai";
 import * as nock from "nock";
 import * as _ from "lodash";
 import * as supertest from "supertest";
-// import * as URI from "urijs";
+import * as URI from "urijs";
 
 import buildApp from "../buildApp";
 
@@ -17,14 +16,8 @@ const PROXY_ROOTS = {
 describe("proxying", () => {
     let app: express.Application;
 
-    before(() => {
-        // registryScope = nock(registryUrl);
-        // nock.disableNetConnect();
-    });
-
     after(() => {
         nock.cleanAll();
-        // nock.enableNetConnect();
     });
 
     beforeEach(() => {
@@ -79,6 +72,23 @@ describe("proxying", () => {
                 return supertest(app)
                     .get(key)
                     .set("Authorization", "blah")
+                    .expect(200);
+            });
+
+            it("should rewrite host header", () => {
+                nock(value, {
+                    reqheaders: {
+                        host: URI(value).host()
+                    }
+                })
+                    .get("/")
+                    .reply(() => {
+                        return 200;
+                    });
+
+                return supertest(app)
+                    .get(key)
+                    .set("Host", "test")
                     .expect(200);
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -13789,6 +13789,20 @@ nock@^9.0.14, nock@^9.1.6, nock@^9.2.5:
     qs "^6.5.1"
     semver "^5.5.0"
 
+"nock@git://github.com/magda-io/nock.git#master":
+  version "0.0.0-development"
+  resolved "git://github.com/magda-io/nock.git#b82b93a80b4893f39bbdd83a81dd4db610894f2a"
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"


### PR DESCRIPTION
### What this PR does

Fixes #2099 

Right now the gateway passes pretty much all the headers along. This is bad because A) some headers are supposed to be single-hop and B) we don't really want to trust the services behind the gateway with stuff like Authorization headers and session ids. In particular this is breaking the data.gov.au geoserver because we're sending Authorization headers meant for Magda that it doesn't expect.

So this implements a filter to take them out, and also turns on rewriting of the Host header.

#### Testing
- You should be able to find the same dataset in the issue on the test instance and verify that it now works behind a username/password.
- Testing that the headers are getting removed in general is a bit more complicated - I've made `/api/v0/test` proxy to https://webhook.site/#!/64bb96bf-647e-4559-bdd5-eec78dd6f841/698d967a-265b-4ced-a58f-7e73354a86c0/1 - if you GET `/api/v0/test` you should be able to see it there. Keep in mind that the gateway is continually checking it so there's a lot of cruft requests.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
