### PR TITLE
Tweaks for running on Windows.

### DIFF
--- a/deploy/helm/docker-desktop-windows.yml
+++ b/deploy/helm/docker-desktop-windows.yml
@@ -1,0 +1,3 @@
+combined-db:
+    data:
+        storageClass: local-storage

--- a/deploy/helm/docker-registry.yml
+++ b/deploy/helm/docker-registry.yml
@@ -1,3 +1,2 @@
 persistence:
   enabled: true
-  storageClass: standard

--- a/deploy/kubernetes/local-storage-volume.yaml
+++ b/deploy/kubernetes/local-storage-volume.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-storage-volume
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-storage
+  local:
+    path: /etc/kubernetes
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - docker-for-desktop

--- a/deploy/kubernetes/local-storage.yaml
+++ b/deploy/kubernetes/local-storage.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -85,10 +85,25 @@ lerna run docker-build-local --include-filtered-dependencies
 yarn run create-secrets
 ```
 
+### Windows only: Set up a volume for Postgres data
+
+If you're using Docker Desktop on Windows, you'll need to set up a volume to store Postgres data because the standard strategy approach - a `hostpath` volume mapped to a Windows share - will result in file/directory permissions that are not to Postgres's liking. Instead, we'll set up a volume manually which is just a directory in the Docker Desktop VM's virtual disk. We use the unusual path of `/etc/kubernetes` because it is one of the few mount points backed by an actual virtual disk.
+
+```bash
+kubectl apply -f deploy/kubernetes/local-storage.yaml
+kubectl apply -f deploy/kubernetes/local-storage-volume.yaml
+```
+
 ### Install Magda on your minikube/docker-desktop cluster
 
 ```bash
-helm upgrade --install --timeout 9999999999 --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/magda
+helm upgrade --install --timeout 9999 --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/magda
+```
+
+If you're using Docker Desktop on Windows, add `-f deploy/helm/docker-desktop-windows.yml` too, i.e. do this instead of the above:
+
+```bash
+helm upgrade --install --timeout 9999 --wait -f deploy/helm/docker-desktop-windows.yml -f deploy/helm/minikube-dev.yml magda deploy/helm/magda
 ```
 
 This can take a while as it does a lot - downloading all the docker images, starting them up and running database migration jobs. You can see what's happening by opening another tab and running `kubectl get pods -w`.

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -20,8 +20,8 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u201
-ENV JAVA_ALPINE_VERSION 8.201.08-r0
+ENV JAVA_VERSION 8u212
+ENV JAVA_ALPINE_VERSION 8.212.04-r0
 
 RUN set -x \
 	&& apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \


### PR DESCRIPTION
* Don't specify a storageclass for the Docker registry, cause `standard` doesn't exist in Docker Desktop and the default should be fine everywhere.
* Add yaml and instructions for setting up a volume for Postgres data on Windows, because Postgres is grumpy about the permissions for a hostpath backed by a Windows share.
* (not Windows specific) bump the version of Java used by `magda-builder-scala`.
