### PR TITLE
Schema.org markup fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,8 @@ UI:
 -   Fixed "NOT SET" appears on the dataset page for non-admins
 -   Made the add dataset flow only say it found keywords in the document if it actually did so.
 -   Made the datepicker for add dataset use the correct colours.
+-   Updated schema.org Dataset and DataDownload semantic markup for rich search results 
+-   Fixed typos in no-print styling and adding keywords tooltip
 
 Gateway:
 

--- a/magda-web-client/src/Components/Common/ContactPoint.js
+++ b/magda-web-client/src/Components/Common/ContactPoint.js
@@ -30,7 +30,7 @@ class ContactPoint extends React.Component {
                         <div className="heading">
                             {translate(["contactPointTitle", "Contact Point"])}:
                         </div>
-                        <div class="no-print">
+                        <div className="no-print">
                             {this.state.reveal ? (
                                 <MarkdownViewer
                                     markdown={this.props.contactPoint}
@@ -43,7 +43,7 @@ class ContactPoint extends React.Component {
                                 </ToggleButton>
                             )}
                         </div>
-                        <div class="print-only">
+                        <div className="print-only">
                             <MarkdownViewer
                                 markdown={this.props.contactPoint}
                             />

--- a/magda-web-client/src/Components/Common/DataPreviewMap.js
+++ b/magda-web-client/src/Components/Common/DataPreviewMap.js
@@ -170,7 +170,7 @@ class DataPreviewMap extends Component {
         if (!selectedDistribution) return null; // hide the section if no data available
 
         return (
-            <div class="no-print">
+            <div className="no-print">
                 <h3 className="section-heading">Map Preview</h3>
                 <Small>
                     <DataPreviewMapOpenInNationalMapButton

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -110,7 +110,7 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                         Keywords are specific words that your dataset contains,
                         and they help people search for specific datasets.{" "}
                         {dataset!.keywords && dataset.keywords.derived
-                            ? "We recommend keywords and kept to 10-15 words. We've identified the top keywords from your file(s)."
+                            ? "We recommend keywords are kept to 10-15 words. We've identified the top keywords from your file(s)."
                             : null}
                     </ToolTip>
                     <div className="clearfix">

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -490,8 +490,14 @@ class RecordHandler extends React.Component {
                                     >
                                         <Link
                                             to={`/organisations/${publisherId}`}
+                                            itemProp="url"
                                         >
-                                            {this.props.dataset.publisher.name}
+                                            <span itemProp="name">
+                                                {
+                                                    this.props.dataset.publisher
+                                                        .name
+                                                }
+                                            </span>
                                         </Link>
                                     </span>
 

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -105,7 +105,10 @@ class DistributionRow extends Component<PropType> {
                                         )
                                     </div>
                                 ) : (
-                                    <Link to={distributionLink}>
+                                    <Link
+                                        to={distributionLink}
+                                        itemProp="contentUrl"
+                                    >
                                         <span itemProp="name">
                                             {this.renderDistributionLink(
                                                 distribution.title


### PR DESCRIPTION
### What this PR does

Add url/name properties to Organisation and contentUrl to DataDownload for each distribution. These are required to get proper Dataset rich search results from Google etc.

Further improvements could be made to pick a dataset licence, change the date format and add distribution format as a mime-type.

Also Fixes #2502 a typo in a tooltip and class instead of className in no-print styling application  #2235 

![search google com_structured-data_testing-tool_u_0_ (1)](https://user-images.githubusercontent.com/81432/65398816-b930f000-ddfc-11e9-8ce0-5fb9fb55d413.png)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
