### PR TITLE
Deactivate ckan redirection on dev

### DIFF
--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -25,9 +25,7 @@ ingress:
     - "*.dev.magda.io"
 
 gateway:
-  ckanRedirectionDomain: "ckan.data.gov.au"
-  ckanRedirectionPath: ""
-  enableCkanRedirection: true
+  enableCkanRedirection: false
   enableAuthEndpoint: true
   enableHttpsRedirection: true
   auth:

--- a/deploy/helm/magda/charts/registry-api/values.yaml
+++ b/deploy/helm/magda/charts/registry-api/values.yaml
@@ -1,5 +1,6 @@
 image: {}
 livenessProbe: {}
+db: {}
 resources: 
   requests:
     cpu: 250m


### PR DESCRIPTION
### What this PR does
This turns off ckan redirection on dev, because it stops Alyce from looking at `/dataset/new` as a result of https://github.com/magda-io/magda/issues/2143.

It also fixes a problem with the registry chart that stops it deploying on dev.