### PR TITLE
Make underlength JWTs more obvious and less likely

### DIFF
--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -7,7 +7,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, OverflowStrategy}
-import au.csiro.data61.magda.indexer.external.registry.RegistryInterface
+import au.csiro.data61.magda.client.RegistryExternalInterface
 import au.csiro.data61.magda.indexer.search.SearchIndexer
 import au.csiro.data61.magda.indexer.search.SearchIndexer.IndexResult
 import au.csiro.data61.magda.model.misc.DataSet
@@ -37,7 +37,7 @@ class StreamControllerTest extends FlatSpec with Matchers {
     start + r.nextInt((end - start) + 1)
   }
 
-  class MockRegistryInterface extends RegistryInterface {
+  class MockRegistryInterface extends RegistryExternalInterface {
     private val nextIndex = new AtomicInteger(0)
     private val dataSetCount = new AtomicInteger(0)
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/Authentication.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/Authentication.scala
@@ -38,24 +38,20 @@ object Authentication {
     Jwts
       .parser()
       .setSigningKey(
-        ju.Base64
-          .getEncoder()
-          .encodeToString(secret(logger).getBytes("utf-8"))
+        key(logger)
       )
 
   def signToken(jwtBuilder: JwtBuilder, logger: LoggingAdapter) = {
     jwtBuilder
       .serializeToJsonWith(jwtJsonSerializer)
       .signWith(
-        SignatureAlgorithm.HS256,
-        ju.Base64
-          .getEncoder()
-          .encodeToString(
-            Authentication.secret(logger).getBytes("utf-8")
-          )
+        key(logger)
       )
       .compact()
   }
+
+  def key(logger: LoggingAdapter) =
+    Keys.hmacShaKeyFor(Authentication.secret(logger).getBytes("utf-8"))
 
   private val jwtJsonSerializer = new Serializer[java.util.Map[String, _]] {
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/directives/AuthDirectives.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/directives/AuthDirectives.scala
@@ -57,8 +57,11 @@ object AuthDirectives {
                 userId
               )
             } catch {
-              case NonFatal(_) =>
-                log.info("Could not verify X-Magda-Session header in request")
+              case NonFatal(e) =>
+                log.error(
+                  e,
+                  "Could not verify X-Magda-Session header in request"
+                )
                 reject(
                   AuthenticationFailedRejection(
                     AuthenticationFailedRejection.CredentialsRejected,

--- a/scripts/create-secrets/k8sExecution.js
+++ b/scripts/create-secrets/k8sExecution.js
@@ -170,7 +170,7 @@ function doK8sExecution(config, shouldNotAsk = false) {
         }
 
         createSecret(env, namespace, "auth-secrets", {
-            "jwt-secret": pwgen(512),
+            "jwt-secret": pwgen(64),
             "session-secret": pwgen()
         });
     });

--- a/scripts/create-secrets/k8sExecution.js
+++ b/scripts/create-secrets/k8sExecution.js
@@ -170,7 +170,7 @@ function doK8sExecution(config, shouldNotAsk = false) {
         }
 
         createSecret(env, namespace, "auth-secrets", {
-            "jwt-secret": pwgen(),
+            "jwt-secret": pwgen(512),
             "session-secret": pwgen()
         });
     });

--- a/scripts/create-secrets/pwgen.js
+++ b/scripts/create-secrets/pwgen.js
@@ -1,15 +1,15 @@
 const Pwgen = require("pwgen/lib/pwgen_module");
 
-const pwgenGenerator = new Pwgen();
-pwgenGenerator.includeCapitalLetter = true;
-pwgenGenerator.includeNumber = true;
-pwgenGenerator.maxLength = 16;
-
 function generatePassword(
-    maxLength,
+    maxLength = 16,
     includeCapitalLetter = true,
     includeNumber = true
 ) {
+    const pwgenGenerator = new Pwgen();
+    pwgenGenerator.includeCapitalLetter = includeCapitalLetter;
+    pwgenGenerator.includeNumber = includeNumber;
+    pwgenGenerator.maxLength = maxLength;
+
     return pwgenGenerator.generate();
 }
 


### PR DESCRIPTION
### What this PR does

Dev just had some problems because our old dev JWT secret was too short to be an effective HS256 secret, and the new Java JWT library fails if this is the case. It throws an exception informing you of this but this wasn't being logged properly.

This change makes it properly log any error encountered during JWT parsing, and also makes the code around that a bit simpler (I realised I was using a deprecated method before).

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] No CHANGES, this fixes up my last change
