### PR TITLE
Manual dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,7 @@ UI:
 -   Made the default name of a dataset blank
 -   Added a tooltip for dataset names
 -   Rename "Spatial area" to "Spatial extent"
+-   Fix issue with user manually typing dates
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -93,9 +93,7 @@ class NewDataset extends React.Component<Props, State> {
     componentDidMount() {
         if (this.props.isNewDataset) {
             this.props.history.replace(
-                `/dataset/add/metadata/${this.props.datasetId}/${
-                    this.props.step
-                }`
+                `/dataset/add/metadata/${this.props.datasetId}/${this.props.step}`
             );
         }
     }
@@ -133,7 +131,7 @@ class NewDataset extends React.Component<Props, State> {
     edit = <K extends keyof State>(aspectField: K) => (field: string) => (
         newValue: any
     ) => {
-        this.setState(state => {
+        this.setState((state: any) => {
             return {
                 [aspectField]: { ...state[aspectField], [field]: newValue }
             } as Pick<State, K>;

--- a/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
@@ -29,7 +29,9 @@ function MagdaSingleDatePicker({
     const [focused, setFocused] = useState(false);
 
     const onDateChange = (moment: Moment.Moment | null) => {
-        callback(moment && moment.toDate());
+        if (moment) {
+            callback(moment && moment.toDate());
+        }
     };
 
     return (


### PR DESCRIPTION
### What this PR does

Fixes #2564 

User should be able to manually type in dates now

### Checklist

-   [x] Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
