### PR TITLE
Upgraded ci helm to 2.16.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -498,7 +498,7 @@ dockerize:dockerExtensions:
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl:2.15.2
+    name: dtzar/helm-kubectl:2.16.1
   retry: 1
   environment:
     name: preview/$CI_COMMIT_REF_NAME
@@ -564,7 +564,7 @@ Stop Preview: &stopPreview
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl:2.15.2
+    name: dtzar/helm-kubectl:2.16.1
   retry: 1
   before_script: []
   environment:
@@ -582,7 +582,7 @@ Deploy Master To Dev:
     - master
   cache: {}
   image:
-    name: dtzar/helm-kubectl:2.15.2
+    name: dtzar/helm-kubectl:2.16.1
   retry: 1
   before_script: []
   environment:
@@ -623,7 +623,7 @@ Publish Helm Chart:
     - triggers
   dependencies: []
   image:
-    name: dtzar/helm-kubectl:2.15.2
+    name: dtzar/helm-kubectl:2.16.1
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:


### PR DESCRIPTION
Should allow us to deploy via gitlab again.

This is using a specific version instead of `latest` because `latest` is helm 3 now and that sounds like work we don't want to do yet 😬 