### PR TITLE
Use distribution link on title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,7 @@ UI:
 -   Changed text to reflect state/territory/country accordingly
 -   Saved publisher id in the database
 -   Added hover text for the tooltip beside the date-picker in the Add Dataset page
+-   Add a distribution hyperlink to the title of resource links
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -49,13 +49,6 @@ class DistributionRow extends Component<PropType> {
             this.props.searchText
         }`;
 
-        let newTabLink;
-        if (!distribution.downloadURL && distribution.accessURL) {
-            newTabLink = distribution.accessURL;
-        } else {
-            newTabLink = distributionLink;
-        }
-
         let apiUrl = "";
 
         if (
@@ -108,14 +101,16 @@ class DistributionRow extends Component<PropType> {
                                     </span>
                                     )
                                 </Link>
-                                <a
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    href={newTabLink}
-                                    className="new-tab-button"
-                                >
-                                    <img src={newTabIcon} alt="new tab" />
-                                </a>
+                                {distribution.accessURL && (
+                                    <a
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        href={distribution.accessURL}
+                                        className="new-tab-button"
+                                    >
+                                        <img src={newTabIcon} alt="new tab" />
+                                    </a>
+                                )}
                             </div>
 
                             <div

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -43,7 +43,7 @@ class DistributionRow extends Component<PropType> {
     render() {
         const { dataset, distribution } = this.props;
 
-        let distributionLink = `/dataset/${encodeURIComponent(
+        const distributionLink = `/dataset/${encodeURIComponent(
             dataset.identifier
         )}/distribution/${encodeURIComponent(distribution.identifier!)}/?q=${
             this.props.searchText

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -42,15 +42,18 @@ class DistributionRow extends Component<PropType> {
 
     render() {
         const { dataset, distribution } = this.props;
-        let distributionLink;
+
+        let distributionLink = `/dataset/${encodeURIComponent(
+            dataset.identifier
+        )}/distribution/${encodeURIComponent(distribution.identifier!)}/?q=${
+            this.props.searchText
+        }`;
+
+        let newTabLink;
         if (!distribution.downloadURL && distribution.accessURL) {
-            distributionLink = distribution.accessURL;
+            newTabLink = distribution.accessURL;
         } else {
-            distributionLink = `/dataset/${encodeURIComponent(
-                dataset.identifier
-            )}/distribution/${encodeURIComponent(
-                distribution.identifier!
-            )}/?q=${this.props.searchText}`;
+            newTabLink = distributionLink;
         }
 
         let apiUrl = "";
@@ -90,41 +93,25 @@ class DistributionRow extends Component<PropType> {
 
                         <div className="col-sm-11">
                             <div className="distribution-row-link">
-                                {!distribution.downloadURL &&
-                                distribution.accessURL ? (
-                                    <div>
-                                        <span itemProp="name">
-                                            {this.renderDistributionLink(
-                                                distribution.title
-                                            )}
-                                        </span>
-                                        (
-                                        <span itemProp="fileFormat">
-                                            {distribution.format}
-                                        </span>
-                                        )
-                                    </div>
-                                ) : (
-                                    <Link
-                                        to={distributionLink}
-                                        itemProp="contentUrl"
-                                    >
-                                        <span itemProp="name">
-                                            {this.renderDistributionLink(
-                                                distribution.title
-                                            )}
-                                        </span>
-                                        (
-                                        <span itemProp="fileFormat">
-                                            {distribution.format}
-                                        </span>
-                                        )
-                                    </Link>
-                                )}
+                                <Link
+                                    to={distributionLink}
+                                    itemProp="contentUrl"
+                                >
+                                    <span itemProp="name">
+                                        {this.renderDistributionLink(
+                                            distribution.title
+                                        )}
+                                    </span>
+                                    (
+                                    <span itemProp="fileFormat">
+                                        {distribution.format}
+                                    </span>
+                                    )
+                                </Link>
                                 <a
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    href={distributionLink}
+                                    href={newTabLink}
                                     className="new-tab-button"
                                 >
                                     <img src={newTabIcon} alt="new tab" />


### PR DESCRIPTION
### What this PR does

Fixes #2335

Use distribution link as a hyperlink for the title, use the access URL (defaulting to the distribution URL) for the newtab link.

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
