### PR TITLE
Issue/2042 Fixed Registry History API Performance Issue when limit=1 & Updated Registry History API Document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Authorization:
 Others:
 
 -   Use a "Year" column from a CSV file to extract a temporal extent
+-   Fixed Registry History API Performance Issue when limit=1 & Updated Registry History API Document
 
 ## 0.0.56
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -62,7 +62,7 @@ object EventPersistence extends Protocols with DiffsonProtocol {
 
   def getLatestEventId(implicit session: DBSession): Option[Long] = {
     sql"""select
-          eventId,            
+          eventId,
           from Events
           order by eventId desc
           limit 1""".map(rs => rs.long("eventId")).headOption().apply()
@@ -169,7 +169,7 @@ object EventPersistence extends Protocols with DiffsonProtocol {
             tenantId
           from Events
           $whereClause
-          order by eventId asc
+          order by eventTime asc
           offset ${start.getOrElse(0)}
           limit ${limit.getOrElse(1000)}"""
         .map(rs => {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -23,6 +23,10 @@ import scalikejdbc.DB
   * @apiDescription Get the version of a record that existed after a given event was applied
   * @apiParam (path) {string} recordId ID of the record to fetch.
   * @apiParam (path) {string} eventId The ID of the last event to be applied to the record. The event with this ID need not actually apply to the record, in which case that last event prior to this even that does apply will be used.
+  * 
+  * @apiParam (query) {string} pageToken A token that identifies the start of a page of results. This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
+  * @apiParam (query) {number} start The index of the first event to retrieve. When possible, specify pageToken instead as it will result in better performance. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
+  * @apiParam (query) {number} limit The maximum number of records to receive. The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
   *
   * @apiSuccess (Success 200) {json} Response the record detail
   * @apiSuccessExample {json} Response:

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -18,21 +18,30 @@ import scalikejdbc.DB
 
 /**
   * @apiGroup Registry Record History
-  * @api {get} /v0/registry/records/{recordId}/history/{eventId} Get the version of a record that existed after a given event was applied
-  * @apiDescription Get the version of a record that existed after a given event was applied
+  * @api {get} /v0/registry/records/{recordId}/history Get a list of all events affecting this record
+  * @apiDescription Get a list of all aspects of a record
   * @apiParam (path) {string} recordId ID of the record to fetch.
-  * @apiParam (path) {string} eventId The ID of the last event to be applied to the record. The event with this ID need not actually apply to the record, in which case that last event prior to this even that does apply will be used.
   * @apiParam (query) {string} pageToken A token that identifies the start of a page of results. This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
-  * @apiParam (query) {number} start The index of the first event to retrieve. When possible, specify pageToken instead as it will result in better performance. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
+  * @apiParam (query) {number} start The index of the first event to retrieve. Specify pageToken instead will result in better performance when access high offset. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
   * @apiParam (query) {number} limit The maximum number of records to receive. The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
-  * @apiSuccess (Success 200) {json} Response the record detail
+  * @apiSuccess (Success 200) {json} Response the event list
   * @apiSuccessExample {json} Response:
-  *                    {
-  *                    "id": "string",
-  *                    "name": "string",
-  *                    "aspects": {},
-  *                    "sourceTag": "string"
-  *                    }
+                        {
+                            "events": [
+                                {
+                                    "eventTime": "2018-08-29T07:45:48.011Z",
+                                    "eventType": "CreateRecord",
+                                    "tenantId": 0,
+                                    "userId": 0,
+                                    "data": {
+                                        ...
+                                    }
+                                },
+                                ...
+                            ],
+                            "hasMore": true,
+                            "nextPageToken": "xxx"
+                        }
   * @apiUse GenericError
   */
 @Path("/records/{recordId}/history")
@@ -97,30 +106,30 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
 
   /**
     * @apiGroup Registry Record History
-    * @api {get} /v0/registry/records/{recordId}/history Get a list of all events affecting this record
-    * @apiDescription Get a list of all aspects of a record
+    * @api {get} /v0/registry/records/{recordId}/history/{eventId} Get the version of a record that existed after a given event was applied
+    * @apiDescription Get the version of a record that existed after a given event was applied
     * @apiParam (path) {string} recordId ID of the record to fetch.
-    * @apiSuccess (Success 200) {json} Response the event list
+    * @apiParam (path) {string} eventId The ID of the last event to be applied to the record. The event with this ID need not actually apply to the record, in which case that last event prior to this even that does apply will be used.
+    * @apiSuccess (Success 200) {json} Response the record detail
     * @apiSuccessExample {json} Response:
-    *                    {
-    *                    "hasMore": true,
-    *                    "nextPageToken": "string",
-    *                    "events": [
-    *                    {
-    *                    "id": {},
-    *                    "eventTime": "2018-08-29T07:45:48.011Z",
-    *                    "eventType": "CreateRecord",
-    *                    "userId": 0,
-    *                    "data": {
-    *                    "fields": {
-    *                    "additionalProp1": {},
-    *                    "additionalProp2": {},
-    *                    "additionalProp3": {}
-    *                    }
-    *                    }
-    *                    }
-    *                    ]
-    *                    }
+                            {
+                                "data": {
+                                    "aspect": {
+                                        "id": "dga",
+                                        "name": "data.gov.au",
+                                        "type": "ckan-organization",
+                                        "url": "https://data.gov.au/api/3/action/organization_show?id=760c24b1-3c3d-4ccb-8196-41530fcdebd5"
+                                    },
+                                    "aspectId": "source",
+                                    "recordId": "org-dga-760c24b1-3c3d-4ccb-8196-41530fcdebd5",
+                                    "tenantId": 0
+                                },
+                                "eventTime": "2011-12-10T15:40:55.987+11:00",
+                                "eventType": "CreateRecordAspect",
+                                "id": 11,
+                                "tenantId": 0,
+                                "userId": 0
+                            }
     * @apiUse GenericError
     */
   @Path("/{eventId}")

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -19,23 +19,20 @@ import scalikejdbc.DB
 /**
   * @apiGroup Registry Record History
   * @api {get} /v0/registry/records/{recordId}/history/{eventId} Get the version of a record that existed after a given event was applied
-  *
   * @apiDescription Get the version of a record that existed after a given event was applied
   * @apiParam (path) {string} recordId ID of the record to fetch.
   * @apiParam (path) {string} eventId The ID of the last event to be applied to the record. The event with this ID need not actually apply to the record, in which case that last event prior to this even that does apply will be used.
-  * 
   * @apiParam (query) {string} pageToken A token that identifies the start of a page of results. This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
   * @apiParam (query) {number} start The index of the first event to retrieve. When possible, specify pageToken instead as it will result in better performance. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
   * @apiParam (query) {number} limit The maximum number of records to receive. The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
-  *
   * @apiSuccess (Success 200) {json} Response the record detail
   * @apiSuccessExample {json} Response:
-  *  {
-  *      "id": "string",
-  *      "name": "string",
-  *      "aspects": {},
-  *      "sourceTag": "string"
-  *  }
+  *                    {
+  *                    "id": "string",
+  *                    "name": "string",
+  *                    "aspects": {},
+  *                    "sourceTag": "string"
+  *                    }
   * @apiUse GenericError
   */
 @Path("/records/{recordId}/history")
@@ -47,6 +44,10 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
     extends Protocols
     with SprayJsonSupport {
   val recordPersistence = DefaultRecordPersistence
+
+  val route =
+    history ~
+      version
 
   @ApiOperation(
     value = "Get a list of all events affecting this record",
@@ -97,31 +98,29 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
   /**
     * @apiGroup Registry Record History
     * @api {get} /v0/registry/records/{recordId}/history Get a list of all events affecting this record
-    *
     * @apiDescription Get a list of all aspects of a record
     * @apiParam (path) {string} recordId ID of the record to fetch.
-    *
     * @apiSuccess (Success 200) {json} Response the event list
     * @apiSuccessExample {json} Response:
-    *  {
-    *    "hasMore": true,
-    *    "nextPageToken": "string",
-    *    "events": [
-    *        {
-    *            "id": {},
-    *            "eventTime": "2018-08-29T07:45:48.011Z",
-    *            "eventType": "CreateRecord",
-    *            "userId": 0,
-    *            "data": {
-    *                "fields": {
-    *                  "additionalProp1": {},
-    *                  "additionalProp2": {},
-    *                  "additionalProp3": {}
-    *                }
-    *            }
-    *        }
-    *    ]
-    *  }
+    *                    {
+    *                    "hasMore": true,
+    *                    "nextPageToken": "string",
+    *                    "events": [
+    *                    {
+    *                    "id": {},
+    *                    "eventTime": "2018-08-29T07:45:48.011Z",
+    *                    "eventType": "CreateRecord",
+    *                    "userId": 0,
+    *                    "data": {
+    *                    "fields": {
+    *                    "additionalProp1": {},
+    *                    "additionalProp2": {},
+    *                    "additionalProp3": {}
+    *                    }
+    *                    }
+    *                    }
+    *                    ]
+    *                    }
     * @apiUse GenericError
     */
   @Path("/{eventId}")
@@ -205,8 +204,4 @@ class RecordHistoryService(system: ActorSystem, materializer: Materializer)
       }
     }
   }
-
-  val route =
-    history ~
-      version
 }


### PR DESCRIPTION
### What this PR does

Fixes #2042 

- Fixed Registry History API Performance Issue when limit=1

Tried setup index in different ways (multiple columns in different orders) but could make PostgresSQL reliable use the index (rather the primary key eventId)

From the query plan, we can tell PostgresSQL's cost estimate is much smaller than the actual cost.
```
Limit  (cost=0.56..2718.66 rows=1 width=291) (actual time=341701.799..341701.802 rows=1 loops=1)
  ->  Index Scan using events_pkey on events  (cost=0.56..2489780.90 rows=916 width=291) (actual time=341701.797..341701.797 rows=1 loops=1)
        Filter: (((tenantid IS NULL) OR (tenantid = 0)) AND ((data ->> 'recordId'::text) = 'org-dga-760c24b1-3c3d-4ccb-8196-41530fcdebd5'::text))
        Rows Removed by Filter: 4425064
Planning time: 0.112 ms
Execution time: 341701.828 ms
```

It could be caused by the outdated analysis statics --- tried to run `vacuum analyze`. But couldn't finish it due to timeout errors.  

Still use your `order by eventTime` approach --- somehow, this make PostgresSQL always pick the correct index (as long as `pageToken` is not used)

- Updated Registry History API Document

### Checklist

-   [ ] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
