### PR TITLE
Improve CI yarn caching

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
     -Dsbt.ivy.home=$CI_PROJECT_DIR/sbt-cache/ivy
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button` 
-  CACHE_VERSION: fix-typescript-issue
+  CACHE_VERSION: 5
 
 stages:
   - builders
@@ -32,8 +32,7 @@ builders-and-yarn:
     paths:
       - .yarn
   before_script:
-    - yarn config set cache-folder .yarn
-    - yarn install --no-progress --child-concurrency 1
+    - yarn install --no-progress --child-concurrency 1 --cache-folder .yarn
   services:
     - docker:dind
   script:
@@ -297,7 +296,6 @@ buildtest:typescript-apis:
     - pip3 install --upgrade pip
     - pip3 install docker-compose
     - docker-compose --version
-    - yarn # Just to make sure the artifacts are in sync
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
     -Dsbt.ivy.home=$CI_PROJECT_DIR/sbt-cache/ivy
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button` 
-  CACHE_VERSION: 4
+  CACHE_VERSION: fix-typescript-issue
 
 stages:
   - builders
@@ -33,7 +33,7 @@ builders-and-yarn:
       - .yarn
   before_script:
     - yarn config set cache-folder .yarn
-    - yarn install
+    - yarn install --no-progress --child-concurrency 1
   services:
     - docker:dind
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
     -Dsbt.ivy.home=$CI_PROJECT_DIR/sbt-cache/ivy
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button` 
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
 
 stages:
   - builders
@@ -31,7 +31,6 @@ builders-and-yarn:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:
       - .yarn
-      - "yarn.lock"
   before_script:
     - yarn config set cache-folder .yarn
     - yarn install
@@ -298,6 +297,7 @@ buildtest:typescript-apis:
     - pip3 install --upgrade pip
     - pip3 install docker-compose
     - docker-compose --version
+    - yarn # Just to make sure the artifacts are in sync
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,6 +1920,11 @@
   resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.1.29.tgz#5551487728b154a361eb1caf82fee226cabebcd1"
   integrity sha1-VVFIdyixVKNh6xyvgv7iJsq+vNE=
 
+"@types/jsonpath@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
+  integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
+
 "@types/lodash@^4.14.108", "@types/lodash@^4.14.66", "@types/lodash@^4.14.68", "@types/lodash@^4.14.71", "@types/lodash@^4.14.73", "@types/lodash@^4.14.74", "@types/lodash@^4.14.88", "@types/lodash@^4.14.96":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
@@ -2250,6 +2255,11 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
+"@types/smoothscroll-polyfill@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz#77fb3a6e116bdab4a5959122e3b8e201224dcd49"
+  integrity sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==
 
 "@types/superagent@*":
   version "4.1.1"
@@ -12637,6 +12647,15 @@ jsonpath@^1.0.0:
     static-eval "2.0.2"
     underscore "1.7.0"
 
+jsonpath@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.2.tgz#e6aae681d03e9a77b4651d5d96eac5fc63b1fd13"
+  integrity sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.7.0"
+
 jsonschema@terriajs/jsonschema:
   version "1.0.3"
   resolved "https://codeload.github.com/terriajs/jsonschema/tar.gz/55cedb27a265bbae2b366a3824863c586c5d34cf"
@@ -19697,6 +19716,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
### What this PR does
- Removes yarn.lock from cache
- Makes yarn cache work for CI again
- Sets child-concurrency to 1 for gitlab-ci, which makes the yarn build step more reliable.