### PR TITLE
Readded exclusion for lexicon js to speed up build times.

### DIFF
--- a/magda-web-client/craco.config.js
+++ b/magda-web-client/craco.config.js
@@ -18,6 +18,37 @@ module.exports = {
             );
             webpackConfig.module.rules = updatedRules;
 
+            // For some reason the unusual structure of lexicon.js causes babel-web-server to take 20 minutes to compile.
+            // Exclude it
+            webpackConfig.module.rules = webpackConfig.module.rules.map(
+                rule => {
+                    if (rule.oneOf) {
+                        rule.oneOf.forEach(rule => {
+                            if (
+                                rule.options &&
+                                rule.options.presets &&
+                                rule.options.presets.length &&
+                                rule.options.presets[0].some &&
+                                rule.options.presets[0].some(
+                                    preset =>
+                                        preset.indexOf(
+                                            "babel-preset-react-app"
+                                        ) > -1
+                                ) &&
+                                !rule.include
+                            ) {
+                                rule.exclude = [
+                                    rule.exclude,
+                                    /.*\/lexicon.js$/
+                                ];
+                            }
+                        });
+                    }
+
+                    return rule;
+                }
+            );
+
             return webpackConfig;
         }
     }


### PR DESCRIPTION
### What this PR does

This still makes the difference between `yarn run dev` taking 30 minutes vs a couple of minutes for me, so I'd like to re-add it.
