### PR TITLE
Set background color for map preview loading div to #F5F5F5; closes #…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,9 +102,10 @@ UI:
 -   Fixed "NOT SET" appears on the dataset page for non-admins
 -   Made the add dataset flow only say it found keywords in the document if it actually did so.
 -   Made the datepicker for add dataset use the correct colours.
--   Updated schema.org Dataset and DataDownload semantic markup for rich search results 
+-   Updated schema.org Dataset and DataDownload semantic markup for rich search results
 -   Fixed typos in no-print styling and adding keywords tooltip
 -   Added a preview mode for add dataset, that allows all users to use add dataset but prevents them from submitting.
+-   Added a new color (slightly grey) for preview screens
 
 Gateway:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ The following people have contributed to Magda:
     -   [Alyce Lythall](https://github.com/alyce)
     -   [Aneesha Govil](https://github.com/aneesha09)
     -   [Rowan Winsemius](https://github.com/rowanwins)
+    -   [Sajid Ibne Anower](https://github.com/sajidanower23)
 -   [Department of the Prime Minister and Cabinet](https://www.dpmc.gov.au/)
     -   [Toby Bellwood](https://github.com/tobybellwood)
 -   [CSIRO Land and Water](https://www.csiro.au/en/Research/LWF)

--- a/magda-web-client/src/Components/Common/Spinner.scss
+++ b/magda-web-client/src/Components/Common/Spinner.scss
@@ -43,7 +43,7 @@
 .spinner_container {
     display: flex;
     align-items: center;
-    background-color: $AU-color-background;
+    background-color: $AU-color-preview;
 }
 
 .sk-cube-grid {

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -9,7 +9,8 @@ $magda-color-dark: darken($magda-color-primary, 15%);
 $AU-color-foreground-action: $magda-color-light;
 $AU-color-foreground-focus: $magda-color-dark;
 $AU-color-foreground-text: $magda-color-dark;
-$AU-color-background: #f5f5f5;
+$AU-color-background: #ffffff;
+$AU-color-preview: #f5f5f5;
 
 $AU-colordark-foreground-action: #f7f7f7;
 $AU-colordark-foreground-focus: $magda-color-secondary;

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -9,7 +9,7 @@ $magda-color-dark: darken($magda-color-primary, 15%);
 $AU-color-foreground-action: $magda-color-light;
 $AU-color-foreground-focus: $magda-color-dark;
 $AU-color-foreground-text: $magda-color-dark;
-$AU-color-background: #ffffff;
+$AU-color-background: #f5f5f5;
 
 $AU-colordark-foreground-action: #f7f7f7;
 $AU-colordark-foreground-focus: $magda-color-secondary;


### PR DESCRIPTION
### What this PR does

Fixes #1596 

Set a background color for loading screens.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)

![FireShot Capture 002 - Interim Biogeographic Regionalisation for Australia (IBRA), Version 7_ - localhost](https://user-images.githubusercontent.com/20970821/66540985-69cb1d80-eb79-11e9-9fa2-644e8a36840e.png)
