### PR TITLE
Issue/2416 Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Indexer:
 -   Fixed indexer throws an error when temporalCoverage aspects intervals is an empty array
 -   Index datasets with tenant ID.
 -   Fixed indexer throws an error when affiliatedOrganisation field is created
+-   Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect
 
 Cataloging:
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -264,11 +264,13 @@ trait RegistryConverters extends RegistryProtocols {
                 None
               } else {
                 Some(
+                  // --- see magda-registry-aspects/spatial-coverage.schema.json
+                  // --- Bounding box in order minlon (west), minlat (south), maxlon (east), maxlat (north)
                   BoundingBox(
                     bbox.elements(3).convertTo[Double],
                     bbox.elements(2).convertTo[Double],
-                    bbox.elements(0).convertTo[Double],
-                    bbox.elements(1).convertTo[Double]
+                    bbox.elements(1).convertTo[Double],
+                    bbox.elements(0).convertTo[Double]
                   )
                 ).map(Location(_))
               }


### PR DESCRIPTION
### What this PR does

Fixes #2416 

Fixed indexer incorrect parsing bounding box data in `spatialCoverage` aspect

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
