### PR TITLE
Issue/2405 Fixed Search API / Facet Option May throw `Invalid aggregation name` error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Search:
 
 -   Prevent freeText query from being None which will cause score to be 0
 -   Add tenant specific search.
+-   Fixed facet options (publishers) API error: Invalid aggregation name
 
 Indexer:
 

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -31,7 +31,6 @@ import com.sksamuel.elastic4s.searches.sort.SortOrder
 import com.sksamuel.elastic4s.searches.{ScoreMode, SearchRequest}
 import com.sksamuel.elastic4s.searches.queries.matches.{MatchAllQuery, MatchNoneQuery}
 import com.typesafe.config.Config
-import java.security.MessageDigest
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -72,7 +71,6 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
   val ALLOWED_AUTO_COMPLETE_FIELDS = Seq(
     "accessNotes.location"
   )
-
 
   override def search(
     jwtToken: Option[String],

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -554,7 +554,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
   }
 
   /**
-    * Encode AggName into a string only contains [a-z0-9_-]
+    * Encode AggName into a string only contains [a-z0-9_-], because anything else will break ElasticSearch
     * @param name name string
     * @return encoded string
     */


### PR DESCRIPTION
### What this PR does

Fixes #2405 

- Use base64 encoded (plus replace `=` with `_`) version name string for aggregation name. As elasticsearch allows only `0-9` `a-z` `-` & `_`


### Test Site:

https://issue-2405.dev.magda.io

This site is deployed with `Full Preview` option. Thus, its data is identical to the dev site.

To test it, access URL: 
https://dev.magda.io/api/v0/search/facets/publisher/options?generalQuery=*&query=*&start=0&limit=11&facetQuery=au

Should give you the following result (the same request on dev site will trigger an error):

![image](https://user-images.githubusercontent.com/674387/63244389-9a40ba80-c2a0-11e9-8b6e-623a9e8f68d4.png)



### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
