### PR TITLE
Change text to state/territory in appropriate places; closes #2537

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,7 @@ UI:
 -   Fixed Add Dataset / License setting: Long file names should be wrapped to the next line
 -   Added a new color (slightly grey) for preview screens
 -   Removed unnecessary margin in the filter facets
+-   Changed text to reflect state/territory/country accordingly
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/StateSelect.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/StateSelect.tsx
@@ -51,8 +51,8 @@ const StateSelect: FunctionComponent<PropsType> = props => {
     const { countryRegion } = props;
 
     const placeHolderText = countryRegion
-        ? "Please select country..."
-        : "Please select a country option first.";
+        ? "Please select state or a territory..."
+        : "Please select a state/territory option first.";
     const isDisabled = countryRegion ? false : true;
 
     return (

--- a/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/TerritorySelect.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/TerritorySelect.tsx
@@ -50,8 +50,8 @@ const TerritorySelect: FunctionComponent<PropsType> = props => {
     const { countryRegion } = props;
 
     const placeHolderText = countryRegion
-        ? "Please select a state or a territory..."
-        : "Please select a state/territory option first.";
+        ? "Please select an Offshore Remote Territory..."
+        : "Please select an Offshore Remote Territory first.";
     const isDisabled = countryRegion ? false : true;
 
     return (

--- a/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/TerritorySelect.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/TerritorySelect.tsx
@@ -50,8 +50,8 @@ const TerritorySelect: FunctionComponent<PropsType> = props => {
     const { countryRegion } = props;
 
     const placeHolderText = countryRegion
-        ? "Please select country..."
-        : "Please select a country option first.";
+        ? "Please select a state or a territory..."
+        : "Please select a state/territory option first.";
     const isDisabled = countryRegion ? false : true;
 
     return (


### PR DESCRIPTION
### What this PR does

Fixes #2537 

Changed text to reflect state/territory/country accordingly

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
