### PR TITLE
2559 new dataset placeholder text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,7 +119,9 @@ UI:
 -   Fixed CSV loader didn't retry the different line ending correctly
 -   Saved publisher id in the database
 -   Added hover text for the tooltip beside the date-picker in the Add Dataset page
--   Add a distribution hyperlink to the title of resource links
+-   Added a distribution hyperlink to the title of resource links
+-   Made the default name of a dataset blank
+-   Added a tooltip for dataset names
 
 Gateway:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,7 +122,6 @@ UI:
 -   Added a distribution hyperlink to the title of resource links
 -   Made the default name of a dataset blank
 -   Added a tooltip for dataset names
--   Add a distribution hyperlink to the title of resource links
 -   Rename "Spatial area" to "Spatial extent"
 
 Gateway:

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -170,7 +170,7 @@ export function createBlankState(user?: User): State {
         files: [],
         processing: false,
         dataset: {
-            title: "Untitled",
+            title: "",
             languages: ["eng"],
             owningOrgUnitId: user ? user.orgUnitId : undefined,
             defaultLicense: "world"

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddFilesPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddFilesPage.tsx
@@ -123,7 +123,7 @@ class DatasetAddFilesPage extends React.Component<
                                 case "datasetTitle":
                                     if (
                                         !dataset["title"] ||
-                                        dataset["title"] === "Untitled"
+                                        dataset["title"] === ""
                                     ) {
                                         dataset["title"] = file[key];
                                     }
@@ -360,9 +360,9 @@ async function processFile(thisFile: any, update: Function) {
 
     update({ _state: FileState.Processing });
 
-    const runExtractors = await import(
-        "Components/Dataset/MetadataExtraction"
-    ).then(mod => mod.runExtractors);
+    const runExtractors = await import("Components/Dataset/MetadataExtraction").then(
+        mod => mod.runExtractors
+    );
 
     await runExtractors(input, update);
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
@@ -36,6 +36,10 @@
 
         .question-title {
             margin-bottom: 58px;
+            .inner {
+                width: 400px;
+                left: -135px;
+            }
         }
 
         .question-language {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
@@ -38,7 +38,7 @@
             margin-bottom: 58px;
             .inner {
                 width: 400px;
-                left: -135px;
+                left: 15px;
             }
         }
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.scss
@@ -36,10 +36,6 @@
 
         .question-title {
             margin-bottom: 58px;
-            .inner {
-                width: 400px;
-                left: 15px;
-            }
         }
 
         .question-language {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -37,6 +37,8 @@ import "../People/DatasetAutocomplete.scss";
 
 import "./index.scss";
 
+import LightBulbIcon from "assets/light-bulb.svg";
+
 type Props = {
     edit: <K extends keyof State>(
         aspectField: K
@@ -73,7 +75,9 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                                 launcher={() => (
                                     <div className="tooltip-launcher-icon help-icon">
                                         <img
-                                            src={helpIcon}
+                                            src={LightBulbIcon}
+                                            height="20"
+                                            width="25"
                                             alt="We recommend ensuring dataset file names are descriptive so users can easily understand the contents"
                                         />
                                     </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -65,7 +65,27 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                 <h2>Details and Contents</h2>
                 <h3 className="with-underline">Title and language</h3>
                 <div className="question-title">
-                    <h4>What is the title of the dataset?</h4>
+                    <h4>
+                        <span>What is the title of the dataset?</span>
+                        <span className="tooltip-container">
+                            <PurpleToolTip
+                                className="tooltip no-print"
+                                launcher={() => (
+                                    <div className="tooltip-launcher-icon help-icon">
+                                        <img
+                                            src={helpIcon}
+                                            alt="We recommend ensuring dataset file names are descriptive so users can easily understand the contents"
+                                        />
+                                    </div>
+                                )}
+                                innerElementClassName="inner"
+                            >
+                                {() =>
+                                    "We recommend ensuring dataset file names are descriptive so users can easily understand the contents"
+                                }
+                            </PurpleToolTip>
+                        </span>
+                    </h4>
                     <div>
                         <AlwaysEditor
                             value={dataset.title}

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -74,7 +74,11 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                         <AlwaysEditor
                             value={dataset.title}
                             onChange={editDataset("title")}
-                            editor={textEditorEx({ required: true })}
+                            editor={textEditorEx({
+                                placeholder:
+                                    !dataset.title && "Enter dataset title",
+                                required: true
+                            })}
                         />
                     </div>
                 </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -37,8 +37,6 @@ import "../People/DatasetAutocomplete.scss";
 
 import "./index.scss";
 
-import LightBulbIcon from "assets/light-bulb.svg";
-
 type Props = {
     edit: <K extends keyof State>(
         aspectField: K
@@ -67,29 +65,11 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                 <h2>Details and Contents</h2>
                 <h3 className="with-underline">Title and language</h3>
                 <div className="question-title">
-                    <h4>
-                        <span>What is the title of the dataset?</span>
-                        <span className="tooltip-container">
-                            <PurpleToolTip
-                                className="tooltip no-print"
-                                launcher={() => (
-                                    <div className="tooltip-launcher-icon help-icon">
-                                        <img
-                                            src={LightBulbIcon}
-                                            height="20"
-                                            width="25"
-                                            alt="We recommend ensuring dataset file names are descriptive so users can easily understand the contents"
-                                        />
-                                    </div>
-                                )}
-                                innerElementClassName="inner"
-                            >
-                                {() =>
-                                    "We recommend ensuring dataset file names are descriptive so users can easily understand the contents"
-                                }
-                            </PurpleToolTip>
-                        </span>
-                    </h4>
+                    <h4>What is the title of the dataset?</h4>
+                    <ToolTip>
+                        We recommend ensuring dataset file names are descriptive
+                        so users can easily understand the contents.
+                    </ToolTip>
                     <div>
                         <AlwaysEditor
                             value={dataset.title}


### PR DESCRIPTION
### What this PR does

Fixes #2559 

- Makes the placeholder title for a new dataset blank
- Adds a tooltip for the title

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)

![maga_untitled_tooltip](https://user-images.githubusercontent.com/20970821/67739573-055bf980-fa67-11e9-8813-61cb0902d8ab.jpg)
 
