### PR TITLE
Fix data.json connector uses "keyword" instead of "keywords" 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,7 @@ Others:
 -   Removed Travis CI (Gitlab CI still remains)
 -   Disabled tenant-api & tenant-db when `enableMultiTenants` = false
 -   Excluded organisations that are owners of thesauruses (keyword taxonomies) from being considered as owners of datasets via CSW connector
+-   Fix data.json connector dcat-dataset-strings aspect so keywords are stored correctly
 
 ## 0.0.55
 

--- a/magda-project-open-data-connector/aspect-templates/dcat-dataset-strings.js
+++ b/magda-project-open-data-connector/aspect-templates/dcat-dataset-strings.js
@@ -14,7 +14,7 @@ return {
         end: parsedTemporal[1]
     },
     themes: dataset.theme,
-    keyword: dataset.keyword,
+    keywords: dataset.keyword,
     contactPoint: dataset.contactPoint ? dataset.contactPoint.fn : undefined,
     landingPage: dataset.landingPage
 };

--- a/magda-project-open-data-connector/src/test/black-box.spec.ts
+++ b/magda-project-open-data-connector/src/test/black-box.spec.ts
@@ -13,6 +13,7 @@ const TEST_CASES = [
                     description: "dataset-desc",
                     title: "dataset-title",
                     license: "dataset-license-url",
+                    keyword: ["key", "words"],
                     distribution: [
                         {
                             "@type": "dcat:Distribution",
@@ -97,12 +98,14 @@ const TEST_CASES = [
                         identifier: "dataset-id",
                         description: "dataset-desc",
                         title: "dataset-title",
-                        license: "dataset-license-url"
+                        license: "dataset-license-url",
+                        keyword: ["key", "words"]
                     },
                     "dcat-dataset-strings": {
                         title: "dataset-title",
                         description: "dataset-desc",
-                        temporal: {}
+                        temporal: {},
+                        keywords: ["key", "words"]
                     },
                     source: {
                         type: "project-open-data-dataset",


### PR DESCRIPTION
### What this PR does

Fixes #2000 which was due to subtle difference between DCAT and data.json parameter names for dataset keywords/tags https://project-open-data.cio.gov/v1.1/schema/#keyword

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
