### PR TITLE
Fixed: if featureFlags are not set, edit buttons are always shown on dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,7 @@ UI:
 -   Added tooltips to the `Production` section of the `People and Production` page
 -   Reworded the user access options
 -   Removed help icons without content
+-   Fixed: if featureFlags are not set, edit buttons are always shown on dataset page
 
 Gateway:
 

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -17,7 +17,9 @@ disableAuthenticationFeatures: false
 service: {}
 useLocalStyleSheet: false
 contentApiBaseUrlInternal: "http://content-api/v0/"
-featureFlags: {}
+featureFlags:
+ cataloguing: false
+ previewAddDataset: false
 vocabularyApiEndpoints: []
 defaultContactEmail: "mail@example.com"
 custodianOrgLevel: 2

--- a/magda-web-client/src/Components/Dataset/DatasetPage.js
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.js
@@ -475,7 +475,7 @@ class RecordHandler extends React.Component {
                             <div className="col-sm-8">
                                 <h1 itemProp="name">
                                     <ToggleEditor
-                                        enabled={hasEditPermissions}
+                                        editable={hasEditPermissions}
                                         value={this.props.dataset.title}
                                         onChange={datasetChange("title")}
                                         editor={textEditorFullWidth}
@@ -530,7 +530,7 @@ class RecordHandler extends React.Component {
                                     )}
                                     <div className="dataset-details-overview">
                                         <ToggleEditor
-                                            enabled={hasEditPermissions}
+                                            editable={hasEditPermissions}
                                             value={
                                                 this.props.dataset.description
                                             }
@@ -570,7 +570,7 @@ class RecordHandler extends React.Component {
                                         </div>
                                     ) : null}
                                     <ToggleEditor
-                                        enabled={hasEditPermissions}
+                                        editable={hasEditPermissions}
                                         value={dataset.contactPoint}
                                         onChange={datasetChange("contactPoint")}
                                         editor={multilineTextEditor}
@@ -587,7 +587,7 @@ class RecordHandler extends React.Component {
                                         )}
                                     </ToggleEditor>
                                     <ToggleEditor
-                                        enabled={hasEditPermissions}
+                                        editable={hasEditPermissions}
                                         value={this.props.dataset.tags}
                                         onChange={datasetChange("keywords")}
                                         editor={multiTextEditor}
@@ -696,7 +696,9 @@ class RecordHandler extends React.Component {
                                             </h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset.temporalCoverage
                                                             .intervals
@@ -725,7 +727,9 @@ class RecordHandler extends React.Component {
                                             </h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset.spatialCoverageBbox
                                                     }
@@ -759,7 +763,9 @@ class RecordHandler extends React.Component {
                                             </h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset.provenance
                                                             .mechanism
@@ -773,7 +779,9 @@ class RecordHandler extends React.Component {
                                             <h4>Source system:</h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset.provenance
                                                             .sourceSystem
@@ -795,7 +803,9 @@ class RecordHandler extends React.Component {
                                             </h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset
                                                             .informationSecurity
@@ -816,7 +826,9 @@ class RecordHandler extends React.Component {
                                             </h4>
                                             <div>
                                                 <ToggleEditor
-                                                    enabled={hasEditPermissions}
+                                                    editable={
+                                                        hasEditPermissions
+                                                    }
                                                     value={
                                                         dataset
                                                             .informationSecurity
@@ -969,7 +981,7 @@ function mapStateToProps(state) {
         distributionFetchError,
         datasetFetchError,
         strings: state.content.strings,
-        hasEditPermissions
+        hasEditPermissions: hasEditPermissions ? true : false
     };
 }
 

--- a/magda-web-client/src/Components/Editing/ToggleEditor.tsx
+++ b/magda-web-client/src/Components/Editing/ToggleEditor.tsx
@@ -6,12 +6,12 @@ interface ToggleEditorProps<V> {
     value: any;
     onChange: Function;
     editor: Editor<V>;
-    enabled?: boolean;
+    editable: boolean;
 }
 
 /**
  * Will toggle between editing and viewing with an edit button.
- * Will always show if enabled is false.
+ * Will always show if editable is false.
  * Can specify custom viewer by specifying children which will be rendered instead of viewer of the editor.
  * Interchangable with AlwaysEditor.
  */
@@ -51,13 +51,18 @@ export class ToggleEditor<V> extends React.Component<ToggleEditorProps<V>> {
 
     render() {
         let { value } = this.state;
-        let { editor, enabled } = this.props;
+        let { editor, editable } = this.props;
         if (value === undefined) {
             value = this.props.value;
         }
 
-        enabled = enabled ? true : false;
-        const isEditing = enabled && this.state.isEditing;
+        if (typeof editable !== "boolean") {
+            throw new Error(
+                "The `editable` property of ToggleEditor is compulsory and requires a boolean value"
+            );
+        }
+
+        const isEditing = editable && this.state.isEditing;
 
         return (
             <div className="toggle-editor-container">
@@ -82,7 +87,7 @@ export class ToggleEditor<V> extends React.Component<ToggleEditorProps<V>> {
                     </React.Fragment>
                 ) : (
                     <React.Fragment>
-                        {enabled && (
+                        {editable && (
                             <button
                                 className="toggle-edit-button"
                                 title="Edit data item"

--- a/magda-web-client/src/Components/Editing/ToggleEditor.tsx
+++ b/magda-web-client/src/Components/Editing/ToggleEditor.tsx
@@ -56,7 +56,7 @@ export class ToggleEditor<V> extends React.Component<ToggleEditorProps<V>> {
             value = this.props.value;
         }
 
-        enabled = enabled === undefined || enabled;
+        enabled = enabled ? true : false;
         const isEditing = enabled && this.state.isEditing;
 
         return (

--- a/magda-web-client/src/Components/Footer/FooterCopyrightAdminPage.tsx
+++ b/magda-web-client/src/Components/Footer/FooterCopyrightAdminPage.tsx
@@ -46,6 +46,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Prefix:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={value.htmlContent}
                         onChange={save("htmlContent")}
@@ -54,6 +55,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p style={{ backgroundColor: "grey" }}>
                     Image:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={base64ImageEditor}
                         value={value.logoSrc}
                         onChange={save("logoSrc")}
@@ -62,6 +64,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Link:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={value.href}
                         onChange={save("href")}
@@ -70,6 +73,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Hover Text:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={value.logoAlt}
                         onChange={save("logoAlt")}

--- a/magda-web-client/src/Components/Footer/FooterNavigationLinksAdminPage.tsx
+++ b/magda-web-client/src/Components/Footer/FooterNavigationLinksAdminPage.tsx
@@ -53,6 +53,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Edit Label:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={categoryLabel}
                         onChange={saveCategoryLabel}
@@ -82,6 +83,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Label:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={value.label}
                         onChange={save("label")}
@@ -90,6 +92,7 @@ class StoriesAdminPage extends Component<any, any> {
                 <p>
                     Link:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={value.href}
                         onChange={save("href")}

--- a/magda-web-client/src/Components/Header/HeaderNavigationAdminPage.tsx
+++ b/magda-web-client/src/Components/Header/HeaderNavigationAdminPage.tsx
@@ -59,6 +59,7 @@ export default class HeaderNavigationAdminPage extends Component {
                 <p>
                     Type:{" "}
                     <ToggleEditor
+                        editable={true}
                         editor={codelistEditor({
                             default: "Regular",
                             auth: "Authentication"
@@ -74,6 +75,7 @@ export default class HeaderNavigationAdminPage extends Component {
                         <p>
                             Label:{" "}
                             <ToggleEditor
+                                editable={true}
                                 editor={textEditor}
                                 value={value.label}
                                 onChange={save("label")}
@@ -82,6 +84,7 @@ export default class HeaderNavigationAdminPage extends Component {
                         <p>
                             Link:{" "}
                             <ToggleEditor
+                                editable={true}
                                 editor={textEditor}
                                 value={value.href}
                                 onChange={save("href")}
@@ -90,6 +93,7 @@ export default class HeaderNavigationAdminPage extends Component {
                         <p>
                             rel:{" "}
                             <ToggleEditor
+                                editable={true}
                                 editor={textEditor}
                                 value={value.rel}
                                 onChange={save("rel")}
@@ -98,6 +102,7 @@ export default class HeaderNavigationAdminPage extends Component {
                         <p>
                             target:{" "}
                             <ToggleEditor
+                                editable={true}
                                 editor={textEditor}
                                 value={value.target}
                                 onChange={save("target")}

--- a/magda-web-client/src/Components/Home/HighlightsAdminPage.tsx
+++ b/magda-web-client/src/Components/Home/HighlightsAdminPage.tsx
@@ -124,6 +124,7 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
                     <p>
                         Text:{" "}
                         <ToggleEditor
+                            editable={true}
                             editor={textEditor}
                             value={item.text}
                             onChange={save("text")}
@@ -131,6 +132,7 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
                         <br />
                         Link:{" "}
                         <ToggleEditor
+                            editable={true}
                             editor={textEditor}
                             value={item.url}
                             onChange={save("url")}

--- a/magda-web-client/src/Components/Home/HomeAdminPage.tsx
+++ b/magda-web-client/src/Components/Home/HomeAdminPage.tsx
@@ -49,14 +49,14 @@ class HomeAdminPage extends Component<any, any> {
                 <h2>Taglines</h2>
                 <h3>Desktop Tagline</h3>
                 <ToggleEditor
-                    enabled={hasEditPermissions}
+                    editable={hasEditPermissions}
                     value={content.desktopTagLine}
                     onChange={save("home/tagline/desktop")}
                     editor={textEditor}
                 />
                 <h3>Mobile Tagline</h3>
                 <ToggleEditor
-                    enabled={hasEditPermissions}
+                    editable={hasEditPermissions}
                     value={content.mobileTagLine}
                     onChange={save("home/tagline/mobile")}
                     editor={textEditor}
@@ -73,7 +73,7 @@ function mapStateToProps(state, old) {
         state.userManagement.user.isAdmin;
     return {
         content: state.content,
-        hasEditPermissions
+        hasEditPermissions: hasEditPermissions ? true : false
     };
 }
 

--- a/magda-web-client/src/Components/Home/StoriesAdminPage.tsx
+++ b/magda-web-client/src/Components/Home/StoriesAdminPage.tsx
@@ -40,6 +40,7 @@ function editStory(item, onChange) {
         <div>
             <h1>
                 <ToggleEditor
+                    editable={true}
                     value={item.content.title}
                     onChange={save("title")}
                     editor={textEditor}
@@ -55,6 +56,7 @@ function editStory(item, onChange) {
             <p>
                 Linked to:{" "}
                 <ToggleEditor
+                    editable={true}
                     value={item.content.titleUrl}
                     onChange={save("titleUrl")}
                     editor={textEditor}
@@ -62,6 +64,7 @@ function editStory(item, onChange) {
             </p>
 
             <ToggleEditor
+                editable={true}
                 value={item.content.content}
                 onChange={save("content")}
                 editor={markdownEditor}

--- a/magda-web-client/src/Components/Static/StaticPage.js
+++ b/magda-web-client/src/Components/Static/StaticPage.js
@@ -66,14 +66,14 @@ class StaticPage extends Component {
                         <div className="col-sm-12">
                             <h1>
                                 <ToggleEditor
-                                    enabled={hasEditPermissions}
+                                    editable={hasEditPermissions}
                                     value={title}
                                     onChange={save("title")}
                                     editor={textEditor}
                                 />
                             </h1>
                             <ToggleEditor
-                                enabled={hasEditPermissions}
+                                editable={hasEditPermissions}
                                 value={bodyContent}
                                 onChange={save("content")}
                                 editor={markdownEditor}
@@ -104,7 +104,7 @@ function mapStateToProps(state, old) {
             title: "Loading...",
             content: "Loading..."
         },
-        hasEditPermissions
+        hasEditPermissions: hasEditPermissions ? true : false
     };
 }
 

--- a/magda-web-client/src/Components/i18n/LanguageAdminPage.tsx
+++ b/magda-web-client/src/Components/i18n/LanguageAdminPage.tsx
@@ -59,6 +59,7 @@ class Account extends React.Component<any, any> {
                 <td>{head}</td>
                 <td>
                     <ToggleEditor
+                        editable={true}
                         editor={textEditor}
                         value={item.content}
                         onChange={save}


### PR DESCRIPTION
### What this PR does

Fixes #2671 
Cause:
- Default value for `featureFlags` in helm chart is `{}`
- If `featureFlags` is not set when deployed, `config.featureFlags.cataloguing` will be `undefined`
- `hasEditPermissions` property (`DatasetPage`) is calculated as:
```js
const hasEditPermissions =
        config.featureFlags.cataloguing &&
        state.userManagement &&
        state.userManagement.user &&
        state.userManagement.user.isAdmin;
```

Its value will **always** be `undefined` rather than `false`

- The way of `ToggleEditor` figure out whether the edit mode is enable or not was:
```js
enabled = enabled === undefined || enabled;
```
This make it `true` when `enabled` = `undefined`

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
