### PR TITLE
Usability testing items

### DIFF
--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -286,7 +286,7 @@ class NewDataset extends React.Component<Prop, State> {
                 </p>
                 <hr />
                 <h3>Dates and updates</h3>
-                <h4>When was the dataset was published or issued?</h4>
+                <h4>When was the data first issued?</h4>
                 <p>
                     <AlwaysEditor
                         value={dataset.issued}

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -243,7 +243,11 @@ class NewDataset extends React.Component<Prop, State> {
                     <AlwaysEditor
                         value={dataset.languages}
                         onChange={editDataset("languages")}
-                        editor={multiCodelistEditor(codelists.languages, true)}
+                        editor={multiCodelistEditor(
+                            codelists.languages,
+                            true,
+                            "Add another language"
+                        )}
                     />
                 </p>
                 <hr />

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -558,7 +558,7 @@ class RecordHandler extends React.Component {
                                                 How frequently is the dataset
                                                 updated?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -571,12 +571,12 @@ class RecordHandler extends React.Component {
                                                         codelists.accrualPeriodicity
                                                     )}
                                                 />
-                                            </p>
+                                            </div>
                                             <h4>
                                                 What time period does the
                                                 dataset cover?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -598,14 +598,14 @@ class RecordHandler extends React.Component {
                                                         />
                                                     </div>
                                                 </ToggleEditor>
-                                            </p>
+                                            </div>
                                             <hr />
                                             <h3>Spatial area</h3>
                                             <h4>
                                                 We've determined that the
                                                 spatial extent of your data is:
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -616,7 +616,7 @@ class RecordHandler extends React.Component {
                                                     )}
                                                     editor={bboxEditor}
                                                 />
-                                            </p>
+                                            </div>
                                             <hr />
                                             <h2>People and production</h2>
                                             <h4>
@@ -624,7 +624,7 @@ class RecordHandler extends React.Component {
                                                 collaborating with other
                                                 organisations?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -635,11 +635,11 @@ class RecordHandler extends React.Component {
                                                     )}
                                                     editor={multilineTextEditor}
                                                 />
-                                            </p>
+                                            </div>
                                             <h4>
                                                 How was the dataset produced?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -651,9 +651,9 @@ class RecordHandler extends React.Component {
                                                     )}
                                                     editor={multilineTextEditor}
                                                 />
-                                            </p>
+                                            </div>
                                             <h4>Source system:</h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -665,7 +665,7 @@ class RecordHandler extends React.Component {
                                                     )}
                                                     editor={textEditor}
                                                 />
-                                            </p>
+                                            </div>
                                             <hr />
                                             <h2>
                                                 Dataset visibility, access and
@@ -675,7 +675,7 @@ class RecordHandler extends React.Component {
                                                 What is the security
                                                 classification of this dataset?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -690,13 +690,13 @@ class RecordHandler extends React.Component {
                                                         codelists.disseminationLimits
                                                     )}
                                                 />
-                                            </p>
+                                            </div>
 
                                             <h4>
                                                 What is the sensitivity of this
                                                 dataset?
                                             </h4>
-                                            <p>
+                                            <div>
                                                 <ToggleEditor
                                                     enabled={hasEditPermissions}
                                                     value={
@@ -711,7 +711,7 @@ class RecordHandler extends React.Component {
                                                         codelists.classification
                                                     )}
                                                 />
-                                            </p>
+                                            </div>
                                             <hr />
                                         </div>
                                     )}

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -31,6 +31,7 @@ import { getFormatIcon } from "./View/DistributionIcon";
 import apiAccessIcon from "assets/apiAccess.svg";
 import downloadWhiteIcon from "assets/download-white.svg";
 import { get } from "lodash";
+import AUpageAlert from "@gov.au/page-alerts";
 
 import { ToggleEditor } from "Components/Editing/ToggleEditor";
 import {
@@ -421,6 +422,16 @@ class RecordHandler extends React.Component {
                         <Medium>
                             <Breadcrumbs breadcrumbs={this.getBreadcrumbs()} />
                         </Medium>
+                        {dataset.publishingState === "draft" ? (
+                            <AUpageAlert as="info">
+                                <h3>Draft Dataset</h3>
+                                <p>
+                                    This dataset is a draft and has not been
+                                    published yet. Once the dataset is approved,
+                                    it will appear in your catalogue.
+                                </p>
+                            </AUpageAlert>
+                        ) : null}
                         <div className="row">
                             <div className="col-sm-8">
                                 <h1 itemProp="name">

--- a/magda-web-client/src/Components/Dataset/DatasetPage.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.scss
@@ -1,5 +1,13 @@
 @import "variables";
 
+.record--dataset {
+    .au-page-alerts {
+        p {
+            max-width: none;
+        }
+    }
+}
+
 .dataset-details {
     h3.section-heading {
         @include AU-fontgrid(lg, heading);

--- a/magda-web-client/src/Components/Editing/Editors/Editor.ts
+++ b/magda-web-client/src/Components/Editing/Editors/Editor.ts
@@ -2,6 +2,11 @@
  * Abstract Editor. Can view or edit.
  */
 export default interface Editor {
-    edit: (value: any, onChange: Function, multiValues?: any) => JSX.Element;
+    edit: (
+        value: any,
+        onChange: Function,
+        multiValues?: any,
+        extraProps?: any
+    ) => JSX.Element;
     view: (value: any) => JSX.Element;
 }

--- a/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import Editor from "./Editor";
 import { ListMultiItemEditor } from "./multiItem";
 
-export function codelistEditor(options: any, reorder = false): Editor {
+export function codelistEditor(
+    options: any,
+    reorder = false,
+    defaultOptionText: string = ""
+): Editor {
     return {
         edit: (value: any, onChange: Function, valuesToAvoid?: any) => {
             const callback = event => {
@@ -22,7 +26,9 @@ export function codelistEditor(options: any, reorder = false): Editor {
                     key={valuesToAvoid.join("-")}
                 >
                     <option value="" disabled>
-                        Please select one
+                        {defaultOptionText
+                            ? defaultOptionText
+                            : "Please select one"}
                     </option>
                     {keys
                         .filter(item => valuesToAvoid.indexOf(item) === -1)
@@ -109,7 +115,11 @@ function alphaLabelSort(labels, order = 1) {
     };
 }
 
-export function multiCodelistEditor(options: any, reorder = false): Editor {
-    const single = codelistEditor(options, reorder);
+export function multiCodelistEditor(
+    options: any,
+    reorder = false,
+    defaultOptionText: string = ""
+): Editor {
+    const single = codelistEditor(options, reorder, defaultOptionText);
     return ListMultiItemEditor.create(single, () => "");
 }

--- a/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
@@ -32,8 +32,12 @@ export function codelistEditor(
                     </option>
                     {keys
                         .filter(item => valuesToAvoid.indexOf(item) === -1)
-                        .map(val => {
-                            return <option value={val}>{options[val]}</option>;
+                        .map((val, i) => {
+                            return (
+                                <option key={i} value={val}>
+                                    {options[val]}
+                                </option>
+                            );
                         })}
                 </select>
             );

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -70,14 +70,35 @@ export class ListMultiItemEditor extends MultiItemEditor {
         const { editor, enabled } = this.props;
         const { newValue } = this.state;
         const value = this.value();
-
         return (
             <React.Fragment>
+                {enabled && (
+                    <React.Fragment>
+                        {editor.edit(newValue, this.change.bind(this), value, {
+                            onKeyUp: e => {
+                                if (e.keyCode !== 13) return;
+                                this.add(e);
+                            }
+                        })}
+                        {newValue && (
+                            <button
+                                className="au-btn add-button"
+                                onClick={this.add.bind(this)}
+                            >
+                                Add
+                            </button>
+                        )}
+                    </React.Fragment>
+                )}
+                {!enabled && (!value || !value.length) && "NOT SET"}
                 {!enabled && (!value || !value.length) ? null : (
                     <div className="multi-list-item-editor-container">
                         {value.map((val, i) => {
                             return (
-                                <div className="multi-list-item-editor-item">
+                                <div
+                                    key={i}
+                                    className="multi-list-item-editor-item"
+                                >
                                     {editor.view(val)}
                                     {enabled && (
                                         <button
@@ -92,20 +113,6 @@ export class ListMultiItemEditor extends MultiItemEditor {
                         })}
                     </div>
                 )}
-                {enabled && (
-                    <React.Fragment>
-                        {editor.edit(newValue, this.change.bind(this), value)}
-                        {newValue && (
-                            <button
-                                className="au-btn add-button"
-                                onClick={this.add.bind(this)}
-                            >
-                                Add
-                            </button>
-                        )}
-                    </React.Fragment>
-                )}
-                {!enabled && (!value || !value.length) && "NOT SET"}
             </React.Fragment>
         );
     }

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -5,7 +5,12 @@ import { ListMultiItemEditor } from "./multiItem";
 
 export function textEditorEx(options: any = {}) {
     return {
-        edit: (value: any, onChange: Function) => {
+        edit: (
+            value: any,
+            onChange: Function,
+            multiValues: any = null,
+            extraProps: any = {}
+        ) => {
             const callback = event => {
                 onChange(event.target.value);
             };
@@ -16,12 +21,13 @@ export function textEditorEx(options: any = {}) {
                 <input
                     className={
                         options.fullWidth
-                            ? "au-text-input full-width-ctrl"
-                            : "au-text-input non-full-width-ctrl"
+                            ? "au-text-input full-width-ctrl textEditorEx"
+                            : "au-text-input non-full-width-ctrl textEditorEx"
                     }
                     defaultValue={value as string}
                     onChange={callback}
                     {...options}
+                    {...extraProps}
                 />
             );
         },

--- a/magda-web-client/src/Components/Editing/Style.scss
+++ b/magda-web-client/src/Components/Editing/Style.scss
@@ -1,5 +1,10 @@
 @import "variables";
 
+.textEditorEx {
+    margin-right: 5px;
+    margin-bottom: 5px;
+}
+
 .toggle-editor-container {
     position: relative;
     .toggle-edit-button {

--- a/magda-web-client/src/Components/Footer/Footer.js
+++ b/magda-web-client/src/Components/Footer/Footer.js
@@ -46,8 +46,8 @@ function FooterNavs({ footerNavs }) {
             <h3 className="au-display-lg">{item.label}</h3>
 
             <ul className="au-link-list">
-                {item.links.map(link => (
-                    <li key={link.href}>
+                {item.links.map((link, i) => (
+                    <li key={i}>
                         <FooterLink link={link} />
                     </li>
                 ))}


### PR DESCRIPTION
### What this PR does

Fixed the followings:
- Add a Page info box to top area of the edit dataset page to indicate it's a Draft --- I will work on this first
- What languages - change default text to “Add another language”
- Keywords/themes - pressing “enter” should be the same as clicking “Add”
- Keywords/themes - put the entered ones _below_ the entry checkbox
- Fixed a few React warnings. 
- Change publish date text to “when was the data first issued”


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
