### PR TITLE
lock helm version in gitlab to 2.15.2 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -484,7 +484,7 @@ dockerize:dockerExtensions:
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl
+    name: dtzar/helm-kubectl:2.15.2
   retry: 1
   environment:
     name: preview/$CI_COMMIT_REF_NAME
@@ -550,7 +550,7 @@ Stop Preview: &stopPreview
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl
+    name: dtzar/helm-kubectl:2.15.2
   retry: 1
   before_script: []
   environment:
@@ -568,7 +568,7 @@ Deploy Master To Dev:
     - master
   cache: {}
   image:
-    name: dtzar/helm-kubectl
+    name: dtzar/helm-kubectl:2.15.2
   retry: 1
   before_script: []
   environment:
@@ -609,7 +609,7 @@ Publish Helm Chart:
     - triggers
   dependencies: []
   image:
-    name: dtzar/helm-kubectl
+    name: dtzar/helm-kubectl:2.15.2
   cache:
     key: $CI_JOB_NAME
     paths:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ General:
     The registry service can be configured to support either hierarchical organization based access
     policy (default) or Esri groups based access policy.
 -   Add esri portal connector. Read its README.md file before use.
+-   Lock helm version in gitlab to 2.15.2 due to issue: https://github.com/helm/helm/issues/6894
 
 Registry:
 


### PR DESCRIPTION
### What this PR does

lock helm version in Gitlab to 2.15.2  due to this bug:

https://github.com/helm/helm/issues/6894

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
