### PR TITLE
Improve keywords generation logic for Spreadsheet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,7 @@ UI:
 -   Added tooltips to the `Production` section of the `People and Production` page
 -   Reworded the user access options
 -   Removed help icons without content
+-   Improve keywords generation logic for Spreadsheet
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
@@ -28,7 +28,7 @@ export async function extractKeywords(
         }
     }
 
-    if (output.keywords.length >= MAX_KEYWORDS) {
+    if (output.keywords && output.keywords.length >= MAX_KEYWORDS) {
         return;
     }
 

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
@@ -6,15 +6,20 @@ import { isValidKeyword } from "api-clients/VocabularyApis";
 /** The maximum number of characters to feed into retext (input after this char length will be trimmed off) */
 const MAX_CHARACTERS_FOR_EXTRACTION = 150000;
 /** The maximum number of keywords to return */
-const MAX_KEYWORDS = 10;
+export const MAX_KEYWORDS = 10;
 
 /**
  * Extract keywords from text based file formats
  */
 export async function extractKeywords(
-    input: { text: string },
+    input: { text: string; keywords: string[] },
     output: { keywords: string[] }
 ) {
+    if (input.keywords && input.keywords.length) {
+        // --- exit if extractText has product keywords from headers
+        output.keywords = input.keywords;
+        return;
+    }
     if (input.text) {
         // Only take up to a certain length - anything longer results in massive delays and the browser
         // prompting with a "Should I stop this script?" warning.

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
@@ -12,14 +12,26 @@ export const MAX_KEYWORDS = 10;
  * Extract keywords from text based file formats
  */
 export async function extractKeywords(
-    input: { text: string; keywords: string[] },
+    input: {
+        text: string;
+        keywords: string[];
+        skippedCellForKeywords: boolean;
+    },
     output: { keywords: string[] }
 ) {
     if (input.keywords && input.keywords.length) {
-        // --- exit if extractText has product keywords from headers
+        // --- if extractText has product keywords from headers, copy from input
         output.keywords = input.keywords;
+        // --- if no cells are skipped due to large content, no need to NLP
+        if (input.skippedCellForKeywords === false) {
+            return;
+        }
+    }
+
+    if (output.keywords.length >= MAX_KEYWORDS) {
         return;
     }
+
     if (input.text) {
         // Only take up to a certain length - anything longer results in massive delays and the browser
         // prompting with a "Should I stop this script?" warning.

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
@@ -15,15 +15,15 @@ export async function extractKeywords(
     input: {
         text: string;
         keywords: string[];
-        skippedCellForKeywords: boolean;
+        largeTextBlockIdentified: boolean;
     },
     output: { keywords: string[] }
 ) {
     let keywords = [] as string[];
 
-    console.log(input.skippedCellForKeywords);
-
-    if (input.text && input.skippedCellForKeywords !== false) {
+    // --- please note: `largeTextBlockIdentified` can be undefined
+    // --- only spreadsheet like source will set this field
+    if (input.text && input.largeTextBlockIdentified !== false) {
         // Only take up to a certain length - anything longer results in massive delays and the browser
         // prompting with a "Should I stop this script?" warning.
         const trimmedText = input.text.slice(0, MAX_CHARACTERS_FOR_EXTRACTION);
@@ -49,8 +49,6 @@ export async function extractKeywords(
             )
         ].map(keyword => keyword.toLowerCase());
     }
-
-    console.log(keywords);
 
     // --- Ignore headers keywords if already generate enough from NLP
     // --- or header keywords not exists

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
@@ -126,7 +126,7 @@ function getKeywordsFromWorksheet(
                 return;
             }
 
-            const value = sheet[key].v.trim();
+            let value = sheet[key].v.trim();
 
             if (value === "") {
                 return;
@@ -142,6 +142,8 @@ function getKeywordsFromWorksheet(
                 skippedCellForKeywords = true;
                 return;
             }
+
+            value = value.toLowerCase().replace(/[,._;?@!^]/g, " ");
 
             if (keywords.indexOf(value) !== -1) {
                 // --- will not create duplicated keywords

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
@@ -62,7 +62,12 @@ async function extractSpreadsheetFile(input, output, bookType = "xlsx") {
     }
 
     // --- pass to keywords extractor for processing
+    skippedCellForKeywords = false;
     input.keywords = productKeywordsFromInput(input);
+    input.skippedCellForKeywords = skippedCellForKeywords;
+    if (skippedCellForKeywords) {
+        skippedCellForKeywords = false;
+    }
 
     input.text = Object.values(input.workbook.Sheets)
         .map(worksheet => {
@@ -75,6 +80,7 @@ async function extractSpreadsheetFile(input, output, bookType = "xlsx") {
 }
 
 const CONTAINS_LETTER = /[a-zA-Z]+/;
+let skippedCellForKeywords = false;
 
 function getKeywordsFromWorksheet(
     sheet,
@@ -127,6 +133,13 @@ function getKeywordsFromWorksheet(
             }
 
             if (!CONTAINS_LETTER.test(value)) {
+                return;
+            }
+
+            if (value.length > 100 || value.split(/\b/).length > 10) {
+                // --- will not capture very long content or more than 10 words
+                // --- leave to NLP
+                skippedCellForKeywords = true;
                 return;
             }
 


### PR DESCRIPTION
### What this PR does

Fixes #2635 
- Make sure headers are always captured as keywords (except contents without [a-zA-Z] or none text field)
  - If cell content too long (> 100 char or 10 words), still leave for NLP (Only when not enough keywords produced)
- If not enough keywords are produced, non header cells will be used to created keywords as well


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
