### PR TITLE
Fixed indexer throws an error when temporalCoverage aspects contains an empty array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Search:
 
 -   Prevent freeText query from being None which will cause score to be 0
 
+Indexer:
+
+-   Fixed indexer throws an error when temporalCoverage aspects intervals is an empty array
+
 Others:
 
 -   Made registry-api DB pool settings configurable via Helm

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -250,8 +250,26 @@ object Registry {
         case _ => 1d
       }
 
-      val coverageStart = ApiDate(tryParseDate(temporalCoverage.extract[String]('intervals.? / element(0) / 'start.?)), dcatStrings.extract[String]('temporal.? / 'start.?).getOrElse(""))
-      val coverageEnd = ApiDate(tryParseDate(temporalCoverage.extract[String]('intervals.? / element(0) / 'end.?)), dcatStrings.extract[String]('temporal.? / 'end.?).getOrElse(""))
+      // --- intervals could be an empty array
+      // --- put in a Try to avoid exceptions
+      val coverageStart = ApiDate(tryParseDate(
+        Try[Option[String]]{
+          temporalCoverage.extract[String]('intervals.? / element(0) / 'start.?)
+        } match {
+          case Success(Some(v)) => Some(v)
+          case _ => None
+        }
+      ), dcatStrings.extract[String]('temporal.? / 'start.?).getOrElse(""))
+
+      val coverageEnd = ApiDate(tryParseDate(
+        Try[Option[String]]{
+          temporalCoverage.extract[String]('intervals.? / element(0) / 'end.?)
+        } match {
+          case Success(Some(v)) => Some(v)
+          case _ => None
+        }
+      ), dcatStrings.extract[String]('temporal.? / 'end.?).getOrElse(""))
+
       val temporal = (coverageStart, coverageEnd) match {
         case (ApiDate(None, ""), ApiDate(None, "")) => None
         case (ApiDate(None, ""), end)               => Some(PeriodOfTime(None, Some(end)))


### PR DESCRIPTION
### What this PR does

Fixes #2169 

Fixed indexer throws an error when temporalCoverage aspects intervals is an empty array

Happens when you create a new dataset using the new dataset page without specifying temporalCoverage info.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
