### PR TITLE
fixed docker build cache issue that causes DB not build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@ Others:
 -   Added craco to allow for some Create React App overrides for a faster build and to allow use of PDFjs without warnings.
 -   Fixed Unable to use Google / Facebook Login on Preview Site
 -   Fixed warnings: `as` props is compulsory for AUpageAlert & boolean value was sent to `id` props
+-   Fixed docker build cache issue that causes DB image not build
 
 ## 0.0.54
 

--- a/magda-postgres/Dockerfile
+++ b/magda-postgres/Dockerfile
@@ -5,15 +5,14 @@ RUN apt-get update && \
     apt-get install -y patch && \
     apt-get install -y python3-pip lzop pv && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install wal-e[aws,google,swift]
-
+    python3 -m pip install wal-e[aws,google,swift] && \
 # Install postgresql pl debugger
 # The debugger module won't be loaded until you modify the postgresql.conf with:
 # shared_preload_libraries = ‘$libdir/other_libraries/plugin_debugger’
 # We will do it in start.sh depends on env var switch
 # After that, you need to run `CREATE EXTENSION pldbgapi;` 
 # in the database that you want to debug to turn it on database level
-RUN apt-get install -y postgresql-9.6-pldebugger
+    apt-get install -y postgresql-9.6-pldebugger
 
 COPY component/start.sh /usr/local/bin/
 


### PR DESCRIPTION
### What this PR does

fixed docker build cache issue that causes DB not build

As docker use cache when build, the apt-get update will not be re-run.

This change force it re-run (or use the cache appropriate for all apt-get)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
