### PR TITLE
Slightly increased the memory requests for some api pods

### DIFF
--- a/deploy/helm/magda/charts/admin-api/values.yaml
+++ b/deploy/helm/magda/charts/admin-api/values.yaml
@@ -2,4 +2,4 @@ image: {}
 resources:
   requests:
     cpu: 50m
-    memory: 30Mi
+    memory: 50Mi

--- a/deploy/helm/magda/charts/authorization-api/values.yaml
+++ b/deploy/helm/magda/charts/authorization-api/values.yaml
@@ -2,6 +2,6 @@ image: {}
 resources:
   requests:
     cpu: 10m
-    memory: 30Mi
+    memory: 50Mi
   limits:
     cpu: 50m

--- a/deploy/helm/magda/charts/correspondence-api/values.yaml
+++ b/deploy/helm/magda/charts/correspondence-api/values.yaml
@@ -2,7 +2,7 @@ image: {}
 resources:
   requests:
     cpu: 10m
-    memory: 50Mi
+    memory: 60Mi
   limits:
     cpu: 50m
 smtpPort: 587

--- a/deploy/helm/magda/charts/minion-broken-link/values.yaml
+++ b/deploy/helm/magda/charts/minion-broken-link/values.yaml
@@ -3,6 +3,6 @@ schedule: "0 0 14,28 * *"
 resources:
   requests:
     cpu: 50m
-    memory: 30Mi
+    memory: 40Mi
   limits:
     cpu: 200m

--- a/deploy/helm/magda/charts/tenant-api/values.yaml
+++ b/deploy/helm/magda/charts/tenant-api/values.yaml
@@ -2,6 +2,6 @@ image: {}
 resources:
   requests:
     cpu: 10m
-    memory: 30Mi
+    memory: 50Mi
   limits:
     cpu: 50m


### PR DESCRIPTION
I'm seeing some pod evictions on dev because a few node apis are using _slightly_ more memory than they request, this bumps it up a bit.