### PR TITLE
Clarify what version of Helm is used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,6 @@ General:
     The registry service can be configured to support either hierarchical organization based access
     policy (default) or Esri groups based access policy.
 -   Add esri portal connector. Read its README.md file before use.
--   Lock helm version in gitlab to 2.15.2 due to issue: https://github.com/helm/helm/issues/6894
 
 Registry:
 
@@ -159,6 +158,7 @@ Others:
 
 -   Made registry-api DB pool settings configurable via Helm
 -   Make broken link sleuther recrawl period configurable via Helm
+-   Set version of Helm used by GitLab CI to 2.16.1
 -   Format minion will trust dcat format if other measures indicate a ZIP format
 -   Format minion will trust dcat format if other measures indicate a ESRI REST format
 -   Added ASC to 4 stars rating list

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -17,7 +17,7 @@ To push the images and run them on kubernetes, you'll need to install:
 
 -   [GNU tar](https://www.gnu.org/software/tar/) - (Mac only) MacOS ships with `BSD tar`. However, you will need `GNU tar` for docker images operations. On MacOS, you can install `GNU Tar` via [Homebrew](https://brew.sh/): `brew install gnu-tar`
 -   [gcloud](https://cloud.google.com/sdk/gcloud/) - For the `kubectl` tool used to control your Kubernetes cluster. You will also need to this to deploy to our test and production environment on Google Cloud.
--   [Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md) to manage kubernetes deployments and config.
+-   [Helm 2](https://helm.sh/docs/intro/install/) to manage kubernetes deployments and config.
 -   [Docker](https://docs.docker.com/install/) - Magda uses `docker` command line tool to build docker images.
 
 You'll also need a Kubernetes cluster - to develop locally this means installing either [minikube](./installing-minikube.md) or [docker](./installing-docker-k8s.md) (MacOS only at this stage). Potentially you could also do this with native Kubernetes, or with a cloud cluster, but we haven't tried it.

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -17,7 +17,7 @@ To push the images and run them on kubernetes, you'll need to install:
 
 -   [GNU tar](https://www.gnu.org/software/tar/) - (Mac only) MacOS ships with `BSD tar`. However, you will need `GNU tar` for docker images operations. On MacOS, you can install `GNU Tar` via [Homebrew](https://brew.sh/): `brew install gnu-tar`
 -   [gcloud](https://cloud.google.com/sdk/gcloud/) - For the `kubectl` tool used to control your Kubernetes cluster. You will also need to this to deploy to our test and production environment on Google Cloud.
--   [Helm 2](https://helm.sh/docs/intro/install/) to manage kubernetes deployments and config.
+-   [Helm 2](https://v2.helm.sh/docs/using_helm/#installing-helm) to manage kubernetes deployments and config.
 -   [Docker](https://docs.docker.com/install/) - Magda uses `docker` command line tool to build docker images.
 
 You'll also need a Kubernetes cluster - to develop locally this means installing either [minikube](./installing-minikube.md) or [docker](./installing-docker-k8s.md) (MacOS only at this stage). Potentially you could also do this with native Kubernetes, or with a cloud cluster, but we haven't tried it.


### PR DESCRIPTION
### What this PR does

https://github.com/magda-io/magda/pull/2603 changed the Helm version which was locked in https://github.com/magda-io/magda/pull/2581 

The new version of Helm is compatible with Kubenetes 1.16 (the default in Ubuntu microk8s now?) so it doesn't get the error ```Error: no kind "Job" is registered for version "batch/v1" ```

Also, Helm 3 was released a week ago https://github.com/helm/helm/releases/tag/v3.0.0
and "there are some backward compatibility breakages. For the most part, though, charts that worked with Helm 2 will continue to work with Helm 3."

This includes mention both in the CHANGES.md and build doco that it is version 2 at the moment.
