### PR TITLE
Fixed mobile views incorrect min. width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,7 @@ UI:
 -   Fixed Add Dataset / License setting: Long file names should be wrapped to the next line
 -   Added a new color (slightly grey) for preview screens
 -   Removed unnecessary margin in the filter facets
+-   Fixed mobile views incorrect min. width
 
 Gateway:
 

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -64,7 +64,7 @@ $magda-yellow: #f1c40f;
 
 $banner-text: $AU-color-foreground-text;
 
-$minimum: 576px;
+$minimum: 300px;
 $small: 768px;
 $medium: 992px;
 $large: 1200px;


### PR DESCRIPTION
### What this PR does

Fixes #2492 

- This issue actually impacts every pages (e.g. home page & search result page)
- Cause: min width had been changed from 300px to 567px on [this commit](https://github.com/magda-io/magda/commit/5bd09dce0ae60428aeb4f453361c2d560a7e5d36)
  - Not sure why we originally changed that. But change it back to 300px fixed the issue.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
