### PR TITLE
Issue/2423 Vanguard auth'd users landed on correct account page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,7 @@ Gateway:
 -   Add ArcGIS/ESRI Authentication provider, including support for on-premise instances of ArcGIS Portal.
 -   Add Vanguard (WS-FED) Authentication provider
 -   Made organisation field an autocomplete in add dataset page.
+-   Corrected Vanguard Authentication Landing Url
 
 Access Control:
 

--- a/magda-gateway/src/createAuthRouter.ts
+++ b/magda-gateway/src/createAuthRouter.ts
@@ -103,7 +103,7 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
                 wsFedIdpUrl: options.vanguardWsFedIdpUrl,
                 wsFedRealm: options.vanguardWsFedRealm,
                 wsFedCertificate: options.vanguardWsFedCertificate,
-                externalAuthHome: `${options.externalUrl}/auth`
+                externalUrl: options.externalUrl
             })
         }
     ];

--- a/magda-gateway/src/oauth2/vanguard.ts
+++ b/magda-gateway/src/oauth2/vanguard.ts
@@ -28,7 +28,10 @@ export default function vanguard(options: VanguardOptions) {
     const externalAuthHome = options.externalAuthHome;
 
     if (!wsFedIdpUrl || !wsFedRealm || !wsFedCertificate) {
-        return undefined;
+        // --- we will know we didn't setup vanguard well
+        throw new Error(
+            "Vanguard SSO module is missing one of the following parameters: wsFedIdpUrl, wsFedRealm or wsFedCertificate"
+        );
     }
 
     passport.use(

--- a/magda-gateway/src/oauth2/vanguard.ts
+++ b/magda-gateway/src/oauth2/vanguard.ts
@@ -14,7 +14,7 @@ export interface VanguardOptions {
     wsFedIdpUrl: string;
     wsFedRealm: string;
     wsFedCertificate: string;
-    externalAuthHome: string;
+    externalUrl: string;
 }
 
 const STRATEGY = "vanguard";
@@ -25,7 +25,7 @@ export default function vanguard(options: VanguardOptions) {
     const wsFedIdpUrl = options.wsFedIdpUrl;
     const wsFedRealm = options.wsFedRealm;
     const wsFedCertificate = options.wsFedCertificate;
-    const externalAuthHome = options.externalAuthHome;
+    const externalUrl = options.externalUrl;
 
     if (!wsFedIdpUrl || !wsFedRealm || !wsFedCertificate) {
         // --- we will know we didn't setup vanguard well
@@ -74,6 +74,8 @@ export default function vanguard(options: VanguardOptions) {
         passport.authenticate(STRATEGY, {})(req, res, next);
     });
 
+    const successRedirectUrl = `${externalUrl}/sign-in-redirect?redirectTo=/account`;
+
     router.all(
         "/return",
         passport.authenticate(STRATEGY, {
@@ -81,7 +83,7 @@ export default function vanguard(options: VanguardOptions) {
             failureFlash: true
         }),
         function(req, res) {
-            redirectOnSuccess(req.query.redirect || externalAuthHome, req, res);
+            redirectOnSuccess(successRedirectUrl, req, res);
         }
     );
 


### PR DESCRIPTION
### What this PR does

Fixes #2423

Vanguard auth'd users landed on correct account page
- Updated VANGUARD_CERT variable in gitlab to remove the `begin---certificate` portion
- Throw an error (so that we can tell why gateway pod keeps restarting) when secret is not there
- Also created a script to automate the metadata creation process. It can:
  - Auto pick the non-root CA cert regardless root CA cert position in the file
  - Auto replace the cert before siging
  - Option to set new return URL, `targetScope` & output file

PR here:
https://gitlab.com/magda-data/vanguard-utils/merge_requests/1

### Test Site:

https://issue-2423.dev.magda.io


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
