### PR TITLE
Tidy up edit dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ UI:
 -   Fixed web-client code loaded & run twice
 -   Added basic spatial preview to add dataset
 -   Revised add dataset first metadata page for conformance with design
+-   Improved edit dataset page overall styling & editor behaviour
 
 Access Control:
 

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -35,6 +35,7 @@ import { get } from "lodash";
 import { ToggleEditor } from "Components/Editing/ToggleEditor";
 import {
     textEditor,
+    textEditorFullWidth,
     multilineTextEditor,
     multiTextEditor,
     multiDateIntervalEditor
@@ -432,7 +433,7 @@ class RecordHandler extends React.Component {
                                         enabled={hasEditPermissions}
                                         value={this.props.dataset.title}
                                         onChange={datasetChange("title")}
-                                        editor={textEditor}
+                                        editor={textEditorFullWidth}
                                     />
                                 </h1>
                                 <div className="publisher-basic-info-row">

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -508,165 +508,6 @@ class RecordHandler extends React.Component {
                                             </Medium>
                                         </ToggleEditor>
                                     </div>
-                                    {hasEditPermissions && (
-                                        <div className="au-body au-body--alt">
-                                            <h4>State: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={dataset.publishingState}
-                                                onChange={publishingChange(
-                                                    "state"
-                                                )}
-                                                editor={codelistEditor(
-                                                    codelists.status
-                                                )}
-                                            />
-                                            <h4>Priority: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={dataset.importance}
-                                                onChange={datasetChange(
-                                                    "importance"
-                                                )}
-                                                editor={codelistEditor(
-                                                    codelists.importance
-                                                )}
-                                            />
-                                            <h4>Affiliated Organisations: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.creationAffiliatedOrganisation
-                                                }
-                                                onChange={datasetChange(
-                                                    "creation/affiliatedOrganisation"
-                                                )}
-                                                editor={multilineTextEditor}
-                                            />
-                                            <h4>Update frequency: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.accrualPeriodicity
-                                                }
-                                                onChange={datasetChange(
-                                                    "accrualPeriodicity"
-                                                )}
-                                                editor={codelistEditor(
-                                                    codelists.accrualPeriodicity
-                                                )}
-                                            />
-                                            <h4>Spatial coverage: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.spatialCoverageBbox
-                                                }
-                                                onChange={spatialChange("bbox")}
-                                                editor={bboxEditor}
-                                            />
-                                            <h4>Temporal coverage: </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.temporalCoverage
-                                                        .intervals
-                                                }
-                                                onChange={temporalChange(
-                                                    "intervals"
-                                                )}
-                                                editor={multiDateIntervalEditor}
-                                            >
-                                                <div className="dataset-details-temporal-coverage">
-                                                    <TemporalAspectViewer
-                                                        data={
-                                                            dataset.temporalCoverage
-                                                        }
-                                                    />
-                                                </div>
-                                            </ToggleEditor>
-                                            <h4>Access level:</h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={dataset.accessLevel}
-                                                onChange={datasetChange(
-                                                    "accessLevel"
-                                                )}
-                                                editor={codelistEditor(
-                                                    codelists.accessLevel
-                                                )}
-                                            />
-                                            <h4>
-                                                Dataset security classification:
-                                            </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.informationSecurity
-                                                        .disseminationLimits
-                                                }
-                                                onChange={datasetChange(
-                                                    "informationSecurity/disseminationLimits"
-                                                )}
-                                                editor={multiCodelistEditor(
-                                                    codelists.disseminationLimits
-                                                )}
-                                            />
-                                            <h4>
-                                                Dataset security
-                                                classification2:
-                                            </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.informationSecurity
-                                                        .classification
-                                                }
-                                                onChange={datasetChange(
-                                                    "informationSecurity/classification"
-                                                )}
-                                                editor={codelistEditor(
-                                                    codelists.classification
-                                                )}
-                                            />
-                                            <h4>Is this public open data?</h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.creation.isOpenData
-                                                }
-                                                onChange={datasetChange(
-                                                    "creation/isOpenData"
-                                                )}
-                                                editor={booleanEditor}
-                                            />
-                                            <h4>
-                                                How was the dataset produced?
-                                            </h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.creation.mechanism
-                                                }
-                                                onChange={datasetChange(
-                                                    "creation/mechanism"
-                                                )}
-                                                editor={multilineTextEditor}
-                                            />
-                                            <h4>Source system:</h4>
-                                            <ToggleEditor
-                                                enabled={hasEditPermissions}
-                                                value={
-                                                    dataset.creation
-                                                        .sourceSystem
-                                                }
-                                                onChange={datasetChange(
-                                                    "creation/sourceSystem"
-                                                )}
-                                                editor={textEditor}
-                                            />
-                                        </div>
-                                    )}
                                     {this.props.dataset.hasQuality ? (
                                         <div className="quality-rating-box">
                                             <QualityIndicator
@@ -702,6 +543,172 @@ class RecordHandler extends React.Component {
                                             tags={this.props.dataset.tags}
                                         />
                                     </ToggleEditor>
+                                    {hasEditPermissions && (
+                                        <div>
+                                            <br />
+                                            <hr />
+                                            <h2>Dates and updates</h2>
+                                            <h4>
+                                                How frequently is the dataset
+                                                updated?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.accrualPeriodicity
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "accrualPeriodicity"
+                                                    )}
+                                                    editor={codelistEditor(
+                                                        codelists.accrualPeriodicity
+                                                    )}
+                                                />
+                                            </p>
+                                            <h4>
+                                                What time period does the
+                                                dataset cover?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.temporalCoverage
+                                                            .intervals
+                                                    }
+                                                    onChange={temporalChange(
+                                                        "intervals"
+                                                    )}
+                                                    editor={
+                                                        multiDateIntervalEditor
+                                                    }
+                                                >
+                                                    <div className="dataset-details-temporal-coverage">
+                                                        <TemporalAspectViewer
+                                                            data={
+                                                                dataset.temporalCoverage
+                                                            }
+                                                        />
+                                                    </div>
+                                                </ToggleEditor>
+                                            </p>
+                                            <hr />
+                                            <h3>Spatial area</h3>
+                                            <h4>
+                                                We've determined that the
+                                                spatial extent of your data is:
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.spatialCoverageBbox
+                                                    }
+                                                    onChange={spatialChange(
+                                                        "bbox"
+                                                    )}
+                                                    editor={bboxEditor}
+                                                />
+                                            </p>
+                                            <hr />
+                                            <h2>People and production</h2>
+                                            <h4>
+                                                Was this dataset produced
+                                                collaborating with other
+                                                organisations?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.creationAffiliatedOrganisation
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "creation/affiliatedOrganisation"
+                                                    )}
+                                                    editor={multilineTextEditor}
+                                                />
+                                            </p>
+                                            <h4>
+                                                How was the dataset produced?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.creation
+                                                            .mechanism
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "creation/mechanism"
+                                                    )}
+                                                    editor={multilineTextEditor}
+                                                />
+                                            </p>
+                                            <h4>Source system:</h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset.creation
+                                                            .sourceSystem
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "creation/sourceSystem"
+                                                    )}
+                                                    editor={textEditor}
+                                                />
+                                            </p>
+                                            <hr />
+                                            <h2>
+                                                Dataset visibility, access and
+                                                control
+                                            </h2>
+                                            <h4>
+                                                What is the security
+                                                classification of this dataset?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset
+                                                            .informationSecurity
+                                                            .disseminationLimits
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "informationSecurity/disseminationLimits"
+                                                    )}
+                                                    editor={multiCodelistEditor(
+                                                        codelists.disseminationLimits
+                                                    )}
+                                                />
+                                            </p>
+
+                                            <h4>
+                                                What is the sensitivity of this
+                                                dataset?
+                                            </h4>
+                                            <p>
+                                                <ToggleEditor
+                                                    enabled={hasEditPermissions}
+                                                    value={
+                                                        dataset
+                                                            .informationSecurity
+                                                            .classification
+                                                    }
+                                                    onChange={datasetChange(
+                                                        "informationSecurity/classification"
+                                                    )}
+                                                    editor={codelistEditor(
+                                                        codelists.classification
+                                                    )}
+                                                />
+                                            </p>
+                                            <hr />
+                                        </div>
+                                    )}
                                 </div>
                             </div>
                             <div

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -45,7 +45,6 @@ import {
     multiCodelistEditor
 } from "Components/Editing/Editors/codelistEditor";
 import { bboxEditor } from "Components/Editing/Editors/spatialEditor";
-import { booleanEditor } from "Components/Editing/Editors/booleanEditor";
 
 import * as codelists from "constants/DatasetConstants";
 import { config } from "config";
@@ -177,10 +176,6 @@ class RecordHandler extends React.Component {
         const datasetChange = this.change(
             this.props.dataset.identifier,
             "dcat-dataset-strings"
-        );
-        const publishingChange = this.change(
-            this.props.dataset.identifier,
-            "publishing"
         );
 
         const spatialChange = this.change(

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -95,7 +95,7 @@ export class ListMultiItemEditor extends MultiItemEditor {
                         {editor.edit(newValue, this.change.bind(this), value)}
                         {newValue && (
                             <button
-                                className="edit-button"
+                                className="au-btn add-button"
                                 onClick={this.add.bind(this)}
                             >
                                 Add

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -73,23 +73,25 @@ export class ListMultiItemEditor extends MultiItemEditor {
 
         return (
             <React.Fragment>
-                <div className="multi-list-item-editor-container">
-                    {value.map((val, i) => {
-                        return (
-                            <div className="multi-list-item-editor-item">
-                                {editor.view(val)}
-                                {enabled && (
-                                    <button
-                                        className="edit-button"
-                                        onClick={this.deleteIndex(i)}
-                                    >
-                                        &#215;
-                                    </button>
-                                )}
-                            </div>
-                        );
-                    })}
-                </div>
+                {!enabled && (!value || !value.length) ? null : (
+                    <div className="multi-list-item-editor-container">
+                        {value.map((val, i) => {
+                            return (
+                                <div className="multi-list-item-editor-item">
+                                    {editor.view(val)}
+                                    {enabled && (
+                                        <button
+                                            className="edit-button"
+                                            onClick={this.deleteIndex(i)}
+                                        >
+                                            &#215;
+                                        </button>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
                 {enabled && (
                     <React.Fragment>
                         {editor.edit(newValue, this.change.bind(this), value)}
@@ -103,6 +105,7 @@ export class ListMultiItemEditor extends MultiItemEditor {
                         )}
                     </React.Fragment>
                 )}
+                {!enabled && (!value || !value.length) && "NOT SET"}
             </React.Fragment>
         );
     }

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -14,7 +14,11 @@ export function textEditorEx(options: any = {}) {
             }
             return (
                 <input
-                    className="au-text-input"
+                    className={
+                        options.fullWidth
+                            ? "au-text-input full-width-ctrl"
+                            : "au-text-input non-full-width-ctrl"
+                    }
                     defaultValue={value as string}
                     onChange={callback}
                     {...options}
@@ -28,6 +32,7 @@ export function textEditorEx(options: any = {}) {
 }
 
 export const textEditor = textEditorEx({});
+export const textEditorFullWidth = textEditorEx({ fullWidth: true });
 
 export const multilineTextEditor: Editor = {
     edit: (value: any, onChange: Function) => {
@@ -36,7 +41,7 @@ export const multilineTextEditor: Editor = {
         };
         return (
             <textarea
-                className="au-text-input"
+                className="au-text-input full-width-ctrl"
                 style={{ width: "100%" }}
                 onChange={callback}
                 defaultValue={value as string}

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -26,7 +26,7 @@ export function textEditorEx(options: any = {}) {
             );
         },
         view: (value: any) => {
-            return <React.Fragment>{value}</React.Fragment>;
+            return <React.Fragment>{value ? value : "NOT SET"}</React.Fragment>;
         }
     };
 }
@@ -49,7 +49,7 @@ export const multilineTextEditor: Editor = {
         ); //<input defaultValue={value as string} onChange={callback} />;
     },
     view: (value: any) => {
-        return <React.Fragment>{value}</React.Fragment>;
+        return <React.Fragment>{value ? value : "NOT SET"}</React.Fragment>;
     }
 };
 

--- a/magda-web-client/src/Components/Editing/Style.scss
+++ b/magda-web-client/src/Components/Editing/Style.scss
@@ -12,6 +12,8 @@
     textarea,
     select {
         margin-bottom: 5px;
+        margin-left: 5px;
+        margin-right: 5px;
     }
 }
 

--- a/magda-web-client/src/Components/Editing/Style.scss
+++ b/magda-web-client/src/Components/Editing/Style.scss
@@ -1,5 +1,73 @@
 @import "variables";
 
+.toggle-editor-container {
+    position: relative;
+    .toggle-edit-button {
+        display: none;
+    }
+}
+
+.toggle-editor-container {
+    input,
+    textarea,
+    select {
+        margin-bottom: 5px;
+    }
+}
+
+.toggle-editor-container {
+    .full-width-ctrl {
+        width: 98%;
+        max-width: none;
+    }
+}
+
+.toggle-editor-container {
+    .non-full-width-ctrl {
+        margin-right: 10px;
+    }
+}
+
+.toggle-editor-container {
+    textarea {
+        height: 250px;
+    }
+}
+
+.toggle-editor-container {
+    .save-button,
+    .add-button {
+        margin-right: 5px;
+    }
+}
+
+.toggle-editor-container:hover {
+    .toggle-edit-button {
+        display: block;
+    }
+}
+
+.toggle-edit-button {
+    font-weight: bold;
+    font-size: 1.5rem;
+    border: 1px solid $AU-colordark-background;
+    border-radius: 5px;
+    padding-left: 10px;
+    padding-right: 13px;
+    background-color: #ffffff;
+    color: $AU-colordark-background;
+    position: absolute;
+    right: 10px;
+    top: 2px;
+    z-index: 999;
+}
+
+.toggle-edit-button:hover {
+    cursor: pointer;
+    background-color: $AU-colordark-background;
+    color: $AU-colordark-foreground-action;
+}
+
 .edit-button {
     margin-left: 0.5em;
     margin-top: 0.5em;

--- a/magda-web-client/src/Components/Editing/ToggleEditor.tsx
+++ b/magda-web-client/src/Components/Editing/ToggleEditor.tsx
@@ -93,7 +93,8 @@ export class ToggleEditor extends React.Component<ToggleEditorProps> {
                         )}
                         {this.props.children
                             ? this.props.children
-                            : editor.view(value)}{" "}
+                            : editor.view(value)}
+                        {""}
                     </React.Fragment>
                 )}
             </div>

--- a/magda-web-client/src/Components/Editing/ToggleEditor.tsx
+++ b/magda-web-client/src/Components/Editing/ToggleEditor.tsx
@@ -60,21 +60,21 @@ export class ToggleEditor extends React.Component<ToggleEditorProps> {
         const isEditing = enabled && this.state.isEditing;
 
         return (
-            <React.Fragment>
+            <div className="toggle-editor-container">
                 {isEditing ? (
                     <React.Fragment>
                         {editor.edit(value, this.change.bind(this))}
                         {this.state.value !== undefined &&
                             this.props.value !== this.state.value && (
                                 <button
-                                    className="edit-button"
+                                    className="au-btn save-button"
                                     onClick={this.save.bind(this)}
                                 >
                                     Save
                                 </button>
                             )}
                         <button
-                            className="edit-button"
+                            className="au-btn cancel-button"
                             onClick={this.cancel.bind(this)}
                         >
                             Cancel
@@ -82,21 +82,21 @@ export class ToggleEditor extends React.Component<ToggleEditorProps> {
                     </React.Fragment>
                 ) : (
                     <React.Fragment>
-                        {this.props.children
-                            ? this.props.children
-                            : editor.view(value)}{" "}
                         {enabled && (
                             <button
-                                className="edit-button"
+                                className="toggle-edit-button"
                                 title="Edit data item"
                                 onClick={this.edit.bind(this)}
                             >
                                 &#9998;
                             </button>
                         )}
+                        {this.props.children
+                            ? this.props.children
+                            : editor.view(value)}{" "}
                     </React.Fragment>
                 )}
-            </React.Fragment>
+            </div>
         );
     }
 }


### PR DESCRIPTION
### What this PR does

Tidy up Edit dataset page for upcoming usability testing.
Summary:
- Make text input / textarea take full available space when appropriate
- Adjust the edit button style
  - consistent with the rest of the system  
  - Only show when mouseover
- Adjust the margin & padding of various controls
- Fixed issue that the editor won't display default value when no value is set
- Re-arrange elements to match the latest new data set workflow & screen

Test URL:

https://tidy-up-edit-dataset-page.dev.magda.io


![image](https://user-images.githubusercontent.com/674387/57603807-eeebdf80-75a5-11e9-862e-58e7e6defe3b.png)


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
