### PR TITLE
Smooth Out Deployment on Big Databases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Registry:
 -   Removed some unused fields from `dcat-dataset-strings` - it should now be back to looking more-or-less like DCAT.
 -   Added the feature of validating aspect data against JSON Schema (Default to off)
 -   Fixed request for all tenant records returning `[]`.
+-   Made the registry treat tenant id `NULL` as equivalent to tenant id `0`
 
 Gateway:
 

--- a/magda-migrator-registry-db/sql/V2__Support_multi_tenants.sql
+++ b/magda-migrator-registry-db/sql/V2__Support_multi_tenants.sql
@@ -24,5 +24,4 @@ ALTER TABLE recordaspects ADD CONSTRAINT recordaspects_recordid_tenantid_fkey FO
     ON DELETE NO ACTION;
 
 ALTER TABLE events ADD COLUMN tenantId bigint;
-UPDATE events SET tenantId = 0 where tenantId is Null;
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
@@ -60,7 +60,7 @@ class Api(
             .map(_.message)).mkString("\n")
         complete(
           StatusCodes.BadRequest,
-          au.csiro.data61.magda.registry.BadRequest(messages)
+          au.csiro.data61.magda.registry.ApiError(messages)
         )
       }
       .result()
@@ -72,7 +72,7 @@ class Api(
       complete(
         StatusCodes.InternalServerError,
         au.csiro.data61.magda.registry
-          .BadRequest("The server encountered an unexpected error.")
+          .ApiError("The server encountered an unexpected error.")
       )
     }
   }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/ApiError.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/ApiError.scala
@@ -1,0 +1,6 @@
+package au.csiro.data61.magda.registry
+
+/**
+  * Case class to provide a consistent JSON object when communicating errors back to API Clients
+  */
+case class ApiError(message: String) {}

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
@@ -96,7 +96,7 @@ class AspectsService(
                 case Failure(exception) =>
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(exception.getMessage)
+                    ApiError(exception.getMessage)
                   )
               }
             }
@@ -188,7 +188,7 @@ class AspectsService(
                   case Failure(exception) =>
                     complete(
                       StatusCodes.BadRequest,
-                      BadRequest(exception.getMessage)
+                      ApiError(exception.getMessage)
                     )
                 }
               }
@@ -281,7 +281,7 @@ class AspectsService(
                 case Failure(exception) =>
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(exception.getMessage)
+                    ApiError(exception.getMessage)
                   )
               }
             }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
@@ -128,7 +128,7 @@ class AspectsServiceRO(
             case None =>
               complete(
                 StatusCodes.NotFound,
-                BadRequest("No aspect exists with that ID.")
+                ApiError("No aspect exists with that ID.")
               )
           }
         }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/BadRequest.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/BadRequest.scala
@@ -1,3 +1,0 @@
-package au.csiro.data61.magda.registry
-
-case class BadRequest(message: String) {}

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -194,7 +194,10 @@ object EventPersistence extends Protocols with DiffsonProtocol {
       eventType = EventType.withValue(rs.int("eventTypeId")),
       userId = rs.int("userId"),
       data = JsonParser(rs.string("data")).asJsObject,
-      tenantId = rs.bigIntOpt("tenantid").map(BigInt.apply).getOrElse(MAGDA_ADMIN_PORTAL_ID)
+      tenantId = rs
+        .bigIntOpt("tenantid")
+        .map(BigInt.apply)
+        .getOrElse(MAGDA_ADMIN_PORTAL_ID)
     )
   }
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -194,7 +194,7 @@ object EventPersistence extends Protocols with DiffsonProtocol {
       eventType = EventType.withValue(rs.int("eventTypeId")),
       userId = rs.int("userId"),
       data = JsonParser(rs.string("data")).asJsObject,
-      tenantId = rs.bigInt("tenantid")
+      tenantId = rs.bigIntOpt("tenantid").map(BigInt.apply).getOrElse(MAGDA_ADMIN_PORTAL_ID)
     )
   }
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -220,7 +220,7 @@ class HooksService(
           HookPersistence.create(session, hook) match {
             case Success(theResult) => complete(theResult)
             case Failure(exception) =>
-              complete(StatusCodes.BadRequest, BadRequest(exception.getMessage))
+              complete(StatusCodes.BadRequest, ApiError(exception.getMessage))
           }
         }
         webHookActor ! WebHookActor.InvalidateWebHookCacheThenProcess()
@@ -320,7 +320,7 @@ class HooksService(
           case None =>
             complete(
               StatusCodes.NotFound,
-              BadRequest("No web hook exists with that ID.")
+              ApiError("No web hook exists with that ID.")
             )
         }
       }
@@ -434,7 +434,7 @@ class HooksService(
               case Failure(exception) =>
                 complete(
                   StatusCodes.BadRequest,
-                  BadRequest(exception.getMessage)
+                  ApiError(exception.getMessage)
                 )
             }
           }
@@ -508,7 +508,7 @@ class HooksService(
       new ApiResponse(
         code = 400,
         message = "The web hook could not be deleted.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -520,7 +520,7 @@ class HooksService(
             case Success(result) =>
               complete(DeleteResult(result))
             case Failure(exception) =>
-              complete(StatusCodes.BadRequest, BadRequest(exception.getMessage))
+              complete(StatusCodes.BadRequest, ApiError(exception.getMessage))
           }
         }
         webHookActor ! WebHookActor.InvalidateWebhookCache
@@ -587,7 +587,7 @@ class HooksService(
             .acknowledgeRaisedHook(session, id, acknowledgement) match {
             case Success(theResult) => complete(theResult)
             case Failure(exception) =>
-              complete(StatusCodes.BadRequest, BadRequest(exception.getMessage))
+              complete(StatusCodes.BadRequest, ApiError(exception.getMessage))
           }
         }
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -7,7 +7,7 @@ import gnieh.diffson.sprayJson._
 final case class ReadyStatus(ready: Boolean = false)
 
 trait Protocols extends DiffsonProtocol {
-  implicit val badRequestFormat = jsonFormat1(BadRequest.apply)
+  implicit val apiErrorFormat = jsonFormat1(ApiError.apply)
   implicit val recordsPageFormat = jsonFormat3(RecordsPage.apply[Record])
   implicit val recordSummariesPageFormat = jsonFormat3(
     RecordsPage.apply[RecordSummary]

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsService.scala
@@ -134,7 +134,7 @@ class RecordAspectsService(
                   case Failure(exception) =>
                     complete(
                       StatusCodes.BadRequest,
-                      BadRequest(exception.getMessage)
+                      ApiError(exception.getMessage)
                     )
                 }
               }
@@ -218,7 +218,7 @@ class RecordAspectsService(
                 case Failure(exception) =>
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(exception.getMessage)
+                    ApiError(exception.getMessage)
                   )
               }
             }
@@ -324,7 +324,7 @@ class RecordAspectsService(
                   case Failure(exception) =>
                     complete(
                       StatusCodes.BadRequest,
-                      BadRequest(exception.getMessage)
+                      ApiError(exception.getMessage)
                     )
                 }
               }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
@@ -90,7 +90,7 @@ class RecordAspectsServiceRO(
       new ApiResponse(
         code = 404,
         message = "No record or aspect exists with the given IDs.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -119,7 +119,7 @@ class RecordAspectsServiceRO(
                   case _ =>
                     complete(
                       StatusCodes.NotFound,
-                      BadRequest(
+                      ApiError(
                         "No record or aspect exists with the given IDs."
                       )
                     )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -160,7 +160,7 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
         code = 404,
         message =
           "No record exists with the given ID, it does not have a CreateRecord event, or it has been deleted.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -190,7 +190,7 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
                   case None =>
                     complete(
                       StatusCodes.NotFound,
-                      BadRequest(
+                      ApiError(
                         "No record exists with that ID, it does not have a CreateRecord event, or it has been deleted."
                       )
                     )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -17,6 +17,7 @@ import gnieh.diffson.sprayJson._
 import scalikejdbc._
 import spray.json._
 import spray.json.lenses.JsonLenses._
+import org.everit.json.schema.ValidationException
 
 import scala.util.{Failure, Success, Try}
 import com.typesafe.config.Config
@@ -462,7 +463,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       _ <- if (id == newRecord.id) Success(newRecord)
       else
         Failure(
-          new RuntimeException(
+          new ValidationException(
             "The provided ID does not match the record's ID."
           )
         )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -20,11 +20,11 @@ import gnieh.diffson.sprayJson._
 import io.swagger.annotations._
 import javax.ws.rs.Path
 import scalikejdbc.DB
+import org.everit.json.schema.ValidationException
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import org.everit.json.schema.ValidationException
 
 @Path("/records")
 @io.swagger.annotations.Api(value = "records", produces = "application/json")
@@ -93,7 +93,7 @@ class RecordsService(
         code = 400,
         message =
           "The record could not be deleted, possibly because it is used by another record.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -107,7 +107,7 @@ class RecordsService(
               case Failure(exception) =>
                 complete(
                   StatusCodes.BadRequest,
-                  BadRequest(exception.getMessage)
+                  ApiError(exception.getMessage)
                 )
             }
           }
@@ -189,7 +189,7 @@ class RecordsService(
         code = 400,
         message =
           "The records could not be deleted, possibly because they are used by other records.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -237,7 +237,7 @@ class RecordsService(
                   )
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(
+                    ApiError(
                       "An error occurred while processing your request."
                     )
                   )
@@ -334,7 +334,7 @@ class RecordsService(
                   case Failure(exception: ValidationException) =>
                     complete(
                       StatusCodes.BadRequest,
-                      BadRequest("Encountered an error")
+                      ApiError("Encountered an error - " + exception.getMessage)
                     )
                   case Failure(exception) =>
                     logger.error(
@@ -343,7 +343,7 @@ class RecordsService(
                     )
                     complete(
                       StatusCodes.InternalServerError,
-                      BadRequest("Encountered an error")
+                      ApiError("Encountered an error")
                     )
                 }
               }
@@ -448,7 +448,7 @@ class RecordsService(
                   )
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(exception.getMessage)
+                    ApiError(exception.getMessage)
                   )
               }
             }
@@ -525,7 +525,7 @@ class RecordsService(
         code = 400,
         message =
           "A record already exists with the supplied ID, or the record includes an aspect that does not exist.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -541,7 +541,7 @@ class RecordsService(
                 case Failure(exception) =>
                   complete(
                     StatusCodes.BadRequest,
-                    BadRequest(exception.getMessage)
+                    ApiError(exception.getMessage)
                   )
               }
             }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -24,6 +24,7 @@ import scalikejdbc.DB
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+import org.everit.json.schema.ValidationException
 
 @Path("/records")
 @io.swagger.annotations.Api(value = "records", produces = "application/json")
@@ -330,10 +331,19 @@ class RecordsService(
                 ) match {
                   case Success(recordOut) =>
                     complete(recordOut)
-                  case Failure(exception) =>
+                  case Failure(exception: ValidationException) =>
                     complete(
                       StatusCodes.BadRequest,
-                      BadRequest(exception.getMessage)
+                      BadRequest("Encountered an error")
+                    )
+                  case Failure(exception) =>
+                    logger.error(
+                      exception,
+                      "Encountered an exception when putting a record"
+                    )
+                    complete(
+                      StatusCodes.InternalServerError,
+                      BadRequest("Encountered an error")
                     )
                 }
               }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -562,7 +562,7 @@ class RecordsServiceRO(
       new ApiResponse(
         code = 404,
         message = "No record exists with that ID.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -592,7 +592,7 @@ class RecordsServiceRO(
                   case None =>
                     complete(
                       StatusCodes.NotFound,
-                      BadRequest(
+                      ApiError(
                         "No record exists with that ID or it does not have the required aspects."
                       )
                     )
@@ -661,7 +661,7 @@ class RecordsServiceRO(
       new ApiResponse(
         code = 404,
         message = "No record exists with that ID.",
-        response = classOf[BadRequest]
+        response = classOf[ApiError]
       )
     )
   )
@@ -682,7 +682,7 @@ class RecordsServiceRO(
               case None =>
                 complete(
                   StatusCodes.NotFound,
-                  BadRequest("No record exists with that ID.")
+                  ApiError("No record exists with that ID.")
                 )
             }
           }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SQLUtil.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SQLUtil.scala
@@ -33,7 +33,7 @@ object SQLUtil {
         if (innerTenantId == MAGDA_ADMIN_PORTAL_ID) {
           // Assume that null values are the same as 0. Why not just set a default in the DB?
           // Because it'll take a whole day to process the migration.
-          sqls"${buildSqlQuery(sqls"IS NULL")} OR ${buildSqlQuery(sqls"= $innerTenantId")}"
+          sqls"(${buildSqlQuery(sqls"IS NULL")} OR ${buildSqlQuery(sqls"= $innerTenantId")})"
         } else {
           buildSqlQuery(sqls"= ${innerTenantId}")
         }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SQLUtil.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SQLUtil.scala
@@ -1,5 +1,7 @@
 package au.csiro.data61.magda.registry
+
 import au.csiro.data61.magda.model.TenantId._
+import au.csiro.data61.magda.model.Registry.MAGDA_ADMIN_PORTAL_ID
 import scalikejdbc._
 
 object SQLUtil {
@@ -22,10 +24,19 @@ object SQLUtil {
       tableName: Option[SQLSyntax] = None
   ) =
     tenantId match {
-      case SpecifiedTenantId(innerTenantId) =>
-        sqls"${tableName
-          .map(tableSql => SQLSyntax.createUnsafely(tableSql + "."))
-          .getOrElse(SQLSyntax.createUnsafely(""))}tenantId = $innerTenantId"
+      case SpecifiedTenantId(innerTenantId: BigInt) =>
+        def buildSqlQuery(condition: SQLSyntax) =
+          sqls"${tableName
+            .map(tableSql => SQLSyntax.createUnsafely(tableSql + "."))
+            .getOrElse(SQLSyntax.createUnsafely(""))}tenantId $condition"
+
+        if (innerTenantId == MAGDA_ADMIN_PORTAL_ID) {
+          // Assume that null values are the same as 0. Why not just set a default in the DB?
+          // Because it'll take a whole day to process the migration.
+          sqls"${buildSqlQuery(sqls"IS NULL")} OR ${buildSqlQuery(sqls"= $innerTenantId")}"
+        } else {
+          buildSqlQuery(sqls"= ${innerTenantId}")
+        }
       case AllTenantsId => sqls"true"
     }
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceMultiTenantSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceMultiTenantSpec.scala
@@ -43,7 +43,7 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
           .api(role)
           .routes ~> check {
           status shouldEqual StatusCodes.NotFound
-          responseAs[BadRequest].message should include("exist")
+          responseAs[ApiError].message should include("exist")
         }
       }
     }
@@ -112,7 +112,7 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
               TENANT_1
             ) ~> param.api(role).routes ~> check {
               status shouldEqual StatusCodes.BadRequest
-              responseAs[BadRequest].message should include("already exists")
+              responseAs[ApiError].message should include("already exists")
             }
           }
       }
@@ -172,7 +172,7 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("ID")
           }
         }
       }
@@ -244,8 +244,8 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("exists")
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("exists")
+            responseAs[ApiError].message should include("ID")
           }
       }
 
@@ -278,7 +278,7 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("ID")
           }
         }
       }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceSpec.scala
@@ -43,7 +43,7 @@ class AspectsServiceSpec extends ApiSpec {
           .api(role)
           .routes ~> check {
           status shouldEqual StatusCodes.NotFound
-          responseAs[BadRequest].message should include("exist")
+          responseAs[ApiError].message should include("exist")
         }
       }
     }
@@ -102,7 +102,7 @@ class AspectsServiceSpec extends ApiSpec {
               TENANT_1
             ) ~> param.api(role).routes ~> check {
               status shouldEqual StatusCodes.BadRequest
-              responseAs[BadRequest].message should include("already exists")
+              responseAs[ApiError].message should include("already exists")
             }
           }
       }
@@ -166,7 +166,7 @@ class AspectsServiceSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("ID")
           }
         }
       }
@@ -238,8 +238,8 @@ class AspectsServiceSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("exists")
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("exists")
+            responseAs[ApiError].message should include("ID")
           }
       }
 
@@ -272,7 +272,7 @@ class AspectsServiceSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.BadRequest
-            responseAs[BadRequest].message should include("ID")
+            responseAs[ApiError].message should include("ID")
           }
         }
       }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -82,7 +82,7 @@ class RecordsServiceSpec extends ApiSpec {
           .api(role)
           .routes ~> check {
           status shouldEqual StatusCodes.NotFound
-          responseAs[BadRequest].message should include("exist")
+          responseAs[ApiError].message should include("exist")
         }
       }
 
@@ -127,7 +127,7 @@ class RecordsServiceSpec extends ApiSpec {
             TENANT_1
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.NotFound
-            responseAs[BadRequest].message should include("exist")
+            responseAs[ApiError].message should include("exist")
           }
       }
 
@@ -2893,7 +2893,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("already exists")
+          responseAs[ApiError].message should include("already exists")
         }
 
         param.asAdmin(Post("/v0/records", updated)) ~> addTenantIdHeader(
@@ -3081,7 +3081,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include(
+          responseAs[ApiError].message should include(
             "does not match the record"
           )
         }
@@ -3230,8 +3230,8 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("exists")
-          responseAs[BadRequest].message should include("ID")
+          responseAs[ApiError].message should include("exists")
+          responseAs[ApiError].message should include("ID")
         }
       }
 
@@ -3294,7 +3294,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("ID")
+          responseAs[ApiError].message should include("ID")
         }
       }
 
@@ -3784,7 +3784,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("test failed")
+          responseAs[ApiError].message should include("test failed")
         }
       }
 
@@ -3824,7 +3824,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("two different aspects")
+          responseAs[ApiError].message should include("two different aspects")
         }
       }
 
@@ -3864,7 +3864,7 @@ class RecordsServiceSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.BadRequest
-          responseAs[BadRequest].message should include("two different aspects")
+          responseAs[ApiError].message should include("two different aspects")
         }
       }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -487,80 +487,84 @@ class WebHookProcessingSpec
       }
 
       it("record created, with legacy tenantId = NULL value") { param =>
-        // First make an inactive hook
-        val hook = defaultWebHook.copy(
-          url = "http://localhost:" + server.localAddress.getPort.toString + "/hook",
-          active = false,
-          enabled = true,
-          eventTypes = Set(EventType.CreateRecord)
-        )
+        try {
+          // First make an inactive hook
+          val hook = defaultWebHook.copy(
+            url = "http://localhost:" + server.localAddress.getPort.toString + "/hook",
+            active = false,
+            enabled = true,
+            eventTypes = Set(EventType.CreateRecord)
+          )
 
-        val hookId = hook.id.get
-        Util.getWebHookActor(hookId) shouldBe None
+          val hookId = hook.id.get
+          Util.getWebHookActor(hookId) shouldBe None
 
-        param.asAdmin(Post("/v0/hooks", hook)) ~> param
-          .api(Full)
-          .routes ~> check {
-          status shouldEqual StatusCodes.OK
+          param.asAdmin(Post("/v0/hooks", hook)) ~> param
+            .api(Full)
+            .routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          // Make sure it's inactive.
+          Util.waitUntilAllDone(1000)
+          Util.getWebHookActor(hookId) shouldBe None
+
+          // Insert a record to put an event into the table
+          val testId = "testId"
+          val record = Record(testId, "testName", Map())
+
+          param.asAdmin(Post("/v0/records", record)) ~> addTenantIdHeader(
+            MAGDA_ADMIN_PORTAL_ID
+          ) ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          // By default this will have given the event a tenant id, set that tenant id back to NULL
+          DB localTx { implicit session =>
+            sql"UPDATE events SET tenantid = NULL".update.apply()
+          }
+
+          // Make sure we can see that event when we request history with the default tenant id
+          Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(
+            MAGDA_ADMIN_PORTAL_ID
+          ) ~> param
+            .api(Full)
+            .routes ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[EventsPage].events.length shouldEqual 1
+          }
+
+          def response(): ToResponseMarshallable = {
+            StatusCodes.OK
+          }
+
+          this.currentResponse = Some(response)
+
+          Util.waitUntilAllDone()
+          payloads.length should be(0)
+
+          // Turn the hook on
+          val actor = param.webHookActor
+          actor ! WebHookActor.RetryInactiveHooks
+          Util.waitUntilAllDone(1000)
+
+          // Check the hook again to see if it's live now
+          Util.getWebHookActor(hookId) should not be None
+
+          // We should now get the event, and the tenant id should be the default
+          payloads.length should be(1)
+          payloads.last.lastEventId shouldBe 2
+
+          assertEventsInPayloads(
+            List(ExpectedEventIdAndTenantId(2, MAGDA_ADMIN_PORTAL_ID))
+          )
+          payloads.head.events.get.head.eventType shouldBe EventType.CreateRecord
+          assertRecordsInPayloads(
+            List(ExpectedRecordIdAndTenantId(testId, MAGDA_ADMIN_PORTAL_ID))
+          )
+        } finally {
+          payloads.clear()
         }
-
-        // Make sure it's inactive.
-        Util.waitUntilAllDone(1000)
-        Util.getWebHookActor(hookId) shouldBe None
-
-        // Insert a record to put an event into the table
-        val testId = "testId"
-        val record = Record(testId, "testName", Map())
-
-        param.asAdmin(Post("/v0/records", record)) ~> addTenantIdHeader(
-          MAGDA_ADMIN_PORTAL_ID
-        ) ~> param.api(Full).routes ~> check {
-          status shouldEqual StatusCodes.OK
-        }
-
-        // By default this will have given the event a tenant id, set that tenant id back to NULL
-        DB localTx { implicit session =>
-          sql"UPDATE events SET tenantid = NULL".update.apply()
-        }
-
-        // Make sure we can see that event when we request history with the default tenant id
-        Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(
-          MAGDA_ADMIN_PORTAL_ID
-        ) ~> param
-          .api(Full)
-          .routes ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[EventsPage].events.length shouldEqual 1
-        }
-
-        def response(): ToResponseMarshallable = {
-          StatusCodes.OK
-        }
-
-        this.currentResponse = Some(response)
-
-        Util.waitUntilAllDone()
-        payloads.length should be(0)
-
-        // Turn the hook on
-        val actor = param.webHookActor
-        actor ! WebHookActor.RetryInactiveHooks
-        Util.waitUntilAllDone(1000)
-
-        // Check the hook again to see if it's live now
-        Util.getWebHookActor(hookId) should not be None
-
-        // We should now get the event, and the tenant id should be the default
-        payloads.length should be(1)
-        payloads.last.lastEventId shouldBe 2
-
-        assertEventsInPayloads(
-          List(ExpectedEventIdAndTenantId(2, MAGDA_ADMIN_PORTAL_ID))
-        )
-        payloads.head.events.get.head.eventType shouldBe EventType.CreateRecord
-        assertRecordsInPayloads(
-          List(ExpectedRecordIdAndTenantId(testId, MAGDA_ADMIN_PORTAL_ID))
-        )
       }
 
       it("aspect definition created") { param =>
@@ -577,6 +581,7 @@ class WebHookProcessingSpec
           }
 
           assertEventsInPayloads(List(ExpectedEventIdAndTenantId(2, TENANT_1)))
+
           payloads.head.events.get.head.eventType shouldBe EventType.CreateAspectDefinition
           payloads.head.aspectDefinitions.get.length shouldBe 1
         }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -116,7 +116,8 @@ object Registry
       ) sourceTag: Option[String] = None,
       @(ApiModelProperty @field)(
         value = "The identifier of a tenant",
-        required = false
+        required = false,
+        allowEmptyValue = true
       ) tenantId: Option[BigInt] = None
   ) extends RecordType
 

--- a/magda-typescript-common/src/createServiceError.ts
+++ b/magda-typescript-common/src/createServiceError.ts
@@ -1,4 +1,4 @@
-import { BadRequest } from "./generated/registry/api";
+import { ApiError } from "./generated/registry/api";
 
 export class ServiceError extends Error {
     public e: any;
@@ -10,7 +10,7 @@ export class ServiceError extends Error {
 }
 
 export class BadRequestError extends ServiceError {
-    constructor(statusCode: number, errorResponse: BadRequest, e: any) {
+    constructor(statusCode: number, errorResponse: ApiError, e: any) {
         super(
             `Status code: ${statusCode}, body:\n${JSON.stringify(
                 errorResponse,

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -21,6 +21,10 @@ let defaultBasePath = "http://localhost/api/v0/registry/";
 
 /* tslint:disable:no-unused-variable */
 
+export class ApiError {
+    "message": string;
+}
+
 /**
  * A type of aspect in the registry, unique for a tenant.
  */
@@ -37,10 +41,6 @@ export class AspectDefinition {
      * The JSON Schema of this aspect.
      */
     "jsonSchema": any;
-}
-
-export class BadRequest {
-    "message": string;
 }
 
 export class CountResponse {
@@ -149,6 +149,7 @@ export class RegistryEvent {
     "eventType": EventType;
     "userId": number;
     "data": JsObject;
+    "tenantId": number;
 }
 
 export class WebHook {


### PR DESCRIPTION
### What this PR does

Fixes #2643 (note that this merges into release/0.0.56 so merging it _won't_ autoclose the issue)

Rather than set the default tenant id to `0` on every event, this defaults it in code - if an event has no tenant id, it's assumed that the tenant id is `0`, both when querying and when serialising from SQL.

This modifies a flyway file, so we'll need to go through and repair migrations on everything 0.0.56 has touched, which sucks but not as badly as taking data.gov.au down for an extended period.

Not the fix that we need, but the fix that we deserve :(. We'll look at fixing it properly once we figure out how to archive some of these events.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
