### PR TITLE
Authorisation for the records (plural) endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,9 @@ Gateway:
 Authorization:
 
 -   Made integration tests for authorisation run automatically as part of CI.
--   Added ability to set per-record authorization policies in the registry
+-   Added ability to set per-record authorization policies in the registry (for getting a single record)
+-   Added ability to set per-record authorization policies in the registry (for getting multiple records)
+-   Added ability to use OPA policies that use data types other than strings in the registry
 
 Others:
 

--- a/magda-registry-api/src/main/resources/application.conf
+++ b/magda-registry-api/src/main/resources/application.conf
@@ -87,7 +87,7 @@ scalikejdbc{
     global {
         loggingSQLAndTime.enabled = false
         loggingSQLAndTime.singleLineMode = true
-        loggingSQLAndTime.logLevel = DEBUG
+        loggingSQLAndTime.logLevel = INFO
         loggingSQLAndTime.warningEnabled = true
         loggingSQLAndTime.warningThresholdMillis = 5000
         loggingSQLAndTime.warningLogLevel = warn

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
@@ -1,14 +1,40 @@
 package au.csiro.data61.magda.registry
 
 import java.net.URLDecoder
-import scalikejdbc.SQLSyntax
+import scalikejdbc._
 
-case class AspectQuery(
-    aspectId: String,
-    path: List[String],
-    value: String,
+sealed trait AspectQuery {
+  val aspectId: String
+  val path: List[String]
+}
+
+case class AspectQueryExists(val aspectId: String, val path: List[String])
+    extends AspectQuery
+
+case class AspectQueryWithValue(
+    val aspectId: String,
+    val path: List[String],
+    value: AspectQueryValue,
     sqlComparator: SQLSyntax = SQLSyntax.createUnsafely("=")
-)
+) extends AspectQuery
+
+sealed trait AspectQueryValue {
+  val value: Any
+  val postgresType: SQLSyntax
+}
+case class AspectQueryString(string: String) extends AspectQueryValue {
+  val value = string
+  val postgresType = SQLSyntax.createUnsafely("TEXT")
+}
+case class AspectQueryBoolean(boolean: Boolean) extends AspectQueryValue {
+  val value = boolean
+  val postgresType = SQLSyntax.createUnsafely("BOOL")
+}
+case class AspectQueryBigDecimal(bigDecimal: BigDecimal)
+    extends AspectQueryValue {
+  val value = bigDecimal
+  val postgresType = SQLSyntax.createUnsafely("NUMERIC")
+}
 
 object AspectQuery {
 
@@ -25,6 +51,10 @@ object AspectQuery {
       throw new Exception("Path for aspect query was empty")
     }
 
-    AspectQuery(pathParts.head, pathParts.tail, value)
+    AspectQueryWithValue(
+      pathParts.head,
+      pathParts.tail,
+      AspectQueryString(value)
+    )
   }
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
@@ -40,13 +40,6 @@ abstract class ApiWithOpa
     with SprayJsonSupport
     with MockFactory
     with AuthProtocols {
-
-  GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
-    enabled = false,
-    singleLineMode = true,
-    logLevel = 'info
-  )
-
   override def testConfigSource: String =
     super.testConfigSource + s"""
                                 |opa.recordPolicyId="object.registry.record.esri_owner_groups"

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/RecordOpaPolicyWithEsriGroupsOrMagdaOrgUnitsOnlySpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/RecordOpaPolicyWithEsriGroupsOrMagdaOrgUnitsOnlySpec.scala
@@ -285,7 +285,6 @@ abstract class RecordOpaPolicyWithEsriGroupsOrMagdaOrgUnitsOnlySpec
               offset => if (offset == 0) 0 else firstRecordToken + offset
             )
 
-            //            println(s"----- $userId, $firstRecordToken, $actualPageTokens")
             actualPageTokens
               .map(Integer.parseInt) shouldEqual expectedPageTokens
           }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
@@ -115,12 +115,6 @@ abstract class ApiSpec
         materializer
       )
 
-    GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
-      enabled = false,
-      singleLineMode = true,
-      logLevel = 'info
-    )
-
     case class DBsWithEnvSpecificConfig(configToUse: Config)
         extends DBs
         with TypesafeConfigReader

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
@@ -94,7 +94,7 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
             recordId,
             "foo",
             Map(
-              "example" -> JsObject(
+              "stringExample" -> JsObject(
                 "nested" -> JsObject("public" -> JsString("true"))
               )
             ),
@@ -105,7 +105,7 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
         expectOpaQueryForPolicy(
           param,
           "not.default.policyid.read",
-          defaultPolicyResponse
+          policyResponseForStringExampleAspect
         )
 
         Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -126,7 +126,7 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
             recordId,
             "foo",
             Map(
-              "example" -> JsObject(
+              "stringExample" -> JsObject(
                 "nested" -> JsObject("public" -> JsString("false"))
               )
             ),
@@ -137,10 +137,89 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
         expectOpaQueryForPolicy(
           param,
           "not.default.policyid.read",
-          defaultPolicyResponse
+          policyResponseForStringExampleAspect
         )
 
         Get(s"/v0/records/foo") ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.NotFound
+        }
+      }
+    }
+
+    describe("policies successfully allow and deny for") {
+      it("a string-based policy") { param =>
+        doPolicyTest(
+          param,
+          "stringExample",
+          addStringExampleRecords,
+          policyResponseForStringExampleAspect
+        )
+      }
+
+      it("a boolean-based policy") { param =>
+        doPolicyTest(
+          param,
+          "booleanExample",
+          addBooleanExampleRecords,
+          policyResponseForBooleanExampleAspect
+        )
+      }
+
+      it("a numeric-based policy") { param =>
+        doPolicyTest(
+          param,
+          "numericExample",
+          addNumericExampleRecords,
+          policyResponseForNumericExampleAspect
+        )
+      }
+
+      it("a policy that tests for the existence of an aspect") { param =>
+        doPolicyTest(
+          param,
+          "aspectExistenceExample",
+          addAspectExistenceExampleRecords,
+          policyResponseForAspectExistenceExampleAspect
+        )
+      }
+
+      it("a policy that tests for the existence of a field within an aspect") {
+        param =>
+          doPolicyTest(
+            param,
+            "existenceExample",
+            addExistenceExampleRecords,
+            policyResponseForExistenceExampleAspect
+          )
+      }
+
+      def doPolicyTest(
+          param: FixtureParam,
+          exampleId: String,
+          addRecords: FixtureParam => Unit,
+          policyResponse: String
+      ) = {
+        val PascalCaseId = exampleId.charAt(0).toUpper + exampleId.substring(1)
+        val camelCaseId = exampleId.charAt(0).toLower + exampleId.substring(1)
+
+        addAspectDef(param, camelCaseId)
+        addRecords(param)
+
+        expectOpaQueryForPolicy(
+          param,
+          s"$camelCaseId.policy.read",
+          policyResponse
+        ).twice()
+
+        Get(s"/v0/records/allow$PascalCaseId") ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get(s"/v0/records/deny$PascalCaseId") ~> addTenantIdHeader(
           TENANT_1
         ) ~> param.api(Full).routes ~> check {
           status shouldEqual StatusCodes.NotFound
@@ -158,7 +237,7 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
             recordId,
             "foo",
             Map(
-              "example" -> JsObject(
+              "stringExample" -> JsObject(
                 "nested" -> JsObject("public" -> JsString("true"))
               )
             ),
@@ -182,75 +261,16 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     }
   }
 
-  val defaultPolicyResponse = """
-      {
-        "result": {
-          "queries": [
-            [
-              {
-                "index": 0,
-                "terms": [
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "eq"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "input"
-                      },
-                      {
-                        "type": "string",
-                        "value": "object"
-                      },
-                      {
-                        "type": "string",
-                        "value": "registry"
-                      },
-                      {
-                        "type": "string",
-                        "value": "record"
-                      },
-                      {
-                        "type": "string",
-                        "value": "example"
-                      },
-                      {
-                        "type": "string",
-                        "value": "nested"
-                      },
-                      {
-                        "type": "string",
-                        "value": "public"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "value": "true"
-                  }
-                ]
-              }
-            ]
-          ]
-        }
-      }
-  """
-
   def addExampleAspectDef(param: FixtureParam) =
+    addAspectDef(param, "stringExample")
+
+  def addAspectDef(param: FixtureParam, id: String) =
     param.asAdmin(
       Post(
         "/v0/aspects",
         AspectDefinition(
-          "example",
-          "an example",
+          id,
+          id,
           None
         )
       )
@@ -304,7 +324,419 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     param.asAdmin(Post("/v0/records", record)) ~> addTenantIdHeader(
       TENANT_1
     ) ~> param.api(Full).routes ~> check {
+      if (status !== StatusCodes.OK) {
+        println(response.entity.toString())
+      }
       status shouldEqual StatusCodes.OK
     }
   }
+
+  def addStringExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowStringExample",
+        "allowStringExample",
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("true"))
+          )
+        ),
+        authnReadPolicyId = Some("stringExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyStringExample",
+        "denyStringExample",
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("false"))
+          )
+        ),
+        authnReadPolicyId = Some("stringExample.policy")
+      )
+    )
+  }
+
+  def addNumericExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowNumericExample",
+        "allowNumericExample",
+        Map(
+          "numericExample" -> JsObject(
+            "number" ->
+              JsNumber(-1)
+          )
+        ),
+        authnReadPolicyId = Some("numericExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyNumericExample",
+        "denyNumericExample",
+        Map(
+          "numericExample" -> JsObject(
+            "number" ->
+              JsNumber(2)
+          )
+        ),
+        authnReadPolicyId = Some("numericExample.policy")
+      )
+    )
+  }
+
+  def addBooleanExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowBooleanExample",
+        "allowBooleanExample",
+        Map(
+          "booleanExample" -> JsObject(
+            "boolean" ->
+              JsTrue
+          )
+        ),
+        authnReadPolicyId = Some("booleanExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyBooleanExample",
+        "denyBooleanExample",
+        Map(
+          "booleanExample" -> JsObject(
+            "boolean" ->
+              JsFalse
+          )
+        ),
+        authnReadPolicyId = Some("booleanExample.policy")
+      )
+    )
+  }
+
+  def addAspectExistenceExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowAspectExistenceExample",
+        "allowAspectExistenceExample",
+        Map(
+          "aspectExistenceExample" -> JsObject(
+            )
+        ),
+        authnReadPolicyId = Some("aspectExistenceExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyAspectExistenceExample",
+        "denyAspectExistenceExample",
+        Map(
+          ),
+        authnReadPolicyId = Some("aspectExistenceExample.policy")
+      )
+    )
+  }
+
+  def addExistenceExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowExistenceExample",
+        "allowExistenceExample",
+        Map(
+          "existenceExample" -> JsObject(
+            "value" -> JsObject()
+          )
+        ),
+        authnReadPolicyId = Some("existenceExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyExistenceExample",
+        "denyExistenceExample",
+        Map(
+          "existenceExample" -> JsObject()
+        ),
+        authnReadPolicyId = Some("existenceExample.policy")
+      )
+    )
+  }
+
+  val policyResponseForStringExampleAspect = """
+      {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "eq"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "input"
+                      },
+                      {
+                        "type": "string",
+                        "value": "object"
+                      },
+                      {
+                        "type": "string",
+                        "value": "registry"
+                      },
+                      {
+                        "type": "string",
+                        "value": "record"
+                      },
+                      {
+                        "type": "string",
+                        "value": "stringExample"
+                      },
+                      {
+                        "type": "string",
+                        "value": "nested"
+                      },
+                      {
+                        "type": "string",
+                        "value": "public"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "value": "true"
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+  """
+
+  val policyResponseForNumericExampleAspect = """
+      {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "lt"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "number",
+                    "value": 0
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "input"
+                      },
+                      {
+                        "type": "string",
+                        "value": "object"
+                      },
+                      {
+                        "type": "string",
+                        "value": "registry"
+                      },
+                      {
+                        "type": "string",
+                        "value": "record"
+                      },
+                      {
+                        "type": "string",
+                        "value": "numericExample"
+                      },
+                      {
+                        "type": "string",
+                        "value": "number"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+  """
+
+  val policyResponseForBooleanExampleAspect = """
+      {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "eq"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "boolean",
+                    "value": true
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "input"
+                      },
+                      {
+                        "type": "string",
+                        "value": "object"
+                      },
+                      {
+                        "type": "string",
+                        "value": "registry"
+                      },
+                      {
+                        "type": "string",
+                        "value": "record"
+                      },
+                      {
+                        "type": "string",
+                        "value": "booleanExample"
+                      },
+                      {
+                        "type": "string",
+                        "value": "boolean"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+  """
+
+  val policyResponseForAspectExistenceExampleAspect =
+    """
+      {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "input"
+                      },
+                      {
+                        "type": "string",
+                        "value": "object"
+                      },
+                      {
+                        "type": "string",
+                        "value": "registry"
+                      },
+                      {
+                        "type": "string",
+                        "value": "record"
+                      },
+                      {
+                        "type": "string",
+                        "value": "aspectExistenceExample"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+  """
+
+  val policyResponseForExistenceExampleAspect = """
+      {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "input"
+                      },
+                      {
+                        "type": "string",
+                        "value": "object"
+                      },
+                      {
+                        "type": "string",
+                        "value": "registry"
+                      },
+                      {
+                        "type": "string",
+                        "value": "record"
+                      },
+                      {
+                        "type": "string",
+                        "value": "existenceExample"
+                      },
+                      {
+                        "type": "string",
+                        "value": "value"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+  """
+
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WithDefaultPolicyRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WithDefaultPolicyRecordsServiceAuthSpec.scala
@@ -84,7 +84,7 @@ class WithDefaultPolicyRecordsServiceAuthSpec
                   recordId,
                   "foo",
                   Map(
-                    "example" -> JsObject(
+                    "stringExample" -> JsObject(
                       "nested" -> JsObject("public" -> JsString("true"))
                     )
                   )
@@ -94,7 +94,7 @@ class WithDefaultPolicyRecordsServiceAuthSpec
               expectOpaQueryForPolicy(
                 param,
                 "default.policy.read",
-                defaultPolicyResponse
+                policyResponseForStringExampleAspect
               )
 
               Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -115,7 +115,7 @@ class WithDefaultPolicyRecordsServiceAuthSpec
                   recordId,
                   "foo",
                   Map(
-                    "example" -> JsObject(
+                    "stringExample" -> JsObject(
                       "nested" -> JsObject("public" -> JsString("false"))
                     )
                   )
@@ -124,7 +124,7 @@ class WithDefaultPolicyRecordsServiceAuthSpec
               expectOpaQueryForPolicy(
                 param,
                 "default.policy.read",
-                defaultPolicyResponse
+                policyResponseForStringExampleAspect
               )
 
               Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -150,7 +150,7 @@ class WithDefaultPolicyRecordsServiceAuthSpec
               expectOpaQueryForPolicy(
                 param,
                 "default.policy.read",
-                defaultPolicyResponse
+                policyResponseForStringExampleAspect
               )
 
               Get(s"/v0/records/foo") ~> addTenantIdHeader(


### PR DESCRIPTION
### What this PR does

Fixes #2369 

- Adds tests for calling `/records` when there's multiple records with multiple policies in the registry
- Expands capabilities around what the registry OPA parser can understand - in particular policies that use numerics or test for the existence of values
- Adds tests for different kinds of policies in general (e.g. matching on strings, booleans etc)

How to test:

I've made an instance at https://issues-2369-multi-record-metadata-auth.dev.magda.io/. There's 6 records in there - 3 have a `owner_orgunit` policy and 3 have a `public` policy. Right now my user id is listed as the owner of the 3 with the owner_orgunit policy, but if you change that to your user id, you should be able to see that while logged out, https://issues-2369-multi-record-metadata-auth.dev.magda.io/api/v0/registry/records returns the 3 public records and logged in, it returns all 6.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
