### PR TITLE
Issue/2406 Show an error message screen if the user is not allowed to access the add dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@ UI:
 -   Style adjustment for question Who can see the dataset once it is published on Access and Use page
 -   Added access location auto complete input on Access and Use page
 -   Fixed a JS error which causes blank screen on Organisations Page
+-   Show an error message screen if the user is not allowed to access the add dataset page
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { RouterProps, withRouter, Redirect } from "react-router-dom";
+import { RouterProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 
 import { loadState, State } from "./DatasetAddCommon";
@@ -9,7 +9,8 @@ type Props = { initialState: State; user: User } & RouterProps;
 
 function mapStateToProps(state: any) {
     return {
-        user: state.userManagement && state.userManagement.user
+        user: state.userManagement && state.userManagement.user,
+        isFetchingWhoAmI: state.userManagement.isFetchingWhoAmI
     };
 }
 
@@ -28,24 +29,30 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
             }
         }, [props.user]);
 
-        if (state && props.user.isAdmin == true) {
+        if (
+            !props.user ||
+            props.user.id === "" ||
+            props.user.isAdmin !== true
+        ) {
+            if (props.isFetchingWhoAmI) {
+                return <div>Loading...</div>;
+            } else {
+                return (
+                    <div
+                        className="au-body au-page-alerts au-page-alerts--error"
+                        style={{ marginTop: "50px" }}
+                    >
+                        <span>
+                            Only admin users are allowed to access this page.
+                        </span>
+                    </div>
+                );
+            }
+        }
+        if (state && props.user.isAdmin === true) {
             return <Component {...props} initialState={state} />;
-        } else if (state && props.user.isAdmin == false) {
-            return (
-                <Redirect
-                    to={`/error?errorCode=403&reason=${encodeURIComponent(
-                        "Only admins users are allowed to access the add dataset page."
-                    )}`}
-                />
-            );
         } else {
-            return (
-                <Redirect
-                    to={`/error?errorCode=401&reason=${encodeURIComponent(
-                        "Only logged-in users are allowed to access the add dataset page."
-                    )}`}
-                />
-            );
+            return <div>Loading...</div>;
         }
     };
 

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { RouterProps, withRouter } from "react-router-dom";
+import { RouterProps, withRouter, Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 
 import { loadState, State } from "./DatasetAddCommon";
@@ -28,10 +28,24 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
             }
         }, [props.user]);
 
-        if (state) {
+        if (state && props.user.isAdmin == true) {
             return <Component {...props} initialState={state} />;
+        } else if (state && props.user.isAdmin == false) {
+            return (
+                <Redirect
+                    to={`/error?errorCode=403&reason=${encodeURIComponent(
+                        "Only admins users are allowed to access the add dataset page."
+                    )}`}
+                />
+            );
         } else {
-            return <div>Loading</div>;
+            return (
+                <Redirect
+                    to={`/error?errorCode=401&reason=${encodeURIComponent(
+                        "Only logged-in users are allowed to access the add dataset page."
+                    )}`}
+                />
+            );
         }
     };
 

--- a/magda-web-client/src/Components/Error/Error401.js
+++ b/magda-web-client/src/Components/Error/Error401.js
@@ -3,7 +3,7 @@ import ErrorHandler from "./ErrorHandler";
 
 export default function ErrorPage({ errorData }) {
     let errorMsg =
-        "An authentication error has ocurred when tried to process your request.";
+        "An authentication error has occurred while to processing your request.";
     if (errorData.reason) {
         errorMsg = errorData.reason;
     }

--- a/magda-web-client/src/Components/Error/Error401.js
+++ b/magda-web-client/src/Components/Error/Error401.js
@@ -1,0 +1,18 @@
+import React from "react";
+import ErrorHandler from "./ErrorHandler";
+
+export default function ErrorPage({ errorData }) {
+    let errorMsg =
+        "An authentication error has ocurred when tried to process your request.";
+    if (errorData.reason) {
+        errorMsg = errorData.reason;
+    }
+    return (
+        <ErrorHandler
+            error={{
+                title: "Authentication error:",
+                detail: errorMsg
+            }}
+        />
+    );
+}

--- a/magda-web-client/src/Components/Error/Error403.js
+++ b/magda-web-client/src/Components/Error/Error403.js
@@ -3,7 +3,7 @@ import ErrorHandler from "./ErrorHandler";
 
 export default function ErrorPage({ errorData }) {
     let errorMsg =
-        "An authorisation error has ocurred when tried to process your request.";
+        "An authorisation error has occurred while to processing your request.";
     if (errorData.reason) {
         errorMsg = errorData.reason;
     }

--- a/magda-web-client/src/Components/Error/Error403.js
+++ b/magda-web-client/src/Components/Error/Error403.js
@@ -1,0 +1,18 @@
+import React from "react";
+import ErrorHandler from "./ErrorHandler";
+
+export default function ErrorPage({ errorData }) {
+    let errorMsg =
+        "An authorisation error has ocurred when tried to process your request.";
+    if (errorData.reason) {
+        errorMsg = errorData.reason;
+    }
+    return (
+        <ErrorHandler
+            error={{
+                title: "Authorisation error:",
+                detail: errorMsg
+            }}
+        />
+    );
+}

--- a/magda-web-client/src/Components/Error/ErrorPage.js
+++ b/magda-web-client/src/Components/Error/ErrorPage.js
@@ -1,6 +1,8 @@
 import React from "react";
 import * as queryString from "query-string";
 import ErrorHandler from "./ErrorHandler";
+import Error401 from "./Error401";
+import Error403 from "./Error403";
 import Error404 from "./Error404";
 import Error500 from "./Error500";
 
@@ -8,6 +10,10 @@ export default function ErrorPage({ location }) {
     const query = queryString.parse(location.search);
     const errorCode = query.errorCode;
     switch (errorCode) {
+        case "401":
+            return <Error401 errorData={query} />;
+        case "403":
+            return <Error403 errorData={query} />;
         case "404":
             return <Error404 errorData={query} />;
         case "500":


### PR DESCRIPTION
### What this PR does

Fixes #2406

Show an error message screen if the user is not allowed to access the add dataset page

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
