### PR TITLE
Fixed Indexer fails with "Object is missing required member 'id'"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Indexer:
 -   Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect
 -   Added auth when crawling the registry
 -   Fixed Data.json spatial bounding box ordering not understood
+-   Indexer fails with "Object is missing required member 'id'"
 
 Cataloging:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@ Indexer:
 -   Fixed indexer incorrect parsing bounding box data in spatialCoverage aspect
 -   Added auth when crawling the registry
 -   Fixed Data.json spatial bounding box ordering not understood
--   Indexer fails with "Object is missing required member 'id'"
+-   Handle and log the exception "Object is missing required member 'id'"
 
 Cataloging:
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -161,15 +161,26 @@ trait RegistryConverters extends RegistryProtocols {
       "dataset-distributions",
       JsObject("distributions" -> JsArray())
     )
-    val publisher: Option[Record] = hit.aspects
-      .getOrElse("dataset-publisher", JsObject())
-      .extract[JsObject]('publisher.?)
-      .map((dataSet: JsObject) => {
-        val theDataSet =
-          JsObject(dataSet.fields + ("tenantId" -> JsNumber(hit.tenantId.get)))
-        val record = theDataSet.convertTo[Record]
-        record
-      })
+    val publisher: Option[Record] = Try {
+      hit.aspects
+        .getOrElse("dataset-publisher", JsObject())
+        .extract[JsObject]('publisher.?)
+        .map((dataSet: JsObject) => {
+          val theDataSet =
+            JsObject(dataSet.fields + ("tenantId" -> JsNumber(hit.tenantId.get)))
+          val record = theDataSet.convertTo[Record]
+          record
+        })
+      } match {
+        case Success(publisher) => publisher
+        case Failure(e) =>
+          if (logger.isDefined) {
+            logger.get.error(
+              s"Failed to parse dataset-publisher: ${e.getMessage}"
+            )
+          }
+          None
+      }
 
     val accessControl = hit.aspects.get("dataset-access-control") match {
       case Some(JsObject(accessControlData)) =>


### PR DESCRIPTION
### What this PR does

Fixes #2484 
- Cause: Some dataset has `{}` as dataset-publisher aspect data. The invalid data was probably created by #2505 
- PR https://github.com/magda-io/magda/pull/2550 probably will help no more invalid data come in registry in future but we probably still want to fix it now as we won't turn the json schema validation on in short term.
- If the publisher JSON is an empty object {}. The indexer will set publisher as `None` and print the following log:

```
[ERROR] [10/29/2019 16:35:34.453] [indexer-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(indexer)] Failed to parser dataset-publisher: Object is missing required member 'id'
[INFO] [10/29/2019 16:35:43.282] [indexer-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(indexer)] Successfully indexed 2 datasets
```

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
