### PR TITLE
Fixed height of the progress bar.

### DIFF
--- a/magda-web-client/src/Components/Common/ProgressBar.scss
+++ b/magda-web-client/src/Components/Common/ProgressBar.scss
@@ -23,7 +23,7 @@
     animation: gradient 3s linear infinite;
     background-position: 0% 0%;
     background-size: 500% auto;
-    height: 2em;
+    height: 10px;
 }
 
 @keyframes gradient {


### PR DESCRIPTION
### What this PR does

Fixes #2193

Resets the height of the loading bar so it's back to normal.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] No CHANGES.md, this just puts a bug back the way it was last release.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
