### PR TITLE
2666 storage delete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ UI:
 Storage:
 
 -   Add an API for storing and streaming content
+-   Add a DELETE endpoint
+-   Improves error handling (returns 404 from GET if the file doesn't exist)
 
 Others:
 

--- a/magda-storage-api/README.md
+++ b/magda-storage-api/README.md
@@ -57,7 +57,7 @@ $ curl -X PUT -H "Content-Type:text/csv" localhost:6121/v0/test-bucket/myFavouri
 ### GET /:bucket/:fileid
 
 Attempts to retrieve content with the name `<fileid>` from the MinIO server
-that is stored in `<bucket>` specified in config while starting the server.
+that is stored in `<bucket>`.
 
 #### Example usage
 
@@ -67,6 +67,20 @@ column1,column2
 A,1234
 B,4321
 C,2007
+```
+
+### DELETE /:bucket/:fileid
+
+Deletes object with the name `<fileid>` from the MinIO server
+that is stored in `<bucket>`.
+
+_Note_ Does **not** throw an error if the object does not exist.
+
+#### Example usage
+
+```console
+$ curl -X DELETE localhost:6121/v0/test-bucket/myFavouriteCSV
+{ message: "File deleted successfully" }
 ```
 
 ### Note

--- a/magda-storage-api/src/MagdaMinioClient.ts
+++ b/magda-storage-api/src/MagdaMinioClient.ts
@@ -139,7 +139,6 @@ export default class MagdaMinioClient implements ObjectStoreClient {
                     console.error("Unable to remove object: ", err);
                     return resolve(false);
                 }
-                console.log("Removed the object " + objectName);
                 return resolve(true);
             });
         });

--- a/magda-storage-api/src/MagdaMinioClient.ts
+++ b/magda-storage-api/src/MagdaMinioClient.ts
@@ -122,4 +122,26 @@ export default class MagdaMinioClient implements ObjectStoreClient {
             );
         });
     }
+
+    /**
+     *
+     * @param bucket Bucket to remove the object from
+     * @param objectName Name of the object in the bucket
+     * @returns Whether or not deletion has been successful
+     */
+    deleteFile(bucket: string, objectName: string): Promise<boolean> {
+        return new Promise((resolve, _reject) => {
+            return this.client.removeObject(bucket, objectName, function(
+                err: any
+            ) {
+                console.log(err);
+                if (err) {
+                    console.error("Unable to remove object: ", err);
+                    return resolve(false);
+                }
+                console.log("Removed the object " + objectName);
+                return resolve(true);
+            });
+        });
+    }
 }

--- a/magda-storage-api/src/ObjectStoreClient.ts
+++ b/magda-storage-api/src/ObjectStoreClient.ts
@@ -8,4 +8,5 @@ export default interface ObjectStoreClient {
         content: any,
         metaData?: object
     ): Promise<any>;
+    deleteFile(bucket: string, name: string): Promise<boolean>;
 }

--- a/magda-storage-api/src/createApiRouter.ts
+++ b/magda-storage-api/src/createApiRouter.ts
@@ -1,4 +1,3 @@
-import { ApiError } from "@google-cloud/common";
 import express from "express";
 import { OutgoingHttpHeaders } from "http";
 import ObjectStoreClient from "./ObjectStoreClient";
@@ -49,15 +48,13 @@ export default function createApiRouter(options: ApiRouterOptions) {
                 }
             });
         } catch (err) {
-            if (err instanceof ApiError) {
-                if (err.code === 404) {
-                    res.status(404).send(
-                        "No such object with fileId " +
-                            fileId +
-                            " in bucket " +
-                            bucket
-                    );
-                }
+            if (err.code === "NotFound") {
+                res.status(404).send(
+                    "No such object with fileId " +
+                        fileId +
+                        " in bucket " +
+                        bucket
+                );
             }
             res.status(500).send("Unknown error");
         }

--- a/magda-storage-api/src/createApiRouter.ts
+++ b/magda-storage-api/src/createApiRouter.ts
@@ -101,5 +101,28 @@ export default function createApiRouter(options: ApiRouterOptions) {
             });
     });
 
+    // Remove/Delete an object
+    router.delete("/:bucket/:fileid", async function(req, res) {
+        const fileId = req.params.fileid;
+        const bucket = req.params.bucket;
+        const encodedRootPath = encodeURIComponent(fileId);
+        const encodeBucketname = encodeURIComponent(bucket);
+        const deletionSuccess = await options.objectStoreClient.deleteFile(
+            encodeBucketname,
+            encodedRootPath
+        );
+        console.log("deletionSuccess: ", deletionSuccess);
+        if (deletionSuccess) {
+            return res.status(200).send({
+                message: "File deleted successfully"
+            });
+        }
+        return res.status(500).send({
+            message:
+                "Encountered error while deleting file." +
+                "This has been logged and we are looking into this."
+        });
+    });
+
     return router;
 }

--- a/magda-storage-api/src/test/storage.spec.ts
+++ b/magda-storage-api/src/test/storage.spec.ts
@@ -153,4 +153,60 @@ describe("Storage API tests", () => {
                 });
         });
     });
+
+    describe("Delete", () => {
+        it("Uploading and then deleting a simple file", () => {
+            return request(app)
+                .put("/v0/" + bucketName + "/delete-test-file-1")
+                .set("Accept", "application/json")
+                .set("Content-Type", "text/plain")
+                .send("Testing delete")
+                .expect(200)
+                .then(_res => {
+                    return request(app)
+                        .delete("/v0/" + bucketName + "/delete-test-file-1")
+                        .expect(200)
+                        .expect({ message: "File deleted successfully" })
+                        .then(_res => {
+                            return request(app)
+                                .get(
+                                    "/v0/" + bucketName + "/delete-test-file-1"
+                                )
+                                .set("Accept", "application/json")
+                                .set("Accept", "text/plain")
+                                .expect(404);
+                        });
+                });
+        });
+
+        it("Uploading and then deleting : Empty content", () => {
+            return request(app)
+                .put("/v0/" + bucketName + "/delete-test-file-2")
+                .set("Accept", "application/json")
+                .set("Content-Type", "text/plain")
+                .send("")
+                .expect(200)
+                .then(_res => {
+                    return request(app)
+                        .delete("/v0/" + bucketName + "/delete-test-file-2")
+                        .expect(200)
+                        .expect({ message: "File deleted successfully" })
+                        .then(_res => {
+                            return request(app)
+                                .get(
+                                    "/v0/" + bucketName + "/delete-test-file-2"
+                                )
+                                .set("Accept", "application/json")
+                                .set("Accept", "text/plain")
+                                .expect(404);
+                        });
+                });
+        });
+
+        it("Deleting non-existent file", () => {
+            return request(app)
+                .delete("/v0/" + bucketName + "/nonexistent-file-dfijgy45")
+                .expect(200);
+        });
+    });
 });


### PR DESCRIPTION
### What this PR does

Fixes #2666 

Adds a DELETE endpoint.
Adds better error handling (returns 404 on GET if the file doesn't exist).

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
