### PR TITLE
Issue/2665 Add horizontal pod autoscalers to crucial services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ General:
     policy (default) or Esri groups based access policy.
 -   Add esri portal connector. Read its README.md file before use.
 -   Changed the way of `auth-secrets` to be created in gitlab
+-   Add horizontal pod autoscalers to crucial services
 
 Registry:
 

--- a/deploy/helm/magda/charts/authorization-api/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/authorization-api/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authorization-api
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: authorization-api
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/authorization-api/values.yaml
+++ b/deploy/helm/magda/charts/authorization-api/values.yaml
@@ -1,4 +1,9 @@
 image: {}
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 resources:
   requests:
     cpu: 10m

--- a/deploy/helm/magda/charts/content-api/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/content-api/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: content-api
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: content-api
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/content-api/values.yaml
+++ b/deploy/helm/magda/charts/content-api/values.yaml
@@ -1,4 +1,9 @@
 image: {}
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 resources:
   requests:
     cpu: 10m

--- a/deploy/helm/magda/charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/deployment.yaml
@@ -6,6 +6,7 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: {{ .Values.global.rollingUpdate.maxUnavailable | default 0 }}
+  replicas: {{ .Values.replicas | default 1 }}
   template:
     metadata:
       labels:

--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -6,7 +6,7 @@ service:
   internalPort: 80
   
 autoscaler:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80

--- a/deploy/helm/magda/charts/opa/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/opa/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: opa
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: opa
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/opa/values.yaml
+++ b/deploy/helm/magda/charts/opa/values.yaml
@@ -1,4 +1,9 @@
 image: {}
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 replicas: 1
 resources:
   requests:

--- a/deploy/helm/magda/charts/preview-map/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/preview-map/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: preview-map
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: preview-map
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/preview-map/values.yaml
+++ b/deploy/helm/magda/charts/preview-map/values.yaml
@@ -1,4 +1,9 @@
 image: {}
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 resources:
   requests:
     cpu: 50m

--- a/deploy/helm/magda/charts/registry-api/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/registry-api/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if and .Values.autoscaler.enabled .Values.deployments.readOnly.enable }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: registry-api-read-only
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: registry-api-read-only
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/registry-api/values.yaml
+++ b/deploy/helm/magda/charts/registry-api/values.yaml
@@ -1,4 +1,10 @@
 image: {}
+# autoscaler is only for readonly instance
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 livenessProbe: {}
 db: {}
 resources: 

--- a/deploy/helm/magda/charts/search-api/templates/autoscaler.yaml
+++ b/deploy/helm/magda/charts/search-api/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: search-api
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: search-api
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/helm/magda/charts/search-api/values.yaml
+++ b/deploy/helm/magda/charts/search-api/values.yaml
@@ -1,4 +1,9 @@
 image: {}
+autoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 resources:
   requests:
     cpu: 50m

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -3,7 +3,7 @@ image: {}
   #tag: latest
   #pullPolicy: Always#
 autoscaler:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
### What this PR does

Fixes #2665 

Add horizontal pod autoscalers to crucial services
- By default, auto scaler is off for all service

### Test

Tested in minikube as the followings
- Update `minikube-dev.yml` with the following content and deploy magda to minikube
```yaml
global:
  externalUrl: http://minikube.data.gov.au:30100
  rollingUpdate:
    maxUnavailable: 1
  exposeNodePorts: true
  image:
    repository: "localhost:5000/data61"
    tag: "latest"
    pullPolicy: Always
  noDbAuth: true
  useCloudSql: false
  useCombinedDb: true
  enablePriorityClass: false
  defaultContactEmail: "magda@mailinator.com"
  enableMultiTenants: false

gateway:
  ckanRedirectionDomain: "ckan.data.gov.au"
  ckanRedirectionPath: ""
  enableCkanRedirection: false
  enableAuthEndpoint: true
  autoscaler:
    enabled: true
  cors:
    credentials: true
    origin: true
  auth:
    facebookClientId: "173073926555600"
    arcgisClientId: "d0MgVUbbg5Z6vmWo"
    googleClientId: "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com"
    ckanAuthenticationUrl: https://data.gov.au/data

registry-api:
  autoscaler:
    enabled: true
  skipAuthorization: false
  deployments:
    readOnly:
      enable: true

correspondence-api:
  smtpPort: 2525
  smtpHostname: "smtp.mailgun.org"

web-server:
  autoscaler:
    enabled: true
  fallbackUrl: "https://data.gov.au"
  featureFlags:
    cataloguing: true

opa:
  autoscaler:
    enabled: true

content-api:
  autoscaler:
    enabled: true

preview-map:
  autoscaler:
    enabled: true

search-api:
  autoscaler:
    enabled: true

connectors:
  includeCronJobs: false
  config:
    - image:
        name: "magda-ckan-connector"
      id: dga
      name: "data.gov.au"
      sourceUrl: "https://data.gov.au/"
      pageSize: 1000
      schedule: "0 * * * *"
      ignoreHarvestSources: ["*"]

```
- Using the following script `add-load.sh` to increase load
```bash
#!/bin/bash
service=$(minikube service -n magda $1 --url)
while true; do curl -s $service > /dev/null; done
```
To increase the load to search API, just `./add-load.sh search-api`

Type `kubectl -n magda get hpa` to observe:
```
NAME                     REFERENCE                           TARGETS    MINPODS   MAXPODS   REPLICAS   AGE
content-api              Deployment/content-api              20%/80%    1         3         1          95m
gateway                  Deployment/gateway                  6%/80%     1         3         1          95m
opa                      Deployment/opa                      5%/80%     1         3         1          95m
preview-map              Deployment/preview-map              0%/80%     1         3         1          95m
registry-api-read-only   Deployment/registry-api-read-only   151%/80%   1         3         2          10m
search-api               Deployment/search-api               12%/80%    1         3         1          95m
web                      Deployment/web                      10%/80%    1         3         1          95m
```

#### Limitation on test script
In order to use `add-load.sh`, the service must come with a nodePort --- registry-api-read-only doesn't have it --- you need to manually add it

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
