### PR TITLE
Fixed CSV data loading unable to work with files < 2mb

### DIFF
--- a/deploy/helm/magda/charts/gateway/values.yaml
+++ b/deploy/helm/magda/charts/gateway/values.yaml
@@ -80,3 +80,4 @@ cors:
   exposedHeaders:
   - "Content-Range"
   - "X-Content-Range"
+  - "Accept-Ranges"

--- a/deploy/helm/magda/charts/web-server/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/configmap.yaml
@@ -18,8 +18,7 @@ data:
     "defaultContactEmail": {{ toJson .Values.defaultContactEmail }},
     {{- end }}
     "custodianOrgLevel": {{ toJson .Values.custodianOrgLevel | quote }},
-    "maxChartProcessingRows": {{ toJson .Values.maxChartProcessingRows | quote }},
-    "maxTableProcessingRows": {{ toJson .Values.maxTableProcessingRows | quote }},
+    "maxCsvProcessingRows": {{ toJson .Values.maxCsvProcessingRows | quote }},
     "csvLoaderChunkSize": {{ toJson .Values.csvLoaderChunkSize | quote }},
     {{- if .Values.mandatoryFields }}
     "mandatoryFields": {{ toJson .Values.mandatoryFields | quote }}

--- a/deploy/helm/magda/charts/web-server/values.yaml
+++ b/deploy/helm/magda/charts/web-server/values.yaml
@@ -23,8 +23,7 @@ featureFlags:
 vocabularyApiEndpoints: []
 defaultContactEmail: "mail@example.com"
 custodianOrgLevel: 2
-maxChartProcessingRows: 20000
-maxTableProcessingRows: 200
+maxCsvProcessingRows: 20000
 # default chunk size 2MB
 csvLoaderChunkSize: 2097152
 mandatoryFields:

--- a/magda-web-client/src/Components/Common/DataPreviewVis.tsx
+++ b/magda-web-client/src/Components/Common/DataPreviewVis.tsx
@@ -73,6 +73,7 @@ class DataPreviewVis extends Component<
                 dataLoadingResult: null
             });
             const result = await this.dataLoader.load();
+            console.log(result);
 
             this.setState({
                 isDataLoading: false,
@@ -82,8 +83,11 @@ class DataPreviewVis extends Component<
             // --- the CSV processing error could be caused by many reasons
             // --- most them here should be source file problem
             // --- But we might still want to keep monitor any rare non-source-file related issues here
-            if (result.errors.length) {
-                console.log("CSV data processing error: ", result.errors);
+            if (result.parseResult && result.parseResult.errors.length) {
+                console.log(
+                    "CSV data processing error: ",
+                    result.parseResult.errors
+                );
             }
         } catch (e) {
             this.setState({

--- a/magda-web-client/src/Components/Common/FileTooBigError.tsx
+++ b/magda-web-client/src/Components/Common/FileTooBigError.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import AUpageAlert from "pancake/react/page-alerts";
+
+export default () => (
+    <AUpageAlert as="error" className="notification__inner">
+        <h3>Oops</h3>
+        <p>
+            Preview not available because either the data file is too big, or
+            because we couldn't determine how big it is.
+        </p>
+    </AUpageAlert>
+);

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -47,8 +47,7 @@ const serverConfig: {
     defaultOrganizationId?: string;
     defaultContactEmail?: string;
     custodianOrgLevel: number;
-    maxChartProcessingRows: number;
-    maxTableProcessingRows: number;
+    maxCsvProcessingRows: number;
     csvLoaderChunkSize: number;
     mandatoryFields: ValidationFieldList;
 } = window.magda_server_config || {};
@@ -161,17 +160,14 @@ export const config = {
     custodianOrgLevel: serverConfig.custodianOrgLevel
         ? serverConfig.custodianOrgLevel
         : 2,
-    maxChartProcessingRows: serverConfig.maxChartProcessingRows
-        ? serverConfig.maxChartProcessingRows
+    maxCsvProcessingRows: serverConfig.maxCsvProcessingRows
+        ? serverConfig.maxCsvProcessingRows
         : 20000, // --- `-1` means no limit
-    maxTableProcessingRows: serverConfig.maxTableProcessingRows
-        ? serverConfig.maxTableProcessingRows
-        : 200, // --- `-1` means no limit
     // --- CSV loader download / processing chunk size
     // --- default to 2MB
     csvLoaderChunkSize: serverConfig.csvLoaderChunkSize
         ? serverConfig.csvLoaderChunkSize
-        : 1000,
+        : 2000000,
     mandatoryFields: serverConfig.mandatoryFields
         ? serverConfig.mandatoryFields
         : [

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -171,7 +171,7 @@ export const config = {
     // --- default to 2MB
     csvLoaderChunkSize: serverConfig.csvLoaderChunkSize
         ? serverConfig.csvLoaderChunkSize
-        : 2097152,
+        : 1000,
     mandatoryFields: serverConfig.mandatoryFields
         ? serverConfig.mandatoryFields
         : [

--- a/magda-web-client/src/helpers/ChartDatasetEncoder.js
+++ b/magda-web-client/src/helpers/ChartDatasetEncoder.js
@@ -377,7 +377,7 @@ class ChartDatasetEncoder {
             return;
         }
         this.distribution = distribution;
-        this.data = dataLoadingResult.data;
+        this.data = dataLoadingResult.parseResult.data;
         this.preProcessData();
     }
 

--- a/magda-web-client/src/helpers/CsvDataLoader.ts
+++ b/magda-web-client/src/helpers/CsvDataLoader.ts
@@ -141,12 +141,17 @@ class CsvDataLoader {
             method: "HEAD"
         });
 
-        const contentLength = res.headers.get("Content-Length");
+        const contentLength =
+            res.headers.get("Content-Length") ||
+            res.headers.get("content-length");
+        debugger;
         if (contentLength) {
             return Number(contentLength);
         }
 
-        const contentRange = res.headers.get("Content-Range");
+        const contentRange =
+            res.headers.get("Content-Range") ||
+            res.headers.get("content-range");
         if (contentRange) {
             const split = contentRange.split("/");
             const length = split[1];

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -141,14 +141,9 @@ const argv = yargs
         describe: "Data custodian org unit tree level",
         type: "number"
     })
-    .option("maxChartProcessingRows", {
+    .option("maxCsvProcessingRows", {
         describe:
-            "Max number of CSV data file rows that chart preview will module process",
-        type: "number"
-    })
-    .option("maxTableProcessingRows", {
-        describe:
-            "Max number of CSV data file rows that table preview will module process",
+            "Max number of CSV data file rows to try to process for previews. This is important because some servers (CKAN) will return a full file even if only part of it is requested, which can mean the user's browser processing megabytes of CSV rows locally. Set to -1 for no limit",
         type: "number"
     })
     .option("csvLoaderChunkSize", {
@@ -244,8 +239,7 @@ const webServerConfig = {
     defaultOrganizationId: argv.defaultOrganizationId,
     defaultContactEmail: argv.defaultContactEmail,
     custodianOrgLevel: argv.custodianOrgLevel,
-    maxChartProcessingRows: argv.maxChartProcessingRows,
-    maxTableProcessingRows: argv.maxTableProcessingRows,
+    maxCsvProcessingRows: argv.maxCsvProcessingRows,
     csvLoaderChunkSize: argv.csvLoaderChunkSize,
     mandatoryFields: argv.mandatoryFields
 };


### PR DESCRIPTION
### What this PR does

Fixes #2686 

This makes CSV download parsing work such that:
- Before trying to download or parse anything, it does a HEAD on the CSV to be parsed
  - If the HEAD doesn't work, throws an error (doesn't show the preview)
  - If the HEAD doesn't come back with a content length, throws an error (doesn't show the preview)
  - If the HEAD does come back with a header that can be used for a content length:
    - If the content length is <= the chunk size, doesn't bother trying to use chunking
    - If the content length is > the chunk size, it does chunk as it did before

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
