### PR TITLE
Remove minItems constraint

### DIFF
--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/JsonSchemaValidationSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/JsonSchemaValidationSpec.scala
@@ -97,6 +97,12 @@ class JsonSchemaValidationSpec extends ApiSpec {
       |  "firstName": "Joe",
       |  "lastName": "Bloggs",
       |  "age": 20,
+      |  "tags": []
+      |}""".stripMargin,
+    """{
+      |  "firstName": "Joe",
+      |  "lastName": "Bloggs",
+      |  "age": 20,
       |  "tags": ["tag1", "tag2", "tag3"]
       |}""".stripMargin,
     """{

--- a/magda-registry-aspects/dcat-dataset-strings.schema.json
+++ b/magda-registry-aspects/dcat-dataset-strings.schema.json
@@ -73,8 +73,7 @@
             "items": {
                 "type": "string",
                 "minLength": 1
-            },
-            "minItems": 1
+            }
         },
         "contactPoint": {
             "title": "Free-text account of who to contact about this dataset.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,6 +1920,11 @@
   resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.1.29.tgz#5551487728b154a361eb1caf82fee226cabebcd1"
   integrity sha1-VVFIdyixVKNh6xyvgv7iJsq+vNE=
 
+"@types/jsonpath@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
+  integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
+
 "@types/lodash@^4.14.108", "@types/lodash@^4.14.66", "@types/lodash@^4.14.68", "@types/lodash@^4.14.71", "@types/lodash@^4.14.73", "@types/lodash@^4.14.74", "@types/lodash@^4.14.88", "@types/lodash@^4.14.96":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
@@ -2250,6 +2255,11 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
+"@types/smoothscroll-polyfill@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz#77fb3a6e116bdab4a5959122e3b8e201224dcd49"
+  integrity sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==
 
 "@types/superagent@*":
   version "4.1.1"
@@ -12637,6 +12647,15 @@ jsonpath@^1.0.0:
     static-eval "2.0.2"
     underscore "1.7.0"
 
+jsonpath@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.2.tgz#e6aae681d03e9a77b4651d5d96eac5fc63b1fd13"
+  integrity sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.7.0"
+
 jsonschema@terriajs/jsonschema:
   version "1.0.3"
   resolved "https://codeload.github.com/terriajs/jsonschema/tar.gz/55cedb27a265bbae2b366a3824863c586c5d34cf"
@@ -19697,6 +19716,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
### What this PR does

Fixes #2626
The `"minItems" : 1` constraint is removed from the aspect schema `magda-registry-aspects/dcat-dataset-strings.schema.json`. 

After this change, the json schema validation will allow `keywords` property to have an empty array.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
