### PR TITLE
Made dataset page printer friendly. Fixes #2230.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Cataloging:
 
 UI:
 
+-   Made dataset page printer friendly
 -   Display search box placeholder text at a lower opacity while the field is in focus.
 -   Showed text message if there are no tags to display in a dataset page.
 -   Removed gap after data quality star rating

--- a/magda-web-client/src/Components/Common/Banner.js
+++ b/magda-web-client/src/Components/Common/Banner.js
@@ -40,7 +40,7 @@ class Banner extends React.Component {
     render() {
         if (this.state.isOpen) {
             return (
-                <div className="banner au-body au-body--dark">
+                <div className="banner au-body au-body--dark no-print">
                     <span>
                         A new look for Australia&apos;s data portal: our updated
                         site makes it easier for you to find relevant open data.

--- a/magda-web-client/src/Components/Common/ContactPoint.js
+++ b/magda-web-client/src/Components/Common/ContactPoint.js
@@ -30,15 +30,24 @@ class ContactPoint extends React.Component {
                         <div className="heading">
                             {translate(["contactPointTitle", "Contact Point"])}:
                         </div>
-                        {this.state.reveal ? (
+                        <div class="no-print">
+                            {this.state.reveal ? (
+                                <MarkdownViewer
+                                    markdown={this.props.contactPoint}
+                                />
+                            ) : (
+                                <ToggleButton
+                                    onClick={this.onRevealButtonClick}
+                                >
+                                    <span>Click to reveal</span>
+                                </ToggleButton>
+                            )}
+                        </div>
+                        <div class="print-only">
                             <MarkdownViewer
                                 markdown={this.props.contactPoint}
                             />
-                        ) : (
-                            <ToggleButton onClick={this.onRevealButtonClick}>
-                                <span>Click to reveal</span>
-                            </ToggleButton>
-                        )}
+                        </div>
                     </div>
                 )}
             </MagdaNamespacesConsumer>

--- a/magda-web-client/src/Components/Common/DataPreviewMap.js
+++ b/magda-web-client/src/Components/Common/DataPreviewMap.js
@@ -170,7 +170,7 @@ class DataPreviewMap extends Component {
         if (!selectedDistribution) return null; // hide the section if no data available
 
         return (
-            <div>
+            <div class="no-print">
                 <h3 className="section-heading">Map Preview</h3>
                 <Small>
                     <DataPreviewMapOpenInNationalMapButton

--- a/magda-web-client/src/Components/Common/DataPreviewVis.tsx
+++ b/magda-web-client/src/Components/Common/DataPreviewVis.tsx
@@ -101,7 +101,7 @@ class DataPreviewVis extends Component<
         const bodyRenderResult = this.renderByState();
         if (!bodyRenderResult) return null;
         return (
-            <div className="data-preview-vis">
+            <div className="data-preview-vis no-print">
                 <h3 className="section-heading">Data Preview</h3>
                 {bodyRenderResult}
             </div>

--- a/magda-web-client/src/Components/Common/DataQualityTooltip.js
+++ b/magda-web-client/src/Components/Common/DataQualityTooltip.js
@@ -10,7 +10,7 @@ import helpIcon from "assets/help-24.svg";
 export default function DataQualityTooltip(props) {
     return (
         <Tooltip
-            className="data-quality-tooltip"
+            className="data-quality-tooltip no-print"
             launcher={() => (
                 <Link to="/page/linked-data-rating">
                     <img

--- a/magda-web-client/src/Components/Common/DescriptionBox.js
+++ b/magda-web-client/src/Components/Common/DescriptionBox.js
@@ -34,39 +34,44 @@ class DescriptionBox extends Component {
                     this.state.isExpanded ? "is-expanded" : ""
                 }`}
             >
-                <MarkdownViewer
-                    markdown={this.props.content}
-                    truncate={
-                        !this.state.isExpanded && this.props.isAutoTruncate
-                    }
-                    truncateLength={this.props.truncateLength}
-                />
-                {shouldShowToggleButton ? (
-                    this.state.isExpanded ? (
-                        <ToggleButton
-                            onClick={e => this.onToggleButtonClick(e)}
-                        >
-                            <span>Show less description</span>
-                            <img
-                                className="description-box-toggle-button-icon"
-                                src={upArrowIcon}
-                                alt="upArrowIcon"
-                            />
-                        </ToggleButton>
-                    ) : (
-                        <ToggleButton
-                            className="description-box-toggle-button"
-                            onClick={e => this.onToggleButtonClick(e)}
-                        >
-                            <span>Show full description</span>
-                            <img
-                                className="description-box-toggle-button-icon"
-                                src={downArrowIcon}
-                                alt="downArrow"
-                            />
-                        </ToggleButton>
-                    )
-                ) : null}
+                <div className="no-print">
+                    <MarkdownViewer
+                        markdown={this.props.content}
+                        truncate={
+                            !this.state.isExpanded && this.props.isAutoTruncate
+                        }
+                        truncateLength={this.props.truncateLength}
+                    />
+                    {shouldShowToggleButton ? (
+                        this.state.isExpanded ? (
+                            <ToggleButton
+                                onClick={e => this.onToggleButtonClick(e)}
+                            >
+                                <span>Show less description</span>
+                                <img
+                                    className="description-box-toggle-button-icon"
+                                    src={upArrowIcon}
+                                    alt="upArrowIcon"
+                                />
+                            </ToggleButton>
+                        ) : (
+                            <ToggleButton
+                                className="description-box-toggle-button"
+                                onClick={e => this.onToggleButtonClick(e)}
+                            >
+                                <span>Show full description</span>
+                                <img
+                                    className="description-box-toggle-button-icon"
+                                    src={downArrowIcon}
+                                    alt="downArrow"
+                                />
+                            </ToggleButton>
+                        )
+                    ) : null}
+                </div>
+                <div className="print-only">
+                    <MarkdownViewer markdown={this.props.content} />
+                </div>
             </div>
         );
     }

--- a/magda-web-client/src/Components/Dataset/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Dataset/Search/SearchBox.scss
@@ -159,6 +159,10 @@
             bottom: 0px;
         }
     }
+
+    @media print {
+        display: none;
+    }
 }
 
 .home {

--- a/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
+++ b/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
@@ -87,7 +87,7 @@ export default class DatasetPageSuggestForm extends React.Component {
             <React.Fragment>
                 {/* If the form is posted don't show the text in the below para*/}
                 {!this.state.showSuggest && (
-                    <div className="dataset-button-container">
+                    <div className="dataset-button-container no-print">
                         <AUbutton
                             className="au-btn--secondary ask-question-button"
                             onClick={this.toggleShowForm}
@@ -96,6 +96,15 @@ export default class DatasetPageSuggestForm extends React.Component {
                         </AUbutton>
                     </div>
                 )}
+                <div className="dataset-button-container no-print">
+                    <AUbutton
+                        className="au-btn--secondary ask-question-button"
+                        onClick={() => window.print()}
+                    >
+                        Print this page
+                    </AUbutton>
+                </div>
+
                 <React.Fragment>
                     <Modal
                         isOpen={this.state.showSuggest}

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -53,6 +53,20 @@ class DistributionRow extends Component<PropType> {
             )}/?q=${this.props.searchText}`;
         }
 
+        let apiUrl = "";
+
+        if (
+            distribution.ckanResource &&
+            distribution.ckanResource.datastore_active
+        ) {
+            apiUrl = get(distribution, "sourceDetails.url")
+                ? get(distribution, "sourceDetails.url", "").replace(
+                      "3/action/resource_show?",
+                      "1/util/snippet/api_info.html?resource_"
+                  )
+                : "https://docs.ckan.org/en/latest/maintaining/datastore.html#the-datastore-api";
+        }
+
         return (
             <div
                 className="distribution-row row"
@@ -128,69 +142,73 @@ class DistributionRow extends Component<PropType> {
                         </div>
                     </div>
                 </div>
-                <div className="col-sm-4 button-area no-print">
-                    {distribution.ckanResource &&
-                        distribution.ckanResource.datastore_active && (
-                            <a
-                                className="download-button au-btn au-btn--secondary au-float-left"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                href={
-                                    get(distribution, "sourceDetails.url")
-                                        ? get(
-                                              distribution,
-                                              "sourceDetails.url",
-                                              ""
-                                          ).replace(
-                                              "3/action/resource_show?",
-                                              "1/util/snippet/api_info.html?resource_"
-                                          )
-                                        : "https://docs.ckan.org/en/latest/maintaining/datastore.html#the-datastore-api"
-                                }
-                            >
-                                <img src={apiAccessIcon} alt="" /> Access Data
-                                API
-                            </a>
-                        )}{" "}
+                <div className="col-sm-4 button-area">
+                    {apiUrl && (
+                        <span>
+                            <span className="no-print">
+                                <a
+                                    className="download-button au-btn au-btn--secondary au-float-left"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    href={apiUrl}
+                                >
+                                    <img src={apiAccessIcon} alt="" /> Access
+                                    Data API
+                                </a>
+                            </span>
+                            <span className="block print-only">
+                                API: {apiUrl}
+                            </span>
+                        </span>
+                    )}{" "}
                     {distribution.downloadURL && (
-                        <a
-                            className="download-button au-btn au-btn--secondary"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href={distribution.downloadURL}
-                            onClick={() => {
-                                // google analytics download tracking
-                                const resource_url = encodeURIComponent(
-                                    distribution.downloadURL!
-                                );
-                                if (resource_url) {
-                                    // legacy support
-                                    gapi.event({
-                                        category: "Resource",
-                                        action: "Download",
-                                        label: resource_url
-                                    });
-                                    // new events
-                                    gapi.event({
-                                        category: "Download by Dataset",
-                                        action: dataset.title,
-                                        label: resource_url
-                                    });
-                                    gapi.event({
-                                        category: "Download by Source",
-                                        action: dataset.source,
-                                        label: resource_url
-                                    });
-                                    gapi.event({
-                                        category: "Download by Publisher",
-                                        action: dataset.publisher.name,
-                                        label: resource_url
-                                    });
-                                }
-                            }}
-                        >
-                            <img src={downloadIcon} alt="download" /> Download
-                        </a>
+                        <span>
+                            <span className="no-print">
+                                <a
+                                    className="download-button au-btn au-btn--secondary"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    href={distribution.downloadURL}
+                                    onClick={() => {
+                                        // google analytics download tracking
+                                        const resource_url = encodeURIComponent(
+                                            distribution.downloadURL!
+                                        );
+                                        if (resource_url) {
+                                            // legacy support
+                                            gapi.event({
+                                                category: "Resource",
+                                                action: "Download",
+                                                label: resource_url
+                                            });
+                                            // new events
+                                            gapi.event({
+                                                category: "Download by Dataset",
+                                                action: dataset.title,
+                                                label: resource_url
+                                            });
+                                            gapi.event({
+                                                category: "Download by Source",
+                                                action: dataset.source,
+                                                label: resource_url
+                                            });
+                                            gapi.event({
+                                                category:
+                                                    "Download by Publisher",
+                                                action: dataset.publisher.name,
+                                                label: resource_url
+                                            });
+                                        }
+                                    }}
+                                >
+                                    <img src={downloadIcon} alt="download" />{" "}
+                                    Download
+                                </a>
+                            </span>
+                            <span className="block print-only">
+                                Download: {distribution.downloadURL}
+                            </span>
+                        </span>
                     )}
                 </div>
             </div>

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -128,7 +128,7 @@ class DistributionRow extends Component<PropType> {
                         </div>
                     </div>
                 </div>
-                <div className="col-sm-4 button-area">
+                <div className="col-sm-4 button-area no-print">
                     {distribution.ckanResource &&
                         distribution.ckanResource.datastore_active && (
                             <a

--- a/magda-web-client/src/Components/Header/Header.scss
+++ b/magda-web-client/src/Components/Header/Header.scss
@@ -31,6 +31,9 @@
     border-bottom: 8px solid $header-color-border;
     border-bottom: 0.5rem solid $header-color-border;
     background-color: transparent;
+    @media print {
+        display: none;
+    }
 }
 
 .header-nav {

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -323,4 +323,20 @@ h4 {
     .print-only {
         display: initial;
     }
+
+    .col-sm-1,
+    .col-sm-2,
+    .col-sm-3,
+    .col-sm-4,
+    .col-sm-5,
+    .col-sm-6,
+    .col-sm-7,
+    .col-sm-8,
+    .col-sm-11 {
+        width: auto !important;
+    }
+
+    .block {
+        display: block;
+    }
 }

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -298,6 +298,10 @@ h4 {
         display: none;
     }
 
+    .wrapper {
+        display: block !important;
+    }
+
     a[href]:after {
         display: none;
         visibility: hidden;

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -312,6 +312,14 @@ h4 {
         max-width: 100% !important;
     }
 
+    .au-body,
+    .au-body *,
+    p,
+    .markdown {
+        color: black !important;
+        opacity: 1 !important;
+    }
+
     .container {
         width: 100% !important;
     }

--- a/magda-web-client/src/index.scss
+++ b/magda-web-client/src/index.scss
@@ -288,3 +288,39 @@ h4 {
 .au-body p {
     max-width: 100%;
 }
+
+.print-only {
+    display: none;
+}
+
+@media print {
+    .au-breadcrumbs {
+        display: none;
+    }
+
+    a[href]:after {
+        display: none;
+        visibility: hidden;
+        position: absolute;
+    }
+
+    .no-print {
+        display: none !important;
+    }
+
+    .au-body p {
+        max-width: 100% !important;
+    }
+
+    .container {
+        width: 100% !important;
+    }
+
+    .au-footer {
+        display: none !important;
+    }
+
+    .print-only {
+        display: initial;
+    }
+}


### PR DESCRIPTION
### What this PR does

Fixes #2230

Made dataset page printer friendly. Hid buttons and elements that are not applicable. Expanded out click to reveal stuff.

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
