### PR TITLE
Removed out-of-place row class.

### DIFF
--- a/magda-web-client/src/Components/Common/AddDatasetProgressMeter.tsx
+++ b/magda-web-client/src/Components/Common/AddDatasetProgressMeter.tsx
@@ -138,7 +138,7 @@ const AddDatasetProgressMeter = (props: PropsType) => {
     const datasetId = determineDatasetId();
 
     return (
-        <div className="row add-dataset-progress-meter">
+        <div className="add-dataset-progress-meter">
             <div className="container">
                 <div className="col-sm-2 step-item-heading">
                     <div className="heading">Add a dataset</div>


### PR DESCRIPTION
### What this PR does

Fixes #2462 

Horizontal scrollbars were on the add dataset screens because of a `row` class outside a `container`.

New personal best for PR golf, 5 characters 😎 ⛳️ 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I don't think it really warrants a CHANGES entry, it just makes an already new change work the way it should
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
