### PR TITLE
Add hover text to tooltip for dataset date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,7 +114,8 @@ UI:
 -   Fixed mobile views incorrect min. width
 -   Drafts should be ordered by date on Drafts list page
 -   Changed text to reflect state/territory/country accordingly
--   Save publisher id in the database
+-   Saved publisher id in the database
+-   Added hover text for the tooltip beside the date-picker in the Add Dataset page
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
@@ -67,6 +67,10 @@
                 color: #484848;
                 position: relative;
             }
+            .inner {
+                width: 400px;
+                left: 15px;
+            }
         }
 
         .question-recent-modify-date {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -11,6 +11,8 @@ import {
 } from "Components/Editing/Editors/dateEditor";
 
 import ToolTip from "Components/Dataset/Add/ToolTip";
+import PurpleToolTip from "Components/Common/TooltipWrapper";
+
 import SpatialAreaInput, {
     InputMethod as SpatialAreaInputInputMethod
 } from "../../SpatialAreaInput";
@@ -219,11 +221,23 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                     <div className="col-sm-4 question-issue-date">
                         <h4>
                             <span>When was the dataset first issued?</span>
-                            <span className="help-icon-container">
-                                <img
-                                    src={helpIcon}
-                                    title="The date the dataset was first created or issued for release"
-                                />
+                            <span className="tooltip-container">
+                                <PurpleToolTip
+                                    className="tooltip no-print"
+                                    launcher={() => (
+                                        <div className="tooltip-launcher-icon help-icon">
+                                            <img
+                                                src={helpIcon}
+                                                alt="The date the dataset was first created or issued for release"
+                                            />
+                                        </div>
+                                    )}
+                                    innerElementClassName="inner"
+                                >
+                                    {() =>
+                                        "The date the dataset was first created or issued for release"
+                                    }
+                                </PurpleToolTip>
                             </span>
                         </h4>
                         <AlwaysEditor

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -220,7 +220,10 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                         <h4>
                             <span>When was the dataset first issued?</span>
                             <span className="help-icon-container">
-                                <img src={helpIcon} />
+                                <img
+                                    src={helpIcon}
+                                    title="The date the dataset was first created or issued for release"
+                                />
                             </span>
                         </h4>
                         <AlwaysEditor


### PR DESCRIPTION
### What this PR does

Fixes #2465 

Added a hover text for the date tooltip.

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)

![dataset_date_hovertext](https://user-images.githubusercontent.com/20970821/67069124-ca84d680-f1c7-11e9-8b3c-8bf36631a49a.jpg)
