### PR TITLE
Removed unnecessary requirement for >= 1 keyword in datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,6 +185,7 @@ Others:
 -   Upgrade Scala dependencies versions & added scalafmt support
 -   Fixed doc to reflect [lerna deprecating an option](https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85)
 -   Fix potential memory leak by deregistering listener when Header is unmounted
+-   Removed unnecessary requirement for >= 1 keyword in the dcat-dataset-strings schema.
 
 ## 0.0.55
 

--- a/magda-registry-aspects/dcat-dataset-strings.schema.json
+++ b/magda-registry-aspects/dcat-dataset-strings.schema.json
@@ -73,8 +73,7 @@
             "items": {
                 "type": "string",
                 "minLength": 1
-            },
-            "minItems": 1
+            }
         },
         "contactPoint": {
             "title": "Free-text account of who to contact about this dataset.",


### PR DESCRIPTION
### What this PR does

This ports over https://github.com/magda-io/magda/commit/5d01797cc955b9c4ea06f16ad3610a114dfa2a88, which just missed the 0.0.56 release, but is really important because it ends up preventing a lot of datasets being added if validation is on in the registry