### PR TITLE
Added OGC:WFS to WFS mapping in format minion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,6 +208,7 @@ Others:
 -   Fixed Unable to use Google / Facebook Login on Preview Site
 -   Fixed warnings: `as` props is compulsory for AUpageAlert & boolean value was sent to `id` props
 -   Fixed docker build cache issue that causes DB image not build
+-   Added a mapping from "OGC:WFS" to "WFS" in the format minion.
 
 ## 0.0.54
 

--- a/magda-minion-format/synonyms.json
+++ b/magda-minion-format/synonyms.json
@@ -21,7 +21,7 @@
         "OGC:WMS-2",
         "OGC WMS"
     ],
-    "wfs": ["OGC-WFS", "OGC:WFS-1", "OGC:WFS-2", "OGC WFS"],
+    "wfs": ["OGC-WFS", "OGC:WFS-1", "OGC:WFS-2", "OGC WFS", "OGC:WFS"],
     "docx": [
         "doc",
         "msword",


### PR DESCRIPTION
### What this PR does

Fixes #2698 

Essentially somehow we missed `OGC:WFS`  in the format minions mapping of formats it should change to `WFS`, even though we have `OGC:WFS-2` etc 🤷‍♂ . Added it now.

To test I've made a full deployment and had it crawl GA ECAT - you can see in this distribution: 
https://issues-2698-ogc-wfs-mapping.dev.magda.io/api/v0/registry-read-only/records/dist-ga-ef9652fa-d3d7-3a9d-e044-00144fdd4fa6-1?aspect=dcat-distribution-strings&optionalAspect=source-link-status&optionalAspect=source&optionalAspect=visualization-info&optionalAspect=access&optionalAspect=usage&optionalAspect=dataset-format&optionalAspect=ckan-resource&optionalAspect=publishing

evidence of it working - the original format was `OGC:WFS` but the format minion has converted it to `WFS` as we want.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
