### PR TITLE
Display placeholder text at a lower opacity while the field is in focus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Others:
 -   Format minion will trust dcat format if other measures indicate a ZIP format
 -   Format minion will trust dcat format if other measures indicate a ESRI REST format
 -   Added ASC to 4 stars rating list
+-   Display search box placeholder text at a lower opacity while the field is in focus.
 
 ## 0.0.55
 

--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -61,16 +61,16 @@
     }
 
     input:focus::-webkit-input-placeholder {
-        opacity: 0;
+        opacity: 0.5;
     }
     input:focus:-moz-placeholder {
-        opacity: 0;
+        opacity: 0.5;
     }
     input:focus::-moz-placeholder {
-        opacity: 0;
+        opacity: 0.5;
     }
     input:focus:-ms-input-placeholder {
-        opacity: 0;
+        opacity: 0.5;
     }
 
     @media (min-width: $medium) {


### PR DESCRIPTION
### What this PR does

Display search field placeholder text at a lower opacity while the field is in focus.

Fixes #1894.

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
