### PR TITLE
2565 add dataset rename

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,7 @@ UI:
 -   Saved publisher id in the database
 -   Added hover text for the tooltip beside the date-picker in the Add Dataset page
 -   Add a distribution hyperlink to the title of resource links
+-   Rename "Spatial area" to "Spatial extent"
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -284,7 +284,7 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                         editor={multiDateIntervalEditor}
                     />
                 </div>
-                <h3>Spatial area</h3>
+                <h3>Spatial extent</h3>
                 <div>
                     <SpatialAreaInput
                         countryId={spatialCoverage.lv1Id}

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -718,7 +718,7 @@ class RecordHandler extends React.Component {
                                                 </ToggleEditor>
                                             </div>
                                             <hr />
-                                            <h3>Spatial area</h3>
+                                            <h3>Spatial extent</h3>
                                             <h4>
                                                 We've determined that the
                                                 spatial extent of your data is:


### PR DESCRIPTION
### What this PR does

Fixes #2565 

Renames `Spatial area` to `Spatial extent`.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
