### PR TITLE
Issue/2456  Fixed "NOT SET" appears on the dataset page for non-admins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,7 @@ UI:
 -   Added Custodian field to the 'People and Production' page
 -   Added the ability to add references to datasets that a new dataset was derived from.
 -   Fixed edit file panel text input layout
+-   Fixed a blank screen issue on dataset page
 
 Gateway:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,7 @@ UI:
 -   Added the ability to add references to datasets that a new dataset was derived from.
 -   Fixed edit file panel text input layout
 -   Fixed a blank screen issue on dataset page
+-   Fixed "NOT SET" appears on the dataset page for non-admins
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -735,9 +735,16 @@ class RecordHandler extends React.Component {
                                                 organisations?
                                             </h4>
                                             <div>
-                                                {dataset.provenance.affiliatedOrganizationIds.map(
-                                                    org => org.name
-                                                )}
+                                                {dataset &&
+                                                    dataset.provenance &&
+                                                    dataset.provenance
+                                                        .affiliatedOrganizationIds &&
+                                                    dataset.provenance
+                                                        .affiliatedOrganizationIds
+                                                        .length &&
+                                                    dataset.provenance.affiliatedOrganizationIds.map(
+                                                        org => org.name
+                                                    )}
                                             </div>
                                             <h4>
                                                 How was the dataset produced?

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -569,13 +569,15 @@ class RecordHandler extends React.Component {
                                         onChange={datasetChange("contactPoint")}
                                         editor={multilineTextEditor}
                                     >
-                                        {this.props.dataset.contactPoint && (
+                                        {this.props.dataset.contactPoint ? (
                                             <ContactPoint
                                                 contactPoint={
                                                     this.props.dataset
                                                         .contactPoint
                                                 }
                                             />
+                                        ) : (
+                                            <></>
                                         )}
                                     </ToggleEditor>
                                     <ToggleEditor


### PR DESCRIPTION
### What this PR does

Fixes #2456 

- This PR includes PR https://github.com/magda-io/magda/pull/2480

Cause: A `false` value will make `ToggleEditor` ignore children and choose to display the editor.


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
