### PR TITLE
Wording and Rearranging per agriculture feedback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,10 @@ UI:
 -   Fixed warning for placeholder text being a boolean value
 -   Added unique key to the topmost `div` of `codelistEditor`
 -   Rename `license` to `licence` where appropriate
+-   Rearranged dropdowns and radio buttons in `People and Production` page
+-   Reworded `team` to `business area`
+-   Added tooltips to the `Production` section of the `People and Production` page
+-   Reworded the user access options
 
 Gateway:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,7 +131,6 @@ UI:
 -   Fixed warning for placeholder text being a boolean value
 -   Added unique key to the topmost `div` of `codelistEditor`
 -   Rename `license` to `licence` where appropriate
--   Rearranged dropdowns and radio buttons in `People and Production` page
 -   Reworded `team` to `business area`
 -   Added tooltips to the `Production` section of the `People and Production` page
 -   Reworded the user access options

--- a/magda-authorization-api/src/NestedSetModelQueryer.ts
+++ b/magda-authorization-api/src/NestedSetModelQueryer.ts
@@ -262,7 +262,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
 
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Children", fields)}
+            `SELECT ${this.selectFields("Children", fields)} 
              FROM "${tbl}" AS Parents,  "${tbl}" AS Children
              WHERE Children."left" ${
                  includeMyself ? ">=" : ">"
@@ -295,7 +295,7 @@ class NestedSetModelQueryer {
     ): Promise<NodeRecord[]> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Parents", fields)}
+            `SELECT ${this.selectFields("Parents", fields)} 
              FROM "${tbl}" AS Parents,  "${tbl}" AS Children
              WHERE Children."left" ${
                  includeMyself ? ">=" : ">"
@@ -325,13 +325,13 @@ class NestedSetModelQueryer {
     ): Promise<NodeRecord[]> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Children", fields)}
+            `SELECT ${this.selectFields("Children", fields)} 
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
-            WHERE Children."left" BETWEEN Parents."left" AND Parents."right"
+            WHERE Children."left" BETWEEN Parents."left" AND Parents."right" 
             AND Parents."left" = (
                 SELECT MAX(S."left") FROM "${tbl}" AS S
                 WHERE S."left" < Children."left" AND S."right" > Children."right"
-            )
+            ) 
             AND Parents."id" = $1
             ORDER BY Children."left" ASC`,
             [parentNodeId]
@@ -357,13 +357,13 @@ class NestedSetModelQueryer {
     ): Promise<Maybe<NodeRecord>> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Parents", fields)}
+            `SELECT ${this.selectFields("Parents", fields)} 
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
-            WHERE Children.left BETWEEN Parents.left AND Parents.right
+            WHERE Children.left BETWEEN Parents.left AND Parents.right 
             AND Parents.left = (
                 SELECT MAX(S.left) FROM "${tbl}" AS S
                 WHERE S.left < Children.left AND S.right > Children.right
-            )
+            ) 
             AND Children.id = $1`,
             [childNodeId]
         );
@@ -387,8 +387,8 @@ class NestedSetModelQueryer {
         const result = await this.pool.query(
             `SELECT ${this.selectFields("t2")}
             FROM "${tbl}" AS t1, "${tbl}" AS t2
-            WHERE t2.left BETWEEN t1.left AND t1.right
-            GROUP BY t2.id
+            WHERE t2.left BETWEEN t1.left AND t1.right 
+            GROUP BY t2.id 
             HAVING COUNT(t1.id) = $1`,
             [level]
         );
@@ -408,7 +408,7 @@ class NestedSetModelQueryer {
     async getLevelOfNode(nodeId: string): Promise<number> {
         const tbl = this.tableName;
         const result = await this.pool.query(
-            `SELECT COUNT(Parents.id) AS level
+            `SELECT COUNT(Parents.id) AS level 
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
             WHERE Children.left BETWEEN Parents.left AND Parents.right AND Children.id = $1`,
             [nodeId]
@@ -434,12 +434,12 @@ class NestedSetModelQueryer {
     async getTreeHeight(): Promise<number> {
         const tbl = this.tableName;
         const result = await this.pool.query(
-            `SELECT MAX(level) AS height
+            `SELECT MAX(level) AS height 
              FROM(
                 SELECT COUNT(t1.id)
                 FROM "${tbl}" AS t1, "${tbl}" AS t2
-                WHERE t2.left BETWEEN t1.left AND t1.right
-                GROUP BY t2.id
+                WHERE t2.left BETWEEN t1.left AND t1.right 
+                GROUP BY t2.id 
              ) AS L(level)`
         );
         if (!result || !result.rows || !result.rows.length)
@@ -463,7 +463,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("Children")}
-            FROM "${tbl}" AS Parents, "${tbl}" AS Children
+            FROM "${tbl}" AS Parents, "${tbl}" AS Children 
             WHERE Children.left = Parents.left + 1 AND Parents.id = $1`,
             [parentNodeId]
         );
@@ -485,7 +485,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("Children")}
-            FROM "${tbl}" AS Parents, "${tbl}" AS Children
+            FROM "${tbl}" AS Parents, "${tbl}" AS Children 
             WHERE Children.right = Parents.right - 1 AND Parents.id = $1`,
             [parentNodeId]
         );
@@ -512,9 +512,9 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("t2")}
-            FROM "${tbl}" AS t1, "${tbl}" AS t2, "${tbl}" AS t3
+            FROM "${tbl}" AS t1, "${tbl}" AS t2, "${tbl}" AS t3 
             WHERE t1.id = $1 AND t3.id = $2
-            AND t2.left BETWEEN t1.left AND t1.right
+            AND t2.left BETWEEN t1.left AND t1.right 
             AND t3.left BETWEEN t2.left AND t2.right
             ORDER BY (t2.right-t2.left) DESC`,
             [higherNodeId, lowerNodeId]
@@ -548,11 +548,11 @@ class NestedSetModelQueryer {
                 CASE
                     WHEN CAST($1 AS varchar) = CAST($2 AS varchar)
                     THEN 0
-                    WHEN t1.left BETWEEN t2.left AND t2.right
+                    WHEN t1.left BETWEEN t2.left AND t2.right 
                     THEN -1
-                    WHEN t2.left BETWEEN t1.left AND t1.right
+                    WHEN t2.left BETWEEN t1.left AND t1.right 
                     THEN 1
-                    ELSE null
+                    ELSE null 
                 END
             ) AS "result"
             FROM "${tbl}" AS t1, "${tbl}" AS t2
@@ -669,7 +669,9 @@ class NestedSetModelQueryer {
             );
             if (result && isNonEmptyArray(result.rows)) {
                 throw new Error(
-                    `A root node with id: ${result.rows[0]["id"]} already exists`
+                    `A root node with id: ${
+                        result.rows[0]["id"]
+                    } already exists`
                 );
             }
             const countResult = await client.query(
@@ -762,8 +764,8 @@ class NestedSetModelQueryer {
             );
 
             await client.query(
-                `UPDATE "${tbl}"
-                SET
+                `UPDATE "${tbl}" 
+                SET 
                     "left" = CASE WHEN "left" > $1 THEN "left" + 2 ELSE "left" END,
                     "right" = CASE WHEN "right" >= $1 THEN "right" + 2 ELSE "right" END
                 WHERE "right" >= $1`,
@@ -841,8 +843,8 @@ class NestedSetModelQueryer {
             }
 
             await client.query(
-                `UPDATE "${tbl}"
-                SET
+                `UPDATE "${tbl}" 
+                SET 
                     "left" = CASE WHEN "left" < $1 THEN "left" ELSE "left" + 2 END,
                     "right" = CASE WHEN "right" < $1 THEN "right" ELSE "right" + 2 END
                 WHERE "right" > $1`,
@@ -936,11 +938,11 @@ class NestedSetModelQueryer {
 
             await client.query(
                 `
-            UPDATE "${tbl}"
-            SET
+            UPDATE "${tbl}" 
+            SET 
             "left" = "left" + CASE
                 WHEN $3::int4 < $1::int4
-                THEN CASE
+                THEN CASE 
                     WHEN "left" BETWEEN $1 AND $2
                     THEN $3 - $1
                     WHEN "left" BETWEEN $3 AND ($1 - 1)
@@ -956,7 +958,7 @@ class NestedSetModelQueryer {
                 ELSE 0 END,
             "right" = "right" + CASE
                 WHEN $3::int4 < $1::int4
-                THEN CASE
+                THEN CASE 
                     WHEN "right" BETWEEN $1 AND $2
                     THEN $3 - $1
                     WHEN "right" BETWEEN $3 AND ($1 - 1)
@@ -1028,10 +1030,10 @@ class NestedSetModelQueryer {
                 SET "left" = CASE
                         WHEN "left" > $1
                             THEN "left" - ($2 - $1 + 1)
-                        ELSE "left" END,
+                        ELSE "left" END, 
                     "right" = CASE
                         WHEN "right" > $1
-                            THEN "right" - ($2 - $1 + 1)
+                            THEN "right" - ($2 - $1 + 1) 
                         ELSE "right" END
                 WHERE "left" > $1 OR "right" > $1
                 `,
@@ -1091,7 +1093,7 @@ class NestedSetModelQueryer {
                             THEN "left" - 1
                         WHEN "left" > $1 AND "right" > $2
                             THEN "left" - 2
-                        ELSE "left" END,
+                        ELSE "left" END, 
                     "right" = CASE
                         WHEN "left" > $1 AND "right" < $2
                             THEN "right" - 1

--- a/magda-authorization-api/src/NestedSetModelQueryer.ts
+++ b/magda-authorization-api/src/NestedSetModelQueryer.ts
@@ -262,7 +262,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
 
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Children", fields)} 
+            `SELECT ${this.selectFields("Children", fields)}
              FROM "${tbl}" AS Parents,  "${tbl}" AS Children
              WHERE Children."left" ${
                  includeMyself ? ">=" : ">"
@@ -295,7 +295,7 @@ class NestedSetModelQueryer {
     ): Promise<NodeRecord[]> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Parents", fields)} 
+            `SELECT ${this.selectFields("Parents", fields)}
              FROM "${tbl}" AS Parents,  "${tbl}" AS Children
              WHERE Children."left" ${
                  includeMyself ? ">=" : ">"
@@ -325,13 +325,13 @@ class NestedSetModelQueryer {
     ): Promise<NodeRecord[]> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Children", fields)} 
+            `SELECT ${this.selectFields("Children", fields)}
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
-            WHERE Children."left" BETWEEN Parents."left" AND Parents."right" 
+            WHERE Children."left" BETWEEN Parents."left" AND Parents."right"
             AND Parents."left" = (
                 SELECT MAX(S."left") FROM "${tbl}" AS S
                 WHERE S."left" < Children."left" AND S."right" > Children."right"
-            ) 
+            )
             AND Parents."id" = $1
             ORDER BY Children."left" ASC`,
             [parentNodeId]
@@ -357,13 +357,13 @@ class NestedSetModelQueryer {
     ): Promise<Maybe<NodeRecord>> {
         const tbl = this.tableName;
         const result = await (client ? client : this.pool).query(
-            `SELECT ${this.selectFields("Parents", fields)} 
+            `SELECT ${this.selectFields("Parents", fields)}
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
-            WHERE Children.left BETWEEN Parents.left AND Parents.right 
+            WHERE Children.left BETWEEN Parents.left AND Parents.right
             AND Parents.left = (
                 SELECT MAX(S.left) FROM "${tbl}" AS S
                 WHERE S.left < Children.left AND S.right > Children.right
-            ) 
+            )
             AND Children.id = $1`,
             [childNodeId]
         );
@@ -387,8 +387,8 @@ class NestedSetModelQueryer {
         const result = await this.pool.query(
             `SELECT ${this.selectFields("t2")}
             FROM "${tbl}" AS t1, "${tbl}" AS t2
-            WHERE t2.left BETWEEN t1.left AND t1.right 
-            GROUP BY t2.id 
+            WHERE t2.left BETWEEN t1.left AND t1.right
+            GROUP BY t2.id
             HAVING COUNT(t1.id) = $1`,
             [level]
         );
@@ -408,7 +408,7 @@ class NestedSetModelQueryer {
     async getLevelOfNode(nodeId: string): Promise<number> {
         const tbl = this.tableName;
         const result = await this.pool.query(
-            `SELECT COUNT(Parents.id) AS level 
+            `SELECT COUNT(Parents.id) AS level
             FROM "${tbl}" AS Parents, "${tbl}" AS Children
             WHERE Children.left BETWEEN Parents.left AND Parents.right AND Children.id = $1`,
             [nodeId]
@@ -434,12 +434,12 @@ class NestedSetModelQueryer {
     async getTreeHeight(): Promise<number> {
         const tbl = this.tableName;
         const result = await this.pool.query(
-            `SELECT MAX(level) AS height 
+            `SELECT MAX(level) AS height
              FROM(
                 SELECT COUNT(t1.id)
                 FROM "${tbl}" AS t1, "${tbl}" AS t2
-                WHERE t2.left BETWEEN t1.left AND t1.right 
-                GROUP BY t2.id 
+                WHERE t2.left BETWEEN t1.left AND t1.right
+                GROUP BY t2.id
              ) AS L(level)`
         );
         if (!result || !result.rows || !result.rows.length)
@@ -463,7 +463,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("Children")}
-            FROM "${tbl}" AS Parents, "${tbl}" AS Children 
+            FROM "${tbl}" AS Parents, "${tbl}" AS Children
             WHERE Children.left = Parents.left + 1 AND Parents.id = $1`,
             [parentNodeId]
         );
@@ -485,7 +485,7 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("Children")}
-            FROM "${tbl}" AS Parents, "${tbl}" AS Children 
+            FROM "${tbl}" AS Parents, "${tbl}" AS Children
             WHERE Children.right = Parents.right - 1 AND Parents.id = $1`,
             [parentNodeId]
         );
@@ -512,9 +512,9 @@ class NestedSetModelQueryer {
         const tbl = this.tableName;
         const result = await this.pool.query(
             `SELECT ${this.selectFields("t2")}
-            FROM "${tbl}" AS t1, "${tbl}" AS t2, "${tbl}" AS t3 
+            FROM "${tbl}" AS t1, "${tbl}" AS t2, "${tbl}" AS t3
             WHERE t1.id = $1 AND t3.id = $2
-            AND t2.left BETWEEN t1.left AND t1.right 
+            AND t2.left BETWEEN t1.left AND t1.right
             AND t3.left BETWEEN t2.left AND t2.right
             ORDER BY (t2.right-t2.left) DESC`,
             [higherNodeId, lowerNodeId]
@@ -548,11 +548,11 @@ class NestedSetModelQueryer {
                 CASE
                     WHEN CAST($1 AS varchar) = CAST($2 AS varchar)
                     THEN 0
-                    WHEN t1.left BETWEEN t2.left AND t2.right 
+                    WHEN t1.left BETWEEN t2.left AND t2.right
                     THEN -1
-                    WHEN t2.left BETWEEN t1.left AND t1.right 
+                    WHEN t2.left BETWEEN t1.left AND t1.right
                     THEN 1
-                    ELSE null 
+                    ELSE null
                 END
             ) AS "result"
             FROM "${tbl}" AS t1, "${tbl}" AS t2
@@ -669,9 +669,7 @@ class NestedSetModelQueryer {
             );
             if (result && isNonEmptyArray(result.rows)) {
                 throw new Error(
-                    `A root node with id: ${
-                        result.rows[0]["id"]
-                    } already exists`
+                    `A root node with id: ${result.rows[0]["id"]} already exists`
                 );
             }
             const countResult = await client.query(
@@ -764,8 +762,8 @@ class NestedSetModelQueryer {
             );
 
             await client.query(
-                `UPDATE "${tbl}" 
-                SET 
+                `UPDATE "${tbl}"
+                SET
                     "left" = CASE WHEN "left" > $1 THEN "left" + 2 ELSE "left" END,
                     "right" = CASE WHEN "right" >= $1 THEN "right" + 2 ELSE "right" END
                 WHERE "right" >= $1`,
@@ -843,8 +841,8 @@ class NestedSetModelQueryer {
             }
 
             await client.query(
-                `UPDATE "${tbl}" 
-                SET 
+                `UPDATE "${tbl}"
+                SET
                     "left" = CASE WHEN "left" < $1 THEN "left" ELSE "left" + 2 END,
                     "right" = CASE WHEN "right" < $1 THEN "right" ELSE "right" + 2 END
                 WHERE "right" > $1`,
@@ -938,11 +936,11 @@ class NestedSetModelQueryer {
 
             await client.query(
                 `
-            UPDATE "${tbl}" 
-            SET 
+            UPDATE "${tbl}"
+            SET
             "left" = "left" + CASE
                 WHEN $3::int4 < $1::int4
-                THEN CASE 
+                THEN CASE
                     WHEN "left" BETWEEN $1 AND $2
                     THEN $3 - $1
                     WHEN "left" BETWEEN $3 AND ($1 - 1)
@@ -958,7 +956,7 @@ class NestedSetModelQueryer {
                 ELSE 0 END,
             "right" = "right" + CASE
                 WHEN $3::int4 < $1::int4
-                THEN CASE 
+                THEN CASE
                     WHEN "right" BETWEEN $1 AND $2
                     THEN $3 - $1
                     WHEN "right" BETWEEN $3 AND ($1 - 1)
@@ -1030,10 +1028,10 @@ class NestedSetModelQueryer {
                 SET "left" = CASE
                         WHEN "left" > $1
                             THEN "left" - ($2 - $1 + 1)
-                        ELSE "left" END, 
+                        ELSE "left" END,
                     "right" = CASE
                         WHEN "right" > $1
-                            THEN "right" - ($2 - $1 + 1) 
+                            THEN "right" - ($2 - $1 + 1)
                         ELSE "right" END
                 WHERE "left" > $1 OR "right" > $1
                 `,
@@ -1093,7 +1091,7 @@ class NestedSetModelQueryer {
                             THEN "left" - 1
                         WHEN "left" > $1 AND "right" > $2
                             THEN "left" - 2
-                        ELSE "left" END, 
+                        ELSE "left" END,
                     "right" = CASE
                         WHEN "left" > $1 AND "right" < $2
                             THEN "right" - 1

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
@@ -68,7 +68,10 @@ export default function DatasetAddPeoplePage({
                         onChange={editDataset("custodianOrgUnitId")}
                     />
                 </div>
-                <h4>Which team is responsible for maintaining this dataset?</h4>
+                <h4>
+                    Which business area is responsible for maintaining this
+                    dataset?
+                </h4>
                 <div>
                     <OrgUnitDropdown
                         orgUnitId={dataset.owningOrgUnitId}

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
@@ -57,13 +57,6 @@ export default function DatasetAddPeoplePage({
                         onOrgSelected={editDataset("publisher")}
                     />
                 </div>
-                <h4>Which team is responsible for maintaining this dataset?</h4>
-                <div>
-                    <OrgUnitDropdown
-                        orgUnitId={dataset.owningOrgUnitId}
-                        onChange={editDataset("owningOrgUnitId")}
-                    />
-                </div>
                 <h4>
                     Which area of the organisation should be referenced as the
                     data custodian?
@@ -73,6 +66,13 @@ export default function DatasetAddPeoplePage({
                         orgUnitId={dataset.custodianOrgUnitId}
                         teamOrgUnitId={dataset.owningOrgUnitId}
                         onChange={editDataset("custodianOrgUnitId")}
+                    />
+                </div>
+                <h4>Which team is responsible for maintaining this dataset?</h4>
+                <div>
+                    <OrgUnitDropdown
+                        orgUnitId={dataset.owningOrgUnitId}
+                        onChange={editDataset("owningOrgUnitId")}
                     />
                 </div>
                 <h4>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
@@ -60,6 +60,16 @@ export default function DatasetAddPeoplePage({
                     />
                 </div>
                 <h4>
+                    Which business area is responsible for maintaining this
+                    dataset?
+                </h4>
+                <div>
+                    <OrgUnitDropdown
+                        orgUnitId={dataset.owningOrgUnitId}
+                        onChange={editDataset("owningOrgUnitId")}
+                    />
+                </div>
+                <h4>
                     Which area of the organisation should be referenced as the
                     data custodian?
                 </h4>
@@ -68,16 +78,6 @@ export default function DatasetAddPeoplePage({
                         orgUnitId={dataset.custodianOrgUnitId}
                         teamOrgUnitId={dataset.owningOrgUnitId}
                         onChange={editDataset("custodianOrgUnitId")}
-                    />
-                </div>
-                <h4>
-                    Which business area is responsible for maintaining this
-                    dataset?
-                </h4>
-                <div>
-                    <OrgUnitDropdown
-                        orgUnitId={dataset.owningOrgUnitId}
-                        onChange={editDataset("owningOrgUnitId")}
                     />
                 </div>
                 <h4>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
@@ -16,6 +16,8 @@ import OrgUnitDropdown from "./OrgUnitDropdown";
 import CustodianDropdown from "./CustodianDropdown";
 import YesNoReveal from "../../YesNoReveal";
 
+import ToolTip from "Components/Dataset/Add/ToolTip";
+
 import "./DatasetAddPeoplePage.scss";
 import { User } from "reducers/userManagementReducer";
 
@@ -95,6 +97,11 @@ export default function DatasetAddPeoplePage({
                 <hr />
                 <h3>Production</h3>
                 <h4>How was this dataset produced?</h4>
+                <ToolTip>
+                    Briefly describe the methodology of producing this dataset
+                    or any other information that might assist consumers of the
+                    dataset.
+                </ToolTip>
                 <div>
                     <AlwaysEditor
                         value={provenance.mechanism}
@@ -103,6 +110,9 @@ export default function DatasetAddPeoplePage({
                     />
                 </div>
                 <h4>What system (if any) was used to produce the data?</h4>
+                <ToolTip>
+                    For example, internal systems, external sources, etc.
+                </ToolTip>
                 <div>
                     <AlwaysEditor
                         value={provenance.sourceSystem}
@@ -132,6 +142,12 @@ export default function DatasetAddPeoplePage({
                     </YesNoReveal>
                 </div>
                 <h4>What datasets (if any) was this data derived from?</h4>
+                <ToolTip>
+                    Derived data is obtained when you apply a process or
+                    transformation to one or more source datasets. Understanding
+                    how data is derived is useful in understanding the
+                    provenance of a dataset.
+                </ToolTip>
                 <div>
                     <DatasetAutoComplete
                         user={user}

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/OrgUnitDropdown.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/OrgUnitDropdown.tsx
@@ -63,7 +63,7 @@ export default function OrgUnitDropdown({
                     label: option.name,
                     value: option.id
                 }))}
-                placeholder="Select a team"
+                placeholder="Select a business area"
             />
         );
     }

--- a/magda-web-client/src/constants/DatasetConstants.ts
+++ b/magda-web-client/src/constants/DatasetConstants.ts
@@ -549,8 +549,8 @@ export type ContactPointDisplayOption = "team" | "custodian" | "organization";
 
 export const contactPointDisplay: Record<ContactPointDisplayOption, string> = {
     organization: "Display organisation name",
-    custodian: "Display data custodian area name",
-    team: "Display maintaining team name"
+    team: "Display maintaining team name",
+    custodian: "Display data custodian area name"
 };
 
 export const publishingLevel = {

--- a/magda-web-client/src/constants/DatasetConstants.ts
+++ b/magda-web-client/src/constants/DatasetConstants.ts
@@ -554,9 +554,9 @@ export const contactPointDisplay: Record<ContactPointDisplayOption, string> = {
 };
 
 export const publishingLevel = {
-    agency: "Everyone in my organisation (recommended)",
+    agency: "Everyone in the department (recommended)",
+    division: "My division only",
     branch: "My branch only",
-    section: "My section only",
     team: "My team only"
 };
 

--- a/magda-web-client/src/constants/DatasetConstants.ts
+++ b/magda-web-client/src/constants/DatasetConstants.ts
@@ -549,7 +549,7 @@ export type ContactPointDisplayOption = "team" | "custodian" | "organization";
 
 export const contactPointDisplay: Record<ContactPointDisplayOption, string> = {
     organization: "Display organisation name",
-    team: "Display maintaining team name",
+    team: "Display maintaining business area name",
     custodian: "Display data custodian area name"
 };
 
@@ -557,7 +557,7 @@ export const publishingLevel = {
     agency: "Everyone in the department (recommended)",
     division: "My division only",
     branch: "My branch only",
-    team: "My team only"
+    team: "My business area only"
 };
 
 // TODO: this is a preconfigured agency level configured license lookup feature being faked here
@@ -567,7 +567,7 @@ export const licenseLevel = {
         "For all of government use (Whole of Australian Government license)",
     agency: "For just my department use (Other organisation-specific license)",
     section: "For just my section use (Other organisation-specific license)",
-    team: "For just my team use (Other organisation-specific license)",
+    team: "For just my business area use (Other organisation-specific license)",
     custom: "Other custom license"
 };
 

--- a/magda-web-client/src/constants/DatasetConstants.ts
+++ b/magda-web-client/src/constants/DatasetConstants.ts
@@ -548,9 +548,9 @@ export const classification = {
 export type ContactPointDisplayOption = "team" | "custodian" | "organization";
 
 export const contactPointDisplay: Record<ContactPointDisplayOption, string> = {
-    team: "Display maintaining team name",
+    organization: "Display organisation name",
     custodian: "Display data custodian area name",
-    organization: "Display organisation name"
+    team: "Display maintaining team name"
 };
 
 export const publishingLevel = {


### PR DESCRIPTION
### What this PR does

Fixes #2596 
Helps #2595 

- Rearranges the dropdowns and radio buttons in 'People and Production' page of the `/dataset/add` flow
![dropdown_1](https://user-images.githubusercontent.com/20970821/68737326-37f51d00-0637-11ea-87a8-0ef33088f0f4.png)
- Rewords `team` to `business area` (for screenshot look above)
- Rewords the user access options
![user_access_2](https://user-images.githubusercontent.com/20970821/68737391-6b37ac00-0637-11ea-8c78-a0826215316e.png)

- Adds tooltips to the 'Production' section of the 'People and Production' page 
![tooltip_3](https://user-images.githubusercontent.com/20970821/68737367-54915500-0637-11ea-84c7-3befe5438b3f.png)

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
