### PR TITLE
Fixed: AppContainer mount & unmount twice on initial load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ UI:
 -   Refactored web client to group similar things togeather
 -   Implemented basic admin pages in react ui
 -   Started implementing new add dataset flow design changes
+-   Fixed web-client code loaded & run twice
 
 ## 0.0.55
 

--- a/magda-web-client/public/index.html
+++ b/magda-web-client/public/index.html
@@ -49,9 +49,5 @@
             >.
         </noscript>
         <div id="root"></div>
-        <script
-            type="text/javascript"
-            src="<%=htmlWebpackPlugin.files.js[0]%>"
-        ></script>
     </body>
 </html>


### PR DESCRIPTION
### What this PR does

Fixes #2196 AppContainer mount & unmount twice on initial load

Cause:
These lines: 

https://github.com/magda-io/magda/blob/7c66964fe1ccb6112e764bc54c7bd282a6bb5e0d/magda-web-client/public/index.html#L52-L55

was about manually insert client JS as we overide the `HtmlWebpackPlugin` here (in order to control CSS output):

https://github.com/magda-io/magda/blob/ac6c471982c457599dd50eadb4063870f722cb9b/magda-web-client/config-overrides.js#L17

As we don't use `react-app-rewire` & override `HtmlWebpackPlugin` anymore, we should remove those lines --- otherwise, client code is linked into index.html twice (and run twice)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
