### PR TITLE
Added feature flag for an add dataset preview mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Indexer:
 -   Index datasets with tenant ID.
 -   Fixed indexer throws an error when affiliatedOrganisation field is created
 -   Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect
+-   Added auth when crawling the registry
 
 Cataloging:
 
@@ -101,6 +102,7 @@ UI:
 -   Fixed "NOT SET" appears on the dataset page for non-admins
 -   Made the add dataset flow only say it found keywords in the document if it actually did so.
 -   Made the datepicker for add dataset use the correct colours.
+-   Added a preview mode for add dataset, that allows all users to use add dataset but prevents them from submitting.
 
 Gateway:
 

--- a/magda-authorization-api/src/createApiRouter.ts
+++ b/magda-authorization-api/src/createApiRouter.ts
@@ -485,41 +485,33 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *      "errorMessage": "Not authorized"
      *    }
      */
-    router.get(
-        "/public/orgunits/bylevel/:orgLevel",
-        MUST_BE_ADMIN,
-        async (req, res) => {
-            try {
-                const orgLevel = req.params.orgLevel;
-                const relationshipOrgUnitId = req.query.relationshipOrgUnitId;
+    router.get("/public/orgunits/bylevel/:orgLevel", async (req, res) => {
+        try {
+            const orgLevel = req.params.orgLevel;
+            const relationshipOrgUnitId = req.query.relationshipOrgUnitId;
 
-                const levelNumber = parseInt(orgLevel);
+            const levelNumber = parseInt(orgLevel);
 
-                if (levelNumber < 1 || isNaN(levelNumber))
-                    throw new Error(`Invalid level number: ${orgLevel}.`);
+            if (levelNumber < 1 || isNaN(levelNumber))
+                throw new Error(`Invalid level number: ${orgLevel}.`);
 
-                const nodes = await orgQueryer.getAllNodesAtLevel(levelNumber);
+            const nodes = await orgQueryer.getAllNodesAtLevel(levelNumber);
 
-                if (relationshipOrgUnitId && nodes.length) {
-                    for (let i = 0; i < nodes.length; i++) {
-                        const r = await orgQueryer.compareNodes(
-                            nodes[i]["id"],
-                            relationshipOrgUnitId
-                        );
-                        nodes[i]["relationship"] = r;
-                    }
+            if (relationshipOrgUnitId && nodes.length) {
+                for (let i = 0; i < nodes.length; i++) {
+                    const r = await orgQueryer.compareNodes(
+                        nodes[i]["id"],
+                        relationshipOrgUnitId
+                    );
+                    nodes[i]["relationship"] = r;
                 }
-
-                res.status(200).json(nodes);
-            } catch (e) {
-                respondWithError(
-                    "GET /public/orgunits/bylevel/:orgLevel",
-                    res,
-                    e
-                );
             }
+
+            res.status(200).json(nodes);
+        } catch (e) {
+            respondWithError("GET /public/orgunits/bylevel/:orgLevel", res, e);
         }
-    );
+    });
 
     /**
      * @apiGroup Auth
@@ -543,7 +535,7 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *      "errorMessage": "Not authorized"
      *    }
      */
-    router.get("/public/orgunits", MUST_BE_ADMIN, async (req, res) => {
+    router.get("/public/orgunits", async (req, res) => {
         try {
             const nodeName: string = req.query.nodeName;
             const leafNodesOnly: string = req.query.leafNodesOnly;
@@ -577,7 +569,7 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *      "errorMessage": "Not authorized"
      *    }
      */
-    router.get("/public/orgunits/root", MUST_BE_ADMIN, async (req, res) => {
+    router.get("/public/orgunits/root", async (req, res) => {
         handleMaybePromise(
             res,
             orgQueryer.getRootNode(),

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -68,7 +68,7 @@ class RegistryExternalInterface(httpFetcher: HttpFetcher)
   }
 
   def getDataSetsToken(pageToken: String, number: Int): scala.concurrent.Future[(Option[String], List[DataSet])] = {
-    fetcher.get(path = s"$baseRecordsPath&dereference=true&pageToken=$pageToken&limit=$number", headers = Seq(systemIdHeader)).flatMap { response =>
+    fetcher.get(path = s"$baseRecordsPath&dereference=true&pageToken=$pageToken&limit=$number", headers = Seq(systemIdHeader, authHeader)).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[RegistryRecordsResponse].map { registryResponse =>
           (registryResponse.nextPageToken, mapCatching[Record, DataSet](registryResponse.records,
@@ -81,7 +81,7 @@ class RegistryExternalInterface(httpFetcher: HttpFetcher)
   }
 
   def getDataSetsReturnToken(start: Long, number: Int): scala.concurrent.Future[(Option[String], List[DataSet])] = {
-    fetcher.get(path = s"$baseRecordsPath&dereference=true&start=$start&limit=$number", headers = Seq(systemIdHeader)).flatMap { response =>
+    fetcher.get(path = s"$baseRecordsPath&dereference=true&start=$start&limit=$number", headers = Seq(systemIdHeader, authHeader)).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[RegistryRecordsResponse].map { registryResponse =>
           (registryResponse.nextPageToken, mapCatching[Record, DataSet](registryResponse.records,

--- a/magda-web-client/src/Components/Common/Choice.scss
+++ b/magda-web-client/src/Components/Common/Choice.scss
@@ -50,3 +50,12 @@
     border: none !important;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
 }
+
+.choice-Disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+
+    a {
+        cursor: not-allowed;
+    }
+}

--- a/magda-web-client/src/Components/Common/Choice.tsx
+++ b/magda-web-client/src/Components/Common/Choice.tsx
@@ -8,6 +8,7 @@ type ChoiceProps = {
     icon: string;
     secondary?: boolean;
     className?: string;
+    disabled?: boolean;
 };
 
 export default function Choice(props: ChoiceProps) {
@@ -15,10 +16,10 @@ export default function Choice(props: ChoiceProps) {
         <div
             className={`col-sm-12 col-md-6 choice-Col ${
                 props.className ? props.className : ""
-            }`}
+            } ${props.disabled ? "choice-Disabled" : ""}`}
         >
             <a
-                href={props.href}
+                href={!props.disabled ? props.href : undefined}
                 className={`au-btn ${
                     props.secondary ? "au-btn--secondary" : ""
                 } choice-Button`}
@@ -26,7 +27,9 @@ export default function Choice(props: ChoiceProps) {
                 <h2 className="choice-buttonHeading">{props.heading}</h2>{" "}
                 <div className="choice-IconRow">
                     <img className="choice-Icon" src={props.icon} />
-                    <div className="text-content">{props.blurb}</div>
+                    <div className="text-content">
+                        {props.blurb} {props.disabled && "(coming soon)"}
+                    </div>
                 </div>
             </a>
         </div>

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -165,14 +165,14 @@ type Access = {
     notes?: string;
 };
 
-export function createBlankState(user: User): State {
+export function createBlankState(user?: User): State {
     return {
         files: [],
         processing: false,
         dataset: {
             title: "Untitled",
             languages: ["eng"],
-            owningOrgUnitId: user.orgUnitId,
+            owningOrgUnitId: user ? user.orgUnitId : undefined,
             defaultLicense: "world"
         },
         datasetPublishing: {
@@ -200,7 +200,7 @@ export function createBlankState(user: User): State {
 
 // saving data in the local storage for now
 // TODO: consider whether it makes sense to store this in registry as a custom state or something
-export async function loadState(id: string, user: User): Promise<State> {
+export async function loadState(id: string, user?: User): Promise<State> {
     const stateString = localStorage[id];
     let state: State;
     if (stateString) {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.scss
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.scss
@@ -1,10 +1,13 @@
 @import "variables";
 
 .add-dataset-page-container {
-    .borderLR {
-        border-left: #e4e4e4 1px solid;
-        border-right: #e4e4e4 1px solid;
+    .heading-wrapper {
+        margin-top: 2px;
+        background-color: #f4f4f4;
+        text-align: center;
+        vertical-align: middle;
     }
+
     .heading {
         font-size: 64px;
         font-weight: normal;
@@ -15,13 +18,8 @@
         letter-spacing: normal;
         color: #3c3c3c;
     }
-    .heading-row {
-        margin-top: 2px;
-        background-color: #f4f4f4;
-        text-align: center;
-        vertical-align: middle;
-    }
-    .lower-header {
+
+    .lower-header-wrapper {
         height: 414px;
         background-color: #fafafa;
         .block {
@@ -46,6 +44,7 @@
             margin-bottom: 33px;
         }
     }
+
     .text-block-container {
         .text-block {
             margin-left: auto;
@@ -72,23 +71,28 @@
             width: 241px;
         }
     }
+
     .body-heading-row {
-        p {
-            margin-left: auto;
-            margin-right: auto;
-            margin-top: 85px;
-            margin-bottom: 66px;
-            width: 592px;
-            height: 96px;
-            font-size: 38px;
-            font-weight: normal;
-            font-style: normal;
-            font-stretch: normal;
-            line-height: 1.26;
-            letter-spacing: normal;
-            text-align: center;
-            color: #484848;
-        }
+        // p {
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: 85px;
+        margin-bottom: 66px;
+        width: 592px;
+        height: 96px;
+        font-size: 38px;
+        font-weight: normal;
+        font-style: normal;
+        font-stretch: normal;
+        line-height: 1.26;
+        letter-spacing: normal;
+        text-align: center;
+        color: #484848;
+        // }
+    }
+
+    .preview-message-row {
+        margin-bottom: 66px;
     }
 
     .choice-Col:nth-child(2),

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Choice from "Components/Common/Choice";
+import { config } from "config";
 
 import iconSearch from "assets/icon-search.svg";
 import iconDocument from "assets/icon-document.svg";
@@ -15,65 +16,78 @@ import "./DatasetAddPage.scss";
 class AddDataset extends React.Component<any, any> {
     render() {
         return (
-            <div className="container-fluid add-dataset-page-container borderLR">
-                <div className="row heading-row borderLR ">
-                    <div className="col-sm-12">
-                        <div className="heading container">Add a Dataset</div>
-                    </div>
-                </div>
-                <div className="row lower-header borderLR">
-                    <div className="col-sm-12">
-                        <div className="container">
-                            <div className="row lower-header-icons">
-                                <div className="col-sm-4 block">
-                                    <img
-                                        src={iconSearch}
-                                        className="icon-search"
-                                    />
-                                </div>
-                                <div className="col-sm-4 block">
-                                    <img
-                                        src={iconDocument}
-                                        className="icon-document"
-                                    />
-                                </div>
-                                <div className="col-sm-4 block">
-                                    <img src={iconSave} className="icon-oval" />
+            <div className="add-dataset-page-container">
+                <div className="heading-wrapper">
+                    <div className="container">
+                        <div className="row">
+                            <div className="col-sm-12">
+                                <div className="heading container">
+                                    Add a Dataset
                                 </div>
                             </div>
-                            <div className="row">
-                                <div className="col-sm-4 text-block-container">
-                                    <div className="text-block text-block-1">
-                                        You can easily{" "}
-                                        <strong>
-                                            add a new record of a dataset to
-                                            your internal catalogue
-                                        </strong>{" "}
-                                        to enable powerful search and discovery
-                                        features.
+                        </div>
+                    </div>
+                </div>
+
+                <div className="lower-header-wrapper">
+                    <div className="container">
+                        <div className="row ">
+                            <div className="col-sm-12">
+                                <div className="row lower-header-icons">
+                                    <div className="col-sm-4 block">
+                                        <img
+                                            src={iconSearch}
+                                            className="icon-search"
+                                        />
+                                    </div>
+                                    <div className="col-sm-4 block">
+                                        <img
+                                            src={iconDocument}
+                                            className="icon-document"
+                                        />
+                                    </div>
+                                    <div className="col-sm-4 block">
+                                        <img
+                                            src={iconSave}
+                                            className="icon-oval"
+                                        />
                                     </div>
                                 </div>
-                                <div className="col-sm-4 text-block-container">
-                                    <div className="text-block text-block-2">
-                                        The MAGDA Publishing Tool can{" "}
-                                        <strong>
-                                            review your files and pre-populate
-                                            metadata
-                                        </strong>{" "}
-                                        to ensure every dataset has a complete
-                                        and high quality metadata record,
-                                        without the need for arduous data entry.
+                                <div className="row">
+                                    <div className="col-sm-4 text-block-container">
+                                        <div className="text-block text-block-1">
+                                            You can easily{" "}
+                                            <strong>
+                                                add a new record of a dataset to
+                                                your internal catalogue
+                                            </strong>{" "}
+                                            to enable powerful search and
+                                            discovery features.
+                                        </div>
                                     </div>
-                                </div>
-                                <div className="col-sm-4 text-block-container">
-                                    <div className="text-block text-block-3">
-                                        You can{" "}
-                                        <strong>
-                                            save your metadata records as a
-                                            draft
-                                        </strong>{" "}
-                                        until you are ready to submit them for
-                                        approval.
+                                    <div className="col-sm-4 text-block-container">
+                                        <div className="text-block text-block-2">
+                                            The MAGDA Publishing Tool can{" "}
+                                            <strong>
+                                                review your files and
+                                                pre-populate metadata
+                                            </strong>{" "}
+                                            to ensure every dataset has a
+                                            complete and high quality metadata
+                                            record, without the need for arduous
+                                            data entry.
+                                        </div>
+                                    </div>
+                                    <div className="col-sm-4 text-block-container">
+                                        <div className="text-block text-block-3">
+                                            You can{" "}
+                                            <strong>
+                                                save your metadata records as a
+                                                draft
+                                            </strong>{" "}
+                                            until you are ready to submit them
+                                            for approval.
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -81,49 +95,73 @@ class AddDataset extends React.Component<any, any> {
                     </div>
                 </div>
 
-                <div className="row body-heading-row borderLR">
-                    <div className="col-sm-12">
-                        <div className="container">
+                <div className="container">
+                    <div className="row body-heading-row">
+                        <div className="col-sm-12">
                             <p>
                                 Choose how you would like to add your dataset to
                                 your catalogue:
                             </p>
                         </div>
                     </div>
-                </div>
 
-                <div className="row main-body-row borderLR">
-                    <div className="container">
-                        <Choice
-                            className={"choice-1"}
-                            heading="Have a single dataset made up of one or more files?"
-                            icon={iconUpload}
-                            blurb="Add your dataset file(s) to pre-populate metadata using the Magda Publishing Tool"
-                            href="/dataset/add/files"
-                        />
-                        <Choice
-                            className={"choice-2"}
-                            heading="Dataset exists elsewhere online?"
-                            icon={iconWebsite}
-                            blurb="Enter the URL of an online dataset to pre-populate metadata using the Magda Publishing Tool."
-                            href="/dataset/add/urls"
-                        />
-                        <Choice
-                            className={"choice-3"}
-                            heading="No files to upload?"
-                            icon={iconDataEntry}
-                            blurb="Manually add the dataset record and the metadata."
-                            href="/dataset/add/metadata/-/0"
-                            secondary
-                        />
-                        <Choice
-                            className={"choice-4"}
-                            heading="Adding multiple datasets?"
-                            icon={iconFolders}
-                            blurb="Add your entire dataset catalogue using our bulk CSV tool or open data catalogue"
-                            href="/catalog/add"
-                            secondary
-                        />
+                    {config.featureFlags.previewAddDataset && (
+                        <div className="row preview-message-row">
+                            <div className="col-sm-8 col-sm-offset-2">
+                                <div className="au-page-alerts au-page-alerts--warning">
+                                    <h3>This is a Preview Only!</h3>
+                                    <p>
+                                        This version is intended to preview the
+                                        new Add Dataset functionality for
+                                        feedback. When you get to the end of
+                                        this process{" "}
+                                        <strong>
+                                            your dataset will not be saved on
+                                            the server
+                                        </strong>
+                                        , but it will persist locally as a
+                                        draft.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="row main-body-row">
+                        <div className="container">
+                            <Choice
+                                className={"choice-1"}
+                                heading="Have a single dataset made up of one or more files?"
+                                icon={iconUpload}
+                                blurb="Add your dataset file(s) to pre-populate metadata using the Magda Publishing Tool"
+                                href="/dataset/add/files"
+                            />
+                            <Choice
+                                className={"choice-2"}
+                                heading="Dataset exists elsewhere online?"
+                                icon={iconWebsite}
+                                blurb="Enter the URL of an online dataset to pre-populate metadata using the Magda Publishing Tool."
+                                href="/dataset/add/urls"
+                                disabled={true}
+                            />
+                            <Choice
+                                className={"choice-3"}
+                                heading="No files to upload?"
+                                icon={iconDataEntry}
+                                blurb="Manually add the dataset record and the metadata."
+                                href="/dataset/add/metadata/-/0"
+                                secondary
+                            />
+                            <Choice
+                                className={"choice-4"}
+                                heading="Adding multiple datasets?"
+                                icon={iconFolders}
+                                blurb="Add your entire dataset catalogue using our bulk CSV tool or open data catalogue"
+                                href="/catalog/add"
+                                secondary
+                                disabled={true}
+                            />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPreviewPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPreviewPage.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { Link } from "react-router-dom";
+
+export default function DatasetAddEndPreviewPage() {
+    return (
+        <div className="row people-and-production-page">
+            <div className="col-sm-12">
+                <h2>You've completed the Add Dataset Preview!</h2>
+                <hr />
+                <p>
+                    Soon, you'll be able to submit the dataset so that it can be
+                    discovered via search and shared with your colleagues. For
+                    now, your dataset is saved on your local computer, and you
+                    can see it at any time in the{" "}
+                    <Link to="/dataset/list">drafts page</Link>.
+                </p>
+
+                <p>
+                    In the meantime, we on the Magda team are looking for
+                    feedback on the process you just completed. If you'd like to
+                    let us know how we did, please click the "Send Us Your
+                    Thoughts" button below:
+                </p>
+                <p>Thanks!</p>
+                <p>
+                    Alex, Alyce, Jacky and Mel from the{" "}
+                    <a href="https://magda.io">Magda</a> team at CSIRO's Data61.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 
 import { loadState, State } from "./DatasetAddCommon";
 import { User } from "reducers/userManagementReducer";
+import { config } from "config";
 
 type Props = { initialState: State; user: User } & RouterProps;
 
@@ -20,39 +21,29 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
 
         useEffect(() => {
             // Once redux has finished getting a logged in user, load the state (we need to pass the current user in to populate default state)
-            if (props.user && props.user.id !== "") {
-                loadState(props.match.params.dataset, props.user).then(
-                    state => {
-                        updateData(state);
-                    }
-                );
-            }
+            loadState(props.match.params.dataset, props.user).then(state => {
+                updateData(state);
+            });
         }, [props.user]);
 
-        if (
-            !props.user ||
-            props.user.id === "" ||
-            props.user.isAdmin !== true
-        ) {
-            if (props.isFetchingWhoAmI) {
-                return <div>Loading...</div>;
-            } else {
-                return (
-                    <div
-                        className="au-body au-page-alerts au-page-alerts--error"
-                        style={{ marginTop: "50px" }}
-                    >
-                        <span>
-                            Only admin users are allowed to access this page.
-                        </span>
-                    </div>
-                );
-            }
-        }
-        if (state && props.user.isAdmin === true) {
-            return <Component {...props} initialState={state} />;
-        } else {
+        if (!state || props.isFetchingWhoAmI) {
             return <div>Loading...</div>;
+        } else if (
+            !config.featureFlags.previewAddDataset &&
+            (!props.user || props.user.id === "" || props.user.isAdmin !== true)
+        ) {
+            return (
+                <div
+                    className="au-body au-page-alerts au-page-alerts--error"
+                    style={{ marginTop: "50px" }}
+                >
+                    <span>
+                        Only admin users are allowed to access this page.
+                    </span>
+                </div>
+            );
+        } else {
+            return <Component {...props} initialState={state} />;
         }
     };
 

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -16,7 +16,8 @@ declare global {
 const fallbackApiHost = "https://dev.magda.io/";
 
 const DEV_FEATURE_FLAGS = {
-    cataloguing: true
+    cataloguing: true,
+    previewAddDataset: true
 };
 
 const homePageConfig: {


### PR DESCRIPTION
### What this PR does

Fixes #2511 

This adds a feature flag ("previewAddDataset") that when set to true, adds messages at the beginning and end of "Add Dataset" that reveal that its a preview, stop the user from actually submitting a dataset, and remove the requirement to be an admin to use it, or even to be logged in.

### Bonus
- Fixed a bug where the indexer would always get 0 results from the registry when crawling it.
- Made GETs to the org tree unauthenticated - I think this can be open for now, and we need it to be in order to have logged out add dataset previews.

Test site: https://issue-2511-thanks-for-playing.dev.magda.io/dataset/add

Be careful deploying to it because it requires a slightly different preview.yml:

```yaml
global:
  rollingUpdate:
    maxUnavailable: 1000
  image:
    imagePullSecret: "regcred"
    pullPolicy: Always
  exposeNodePorts: false
  enablePriorityClass: false
  defaultContactEmail: "magda-test@googlegroups.com"
  enableMultiTenants: false

tags:
  all: true
  ingress: true
  priorities: false

ingress:
  ingressClass: nginx
  enableTls: true
  useDefaultCertificate: true
gateway:
  enableAuthEndpoint: true
  enableHttpsRedirection: true
  auth:
    facebookClientId: "173073926555600"
    arcgisClientId: "d0MgVUbbg5Z6vmWo"
    googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
    ckanAuthenticationUrl: https://data.gov.au/data
    vanguardWsFedIdpUrl: https://thirdparty.authentication.business.gov.au/fas/v2/wsfed12/authenticate
    vanguardWsFedRealm: https://environment.magda.io/integration-test-2
  autoscaler:
    enabled: false
  helmet:
    frameguard: false
  cors:
    credentials: true
    origin: true
  csp:
    directives:
      scriptSrc:
      - "''self''"
      - "''unsafe-inline''"
      - browser-update.org
      objectSrc:
      - "''none''"
      reportUri: https://sdga.report-uri.com/r/d/csp/enforce
      
combined-db:
  waleBackup:
    method: WAL
    readOnly: "TRUE"
    recoveryMode: "immediate"
    gsPrefix: "gs://magda-postgres-backups-asia/dev"
    googleApplicationCreds:
      secretName: storage-account-credentials
      fileName: db-service-account-private-key.json
  data:
    storage: 250Gi
  resources:
    limits:
      cpu: 2000m

elasticsearch:
  data:
    heapSize: 500m
    pluginsInstall: "repository-gcs"
  backup:
    googleApplicationCreds:
      secretName: storage-account-credentials
      fileName: db-service-account-private-key.json
indexer:
  resources:
    requests:
      cpu: 100m
      memory: 0
  readSnapshots: false
  makeSnapshots: false
  elasticsearch:
    useGcsSnapshots: true
    gcsSnapshotBucket: "magda-es-snapshots-dev"
    gcsSnapshotClient: "default"

web-server:
  fallbackUrl: "https://data.gov.au"
  featureFlags:
    cataloguing: true
    previewAddDataset: true
  vocabularyApiEndpoints: 
    - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
    - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"
    - "https://vocabs.ands.org.au/repository/api/lda/ands-nc/controlled-vocabulary-for-resource-type-genres/version-1-1/concept.json"

correspondence-api:
  alwaysSendToDefaultRecipient: true
  smtpHostname: "smtp.mailgun.org"
  smtpPort: 2525

connectors:
  config:
    - image:
        name: magda-project-open-data-connector
      id: act
      name: ACT Government data.act.gov.au
      sourceUrl: http://www.data.act.gov.au/data.json
      tenantId: 0
```

### Checklist
-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
