### PR TITLE
Fixed patch request to registry won't trigger notification to webhook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Indexer:
 
 -   Fixed indexer throws an error when temporalCoverage aspects intervals is an empty array
 
+Registry:
+
+-   PATCH request to registry won't trigger notification to webhook
+
 Others:
 
 -   Made registry-api DB pool settings configurable via Helm


### PR DESCRIPTION
### What this PR does

Fixes #2222 

There are two endpoints missing code of notifying webhook actor.

Found when testing Pre-authorised permission.

I used the following code (to be paste into browser console) for testing:
- authorize permission to the dataset:
```js
fetch("http://192.168.99.100:30100/api/v0/registry/records/magda-ds-a4298a60-8022-11e9-a1e4-a98a09e06f97--6767da09-53d5-48dd-82a9-78e2365ef708/aspects/dataset-access-control", {
  "method": "PATCH",
  "headers": {
    "Content-type": "application/json"
  },
  "body": JSON.stringify([
	{
	  "op": "add",
	  "path": "/preAuthorisedPermissionIds",
	  "value": [
		"54466898-5039-4c61-b051-8592888ec022"
	  ]
	}
  ])
})
```

- de- authorize permission to the dataset:
```js
fetch("http://192.168.99.100:30100/api/v0/registry/records/magda-ds-a4298a60-8022-11e9-a1e4-a98a09e06f97--6767da09-53d5-48dd-82a9-78e2365ef708/aspects/dataset-access-control", {
  "method": "PATCH",
  "headers": {
    "Content-type": "application/json"
  },
  "body": JSON.stringify([
	{
	  "op": "remove",
	  "path": "/preAuthorisedPermissionIds"
	}
  ])
})
```

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
