### PR TITLE
Invalid DOM tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,7 @@ UI:
 -   Made the default name of a dataset blank
 -   Added a tooltip for dataset names
 -   Rename "Spatial area" to "Spatial extent"
+-   Fixed `validateDOMNesting` warning
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -93,9 +93,7 @@ class NewDataset extends React.Component<Props, State> {
     componentDidMount() {
         if (this.props.isNewDataset) {
             this.props.history.replace(
-                `/dataset/add/metadata/${this.props.datasetId}/${
-                    this.props.step
-                }`
+                `/dataset/add/metadata/${this.props.datasetId}/${this.props.step}`
             );
         }
     }
@@ -133,7 +131,7 @@ class NewDataset extends React.Component<Props, State> {
     edit = <K extends keyof State>(aspectField: K) => (field: string) => (
         newValue: any
     ) => {
-        this.setState(state => {
+        this.setState((state: any) => {
             return {
                 [aspectField]: { ...state[aspectField], [field]: newValue }
             } as Pick<State, K>;

--- a/magda-web-client/src/Components/Dataset/Add/ToolTip.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/ToolTip.tsx
@@ -6,8 +6,8 @@ import "./ToolTip.scss";
 
 export default function ToolTip(props: any) {
     return (
-        <p className="tooltip-root">
-            <table>
+        <table className="tooltip-root">
+            <tbody>
                 <tr>
                     <td
                         style={{
@@ -25,7 +25,7 @@ export default function ToolTip(props: any) {
                         </span>
                     </td>
                 </tr>
-            </table>
-        </p>
+            </tbody>
+        </table>
     );
 }


### PR DESCRIPTION
### What this PR does

Fixes #2575 

Removes the `table` as a descendant of `p`.
Uses `tbody`

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
