### PR TITLE
List port for content-api in the docs

### DIFF
--- a/docs/docs/local-ports.md
+++ b/docs/docs/local-ports.md
@@ -24,3 +24,4 @@ It is not necessary to allocate ports to microservices when running on a Kuberne
 | `magda-feedback`                  | 6116 |
 | `magda-correspondence-api`        | 6117 |
 | `magda-apidocs-server`            | 6118 |
+| `magda-content-api`               | 6119 |


### PR DESCRIPTION
### What this PR does

Adds the port for content-api in the docs.

Please `Squash and Merge` this.

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
