### PR TITLE
Replaced unversioned meta-schema URIs with draft version 7 (Targets PR for issue#2001)

### DIFF
--- a/magda-registry-aspects/access.schema.json
+++ b/magda-registry-aspects/access.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Dataset Access Instructions",
     "description": "Provides information that users need to access the dataset.",
     "type": "object",

--- a/magda-registry-aspects/ckan-dataset.schema.json
+++ b/magda-registry-aspects/ckan-dataset.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a dataset according to CKAN",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a dataset according to CKAN",
     "type": "object"
 }

--- a/magda-registry-aspects/ckan-resource.schema.json
+++ b/magda-registry-aspects/ckan-resource.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a resource according to CKAN",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a resource according to CKAN",
     "type": "object"
 }

--- a/magda-registry-aspects/csv-dataset.schema.json
+++ b/magda-registry-aspects/csv-dataset.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a underlyig spreadsheet row extracted from input spreadsheet.",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a underlyig spreadsheet row extracted from input spreadsheet.",
     "type": "object",
     "properties": {
         "json": {

--- a/magda-registry-aspects/csw-dataset.schema.json
+++ b/magda-registry-aspects/csw-dataset.schema.json
@@ -1,12 +1,10 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a dataset according to a CSW server",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a dataset according to a CSW server",
     "type": "object",
     "properties": {
         "xml": {
-            "title":
-                "The XML description of this dataset, according to the CSW server",
+            "title": "The XML description of this dataset, according to the CSW server",
             "type": "string"
         }
     }

--- a/magda-registry-aspects/csw-distribution.schema.json
+++ b/magda-registry-aspects/csw-distribution.schema.json
@@ -1,12 +1,10 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a distribution according to a CSW server",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a distribution according to a CSW server",
     "type": "object",
     "properties": {
         "xml": {
-            "title":
-                "The XML description of this distribution, according to the CSW server",
+            "title": "The XML description of this distribution, according to the CSW server",
             "type": "string"
         }
     }

--- a/magda-registry-aspects/dap-dataset.schema.json
+++ b/magda-registry-aspects/dap-dataset.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a dataset according to DAP",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a dataset according to DAP",
     "type": "object"
 }

--- a/magda-registry-aspects/dap-resource.schema.json
+++ b/magda-registry-aspects/dap-resource.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a resource according to DAP",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a resource according to DAP",
     "type": "object"
 }

--- a/magda-registry-aspects/dataset-format.schema.json
+++ b/magda-registry-aspects/dataset-format.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect containing the format of a distribution, and the probability that it's correct",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect containing the format of a distribution, and the probability that it's correct",
     "type": "object",
     "properties": {
         "format": {
@@ -9,8 +8,7 @@
             "type": "string"
         },
         "confidenceLevel": {
-            "title":
-                "The level of confidence (percentage probability) that this is the correct format",
+            "title": "The level of confidence (percentage probability) that this is the correct format",
             "type": "number"
         }
     }

--- a/magda-registry-aspects/dataset-linked-data-rating.schema.json
+++ b/magda-registry-aspects/dataset-linked-data-rating.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect describing the linked data quality of the dataset out of 5 stars as per https://www.w3.org/DesignIssues/LinkedData.html",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect describing the linked data quality of the dataset out of 5 stars as per https://www.w3.org/DesignIssues/LinkedData.html",
     "type": "object",
     "properties": {
         "stars": {

--- a/magda-registry-aspects/dataset-quality-rating.schema.json
+++ b/magda-registry-aspects/dataset-quality-rating.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect describing the quality rating of a dataset as determined by a number of different minions out of 100, along with the weight that they carry.",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect describing the quality rating of a dataset as determined by a number of different minions out of 100, along with the weight that they carry.",
     "type": "object",
     "properties": {
         "additionalProperties": {

--- a/magda-registry-aspects/dcat-dataset-strings.schema.json
+++ b/magda-registry-aspects/dcat-dataset-strings.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "DCAT Dataset properties as strings",
     "description": "The [DCAT Dataset](https://www.w3.org/TR/vocab-dcat/#class-dataset) properties represented as strings.  This aspect is intended to be quite permissive of arbitrary property values, even those that may be difficult or impossible to interpret.",
     "type": "object",

--- a/magda-registry-aspects/dcat-distribution-strings.schema.json
+++ b/magda-registry-aspects/dcat-distribution-strings.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "DCAT Distribution properties as strings",
     "description": "The [DCAT Distribution](https://www.w3.org/TR/vocab-dcat/#class-distribution) properties represented as strings.  This aspect is intended to be quite permissive of arbitrary property values, even those that may be difficult or impossible to interpret.",
     "type": "object",

--- a/magda-registry-aspects/esri-dataset.schema.json
+++ b/magda-registry-aspects/esri-dataset.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Aspect capturing a complete representation of a dataset according to Esri",
     "type": "object"
 }

--- a/magda-registry-aspects/esri-resource.schema.json
+++ b/magda-registry-aspects/esri-resource.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Aspect capturing a complete representation of a resource according to Esri",
     "type": "object"
 }

--- a/magda-registry-aspects/information-security.schema.json
+++ b/magda-registry-aspects/information-security.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Metadata about information security",
     "type": "object",
     "properties": {

--- a/magda-registry-aspects/organization-details.schema.json
+++ b/magda-registry-aspects/organization-details.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Aspect for capturing basic details of an organization",
     "type": "object",
     "properties": {
@@ -20,8 +20,7 @@
             "type": "string"
         },
         "imageUrl": {
-            "title":
-                "The URL of an image representing the organization, such as its logo.",
+            "title": "The URL of an image representing the organization, such as its logo.",
             "type": "string"
         },
         "phone": {

--- a/magda-registry-aspects/project-open-data-dataset.schema.json
+++ b/magda-registry-aspects/project-open-data-dataset.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a dataset according to Project Open Data (data.json).",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a dataset according to Project Open Data (data.json).",
     "type": "object",
     "allOf": [
         {

--- a/magda-registry-aspects/project-open-data-distribution.schema.json
+++ b/magda-registry-aspects/project-open-data-distribution.schema.json
@@ -1,12 +1,10 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect capturing a complete representation of a distribution according to Project Open Data (data.json).",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect capturing a complete representation of a distribution according to Project Open Data (data.json).",
     "type": "object",
     "allOf": [
         {
-            "$ref":
-                "https://project-open-data.cio.gov/v1.1/schema/distribution.json"
+            "$ref": "https://project-open-data.cio.gov/v1.1/schema/distribution.json"
         }
     ]
 }

--- a/magda-registry-aspects/source-link-status.schema.json
+++ b/magda-registry-aspects/source-link-status.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect describing source link status of a distribution (active or broken)",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect describing source link status of a distribution (active or broken)",
     "type": "object",
     "properties": {
         "status": {

--- a/magda-registry-aspects/source.schema.json
+++ b/magda-registry-aspects/source.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Aspect for capturing the source of a record",
     "type": "object",
     "properties": {
@@ -21,13 +21,11 @@
         },
         "extras": {
             "title": "Extra Metadata",
-            "description":
-                "Any extra metadata a connector may have. \nThis field is auto copied from connector configData.extras.",
+            "description": "Any extra metadata a connector may have. \nThis field is auto copied from connector configData.extras.",
             "type": "object"
         },
         "problems": {
-            "title":
-                "Problems encountered while creating this record from the source.",
+            "title": "Problems encountered while creating this record from the source.",
             "type": "array",
             "items": {
                 "title": "A problem report.",

--- a/magda-registry-aspects/spatial-coverage.schema.json
+++ b/magda-registry-aspects/spatial-coverage.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Spatial extent defined (will try to confom as much to) in geojson.",
     "type": "object",
     "properties": {

--- a/magda-registry-aspects/temporal-coverage.schema.json
+++ b/magda-registry-aspects/temporal-coverage.schema.json
@@ -1,8 +1,7 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "The temporal period that the dataset covers",
-    "description":
-        "Specifies the temporal period that the dataset covers as a list of time intervals.",
+    "description": "Specifies the temporal period that the dataset covers as a list of time intervals.",
     "type": "object",
     "properties": {
         "intervals": {
@@ -18,8 +17,7 @@
                         "format": "date-time"
                     },
                     "startIndeterminate": {
-                        "title":
-                            "An enumeration indicating the manner in which the start date is indeterminate.  If \"before\" or \"after\", the start date is not exactly known, but it is known to be before/after the date in the `start` property.  If \"now\", the start date is usually populated from the date when the dataset was last updated.  If \"unknown\", the start date is unknown and the `start` property is expected to be blank.",
+                        "title": "An enumeration indicating the manner in which the start date is indeterminate.  If \"before\" or \"after\", the start date is not exactly known, but it is known to be before/after the date in the `start` property.  If \"now\", the start date is usually populated from the date when the dataset was last updated.  If \"unknown\", the start date is unknown and the `start` property is expected to be blank.",
                         "type": "string",
                         "enum": ["unknown", "now", "before", "after"]
                     },
@@ -29,8 +27,7 @@
                         "format": "date-time"
                     },
                     "endIndeterminate": {
-                        "title":
-                            "An enumeration indicating the manner in which the end date is indeterminate.  If \"before\" or \"after\", the end date is not exactly known, but it is known to be before/after the date in the `end` property.  If \"now\", the end date is usually populated from the date when the dataset was last updated.  If \"unknown\", the end date is unknown and the `end` property is expected to be undefined.",
+                        "title": "An enumeration indicating the manner in which the end date is indeterminate.  If \"before\" or \"after\", the end date is not exactly known, but it is known to be before/after the date in the `end` property.  If \"now\", the end date is usually populated from the date when the dataset was last updated.  If \"unknown\", the end date is unknown and the `end` property is expected to be undefined.",
                         "type": "string",
                         "enum": ["unknown", "now", "before", "after"]
                     }

--- a/magda-registry-aspects/visualization-info.schema.json
+++ b/magda-registry-aspects/visualization-info.schema.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "title":
-        "Aspect providing information to make front-end visualisations of distributions better",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Aspect providing information to make front-end visualisations of distributions better",
     "type": "object",
     "properties": {
         "format": {


### PR DESCRIPTION
### What this PR does

This PR was created only for ease of review PR https://github.com/magda-io/magda/pull/2550 and targets that PR.

Should merge this before merge https://github.com/magda-io/magda/pull/2550

Summary:
- Replace all meta schema URI `http://json-schema.org/schema#` with `https://json-schema.org/draft-07/schema#`
  - The unversioned meta-schema URIs should no longer be used.
  - Https should no longer be used
  - The Json schema Validation lib we used now support up to draft 7. See [here](https://github.com/everit-org/json-schema#user-content-draft-4-draft-6-or-draft-7). 
    - Please note draft 7 is the current latest one (released on 2019-09). 
    - All other supported versions available are:
      - draft 4: `https://json-schema.org/draft-04/schema#`
      - draft 6: `https://json-schema.org/draft-06/schema#`
      - there is no draft 5 identifier (use draft 4) see [all specs](http://json-schema.org/specification-links.html#table-of-all-versions-of-everything)

