### PR TITLE
Issue/2419 Google oAuth Error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,7 @@ Gateway:
 -   Add Vanguard (WS-FED) Authentication provider
 -   Made organisation field an autocomplete in add dataset page.
 -   Corrected Vanguard Authentication Landing Url
+-   Fixed Google oAuth Error: authRouter
 
 Access Control:
 

--- a/deploy/helm/magda/charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/deployment.yaml
@@ -45,9 +45,6 @@ spec:
 {{- if .Values.auth.aafClientUri}}
             "--aafClientUri", {{ .Values.auth.aafClientUri| quote }},
 {{- end }}
-{{- if .Values.auth.googleClientId }}
-            "--googleClientId", {{ .Values.auth.googleClientId | quote }},
-{{- end }}
 {{- if .Values.auth.vanguardWsFedIdpUrl }}
             "--vanguardWsFedIdpUrl", {{ .Values.auth.vanguardWsFedIdpUrl | quote }},
 {{- end }}

--- a/magda-gateway/src/createAuthRouter.ts
+++ b/magda-gateway/src/createAuthRouter.ts
@@ -42,69 +42,81 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
         {
             id: "facebook",
             enabled: options.facebookClientId ? true : false,
-            authRouter: require("./oauth2/facebook").default({
-                authorizationApi: authApi,
-                passport: passport,
-                clientId: options.facebookClientId,
-                clientSecret: options.facebookClientSecret,
-                externalAuthHome: `${options.externalUrl}/auth`
-            })
+            authRouter: options.facebookClientId
+                ? require("./oauth2/facebook").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      clientId: options.facebookClientId,
+                      clientSecret: options.facebookClientSecret,
+                      externalAuthHome: `${options.externalUrl}/auth`
+                  })
+                : null
         },
         {
             id: "google",
             enabled: options.googleClientId ? true : false,
-            authRouter: require("./oauth2/google").default({
-                authorizationApi: authApi,
-                passport: passport,
-                clientId: options.googleClientId,
-                clientSecret: options.googleClientSecret,
-                externalAuthHome: `${options.externalUrl}/auth`
-            })
+            authRouter: options.googleClientId
+                ? require("./oauth2/google").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      clientId: options.googleClientId,
+                      clientSecret: options.googleClientSecret,
+                      externalAuthHome: `${options.externalUrl}/auth`
+                  })
+                : null
         },
         {
             id: "arcgis",
             enabled: options.arcgisClientId ? true : false,
-            authRouter: require("./oauth2/arcgis").default({
-                authorizationApi: authApi,
-                passport: passport,
-                clientId: options.arcgisClientId,
-                clientSecret: options.arcgisClientSecret,
-                arcgisInstanceBaseUrl: options.arcgisInstanceBaseUrl,
-                externalAuthHome: `${options.externalUrl}/auth`
-            })
+            authRouter: options.arcgisClientId
+                ? require("./oauth2/arcgis").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      clientId: options.arcgisClientId,
+                      clientSecret: options.arcgisClientSecret,
+                      arcgisInstanceBaseUrl: options.arcgisInstanceBaseUrl,
+                      externalAuthHome: `${options.externalUrl}/auth`
+                  })
+                : null
         },
         {
             id: "ckan",
             enabled: options.ckanUrl ? true : false,
-            authRouter: require("./oauth2/ckan").default({
-                authorizationApi: authApi,
-                passport: passport,
-                externalAuthHome: `${options.externalUrl}/auth`,
-                ckanUrl: options.ckanUrl
-            })
+            authRouter: options.ckanUrl
+                ? require("./oauth2/ckan").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      externalAuthHome: `${options.externalUrl}/auth`,
+                      ckanUrl: options.ckanUrl
+                  })
+                : null
         },
         {
             id: "aaf",
             enabled: options.aafClientUri ? true : false,
-            authRouter: require("./oauth2/aaf").default({
-                authorizationApi: authApi,
-                passport: passport,
-                aafClientUri: options.aafClientUri,
-                aafClientSecret: options.aafClientSecret,
-                externalUrl: options.externalUrl
-            })
+            authRouter: options.aafClientUri
+                ? require("./oauth2/aaf").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      aafClientUri: options.aafClientUri,
+                      aafClientSecret: options.aafClientSecret,
+                      externalUrl: options.externalUrl
+                  })
+                : null
         },
         {
             id: "vanguard",
             enabled: options.vanguardWsFedIdpUrl ? true : false,
-            authRouter: require("./oauth2/vanguard").default({
-                authorizationApi: authApi,
-                passport: passport,
-                wsFedIdpUrl: options.vanguardWsFedIdpUrl,
-                wsFedRealm: options.vanguardWsFedRealm,
-                wsFedCertificate: options.vanguardWsFedCertificate,
-                externalUrl: options.externalUrl
-            })
+            authRouter: options.vanguardWsFedIdpUrl
+                ? require("./oauth2/vanguard").default({
+                      authorizationApi: authApi,
+                      passport: passport,
+                      wsFedIdpUrl: options.vanguardWsFedIdpUrl,
+                      wsFedRealm: options.vanguardWsFedRealm,
+                      wsFedCertificate: options.vanguardWsFedCertificate,
+                      externalUrl: options.externalUrl
+                  })
+                : null
         }
     ];
 


### PR DESCRIPTION
### What this PR does

Fixes #2419 

- Fixed: Google oAuth Error. Caused by the extra client_id parameter passed to the gateway pod. oAuth module actually receives an array with duplicate client_id
- Make sure a router is only created when a provider is enabled. This avoids routers with invalid parameters to be created.  

### Tested locally & Online Cluster

Test Site: 

https://issue-2419.dev.magda.io/

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
