### PR TITLE
Issue/2269 Fixed outdated type definition for field `affiliatedOrganisation` in scala

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Search:
 Indexer:
 
 -   Fixed indexer throws an error when temporalCoverage aspects intervals is an empty array
+-   Fixed indexer throws an error when affiliatedOrganisation field is created
 
 Registry:
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -62,7 +62,7 @@ package misc {
      sourceSystem: Option[String] = None,
      likelihoodOfRelease: Option[String] = None,
      isOpenData: Option[Boolean] = None,
-     affiliatedOrganisation: Option[String] = None)
+     affiliatedOrganisation: Option[Seq[String]] = None)
 
   case class AccessControl(
      ownerId: Option[String] = None,


### PR DESCRIPTION
### What this PR does

Fixes #2269 

Fixed outdated type definition for field `affiliatedOrganisation` in scala

This impact both CSV connector & `Add dataset page` (indexer reports an error).

#### How to test:

Go to add dataset page, input the following:
![image](https://user-images.githubusercontent.com/674387/60571928-d0d97900-9db7-11e9-9a44-a6b83edcb696.png)

Indexer should report successfully indexed 1 dataset instead of reporting an error.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
