### PR TITLE
User can't input a future date to date of last modification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -145,6 +145,7 @@ UI:
 -   Improve keywords generation logic for Spreadsheet
 -   Mention that choosing state is optional
 -   Make spatial input default to Australia
+-   User can't input a future date to date of last modification on add dataset page
 
 Gateway:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ General:
 UI:
 
 -   Fixed the issue of modifying date string in text input using backspaces to an empty string will cause text input to reset text input
+-   User can't input a future date to date of last modification on add dataset page
 
 ## 0.0.56
 
@@ -155,7 +156,6 @@ UI:
 -   Improve keywords generation logic for Spreadsheet
 -   Mention that choosing state is optional
 -   Make spatial input default to Australia
--   User can't input a future date to date of last modification on add dataset page
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -275,7 +275,7 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                             callback={editDataset("modified")}
                             date={dataset.modified}
                             isOutsideRange={(date: moment.Moment) =>
-                                date.isAfter(moment())
+                                date.isAfter(moment().endOf("day"))
                             }
                         />
                     </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DetailsAndContents/index.tsx
@@ -5,9 +5,12 @@ import {
     textEditorEx,
     MultilineTextEditor
 } from "Components/Editing/Editors/textEditor";
+
+import moment from "moment";
 import {
     dateEditor,
-    multiDateIntervalEditor
+    multiDateIntervalEditor,
+    MagdaSingleDatePicker
 } from "Components/Editing/Editors/dateEditor";
 
 import ToolTip from "Components/Dataset/Add/ToolTip";
@@ -268,10 +271,12 @@ export default function DatasetAddAccessAndUsePage(props: Props) {
                     </div>
                     <div className="col-sm-4 question-recent-modify-date">
                         <h4>When was the dataset most recently modified?</h4>
-                        <AlwaysEditor
-                            value={dataset.modified}
-                            onChange={editDataset("modified")}
-                            editor={dateEditor}
+                        <MagdaSingleDatePicker
+                            callback={editDataset("modified")}
+                            date={dataset.modified}
+                            isOutsideRange={(date: moment.Moment) =>
+                                date.isAfter(moment())
+                            }
                         />
                     </div>
                 </div>

--- a/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/dateEditor.tsx
@@ -19,12 +19,14 @@ function formatDateForOutput(date: Date | undefined | null) {
     return date ? Moment(date).format(FORMAT) : "Unknown";
 }
 
-function MagdaSingleDatePicker({
+export function MagdaSingleDatePicker({
     date,
-    callback
+    callback,
+    isOutsideRange
 }: {
     date?: Date;
     callback: Function;
+    isOutsideRange?: (date: any) => boolean;
 }) {
     const [focused, setFocused] = useState(false);
 
@@ -34,6 +36,8 @@ function MagdaSingleDatePicker({
         }
     };
 
+    isOutsideRange = isOutsideRange ? isOutsideRange : () => false;
+
     return (
         <span className="date-editor-wrapper">
             <SingleDatePicker
@@ -42,7 +46,7 @@ function MagdaSingleDatePicker({
                 id={Math.random().toString()}
                 focused={focused}
                 onFocusChange={state => setFocused(!!state.focused)}
-                isOutsideRange={() => false}
+                isOutsideRange={isOutsideRange}
                 displayFormat={FORMAT}
                 noBorder
                 small


### PR DESCRIPTION
### What this PR does

Fixes #2586 

User can't input a future date to date of last modification

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
