### PR TITLE
Issue/2701 Fixed: minio chart will not be deployed if storage-api is not turned on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Storage:
 -   Add endpoint to create a bucket
 -   Restrict file upload to admins only
 -   Support multipart upload
+-   Fixed: minio chart will not be deployed if storage-api is not turned on
 
 Gateway:
 

--- a/deploy/helm/magda-core/requirements.yaml
+++ b/deploy/helm/magda-core/requirements.yaml
@@ -71,6 +71,10 @@ dependencies:
     tags:
       - all
       - opa
+  - name: minio
+    tags:
+      - all
+      - storage-api
   - name: storage-api
     tags:
       - all


### PR DESCRIPTION
### What this PR does

Fixes #2701 

Fixed: minio chart will not be deployed if storage-api is not turned on

If you test it locally, please run:
```
helm dep build deploy/helm/magda
```
after you switch branch.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
