### PR TITLE
Issue/2228 Vocabulary Suggestion box for keywords & themes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@ UI:
 -   Revised add dataset first metadata page for conformance with design
 -   Improved edit dataset page overall styling & editor behaviour
 -   Show Database ownership information on dataset page (Admin Only)
+-   Added vocabulary suggestion for keywords & themes input on new dataset page
+-   Extracted keyword will be filtered by vocabulary APIs
 
 Access Control:
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -92,6 +92,10 @@ web-server:
   fallbackUrl: "https://data.gov.au"
   featureFlags:
     cataloguing: true
+  vocabularyApiEndpoints: 
+    - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
+    - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"
+    - "https://vocabs.ands.org.au/repository/api/lda/ands-nc/controlled-vocabulary-for-resource-type-genres/version-1-1/concept.json"
 
 correspondence-api:
   defaultRecipient: "magda-test@googlegroups.com"

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -10,5 +10,5 @@ data:
     "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
     "baseUrl": {{ .Values.baseUrl | default "/" | quote }},
     "featureFlags": {{ toJson .Values.featureFlags | quote }},
-    "vocabularyApiEndpoints": {{ toJson .Values.vocabularyApiEndpoints | default "[]" }}
+    "vocabularyApiEndpoints": {{ toJson .Values.vocabularyApiEndpoints | quote }}
   }'

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -9,5 +9,6 @@ data:
     {{- if .Values.contentApiBaseUrlInternal -}} "contentApiBaseUrlInternal": {{ .Values.contentApiBaseUrlInternal | quote }}, {{- end -}}
     "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
     "baseUrl": {{ .Values.baseUrl | default "/" | quote }},
-    "featureFlags": {{ toJson .Values.featureFlags | quote }}
+    "featureFlags": {{ toJson .Values.featureFlags | quote }},
+    "vocabularyApiEndpoints": {{ toJson .Values.vocabularyApiEndpoints | default "[]" }},
   }'

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -10,5 +10,5 @@ data:
     "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
     "baseUrl": {{ .Values.baseUrl | default "/" | quote }},
     "featureFlags": {{ toJson .Values.featureFlags | quote }},
-    "vocabularyApiEndpoints": {{ toJson .Values.vocabularyApiEndpoints | default "[]" }},
+    "vocabularyApiEndpoints": {{ toJson .Values.vocabularyApiEndpoints | default "[]" }}
   }'

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -18,3 +18,4 @@ service: {}
 useLocalStyleSheet: false
 contentApiBaseUrlInternal: "http://content-api/v0/"
 featureFlags: {}
+vocabularyApiEndpoints: []

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -17,9 +17,6 @@ ingress:
   enableTls: true
   useDefaultCertificate: true
 gateway:
-  ckanRedirectionDomain: "ckan.data.gov.au"
-  ckanRedirectionPath: ""
-  enableCkanRedirection: true
   enableAuthEndpoint: true
   enableHttpsRedirection: true
   auth:
@@ -82,6 +79,10 @@ web-server:
   fallbackUrl: "https://data.gov.au"
   featureFlags:
     cataloguing: true
+  vocabularyApiEndpoints: 
+    - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
+    - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"
+    - "https://vocabs.ands.org.au/repository/api/lda/ands-nc/controlled-vocabulary-for-resource-type-genres/version-1-1/concept.json"
 
 correspondence-api:
   defaultRecipient: "magda-test@googlegroups.com"

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -39,6 +39,7 @@ import datasetDistributionsAspect from "@magda/registry-aspects/dataset-distribu
 import dcatDistributionStringsAspect from "@magda/registry-aspects/dcat-distribution-strings.schema.json";
 import usageAspect from "@magda/registry-aspects/usage.schema.json";
 import accessAspect from "@magda/registry-aspects/access.schema.json";
+import VocabularyAutoCompleteInput from "../../Editing/VocabularyAutoCompleteInput";
 
 const aspects = {
     publishing: datasetPublishingAspect,
@@ -274,9 +275,12 @@ class NewDataset extends React.Component<Prop, State> {
                     <AlwaysEditor
                         value={dataset.keywords}
                         onChange={editDataset("keywords")}
-                        editor={multiTextEditorEx({
-                            placeholder: "Add a keyword"
-                        })}
+                        editor={multiTextEditorEx(
+                            {
+                                placeholder: "Add a keyword"
+                            },
+                            VocabularyAutoCompleteInput
+                        )}
                     />
                 </p>
                 <h4>Which themes does this dataset cover?</h4>

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -277,7 +277,8 @@ class NewDataset extends React.Component<Prop, State> {
                         onChange={editDataset("keywords")}
                         editor={multiTextEditorEx(
                             {
-                                placeholder: "Add a keyword"
+                                placeholder: "Add a keyword",
+                                redrawOnEmpty: false
                             },
                             VocabularyAutoCompleteInput
                         )}
@@ -294,9 +295,13 @@ class NewDataset extends React.Component<Prop, State> {
                     <AlwaysEditor
                         value={dataset.themes}
                         onChange={editDataset("themes")}
-                        editor={multiTextEditorEx({
-                            placeholder: "Add a theme"
-                        })}
+                        editor={multiTextEditorEx(
+                            {
+                                placeholder: "Add a theme",
+                                redrawOnEmpty: false
+                            },
+                            VocabularyAutoCompleteInput
+                        )}
                     />
                 </p>
                 <hr />

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -295,13 +295,9 @@ class NewDataset extends React.Component<Prop, State> {
                     <AlwaysEditor
                         value={dataset.themes}
                         onChange={editDataset("themes")}
-                        editor={multiTextEditorEx(
-                            {
-                                placeholder: "Add a theme",
-                                redrawOnEmpty: false
-                            },
-                            VocabularyAutoCompleteInput
-                        )}
+                        editor={multiTextEditorEx({
+                            placeholder: "Add a theme"
+                        })}
                     />
                 </p>
                 <hr />

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.js
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.js
@@ -8,14 +8,14 @@ import { isValidKeyword } from "../../../helpers/VocabularyApis";
  */
 export async function extractKeywords(input, output) {
     if (input.text) {
-        const candicateKeywords = (output.keywords || []).concat(
+        const candidateKeywords = (output.keywords || []).concat(
             await getKeywords(input.text)
         );
         const keywords = [];
-        for (let i = 0; i < candicateKeywords.length; i++) {
-            const result = await isValidKeyword(candicateKeywords[i]);
+        for (let i = 0; i < candidateKeywords.length; i++) {
+            const result = await isValidKeyword(candidateKeywords[i]);
             if (result) {
-                keywords.push(candicateKeywords[i]);
+                keywords.push(candidateKeywords[i]);
             }
         }
         output.keywords = keywords;

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.js
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.js
@@ -1,15 +1,24 @@
 import retext from "retext";
 import keywords from "retext-keywords";
 import toString from "nlcst-to-string";
+import { isValidKeyword } from "../../../helpers/VocabularyApis";
 
 /**
  * Extract keywords from text based file formats
  */
 export async function extractKeywords(input, output) {
     if (input.text) {
-        output.keywords = (output.keywords || []).concat(
+        const candicateKeywords = (output.keywords || []).concat(
             await getKeywords(input.text)
         );
+        const keywords = [];
+        for (let i = 0; i < candicateKeywords.length; i++) {
+            const result = await isValidKeyword(candicateKeywords[i]);
+            if (result) {
+                keywords.push(candicateKeywords[i]);
+            }
+        }
+        output.keywords = keywords;
     }
 }
 

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -46,6 +46,9 @@ export abstract class MultiItemEditor<V> extends React.Component<
     add() {
         const value = this.value();
         let newValue = this.state.newValue;
+        if (Array.isArray(value) && value.indexOf(newValue) !== -1) {
+            return;
+        }
         if (newValue) {
             value.push(newValue);
             newValue = this.props.createNewValue();

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -3,7 +3,7 @@ import Editor from "./Editor";
 
 import { ListMultiItemEditor } from "./multiItem";
 
-export type InputComponentParmeter = React.ComponentType<{
+export type InputComponentParameter = React.ComponentType<{
     className?: string;
     defaultValue?: string;
     onChange?: ReactEventHandler;
@@ -12,7 +12,7 @@ export type InputComponentParmeter = React.ComponentType<{
 
 export function textEditorEx(
     options: any = {},
-    InputComponent: InputComponentParmeter = null
+    InputComponent: InputComponentParameter = null
 ) {
     return {
         edit: (
@@ -88,7 +88,7 @@ export const multiTextEditor: Editor<string[]> = ListMultiItemEditor.create(
 
 export const multiTextEditorEx = (
     options,
-    inputComponent: InputComponentParmeter = null
+    inputComponent: InputComponentParameter = null
 ) => {
     options.redrawOnEmpty =
         typeof options.redrawOnEmpty !== "boolean"

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -90,7 +90,10 @@ export const multiTextEditorEx = (
     options,
     inputComponent: InputComponentParmeter = null
 ) => {
-    options.redrawOnEmpty = true;
+    options.redrawOnEmpty =
+        typeof options.redrawOnEmpty !== "boolean"
+            ? true
+            : options.redrawOnEmpty;
     return ListMultiItemEditor.create(
         textEditorEx(options, inputComponent),
         () => ""

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -1,9 +1,19 @@
-import React from "react";
+import React, { ReactEventHandler } from "react";
 import Editor from "./Editor";
 
 import { ListMultiItemEditor } from "./multiItem";
 
-export function textEditorEx(options: any = {}) {
+export type InputComponentParmeter = React.ComponentType<{
+    className?: string;
+    defaultValue?: string;
+    onChange?: ReactEventHandler;
+    [k: string]: any;
+}> | null;
+
+export function textEditorEx(
+    options: any = {},
+    InputComponent: InputComponentParmeter = null
+) {
     return {
         edit: (
             value: any,
@@ -17,7 +27,19 @@ export function textEditorEx(options: any = {}) {
             if (options.redrawOnEmpty && !value) {
                 options.key = Math.random();
             }
-            return (
+            return InputComponent ? (
+                <InputComponent
+                    className={
+                        options.fullWidth
+                            ? "au-text-input full-width-ctrl textEditorEx"
+                            : "au-text-input non-full-width-ctrl textEditorEx"
+                    }
+                    defaultValue={value as string}
+                    onChange={callback}
+                    {...options}
+                    {...extraProps}
+                />
+            ) : (
                 <input
                     className={
                         options.fullWidth
@@ -64,7 +86,13 @@ export const multiTextEditor: Editor<string[]> = ListMultiItemEditor.create(
     () => ""
 );
 
-export const multiTextEditorEx = options => {
+export const multiTextEditorEx = (
+    options,
+    inputComponent: InputComponentParmeter = null
+) => {
     options.redrawOnEmpty = true;
-    return ListMultiItemEditor.create(textEditorEx(options), () => "");
+    return ListMultiItemEditor.create(
+        textEditorEx(options, inputComponent),
+        () => ""
+    );
 };

--- a/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.scss
+++ b/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.scss
@@ -1,0 +1,19 @@
+.vocabulary-auto-complete-input {
+    .suggestion-item {
+        border: 1px solid grey;
+        border-radius: 0.5em;
+        padding: 0.5em;
+        margin-bottom: 4px;
+    }
+    .suggestion-item:hover {
+        background-color: #f7f7f7;
+    }
+    .suggestions-list {
+        list-style-type: none;
+        padding-inline-start: unset;
+        margin-top: 2px;
+    }
+    .suggestions-container {
+        margin-bottom: 10px;
+    }
+}

--- a/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.tsx
+++ b/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import Autosuggest from "react-autosuggest";
+import { query } from "../../helpers/VocabularyApis";
+import throttle from "lodash/throttle";
+import debounce from "lodash/debounce";
+
+type StateData = {
+    value: string;
+    suggestions: string[];
+};
+
+type Prop = {
+    [key: string]: any;
+};
+
+const throttledQuery = throttle(query, 500);
+const debouncedQuery = debounce(query, 500);
+
+class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
+    private currentQuery: string;
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: props.defaultValue,
+            suggestions: []
+        };
+        this.currentQuery = "";
+        this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(
+            this
+        );
+        this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(
+            this
+        );
+        this.onChange = this.onChange.bind(this);
+    }
+
+    async onSuggestionsFetchRequested({ value }) {
+        let inputValue = typeof value === "string" && value ? value : "";
+        inputValue = inputValue.trim().toLowerCase();
+        if (!inputValue.length) {
+            this.setState(state => ({ ...state, suggestions: [] }));
+            return;
+        }
+        this.currentQuery = inputValue;
+
+        let keywords: string[];
+        if (inputValue.length < 5 || inputValue.endsWith(" ")) {
+            keywords = await throttledQuery(inputValue);
+        } else {
+            keywords = await debouncedQuery(inputValue);
+        }
+        if (this.currentQuery !== inputValue) {
+            return;
+        }
+        this.setState(state => ({ ...state, suggestions: keywords }));
+    }
+
+    onSuggestionsClearRequested() {
+        this.setState(state => ({ ...state, suggestions: [] }));
+    }
+
+    onChange(event, { newValue }) {
+        this.setState(state => ({
+            ...state,
+            value: newValue
+        }));
+
+        const { onChange: incomingOnChange } = this.props;
+        if (incomingOnChange) {
+            incomingOnChange(event);
+        }
+    }
+
+    render() {
+        const {
+            className: incomingClassName,
+            onChange: incomingOnChange,
+            defaultValue,
+            ...restProps
+        } = this.props;
+
+        const inputProps = {
+            ...restProps,
+            onChange: this.onChange,
+            value: this.state.value
+        };
+
+        return (
+            <Autosuggest
+                inputProps={inputProps}
+                suggestions={this.state.suggestions}
+                onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+                onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+                getSuggestionValue={getSuggestionValue}
+                renderSuggestion={renderSuggestion}
+                theme={{
+                    input: incomingClassName
+                        ? `react-autosuggest__input ${incomingClassName}`
+                        : "react-autosuggest__input"
+                }}
+            />
+        );
+    }
+}
+
+const getSuggestionValue = suggestion => suggestion;
+
+const renderSuggestion = suggestion => <div>{suggestion}</div>;
+
+export default VocabularyAutoCompleteInput;

--- a/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.tsx
+++ b/magda-web-client/src/Components/Editing/VocabularyAutoCompleteInput.tsx
@@ -3,6 +3,7 @@ import Autosuggest from "react-autosuggest";
 import { query } from "../../helpers/VocabularyApis";
 import throttle from "lodash/throttle";
 import debounce from "lodash/debounce";
+import "./VocabularyAutoCompleteInput.scss";
 
 type StateData = {
     value: string;
@@ -10,6 +11,7 @@ type StateData = {
 };
 
 type Prop = {
+    suggestionSize: number;
     [key: string]: any;
 };
 
@@ -18,11 +20,20 @@ const debouncedQuery = debounce(query, 500);
 
 class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
     private currentQuery: string;
+    private inputRef: HTMLInputElement | null = null;
+    private key: string = `VocabularyAutoCompleteInput_${Math.random()}`.replace(
+        ".",
+        ""
+    );
+
+    static defaultProps = {
+        suggestionSize: 10
+    };
 
     constructor(props) {
         super(props);
         this.state = {
-            value: props.defaultValue,
+            value: this.props.defaultValue ? this.props.defaultValue : "",
             suggestions: []
         };
         this.currentQuery = "";
@@ -32,6 +43,7 @@ class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
         this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(
             this
         );
+        this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
         this.onChange = this.onChange.bind(this);
     }
 
@@ -44,16 +56,30 @@ class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
         }
         this.currentQuery = inputValue;
 
-        let keywords: string[];
-        if (inputValue.length < 5 || inputValue.endsWith(" ")) {
-            keywords = await throttledQuery(inputValue);
-        } else {
-            keywords = await debouncedQuery(inputValue);
+        let keywords: string[] = [];
+        try {
+            // --- we repsonse quicker in the begining as people need more hints
+            // --- and slow down when input content is longer than 5
+            if (inputValue.length < 5 || inputValue.endsWith(" ")) {
+                keywords = await throttledQuery(inputValue);
+            } else {
+                keywords = await debouncedQuery(inputValue);
+            }
+            if (this.currentQuery !== inputValue) {
+                return;
+            }
+            keywords = Array.isArray(keywords) ? keywords : [];
+            if (keywords.length > this.props.suggestionSize) {
+                keywords = keywords.slice(0, this.props.suggestionSize);
+            }
+            this.setState(state => ({
+                ...state,
+                suggestions: keywords ? keywords : []
+            }));
+        } catch (e) {
+            console.error(e);
+            this.setState(state => ({ ...state, suggestions: [] }));
         }
-        if (this.currentQuery !== inputValue) {
-            return;
-        }
-        this.setState(state => ({ ...state, suggestions: keywords }));
     }
 
     onSuggestionsClearRequested() {
@@ -72,10 +98,46 @@ class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
         }
     }
 
+    onSuggestionSelected(event, { suggestionValue, method }) {
+        if (this.inputRef) {
+            this.inputRef.value = suggestionValue;
+        }
+        // --- manually trigger event to trigger action of wrapper components
+        // --- we probably should define a proper interface rather than rely on event
+        if (typeof this.props.onChange === "function") {
+            this.props.onChange({
+                preventDefault: () => {},
+                target: this.inputRef,
+                current: this.inputRef,
+                value: suggestionValue
+            });
+        }
+        setTimeout(() => {
+            if (typeof this.props.onKeyUp === "function") {
+                this.props.onKeyUp({
+                    preventDefault: () => {},
+                    target: this.inputRef,
+                    current: this.inputRef,
+                    keyCode: 13,
+                    which: 13
+                });
+                this.setState(state => ({
+                    ...state,
+                    value: ""
+                }));
+                this.props.onChange({
+                    preventDefault: () => {},
+                    target: this.inputRef,
+                    current: this.inputRef,
+                    value: ""
+                });
+            }
+        }, 1);
+    }
+
     render() {
         const {
             className: incomingClassName,
-            onChange: incomingOnChange,
             defaultValue,
             ...restProps
         } = this.props;
@@ -86,18 +148,42 @@ class VocabularyAutoCompleteInput extends React.Component<Prop, StateData> {
             value: this.state.value
         };
 
+        const renderInputComponent = inputProps => {
+            const { ref: propsRef } = inputProps;
+            // -- we need ref of input as well
+            // -- we will retrieve the ref and share with other components
+            return (
+                <input
+                    {...inputProps}
+                    ref={ref => {
+                        this.inputRef = ref;
+                        if (typeof propsRef === "function") {
+                            propsRef(ref);
+                        }
+                    }}
+                />
+            );
+        };
+
         return (
             <Autosuggest
+                id={this.key}
                 inputProps={inputProps}
                 suggestions={this.state.suggestions}
                 onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
                 onSuggestionsClearRequested={this.onSuggestionsClearRequested}
                 getSuggestionValue={getSuggestionValue}
                 renderSuggestion={renderSuggestion}
+                onSuggestionSelected={this.onSuggestionSelected}
+                renderInputComponent={renderInputComponent}
                 theme={{
                     input: incomingClassName
                         ? `react-autosuggest__input ${incomingClassName}`
-                        : "react-autosuggest__input"
+                        : "react-autosuggest__input",
+                    container: "vocabulary-auto-complete-input",
+                    suggestion: "suggestion-item",
+                    suggestionsList: "suggestions-list",
+                    suggestionsContainer: "suggestions-container"
                 }}
             />
         );

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -41,6 +41,7 @@ const serverConfig: {
     featureFlags?: {
         [id: string]: boolean;
     };
+    vocabularyApiEndpoints: string[];
 } = window.magda_server_config || {};
 
 const registryApiUrl =
@@ -72,6 +73,16 @@ const contentApiURL =
 
 const adminApiURL =
     serverConfig.adminApiBaseURL || fallbackApiHost + "api/v0/admin";
+
+const vocabularyApiEndpoints =
+    Array.isArray(serverConfig.vocabularyApiEndpoints) &&
+    serverConfig.vocabularyApiEndpoints.length
+        ? serverConfig.vocabularyApiEndpoints
+        // --- default endpoints
+        : [
+              "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json",
+              "https://vocabs.ands.org.au/repository/api/lda/ands-nc/controlled-vocabulary-for-resource-type-genres/version-1-1/concept.json"
+          ];
 
 export const config = {
     fetchOptions,
@@ -138,7 +149,8 @@ export const config = {
     gapiIds: serverConfig.gapiIds || [],
     featureFlags:
         serverConfig.featureFlags ||
-        (process.env.NODE_ENV === "development" ? DEV_FEATURE_FLAGS : {})
+        (process.env.NODE_ENV === "development" ? DEV_FEATURE_FLAGS : {}),
+    vocabularyApiEndpoints
 };
 
 export const defaultConfiguration = {

--- a/magda-web-client/src/helpers/VocabularyApis.ts
+++ b/magda-web-client/src/helpers/VocabularyApis.ts
@@ -17,7 +17,7 @@ async function queryEndpoint(
     const requestUrl =
         `${apiEndpoint}?labelcontains=` + encodeURIComponent(str);
 
-    const data = await fetch(requestUrl, config.fetchOptions).then(response => {
+    const data = await fetch(requestUrl).then(response => {
         if (response.status === 200) {
             return response.json();
         }

--- a/magda-web-client/src/helpers/VocabularyApis.ts
+++ b/magda-web-client/src/helpers/VocabularyApis.ts
@@ -1,0 +1,83 @@
+import { config } from "../config";
+import fetch from "isomorphic-fetch";
+import uniq from "lodash/uniq";
+import flatMap from "lodash/flatMap";
+const apiEndpoints = config.vocabularyApiEndpoints;
+
+async function queryEndpoint(
+    apiEndpoint: string,
+    str: string
+): Promise<string[]> {
+    if (!apiEndpoint) {
+        throw new Error(
+            "Failed to contact Vocabulary API: API endpoint cannot be empty!"
+        );
+    }
+
+    const requestUrl =
+        `${apiEndpoint}?labelcontains=` + encodeURIComponent(str);
+
+    const data = await fetch(requestUrl, config.fetchOptions).then(response => {
+        if (response.status === 200) {
+            return response.json();
+        }
+        throw new Error(response.statusText);
+    });
+
+    if (!data || !data.result || !Array.isArray(data.result.items)) {
+        throw new Error(
+            "Failed to contact Vocabulary API: Invalid API response!"
+        );
+    }
+
+    const keywords: string[] = [];
+
+    data.result.items.forEach(item => {
+        let prefLabels: {
+            _value: string;
+            _lang: string;
+        }[] = [];
+
+        if (item.broader && item.broader.prefLabel) {
+            if (!Array.isArray(item.broader.prefLabel)) {
+                prefLabels.push(item.broader.prefLabel);
+            } else {
+                prefLabels = prefLabels.concat(item.broader.prefLabel);
+            }
+        }
+
+        if (item.prefLabel) {
+            if (!Array.isArray(item.prefLabel)) {
+                prefLabels.push(item.prefLabel);
+            } else {
+                prefLabels = prefLabels.concat(item.prefLabel);
+            }
+        }
+
+        prefLabels.forEach(label => {
+            if (label._lang && label._lang !== "en") {
+                return;
+            }
+            keywords.push(label._value);
+        });
+    });
+
+    return keywords;
+}
+
+export async function query(str: string): Promise<string[]> {
+    if (!Array.isArray(apiEndpoints) || !apiEndpoints.length) {
+        throw new Error(
+            "Failed to contact Vocabulary API: invalid vocabularyApiEndpoints config!"
+        );
+    }
+    return uniq(
+        flatMap(Promise.all(apiEndpoints.map(api => queryEndpoint(api, str))))
+    );
+}
+
+export async function isValidKeyword(keyword: string): Promise<boolean> {
+    const keywords = await query(keyword);
+    if (!Array.isArray(keywords) || !keywords.length) return false;
+    return true;
+}

--- a/magda-web-client/src/helpers/VocabularyApis.ts
+++ b/magda-web-client/src/helpers/VocabularyApis.ts
@@ -61,7 +61,6 @@ async function queryEndpoint(
             keywords.push(label._value);
         });
     });
-
     return keywords;
 }
 
@@ -71,9 +70,11 @@ export async function query(str: string): Promise<string[]> {
             "Failed to contact Vocabulary API: invalid vocabularyApiEndpoints config!"
         );
     }
-    return uniq(
-        flatMap(Promise.all(apiEndpoints.map(api => queryEndpoint(api, str))))
+    const result = await Promise.all(
+        apiEndpoints.map(api => queryEndpoint(api, str))
     );
+    const keywords = uniq(flatMap(result));
+    return keywords;
 }
 
 export async function isValidKeyword(keyword: string): Promise<boolean> {

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -114,6 +114,12 @@ const argv = yargs
         type: "string",
         coerce: coerceJson("requestOpts"),
         default: "{}"
+    })
+    .option("vocabularyApiEndpoints", {
+        describe: "A list of Vocabulary API Endpoints",
+        type: "string",
+        coerce: coerceJson("vocabularyApiEndpoints"),
+        default: "[]"
     }).argv;
 
 var app = express();
@@ -186,7 +192,8 @@ const webServerConfig = {
     ),
     fallbackUrl: argv.fallbackUrl,
     gapiIds: argv.gapiIds,
-    featureFlags: argv.featureFlags || {}
+    featureFlags: argv.featureFlags || {},
+    vocabularyApiEndpoints: (argv.vocabularyApiEndpoints || []) as string[]
 };
 
 app.get("/server-config.js", function(req, res) {


### PR DESCRIPTION
### What this PR does

Fixes #2228 

Changes:
- Vocabulary Suggestion box for keywords & themes
- API endpoints configurable through helm. e.g.
```yaml
web-server:
  fallbackUrl: "https://data.gov.au"
  featureFlags:
    cataloguing: true
  vocabularyApiEndpoints: 
    - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
    - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"
    - "https://vocabs.ands.org.au/repository/api/lda/ands-nc/controlled-vocabulary-for-resource-type-genres/version-1-1/concept.json"
```
- Keyword extraction result will be filtered out according to Vocabulary API


### Checklist

-   [x]  unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
