### PR TITLE
Render selected options above the date picker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -145,6 +145,7 @@ UI:
 -   Improve keywords generation logic for Spreadsheet
 -   Mention that choosing state is optional
 -   Make spatial input default to Australia
+-   Render selected time intervals above the date picker so that nothing gets hidden
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -301,7 +301,8 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                     <AlwaysEditor
                         value={temporalCoverage.intervals}
                         onChange={editTemporalCoverage("intervals")}
-                        editor={multiDateIntervalEditor}
+                        editor={multiDateIntervalEditor(true)}
+                        renderAbove={true}
                     />
                 </div>
                 <h3>Spatial extent</h3>

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -704,9 +704,9 @@ class RecordHandler extends React.Component {
                                                     onChange={temporalChange(
                                                         "intervals"
                                                     )}
-                                                    editor={
-                                                        multiDateIntervalEditor
-                                                    }
+                                                    editor={multiDateIntervalEditor(
+                                                        true
+                                                    )}
                                                 >
                                                     <div className="dataset-details-temporal-coverage">
                                                         <TemporalAspectViewer

--- a/magda-web-client/src/Components/Editing/AlwaysEditor.tsx
+++ b/magda-web-client/src/Components/Editing/AlwaysEditor.tsx
@@ -8,6 +8,7 @@ interface AlwaysEditorProps<V> {
     editor: Editor<V>;
     validationFieldPath?: string;
     validationFieldLabel?: string;
+    renderAbove?: boolean;
 }
 
 interface AlwaysEditorState {

--- a/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
@@ -125,16 +125,21 @@ export const dateIntervalEditor: Editor<Interval> = {
     }
 };
 
-export const multiDateIntervalEditor: Editor<
-    Interval[]
-> = ListMultiItemEditor.create(
-    dateIntervalEditor,
-    () => {
-        return {
-            start: undefined,
-            end: undefined
-        };
-    },
-    (value: Interval) => !!value.start && !!value.end,
-    true
-);
+export const multiDateIntervalEditor = function(renderAbove: boolean) {
+    const myMultiItemEditor = ListMultiItemEditor.create(
+        dateIntervalEditor,
+        () => {
+            return {
+                start: undefined,
+                end: undefined
+            };
+        },
+        (value: Interval) => !!value.start && !!value.end,
+        true,
+        !!renderAbove
+    );
+    return {
+        edit: myMultiItemEditor.edit,
+        view: myMultiItemEditor.view
+    };
+};

--- a/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
@@ -136,7 +136,7 @@ export const multiDateIntervalEditor = function(renderAbove: boolean) {
         },
         (value: Interval) => !!value.start && !!value.end,
         true,
-        !!renderAbove
+        renderAbove
     );
     return {
         edit: myMultiItemEditor.edit,

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -166,7 +166,7 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
                         onChange={onChange}
                         canBeAdded={canBeAdded}
                         addOnChange={addOnChange}
-                        renderAbove={!!renderAbove}
+                        renderAbove={renderAbove}
                     />
                 );
             },
@@ -179,7 +179,7 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
                         createNewValue={createNewValue}
                         canBeAdded={canBeAdded}
                         addOnChange={addOnChange}
-                        renderAbove={!!renderAbove}
+                        renderAbove={renderAbove}
                     />
                 );
             }

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -11,6 +11,7 @@ export abstract class MultiItemEditor<V> extends React.Component<
         onChange?: Function;
         canBeAdded: (value: V) => boolean;
         addOnChange: boolean;
+        renderAbove?: boolean;
     },
     { value?: V[]; newValue: V }
 > {
@@ -81,12 +82,42 @@ export abstract class MultiItemEditor<V> extends React.Component<
 }
 
 export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
+    // add a renderer? class method to render out the multi-list-item-editor-container with
+    // 'multi-list-item-editor-item'
+
+    renderSelectedOptions(enabled, value, editor) {
+        if (!enabled && (!value || !value.length)) {
+            return null;
+        }
+        return (
+            <div className="multi-list-item-editor-container clearfix">
+                {value.map((val, i) => {
+                    return (
+                        <div key={i} className="multi-list-item-editor-item">
+                            {editor.view(val)}
+                            {enabled && (
+                                <button
+                                    className="edit-button"
+                                    onClick={this.deleteIndex(i)}
+                                >
+                                    &#215;
+                                </button>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
     render() {
-        const { editor, enabled } = this.props;
+        const { editor, enabled, renderAbove } = this.props;
         const { newValue } = this.state;
         const value = this.value();
         return (
             <div className="list-multi-item-editor-container">
+                {renderAbove
+                    ? this.renderSelectedOptions(enabled, value, editor)
+                    : null}
                 {enabled && (
                     <React.Fragment>
                         {editor.edit(newValue, this.change.bind(this), value, {
@@ -107,28 +138,9 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
                     </React.Fragment>
                 )}
                 {!enabled && (!value || !value.length) && "NOT SET"}
-                {!enabled && (!value || !value.length) ? null : (
-                    <div className="multi-list-item-editor-container clearfix">
-                        {value.map((val, i) => {
-                            return (
-                                <div
-                                    key={i}
-                                    className="multi-list-item-editor-item"
-                                >
-                                    {editor.view(val)}
-                                    {enabled && (
-                                        <button
-                                            className="edit-button"
-                                            onClick={this.deleteIndex(i)}
-                                        >
-                                            &#215;
-                                        </button>
-                                    )}
-                                </div>
-                            );
-                        })}
-                    </div>
-                )}
+                {renderAbove
+                    ? null
+                    : this.renderSelectedOptions(enabled, value, editor)}
             </div>
         );
     }
@@ -137,7 +149,8 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
         singleEditor: Editor<V>,
         createNewValue: () => V,
         canBeAdded: (value: V) => boolean = value => !!value,
-        addOnChange: boolean = false
+        addOnChange: boolean = false,
+        renderAbove: boolean = true
     ): Editor<V[]> {
         return {
             edit: (
@@ -153,6 +166,7 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
                         onChange={onChange}
                         canBeAdded={canBeAdded}
                         addOnChange={addOnChange}
+                        renderAbove={!!renderAbove}
                     />
                 );
             },
@@ -165,6 +179,7 @@ export class ListMultiItemEditor<V> extends MultiItemEditor<V> {
                         createNewValue={createNewValue}
                         canBeAdded={canBeAdded}
                         addOnChange={addOnChange}
+                        renderAbove={!!renderAbove}
                     />
                 );
             }


### PR DESCRIPTION
### What this PR does

Fixes #2598 

Renders the selected intervals _above_ the date picker so nothing gets hidden.

![selected_options_render_up](https://user-images.githubusercontent.com/20970821/69933180-e6e39500-1521-11ea-9687-178fa54c4e48.png)

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
