### PR TITLE
Made the print button work slightly more reliably

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,7 @@ UI:
 -   Added tooltips to the `Production` section of the `People and Production` page
 -   Reworded the user access options
 -   Removed help icons without content
+-   Made print button call `window.stop` before `window.print`.
 
 Gateway:
 

--- a/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
+++ b/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
@@ -1,8 +1,10 @@
 import React from "react";
-import RequestFormLogic from "Components/Dataset/Suggest/RequestFormLogic";
-import "./DatasetPageSuggestForm.scss";
-import AUbutton from "pancake/react/buttons";
 import Modal from "react-modal";
+import AUbutton from "pancake/react/buttons";
+
+import RequestFormLogic from "Components/Dataset/Suggest/RequestFormLogic";
+
+import "./DatasetPageSuggestForm.scss";
 
 //This is the question/report on a dataset form on the
 //individual dataset page
@@ -57,6 +59,14 @@ export default class DatasetPageSuggestForm extends React.Component {
         this.props.toggleMargin(!this.state.showSuggest);
     };
 
+    printPage = () => {
+        // If the page isn't stopped, window.print will simply do nothing.
+        if (window.stop) {
+            window.stop();
+        }
+        window.print();
+    };
+
     render() {
         //parameters of the modal pop out
         const customStyles = {
@@ -96,10 +106,11 @@ export default class DatasetPageSuggestForm extends React.Component {
                         </AUbutton>
                     </div>
                 )}
+
                 <div className="dataset-button-container no-print">
                     <AUbutton
                         className="au-btn--secondary ask-question-button"
-                        onClick={() => window.print()}
+                        onClick={this.printPage}
                     >
                         Print this page
                     </AUbutton>


### PR DESCRIPTION
### What this PR does

Doesn't actually fix an issue, but it's an improvement.

While investigating #2669, I learned that in general, calling `window.print` doesn't work if there's a request in flight - while requests are still going, the button will appear to do nothing. So this makes it so that all requests are stopped (window.stop) and the page is printed in its current state.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
