### PR TITLE
Small changes from the terriajs fork of magda.

### DIFF
--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
@@ -33,6 +33,7 @@ class RecordAspectsServiceRO(
     * @apiDescription Get a list of all aspects of a record
     * @apiParam (path) {string} recordId ID of the record for which to fetch an aspect
     * @apiParam (path) {string} aspectId ID of the aspect to fetch
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the aspect detail
     * @apiSuccessExample {json} Response:
     *    {
@@ -75,6 +76,13 @@ class RecordAspectsServiceRO(
         dataType = "string",
         paramType = "path",
         value = "ID of the aspect to fetch."
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -1548,10 +1548,14 @@ object DefaultRecordPersistence
                                       select jsonb_object_agg(aspectId, data)
                                       from RecordAspects
                                       where tenantId=Records.tenantId and recordId=Records.recordId
-                                      ))))
+                                    )
+                                  )
+                                  order by ordinality
+                                )
+                              )
                               from Records
-                              inner join jsonb_array_elements_text(RecordAspects.data->$propertyName) as aggregatedId
-                              on aggregatedId=Records.recordId and RecordAspects.tenantId=Records.tenantId
+                              inner join jsonb_array_elements_text(RecordAspects.data->$propertyName) with ordinality as aggregatedId
+                              on aggregatedId.value=Records.recordId and RecordAspects.tenantId=Records.tenantId
                               where $opaConditions
                             )
                             ELSE (

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -42,6 +42,7 @@ class RecordsServiceRO(
     * @apiParam (query) {boolean} dereference true to automatically dereference links to other records; false to leave them as links. Dereferencing a link means including the record itself where the link would be. Dereferencing only happens one level deep, regardless of the value of this parameter.
     * @apiParam (query) {string[]} aspectQuery Filter the records returned by a value within the aspect JSON. Expressed as 'aspectId.path.to.field:value’, url encoded. NOTE: This is an early stage API and may change greatly in the future
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the record detail
     * @apiSuccessExample {json} Response:
     *  [
@@ -128,6 +129,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )
@@ -191,6 +199,7 @@ class RecordsServiceRO(
     * @apiParam (query) {number} start The index of the first record to retrieve. When possible, specify pageToken instead as it will result in better performance. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
     * @apiParam (query) {number} limit The maximum number of records to receive. The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the record summary
     * @apiSuccessExample {json} Response:
     *  [
@@ -244,6 +253,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )
@@ -279,6 +295,7 @@ class RecordsServiceRO(
     * @apiParam (query) {string[]} aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter. Only records that have all of these aspects will be included in the response.
     * @apiParam (query) {string[]} aspectQuery Filter the records returned by a value within the aspect JSON. Expressed as 'aspectId.path.to.field:value’, url encoded. NOTE: This is an early stage API and may change greatly in the future
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the record count
     * @apiSuccessExample {json} Response:
     *    {
@@ -320,6 +337,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )
@@ -359,6 +383,7 @@ class RecordsServiceRO(
     * @apiParam (query) {string[]} aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter. Only records that have all of these aspects will be included in the response.
     * @apiParam (query) {number} limit The size of each page to get tokens for.
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response a list of page token
     * @apiSuccessExample {json} Response:
     *   [
@@ -398,6 +423,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )
@@ -442,6 +474,7 @@ class RecordsServiceRO(
     * @apiParam (query) {string[]} optionalAspect The optional aspects for which to retrieve data, specified as multiple occurrences of this query parameter. These aspects will be included in a record if available, but a record will be included even if it is missing these aspects.
     * @apiParam (query) {boolean} dereference true to automatically dereference links to other records; false to leave them as links. Dereferencing a link means including the record itself where the link would be. Dereferencing only happens one level deep, regardless of the value of this parameter.
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the record detail
     * @apiSuccessExample {json} Response:
     *      {
@@ -501,6 +534,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )
@@ -557,6 +597,7 @@ class RecordsServiceRO(
     * @apiDescription Gets a summary record, including all the aspect ids for which this record has data.
     * @apiParam (path) {string} id ID of the record to be fetched.
     * @apiHeader {number} X-Magda-Tenant-Id Magda internal tenant id
+    * @apiHeader {string} X-Magda-Session Magda internal session id
     * @apiSuccess (Success 200) {json} Response the record summary detail
     * @apiSuccessExample {json} Response:
     *      {
@@ -592,6 +633,13 @@ class RecordsServiceRO(
         dataType = "number",
         paramType = "header",
         value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = false,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
       )
     )
   )

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -841,11 +841,13 @@ export class RecordAspectsApi {
      * @param xMagdaTenantId 0
      * @param recordId ID of the record for which to fetch an aspect.
      * @param aspectId ID of the aspect to fetch.
+     * @param xMagdaSession Magda internal session id
      */
     public getById(
         xMagdaTenantId: number,
         recordId: string,
-        aspectId: string
+        aspectId: string,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: any }> {
         const localVarPath =
             this.basePath +
@@ -878,6 +880,8 @@ export class RecordAspectsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1537,6 +1541,7 @@ export class RecordsApi {
      * @param limit The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
      * @param dereference true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.
      * @param aspectQuery Filter the records returned by a value within the aspect JSON. Expressed as &#39;aspectId.path.to.field:value&#39;, url encoded. NOTE: This is an early stage API and may change greatly in the future
+     * @param xMagdaSession Magda internal session id
      */
     public getAll(
         xMagdaTenantId: number,
@@ -1546,7 +1551,8 @@ export class RecordsApi {
         start?: number,
         limit?: number,
         dereference?: boolean,
-        aspectQuery?: Array<string>
+        aspectQuery?: Array<string>,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Array<Record> }> {
         const localVarPath = this.basePath + "/records";
         let queryParameters: any = {};
@@ -1589,6 +1595,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1637,12 +1645,14 @@ export class RecordsApi {
      * @param pageToken A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
      * @param start The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
      * @param limit The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
+     * @param xMagdaSession Magda internal session id
      */
     public getAllSummary(
         xMagdaTenantId: number,
         pageToken?: string,
         start?: number,
-        limit?: number
+        limit?: number,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Array<RecordSummary> }> {
         const localVarPath = this.basePath + "/records/summary";
         let queryParameters: any = {};
@@ -1669,6 +1679,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1718,13 +1730,15 @@ export class RecordsApi {
      * @param aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response.
      * @param optionalAspect The optional aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  These aspects will be included in a record if available, but a record will be included even if it is missing these aspects.
      * @param dereference true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.
+     * @param xMagdaSession Magda internal session id
      */
     public getById(
         id: string,
         xMagdaTenantId: number,
         aspect?: Array<string>,
         optionalAspect?: Array<string>,
-        dereference?: boolean
+        dereference?: boolean,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Record }> {
         const localVarPath =
             this.basePath +
@@ -1760,6 +1774,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1805,10 +1821,12 @@ export class RecordsApi {
      * Gets a summary record, including all the aspect ids for which this record has data.
      * @param id ID of the record to be fetched.
      * @param xMagdaTenantId 0
+     * @param xMagdaSession Magda internal session id
      */
     public getByIdSummary(
         id: string,
-        xMagdaTenantId: number
+        xMagdaTenantId: number,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: RecordSummary }> {
         const localVarPath =
             this.basePath +
@@ -1832,6 +1850,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1879,11 +1899,13 @@ export class RecordsApi {
      * @param xMagdaTenantId 0
      * @param aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response.
      * @param aspectQuery Filter the records returned by a value within the aspect JSON. Expressed as &#39;aspectId.path.to.field:value&#39;, url encoded. NOTE: This is an early stage API and may change greatly in the future
+     * @param xMagdaSession Magda internal session id
      */
     public getCount(
         xMagdaTenantId: number,
         aspect?: Array<string>,
-        aspectQuery?: Array<string>
+        aspectQuery?: Array<string>,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: CountResponse }> {
         const localVarPath = this.basePath + "/records/count";
         let queryParameters: any = {};
@@ -1906,6 +1928,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 
@@ -1953,11 +1977,13 @@ export class RecordsApi {
      * @param xMagdaTenantId 0
      * @param aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response.
      * @param limit The size of each page to get tokens for.
+     * @param xMagdaSession Magda internal session id
      */
     public getPageTokens(
         xMagdaTenantId: number,
         aspect?: Array<string>,
-        limit?: number
+        limit?: number,
+        xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Array<string> }> {
         const localVarPath = this.basePath + "/records/pagetokens";
         let queryParameters: any = {};
@@ -1980,6 +2006,8 @@ export class RecordsApi {
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -39,6 +39,7 @@ export default class RegistryClient {
     protected maxRetries: number;
     protected secondsBetweenRetries: number;
     protected tenantId: number;
+    protected jwt: string | undefined;
 
     constructor({
         baseUrl,
@@ -103,7 +104,8 @@ export default class RegistryClient {
                 this.tenantId,
                 aspect,
                 optionalAspect,
-                dereference
+                dereference,
+                this.jwt
             );
         return <any>retry(
             operation(id),
@@ -136,7 +138,8 @@ export default class RegistryClient {
                 undefined,
                 limit,
                 dereference,
-                aspectQueries
+                aspectQueries,
+                this.jwt
             );
         return <any>retry(
             operation(pageToken),
@@ -156,7 +159,12 @@ export default class RegistryClient {
         limit?: number
     ): Promise<string[] | Error> {
         const operation = () =>
-            this.recordsApi.getPageTokens(this.tenantId, aspect, limit);
+            this.recordsApi.getPageTokens(
+                this.tenantId,
+                aspect,
+                limit,
+                this.jwt
+            );
         return <any>retry(
             operation,
             this.secondsBetweenRetries,


### PR DESCRIPTION
A few small changes to the Magda core that we made while working on digital twins:

* Added `@apiHeader {string} X-Magda-Session Magda internal session id` to the read-only registry services, because sometimes read requests need to be authenticated too. This caused the generated api.ts to pick up this new parameter, too.
* Modified `RegistryClient.ts` to pass credentials to the `getRecord`, `getRecords`, and `getRecordsPageTokens` services if a JWT is available. `AuthorizedRegistryClient` will provide a JWT, so the end result is that `AuthorizedRegistryClient` now does authorized read requests, not just write requests.
* Fixes #2571. When getting a record with `dereference=true`, it was not guaranteed that the order of the dereferenced items would be the same as the original order of the IDs.

Hopefully none of this is controversial and it's an easy merge, but let me know if anything is suspicious.