### PR TITLE
Update doc to reflect lerna renaming their option; closes #2570

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -154,6 +154,7 @@ Others:
 -   Disabled tenant-api & tenant-db when `enableMultiTenants` = false
 -   Excluded organisations that are owners of thesauruses (keyword taxonomies) from being considered as owners of datasets via CSW connector
 -   Fix data.json connector dcat-dataset-strings aspect so keywords are stored correctly
+-   Fixed doc to reflect [lerna deprecating an option](https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85)
 
 ## 0.0.55
 

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -43,9 +43,14 @@ Then install `npm` dependencies and set up the links between components by runni
 yarn install
 ```
 
-Once the above prerequisites are in place, and the npm dependencies are installed, building MAGDA is easy. From the MAGDA root directory, simply run:
+Once the above prerequisites are in place, and the npm dependencies are installed, building MAGDA is easy.
+From the MAGDA root directory, simply run the appropriate build command:
 
 ```bash
+# If using lerna v3.18.0 or higher
+lerna run build --stream --concurrency=1 --include-dependencies
+
+# If verison of lerna is lower than v3.18.0
 lerna run build --stream --concurrency=1 --include-filtered-dependencies
 ```
 


### PR DESCRIPTION
### What this PR does

Fixes #2570 

Updates the `building-and-running` doc to reflect this deprecation made in lerna v3.18.0 or higher: https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
