### PR TITLE
Added a retry to the registry test.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,6 +233,7 @@ buildtest:ui:
 
 buildtest:registry:
   stage: buildtest
+  retry: 1
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   dependencies:
     - builders-and-yarn


### PR DESCRIPTION
### What this PR does
The registry tests have become even more flaky of late - obviously we should fix them properly, but until we do, adding a retry should save us some hitting of the ↩️ button.