### PR TITLE
Showed text message if there are no tags to display in a dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Others:
 -   Format minion will trust dcat format if other measures indicate a ZIP format
 -   Format minion will trust dcat format if other measures indicate a ESRI REST format
 -   Added ASC to 4 stars rating list
+-   Showed text message if there are no tags to display in a dataset page.
 
 ## 0.0.55
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,11 +22,6 @@ Cataloging:
 
 UI:
 
--   Made registry-api DB pool settings configurable via Helm
--   Make broken link sleuther recrawl period configurable via Helm
--   Format minion will trust dcat format if other measures indicate a ZIP format
--   Format minion will trust dcat format if other measures indicate a ESRI REST format
--   Added ASC to 4 stars rating list
 -   Showed text message if there are no tags to display in a dataset page.
 -   Removed gap after data quality star rating
 -   Replaced star emoji in static page markdown with quality star icon

--- a/magda-web-client/src/UI/TagsBox.js
+++ b/magda-web-client/src/UI/TagsBox.js
@@ -28,22 +28,26 @@ function TagsBox(props) {
     return (
         <div className="tags-box">
             <div className="heading">Tags: </div>
-            <AUtags
-                tags={
-                    props.tags &&
-                    mergeTags(props.tags)
-                        .sort((a, b) => {
-                            if (a < b) return -1;
-                            else if (a > b) return 1;
-                            else return 0;
-                        })
-                        .map((t, _) => ({
-                            link: `/search?q=${encodeURIComponent(t)}`,
-                            text: t
-                        }))
-                }
-                linkComponent={Link}
-            />
+            {props.tags && props.tags.length > 0 ? (
+                <AUtags
+                    tags={
+                        props.tags &&
+                        mergeTags(props.tags)
+                            .sort((a, b) => {
+                                if (a < b) return -1;
+                                else if (a > b) return 1;
+                                else return 0;
+                            })
+                            .map((t, _) => ({
+                                link: `/search?q=${encodeURIComponent(t)}`,
+                                text: t
+                            }))
+                    }
+                    linkComponent={Link}
+                />
+            ) : (
+                <span>No tags defined</span>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
### What this PR does

Showed text message if there are no tags to display in a dataset page.

Fixes #1898.

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
