### PR TITLE
Changed label of email validation error message in suggest dataset pa…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ UI:
 -   Integrate sentry release notification and source map upload
 -   Added "role" to account page
 -   Fixed clicking out of search filter causes the results to refetch
+-   Changed label of email validation error message in suggest dataset page to be consistent with rest of the error messages in that page
 
 Others:
 

--- a/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
+++ b/magda-web-client/src/Components/RequestDataset/RequestFormTemplate.js
@@ -212,7 +212,7 @@ export default class RequestFormTemplate extends React.Component {
                             id="senderEmailFieldError"
                             aria-live="assertive"
                         >
-                            Email is invalid
+                            Please enter a valid email address
                             <span className="sr-only">.</span>
                         </span>
                     )}


### PR DESCRIPTION
### What this PR does

Changed label of email validation error message in suggest dataset page to be consistent with rest of the error messages in that page.

Fixes #1895


### Checklist

-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
