### PR TITLE
Memory leak: Explicitly set _isMounted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,6 +163,7 @@ Others:
 -   Excluded organisations that are owners of thesauruses (keyword taxonomies) from being considered as owners of datasets via CSW connector
 -   Fix data.json connector dcat-dataset-strings aspect so keywords are stored correctly
 -   Fixed doc to reflect [lerna deprecating an option](https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85)
+-   Fix potential memory leak by explicitly defining `_isMounted` which marks a component as mounted
 
 ## 0.0.55
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,7 +163,7 @@ Others:
 -   Excluded organisations that are owners of thesauruses (keyword taxonomies) from being considered as owners of datasets via CSW connector
 -   Fix data.json connector dcat-dataset-strings aspect so keywords are stored correctly
 -   Fixed doc to reflect [lerna deprecating an option](https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85)
--   Fix potential memory leak by explicitly defining `_isMounted` which marks a component as mounted
+-   Fix potential memory leak by deregistering listener when Header is unmounted
 
 ## 0.0.55
 

--- a/magda-web-client/src/Components/Header/Header.js
+++ b/magda-web-client/src/Components/Header/Header.js
@@ -17,18 +17,15 @@ class Header extends Component {
     }
 
     componentDidMount() {
-        this._isMounted = true;
-        this.context.router.history.listen(() => {
-            if (this._isMounted) {
-                this.setState({
-                    isMobileMenuOpen: false
-                });
-            }
+        this.unListen = this.context.router.history.listen(() => {
+            this.setState({
+                isMobileMenuOpen: false
+            });
         });
     }
 
     componentWillUnmount() {
-        this._isMounted = false;
+        this.unListen();
     }
 
     toggleMenu() {

--- a/magda-web-client/src/Components/Header/Header.js
+++ b/magda-web-client/src/Components/Header/Header.js
@@ -19,9 +19,11 @@ class Header extends Component {
     componentDidMount() {
         this._isMounted = true;
         this.context.router.history.listen(() => {
-            this.setState({
-                isMobileMenuOpen: false
-            });
+            if (this._isMounted) {
+                this.setState({
+                    isMobileMenuOpen: false
+                });
+            }
         });
     }
 
@@ -30,9 +32,11 @@ class Header extends Component {
     }
 
     toggleMenu() {
-        this.setState({
-            isMobileMenuOpen: !this.state.isMobileMenuOpen
-        });
+        if (this._isMounted) {
+            this.setState({
+                isMobileMenuOpen: !this.state.isMobileMenuOpen
+            });
+        }
     }
 
     render() {

--- a/magda-web-client/src/Components/Header/Header.js
+++ b/magda-web-client/src/Components/Header/Header.js
@@ -29,11 +29,9 @@ class Header extends Component {
     }
 
     toggleMenu() {
-        if (this._isMounted) {
-            this.setState({
-                isMobileMenuOpen: !this.state.isMobileMenuOpen
-            });
-        }
+        this.setState({
+            isMobileMenuOpen: !this.state.isMobileMenuOpen
+        });
     }
 
     render() {

--- a/magda-web-client/src/Components/Header/Header.js
+++ b/magda-web-client/src/Components/Header/Header.js
@@ -17,11 +17,16 @@ class Header extends Component {
     }
 
     componentDidMount() {
+        this._isMounted = true;
         this.context.router.history.listen(() => {
             this.setState({
                 isMobileMenuOpen: false
             });
         });
+    }
+
+    componentWillUnmount() {
+        this._isMounted = false;
     }
 
     toggleMenu() {


### PR DESCRIPTION
### What this PR does

Fixes #2583 

Explicitly set `_isMounted` so that a mounted component is marked as such.
Thanks to the comment [here](https://github.com/material-components/material-components-web-react/issues/434#issuecomment-449561024) for the suggestion.

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
