### PR TITLE
Made front-end use read-only-registry url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,7 @@ UI:
 -   Added tooltips to the `Production` section of the `People and Production` page
 -   Reworded the user access options
 -   Removed help icons without content
+-   Made read-only calls to the registry api use `/registry-read-only`.
 
 Gateway:
 

--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -34,6 +34,7 @@ defaultRoutes:
     auth: true
   registry-read-only:
     to: http://registry-api-read-only/v0
+    auth: true
   registry-auth: #left here for legacy reasons - use /registry
     to: http://registry-api/v0
     auth: true

--- a/deploy/helm/magda/charts/opa/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/opa/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           httpGet:
             path: "/health"
             port: 8181
-          initialDelaySeconds: 10
+          initialDelaySeconds: 90
           periodSeconds: 10
           timeoutSeconds: 10
 {{- end }}

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -33,6 +33,7 @@ const serverConfig: {
     contentApiBaseUrl?: string;
     previewMapBaseUrl?: string;
     registryApiBaseUrl?: string;
+    registryApiReadOnlyBaseUrl?: string;
     searchApiBaseUrl?: string;
     correspondenceApiBaseUrl?: string;
     gapiIds?: Array<string>;
@@ -53,7 +54,7 @@ const serverConfig: {
 } = window.magda_server_config || {};
 
 const registryReadOnlyApiUrl =
-    serverConfig.registryApiBaseUrl ||
+    serverConfig.registryApiReadOnlyBaseUrl ||
     fallbackApiHost + "api/v0/registry-read-only/";
 const registryFullApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -79,6 +79,11 @@ const argv = yargs
             "The base URL of the MAGDA Registry API.  If not specified, the URL is built from the apiBaseUrl.",
         type: "string"
     })
+    .option("registryApiReadOnlyBaseUrl", {
+        describe:
+            "The base URL of the MAGDA Registry API for use for read-only operations.  If not specified, the URL is built from the apiBaseUrl.",
+        type: "string"
+    })
     .option("authApiBaseUrl", {
         describe:
             "The base URL of the MAGDA Auth API.  If not specified, the URL is built from the apiBaseUrl.",
@@ -195,6 +200,13 @@ const webServerConfig = {
             new URI(apiBaseUrl)
                 .segment("v0")
                 .segment("registry")
+                .toString()
+    ),
+    registryApiReadOnlyBaseUrl: addTrailingSlash(
+        argv.registryApiReadOnlyBaseUrl ||
+            new URI(apiBaseUrl)
+                .segment("v0")
+                .segment("registry-read-only")
                 .toString()
     ),
     authApiBaseUrl: addTrailingSlash(


### PR DESCRIPTION
### What this PR does

Fixes #2664 (note that this won't autoclose when merged!)

This makes the frontend use `api/v0/registry-read-only` by default for read-only registry operations, which will lead to it putting load on the read-only registry api pods in high-availability deployments.

Test up at https://issues-2664-read-only-registry-url.dev.magda.io/dataset/ds-dga-559708e5-480e-4f94-8429-c49571e82761/details?q= - note that if you go to a dataset it uses `/registry-read-only` but if you sign in as admin and try to edit a dataset the request goes to `/registry`.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
