### PR TITLE
Issues/2460 colour coordinated datepicker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@ UI:
 -   Fixed edit file panel text input layout
 -   Fixed a blank screen issue on dataset page
 -   Fixed "NOT SET" appears on the dataset page for non-admins
+-   Made the datepicker for add dataset use the correct colours.
 
 Gateway:
 

--- a/magda-web-client/src/Components/Editing/Editors/datepicker.scss
+++ b/magda-web-client/src/Components/Editing/Editors/datepicker.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .PresetDateRangePicker_panel {
     padding: 0 22px 11px;
 }
@@ -6,8 +8,8 @@
     height: 100%;
     text-align: center;
     background: 0 0;
-    border: 2px solid #00a699;
-    color: #00a699;
+    border: 2px solid $magda-color-primary;
+    color: $magda-color-primary;
     padding: 4px 12px;
     margin-right: 8px;
     font: inherit;
@@ -23,7 +25,7 @@
 }
 .PresetDateRangePicker_button__selected {
     color: #fff;
-    background: #00a699;
+    background: $magda-color-primary;
 }
 .SingleDatePickerInput {
     display: inline-block;
@@ -189,12 +191,12 @@
 }
 .DayPickerKeyboardShortcuts_show__bottomRight::before {
     border-top: 26px solid transparent;
-    border-right: 33px solid #00a699;
+    border-right: 33px solid $magda-color-primary;
     bottom: 0;
     right: 0;
 }
 .DayPickerKeyboardShortcuts_show__bottomRight:hover::before {
-    border-right: 33px solid #008489;
+    border-right: 33px solid $magda-color-dark;
 }
 .DayPickerKeyboardShortcuts_show__topRight {
     top: 0;
@@ -202,12 +204,12 @@
 }
 .DayPickerKeyboardShortcuts_show__topRight::before {
     border-bottom: 26px solid transparent;
-    border-right: 33px solid #00a699;
+    border-right: 33px solid $magda-color-primary;
     top: 0;
     right: 0;
 }
 .DayPickerKeyboardShortcuts_show__topRight:hover::before {
-    border-right: 33px solid #008489;
+    border-right: 33px solid $magda-color-dark;
 }
 .DayPickerKeyboardShortcuts_show__topLeft {
     top: 0;
@@ -215,12 +217,12 @@
 }
 .DayPickerKeyboardShortcuts_show__topLeft::before {
     border-bottom: 26px solid transparent;
-    border-left: 33px solid #00a699;
+    border-left: 33px solid $magda-color-primary;
     top: 0;
     left: 0;
 }
 .DayPickerKeyboardShortcuts_show__topLeft:hover::before {
-    border-left: 33px solid #008489;
+    border-left: 33px solid $magda-color-dark;
 }
 .DayPickerKeyboardShortcuts_showSpan {
     color: #fff;
@@ -337,33 +339,33 @@
     color: #484848;
 }
 .CalendarDay__selected_span {
-    background: #66e2da;
-    border: 1px double #33dacd;
+    background: lighten($magda-color-light, 30%);
+    border: 1px double $magda-color-light;
     color: #fff;
 }
 .CalendarDay__selected_span:active,
 .CalendarDay__selected_span:hover {
-    background: #33dacd;
-    border: 1px double #33dacd;
+    background: $magda-color-light;
+    border: 1px double $magda-color-light;
     color: #fff;
 }
 .CalendarDay__selected,
 .CalendarDay__selected:active,
 .CalendarDay__selected:hover {
-    background: #00a699;
-    border: 1px double #00a699;
+    background: $magda-color-primary;
+    border: 1px double $magda-color-primary;
     color: #fff;
 }
 .CalendarDay__hovered_span,
 .CalendarDay__hovered_span:hover {
-    background: #b2f1ec;
-    border: 1px double #80e8e0;
-    color: #007a87;
+    background: lighten($magda-color-light, 65%);
+    border: 1px double $magda-color-light;
+    color: #484848;
 }
 .CalendarDay__hovered_span:active {
-    background: #80e8e0;
-    border: 1px double #80e8e0;
-    color: #007a87;
+    background: $magda-color-light;
+    border: 1px double $magda-color-light;
+    color: #fff;
 }
 .CalendarDay__blocked_calendar,
 .CalendarDay__blocked_calendar:active,
@@ -691,7 +693,7 @@
     border: 0;
     border-top: 0;
     border-right: 0;
-    border-bottom: 2px solid #008489;
+    border-bottom: 2px solid $magda-color-dark;
     border-left: 0;
 }
 .DateInput_input__disabled {

--- a/magda-web-client/src/_fns.scss
+++ b/magda-web-client/src/_fns.scss
@@ -1,0 +1,7 @@
+@function white-if-bg-too-dark($fgcolor, $bgcolor) {
+    @if (lightness($bgcolor) > 70%) {
+        @return $fgcolor; // Lighter backgorund, return dark color
+    } @else {
+        @return #ffffff; // Darker background, return light color
+    }
+}

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -1,24 +1,38 @@
-$AU-color-foreground-action: #4c2a85;
-$AU-color-foreground-focus: #0e0021;
-$AU-color-foreground-text: #0e0021;
+@import "fns";
+
+$magda-color-primary: #320e3b;
+$magda-color-secondary: #ffffff;
+
+$magda-color-light: lighten($magda-color-primary, 10%);
+$magda-color-dark: darken($magda-color-primary, 15%);
+
+$AU-color-foreground-action: $magda-color-light;
+$AU-color-foreground-focus: $magda-color-dark;
+$AU-color-foreground-text: $magda-color-dark;
 $AU-color-background: #ffffff;
 
 $AU-colordark-foreground-action: #f7f7f7;
-$AU-colordark-foreground-focus: #6b7fd7;
+$AU-colordark-foreground-focus: $magda-color-secondary;
 $AU-colordark-foreground-text: #f7f7f7;
-$AU-colordark-background: #320e3b;
+$AU-colordark-background: $magda-color-primary;
 
-$header-color-background: #ffffff;
+$header-color-background: $magda-color-secondary;
 $header-opacity-desktop-background: 0.9;
-$header-color-border: #341039;
+$header-color-border: $magda-color-primary;
 
-$header-color-text: $AU-color-foreground-action;
-$header-color-action: $AU-color-foreground-action;
+$header-color-text: white-if-bg-too-dark(
+    $AU-color-foreground-action,
+    $header-color-background
+);
+$header-color-action: white-if-bg-too-dark(
+    $AU-color-foreground-action,
+    $header-color-background
+);
 $header-color-action-background: transparent;
 $header-color-focus: #fff;
-$header-color-focus-background: #341039;
+$header-color-focus-background: $magda-color-primary;
 
-$header-color-mobile-toggle-button-text: #6b7fd7;
+$header-color-mobile-toggle-button-text: $magda-color-secondary;
 $header-color-mobile-toggle-button-icon: #000000;
 $header-color-mobile-nav-background: white;
 $header-color-mobile-nav-border-bottom: #dad9db;
@@ -29,17 +43,17 @@ $header-color-mobile-nav-active: inherit;
 $header-color-mobile-nav-active-background: #f4f3f5;
 $header-color-mobile-nav-active-border: $AU-colordark-background;
 $header-color-mobile-nav-focus: #ffffff;
-$header-color-mobile-nav-focus-background: #341039;
+$header-color-mobile-nav-focus-background: $magda-color-dark;
 $header-color-mobile-nav-focus-border: transparent;
 $header-color-mobile-nav-content: inherit;
 $header-color-mobile-nav-content-background: transparent;
 $header-color-mobile-nav-content-border-bottom: $AU-color-foreground-action;
 
 $footer-color-background: $AU-colordark-background;
-$footer-color-border: $AU-colordark-foreground-focus;
+$footer-color-border: $magda-color-secondary;
 $footer-color-text: $AU-colordark-foreground-text;
 $footer-color-action: $AU-colordark-foreground-action;
-$footer-color-focus: $AU-colordark-foreground-focus;
+$footer-color-focus: $magda-color-secondary;
 
 $add-dataset-page-button-top-rows: #30384d;
 
@@ -53,4 +67,5 @@ $minimum: 576px;
 $small: 768px;
 $medium: 992px;
 $large: 1200px;
+
 @import "./pancake/sass/core.scss";


### PR DESCRIPTION
### What this PR does

Fixes #2460 

This makes the react-dates datepicker uses Magda colours, as set through the SCSS compiler config.

As part of this I made the default config colours a bit more organised - you should now be able to set the whole colour scheme by just specifying a primary and secondary colour.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
