### PR TITLE
Fixed Data.json spatial bounding box ordering not understood

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Indexer:
 -   Fixed indexer throws an error when affiliatedOrganisation field is created
 -   Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect
 -   Added auth when crawling the registry
+-   Fixed Data.json spatial bounding box ordering not understood
 
 Cataloging:
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -178,7 +178,7 @@ package misc {
         case emptyPolygonPattern() => None
         case csvPattern(_) =>
           val latLongs = string.split(",").map(str => CoordinateFormat.convertStringToBigDecimal(str))
-          fromBoundingBox(Seq(BoundingBox(latLongs(0), latLongs(1), latLongs(2), latLongs(3))))
+          fromBoundingBox(Seq(BoundingBox(latLongs(3), latLongs(2), latLongs(1), latLongs(0))))
         case polygonPattern(polygonCoords, _) =>
           val coords = polygonCoords.split(",")
             .map { stringCoords =>


### PR DESCRIPTION
### What this PR does

Fixes #2450 

Fixed Data.json spatial bounding box ordering not understood
- Cause
  - Our case class `BoundingBox` defines in order of North, East, South, West while most standards are West, South, East, North. Adjusted how we interpret `csvPattern`

Tested with `https://data-melbournewater.opendata.arcgis.com/data.json` & DGA data source.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
