### PR TITLE
Issue/1426 Make format minion recognise ASC correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ Others:
 
 -   Made registry-api DB pool settings configurable via Helm
 -   Make broken link sleuther recrawl period configurable via Helm
+-   Format minion will trust dcat format if other measures indicate a ZIP format
+-   Format minion will trust dcat format if other measures indicate a ESRI REST format
+-   Added ASC to 4 stars rating list
 
 ## 0.0.55
 

--- a/magda-minion-format/src/format-engine/measureEvaluatorByHierarchy.ts
+++ b/magda-minion-format/src/format-engine/measureEvaluatorByHierarchy.ts
@@ -26,13 +26,21 @@ export default function getBestMeasureResult(
                 "" + sortedCandidates[0].measureResult.formats[0].format
             )
                 .trim()
-                .toLowerCase();
+                .toUpperCase();
             const dcatFormat = ("" + dcatSet.measureResult.formats[0].format)
                 .trim()
-                .toLowerCase();
-            if (sortedFormat === "zip" && dcatFormat !== sortedFormat) {
-                // --- if sortedFormat is zip & is different from dcatFormat
-                // --- we should trust dcatFormat
+                .toUpperCase();
+            if (
+                /**
+                 * if sortedFormat is `ZIP` & is different from dcatFormat, we should trust dcatFormat
+                 */
+                (sortedFormat === "ZIP" && dcatFormat !== sortedFormat) ||
+                /**
+                 * if sortedFormat is `ESRI REST` & is different from dcatFormat, we should trust dcatFormat
+                 * The Regex for testing `ESRI REST` URL cannot be very specific. Thus, should only be used when DcatFormat not present
+                 */
+                (sortedFormat === "ESRI REST" && dcatFormat !== sortedFormat)
+            ) {
                 finalCandidate = dcatSet;
             }
         }

--- a/magda-minion-format/src/format-engine/measureEvaluatorByHierarchy.ts
+++ b/magda-minion-format/src/format-engine/measureEvaluatorByHierarchy.ts
@@ -12,15 +12,33 @@ export default function getBestMeasureResult(
         return null;
     }
 
+    const dcatSet = candidates[0];
+
     let sortedCandidates = candidates.sort(candidateSortFn);
 
     //TODO produce a system that mitigates when all measures return null. What should happen then?
     if (!sortedCandidates[0].measureResult) {
         return null;
     } else {
+        let finalCandidate = sortedCandidates[0];
+        if (dcatSet.measureResult) {
+            const sortedFormat = (
+                "" + sortedCandidates[0].measureResult.formats[0].format
+            )
+                .trim()
+                .toLowerCase();
+            const dcatFormat = ("" + dcatSet.measureResult.formats[0].format)
+                .trim()
+                .toLowerCase();
+            if (sortedFormat === "zip" && dcatFormat !== sortedFormat) {
+                // --- if sortedFormat is zip & is different from dcatFormat
+                // --- we should trust dcatFormat
+                finalCandidate = dcatSet;
+            }
+        }
         return {
-            format: sortedCandidates[0].measureResult.formats[0],
-            absConfidenceLevel: sortedCandidates[0].getProcessedData()
+            format: finalCandidate.measureResult.formats[0],
+            absConfidenceLevel: finalCandidate.getProcessedData()
                 .absoluteConfidenceLevel
         };
     }

--- a/magda-minion-format/src/test/onRecordFound.spec.ts
+++ b/magda-minion-format/src/test/onRecordFound.spec.ts
@@ -22,6 +22,8 @@ import * as dsaDistCsv from "./sampleDataFiles/dsa-dist-csv.json";
 
 import * as failingDocs from "./sampleDataFiles/failing-docs.json";
 
+import * as ascGridDist from "./sampleDataFiles/asc-grid-dist.json";
+
 import Registry from "@magda/typescript-common/dist/registry/AuthorizedRegistryClient";
 
 describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
@@ -101,6 +103,10 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
 
     it("Should a dataset with the format '.csv' correctly even if the file doesn't have a csv extension", () => {
         return testDistReturnsFormat(dsaDistCsv, "CSV");
+    });
+
+    it("Dataset's dcat format should be trust if other measures report it as a ZIP", () => {
+        return testDistReturnsFormat(ascGridDist, "ASC");
     });
 
     /**

--- a/magda-minion-format/src/test/onRecordFound.spec.ts
+++ b/magda-minion-format/src/test/onRecordFound.spec.ts
@@ -24,6 +24,10 @@ import * as failingDocs from "./sampleDataFiles/failing-docs.json";
 
 import * as ascGridDist from "./sampleDataFiles/asc-grid-dist.json";
 
+import * as soilRiskMap1 from "./sampleDataFiles/soil-risk-map-1.json";
+
+import * as soilRiskMap2 from "./sampleDataFiles/soil-risk-map-2.json";
+
 import Registry from "@magda/typescript-common/dist/registry/AuthorizedRegistryClient";
 
 describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
@@ -107,6 +111,16 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
 
     it("Dataset's dcat format should be trust if other measures report it as a ZIP", () => {
         return testDistReturnsFormat(ascGridDist, "ASC");
+    });
+
+    describe("Should process soil risk map dataset correctly", function() {
+        it("Should process (1st distribution) as `WFS` rather than `ESRI`", () => {
+            return testDistReturnsFormat(soilRiskMap1, "WFS");
+        });
+
+        it("Should process (2nd distribution) as `WMS` rather than `ESRI`", () => {
+            return testDistReturnsFormat(soilRiskMap2, "WMS");
+        });
     });
 
     /**

--- a/magda-minion-format/src/test/sampleDataFiles/asc-grid-dist.json
+++ b/magda-minion-format/src/test/sampleDataFiles/asc-grid-dist.json
@@ -1,0 +1,52 @@
+{
+    "id": "dist-dga-92b17b46-2115-44ca-bbbc-9f815a6cae36",
+    "name": "Esri ASCII Grid",
+    "aspects": {
+        "ckan-resource": {
+            "cache_last_updated": null,
+            "cache_url": null,
+            "created": "2017-07-07T11:02:28.928692",
+            "datastore_active": false,
+            "description": "",
+            "format": "ASC",
+            "hash": "",
+            "id": "92b17b46-2115-44ca-bbbc-9f815a6cae36",
+            "last_modified": "2017-07-07T01:02:28.824384",
+            "mimetype": null,
+            "mimetype_inner": null,
+            "name": "Esri ASCII Grid",
+            "package_id": "ccbc03e4-b788-419c-b456-f9819d80e277",
+            "position": 0,
+            "resource_type": null,
+            "revision_id": "c090a202-0ea5-4595-8591-10e8397675dc",
+            "size": null,
+            "state": "active",
+            "url": "https://data.gov.au/dataset/ccbc03e4-b788-419c-b456-f9819d80e277/resource/92b17b46-2115-44ca-bbbc-9f815a6cae36/download/dtmmountain-creekcatchment2014.zip",
+            "url_type": "upload",
+            "wms_layer": "",
+            "zip_extract": "True"
+        },
+        "dataset-format": {
+            "confidenceLevel": 90,
+            "format": "ZIP"
+        },
+        "dcat-distribution-strings": {
+            "downloadURL": "https://data.gov.au/dataset/ccbc03e4-b788-419c-b456-f9819d80e277/resource/92b17b46-2115-44ca-bbbc-9f815a6cae36/download/dtmmountain-creekcatchment2014.zip",
+            "format": "ASC",
+            "issued": "2017-07-07T11:02:28Z",
+            "license": "Creative Commons Attribution 3.0 Australia",
+            "modified": "2017-07-07T01:02:28Z",
+            "title": "Esri ASCII Grid"
+        },
+        "source": {
+            "id": "dga",
+            "name": "data.gov.au",
+            "type": "ckan-resource",
+            "url": "https://data.gov.au/api/3/action/resource_show?id=92b17b46-2115-44ca-bbbc-9f815a6cae36"
+        },
+        "source-link-status": {
+            "httpStatusCode": 200,
+            "status": "active"
+        }
+    }
+}

--- a/magda-minion-format/src/test/sampleDataFiles/asc-grid-dist.json
+++ b/magda-minion-format/src/test/sampleDataFiles/asc-grid-dist.json
@@ -26,10 +26,6 @@
             "wms_layer": "",
             "zip_extract": "True"
         },
-        "dataset-format": {
-            "confidenceLevel": 90,
-            "format": "ZIP"
-        },
         "dcat-distribution-strings": {
             "downloadURL": "https://data.gov.au/dataset/ccbc03e4-b788-419c-b456-f9819d80e277/resource/92b17b46-2115-44ca-bbbc-9f815a6cae36/download/dtmmountain-creekcatchment2014.zip",
             "format": "ASC",

--- a/magda-minion-format/src/test/sampleDataFiles/soil-risk-map-1.json
+++ b/magda-minion-format/src/test/sampleDataFiles/soil-risk-map-1.json
@@ -1,0 +1,91 @@
+{
+    "aspects": {
+        "ckan-resource": {
+            "access_level": "open",
+            "cache_last_updated": null,
+            "cache_url": null,
+            "created": "2018-02-19T22:02:22.462231",
+            "datastore_active": false,
+            "description": "This URL provides a machine-readable Web Feature Service (WFS) to access this dataset. You can open these resource URLs in GIS applications (e.g. QGIS, ArcGIS) as layer Acid Sulphate Soil Risk Map, Albany-Torbay (DWER-054). You can may also simply preview the resource below using NationalMap.\n\nAccess to this resource requires a SLIP account, and may involve a charge to access the data, or be restricted to pre-approved users.",
+            "format": "WFS",
+            "harvesting_service": "SLIP_Public_Services/Soil_Risk_Map_WFS",
+            "harvesting_source": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer",
+            "hash": "",
+            "id": "9324442e-7d46-307e-8676-83d512fd7664",
+            "last_modified": null,
+            "mimetype": null,
+            "mimetype_inner": null,
+            "name": "Web Feature Service",
+            "package_id": "0f28e25f-df3c-4066-b485-565f77e3acf2",
+            "position": 0,
+            "resource_type": null,
+            "revision_id": "846005d6-e72e-472f-a882-09664efd85c8",
+            "size": null,
+            "state": "active",
+            "typeNames": "SLIP_Public_Services_Soil_Risk_Map_WFS:Acid_Sulphate_Soil_Risk_Map__Albany_Torbay__DWER_054_",
+            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer/WFSServer",
+            "url_type": null,
+            "wfs_layer": "2"
+        },
+        "dcat-distribution-strings": {
+            "description": "This URL provides a machine-readable Web Feature Service (WFS) to access this dataset. You can open these resource URLs in GIS applications (e.g. QGIS, ArcGIS) as layer Acid Sulphate Soil Risk Map, Albany-Torbay (DWER-054). You can may also simply preview the resource below using NationalMap.\n\nAccess to this resource requires a SLIP account, and may involve a charge to access the data, or be restricted to pre-approved users.",
+            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer/WFSServer",
+            "format": "WFS",
+            "issued": "2018-02-19T22:02:22Z",
+            "license": "Creative Commons Attribution Non-Commercial 4.0",
+            "title": "Web Feature Service"
+        },
+        "source": {
+            "id": "wa",
+            "name": "Western Australia Government",
+            "type": "ckan-resource",
+            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=9324442e-7d46-307e-8676-83d512fd7664"
+        },
+        "source-link-status": {
+            "errorDetails": {
+                "httpStatusCode": 400,
+                "response": {
+                    "headers": {
+                        "cache-control": "private",
+                        "connection": "close",
+                        "content-language": "en",
+                        "content-length": "968",
+                        "content-type": "text/html;charset=utf-8",
+                        "date": "Tue, 19 Mar 2019 16:50:54 GMT",
+                        "expires": "Thu, 01 Jan 1970 08:00:00 AWST",
+                        "server": "Apache-Coyote/1.1",
+                        "set-cookie": [
+                            "PA_Services.Administrator=AQEI; Path=/; Domain=slip.wa.gov.au; Secure; HttpOnly"
+                        ]
+                    },
+                    "request": {
+                        "headers": {
+                            "Range": "bytes=0-50",
+                            "User-Agent": "magda-minion-broken-link/0.0.54-RC1"
+                        },
+                        "method": "GET",
+                        "uri": {
+                            "auth": null,
+                            "hash": null,
+                            "host": "services.slip.wa.gov.au",
+                            "hostname": "services.slip.wa.gov.au",
+                            "href": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer/WFSServer",
+                            "path": "/public/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer/WFSServer",
+                            "pathname": "/public/services/SLIP_Public_Services/Soil_Risk_Map_WFS/MapServer/WFSServer",
+                            "port": 443,
+                            "protocol": "https:",
+                            "query": null,
+                            "search": null,
+                            "slashes": true
+                        }
+                    },
+                    "statusCode": 400
+                }
+            },
+            "httpStatusCode": 400,
+            "status": "broken"
+        }
+    },
+    "id": "dist-wa-9324442e-7d46-307e-8676-83d512fd7664",
+    "name": "Web Feature Service"
+}

--- a/magda-minion-format/src/test/sampleDataFiles/soil-risk-map-2.json
+++ b/magda-minion-format/src/test/sampleDataFiles/soil-risk-map-2.json
@@ -1,0 +1,50 @@
+{
+    "aspects": {
+        "ckan-resource": {
+            "access_level": "open",
+            "cache_last_updated": null,
+            "cache_url": null,
+            "created": "2018-02-19T22:38:12.714210",
+            "datastore_active": false,
+            "description": "This URL provides a machine-readable Web Mapping Service (WMS) to access this dataset. You can open these resource URLs in GIS applications (e.g. QGIS, ArcGIS) to view Acid Sulphate Soil Risk Map, Albany-Torbay (DWER-054). You can may also simply preview the resource below using NationalMap.\n\nAccess to this resource requires a SLIP account, and may involve a charge to access the data, or be restricted to pre-approved users.",
+            "format": "WMS",
+            "harvesting_service": "SLIP_Public_Services/Soil_Risk_Map",
+            "harvesting_source": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/Soil_Risk_Map/MapServer",
+            "hash": "",
+            "id": "9ffd6d3f-873b-3fd1-b52c-d5fadab4c62b",
+            "last_modified": null,
+            "mimetype": null,
+            "mimetype_inner": null,
+            "name": "Web Mapping Service",
+            "package_id": "0f28e25f-df3c-4066-b485-565f77e3acf2",
+            "position": 1,
+            "resource_type": null,
+            "revision_id": "c0a2bed8-41c4-4dee-934f-593014eeb00f",
+            "size": null,
+            "state": "active",
+            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/Soil_Risk_Map/MapServer/WMSServer",
+            "url_type": null,
+            "wms_layer": "4"
+        },
+        "dcat-distribution-strings": {
+            "description": "This URL provides a machine-readable Web Mapping Service (WMS) to access this dataset. You can open these resource URLs in GIS applications (e.g. QGIS, ArcGIS) to view Acid Sulphate Soil Risk Map, Albany-Torbay (DWER-054). You can may also simply preview the resource below using NationalMap.\n\nAccess to this resource requires a SLIP account, and may involve a charge to access the data, or be restricted to pre-approved users.",
+            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/Soil_Risk_Map/MapServer/WMSServer",
+            "format": "WMS",
+            "issued": "2018-02-19T22:38:12Z",
+            "license": "Creative Commons Attribution Non-Commercial 4.0",
+            "title": "Web Mapping Service"
+        },
+        "source": {
+            "id": "wa",
+            "name": "Western Australia Government",
+            "type": "ckan-resource",
+            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=9ffd6d3f-873b-3fd1-b52c-d5fadab4c62b"
+        },
+        "source-link-status": {
+            "httpStatusCode": 200,
+            "status": "active"
+        }
+    },
+    "id": "dist-wa-9ffd6d3f-873b-3fd1-b52c-d5fadab4c62b",
+    "name": "Web Mapping Service"
+}

--- a/magda-minion-linked-data-rating/src/openFormats.ts
+++ b/magda-minion-linked-data-rating/src/openFormats.ts
@@ -18,7 +18,14 @@ const FORMAT_STARS: { [stars: number]: string[] } = {
         "rss",
         "gpx"
     ],
-    4: ["csv geo au", "sparql", "rdf", "relational document format", "json ld"]
+    4: [
+        "csv geo au",
+        "sparql",
+        "rdf",
+        "relational document format",
+        "json ld",
+        "asc"
+    ]
 };
 
 export default FORMAT_STARS;

--- a/magda-minion-linked-data-rating/src/test/examples.ts
+++ b/magda-minion-linked-data-rating/src/test/examples.ts
@@ -27,5 +27,5 @@ export const ZERO_STAR_FORMATS = [undefined, "", "pdf", "doc", "png", "tiff"];
 export const FORMAT_EXAMPLES: { [a: number]: string[] } = {
     2: ["XSLX (Microsoft Excel)", "Excel", "MS EXCEL"],
     3: ["CSV", "Comma-Separated Values"],
-    4: ["Csv-geo-au"]
+    4: ["Csv-geo-au", "ASC"]
 };


### PR DESCRIPTION
### What this PR does

Fixes #1426 

- Make format minion recognize ASC correctly
  - Make format minion trust dcat format if other measures indicate a ZIP format
- Set ASC to a 4 stars format

Fixes #2137 Sometimes, format minion will incorrectly recognize WMS as ESRI REST format
- The current `ESRI REST` URL detect regex is too generic
```javascript
[new RegExp("\\W+MapServer\\W*|\\W+FeatureServer\\W*", "i"), "ESRI REST"],
```
And there probably no way of making it more specific.

Thus, we probably want format minion only use the ESRI REST format result if the dcat format not exists

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
