### PR TITLE
Made OPA array comparisons work in the registry again.

### DIFF
--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
 
 import org.scalatest.concurrent.ScalaFutures._
 import scala.concurrent.duration._
+import au.csiro.data61.magda.client.RegistryExternalInterface
 
 class StreamControllerTest extends FlatSpec with Matchers {
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
@@ -18,6 +18,12 @@ case class AspectQueryWithValue(
     sqlComparator: SQLSyntax = SQLSyntax.createUnsafely("=")
 ) extends AspectQuery
 
+case class AspectQueryAnyInArray(
+    val aspectId: String,
+    val path: List[String],
+    value: AspectQueryValue
+) extends AspectQuery
+
 sealed trait AspectQueryValue {
   val value: Any
   val postgresType: SQLSyntax

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
@@ -1,6 +1,5 @@
 package au.csiro.data61.magda.registry
 
-import au.csiro.data61.magda.opa.OpaConsts.ANY_IN_ARRAY
 import au.csiro.data61.magda.opa.OpaTypes.{
   OpaOp,
   OpaQuery,
@@ -117,6 +116,15 @@ object SqlHelper {
              aspectid = $aspectId AND (data #>> string_to_array(${path
           .mkString(",")}, ','))::${value.postgresType} $sqlComparator ${value.value}
         """
+      case AspectQueryAnyInArray(
+          aspectId,
+          path,
+          value
+          ) =>
+        sqls"""
+             aspectid = $aspectId AND jsonb_exists((data #>> string_to_array(${path
+          .mkString(",")}, ','))::JSONB, ${value.value})
+        """
       case e => throw new Exception(s"Could not handle query $e")
     }
   }
@@ -166,8 +174,10 @@ object SqlHelper {
     case Nil                       => List(SQL_TRUE)
     case List(OpaQueryAllMatched)  => List(SQL_TRUE)
     case List(OpaQueryNoneMatched) => List(SQL_FALSE)
+
     case _ =>
       val opaAspectQueries: List[AspectQuery] = opaQueries.map({
+        // Query that's testing for the existence of a property, rather than its value
         case OpaQueryExists(
             OpaRefObjectKey("object")
               :: OpaRefObjectKey("registry")
@@ -180,6 +190,29 @@ object SqlHelper {
             case e =>
               throw new Exception("Could not understand " + e)
           })
+
+        // Query that's testing for any value in an array matching a value
+        case OpaQueryMatchValue(
+            OpaRefObjectKey("object")
+              :: OpaRefObjectKey("registry")
+              :: OpaRefObjectKey("record")
+              :: OpaRefObjectKey(accessAspectId)
+              :: restOfKeys,
+            Eq,
+            aValue
+            ) if (restOfKeys.last) == OpaRefAnyInArray =>
+          AspectQueryAnyInArray(
+            aspectId = accessAspectId,
+            path = restOfKeys.flatMap {
+              case OpaRefObjectKey(key) => Some(key)
+              case OpaRefAnyInArray     => None
+              case e =>
+                throw new Exception("Could not understand " + e)
+            },
+            value = opaValueToAspectQueryValue(aValue)
+          )
+
+        // Simple, a = b style match
         case OpaQueryMatchValue(
             OpaRefObjectKey("object")
               :: OpaRefObjectKey("registry")
@@ -196,16 +229,20 @@ object SqlHelper {
               case e =>
                 throw new Exception("Could not understand " + e)
             },
-            value = aValue match {
-              case OpaValueString(string)   => AspectQueryString(string)
-              case OpaValueBoolean(boolean) => AspectQueryBoolean(boolean)
-              case OpaValueNumber(bigDec)   => AspectQueryBigDecimal(bigDec)
-            },
+            value = opaValueToAspectQueryValue(aValue),
             sqlComparator = convertToSql(operation)
           )
         case e => throw new Exception(s"Could not understand $e")
       })
 
       aspectQueriesToSql(opaAspectQueries)
+  }
+
+  private def opaValueToAspectQueryValue(value: OpaValue) = {
+    value match {
+      case OpaValueString(string)   => AspectQueryString(string)
+      case OpaValueBoolean(boolean) => AspectQueryBoolean(boolean)
+      case OpaValueNumber(bigDec)   => AspectQueryBigDecimal(bigDec)
+    }
   }
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
@@ -195,6 +195,17 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
           )
       }
 
+      it(
+        "a policy that involves checking if one array and another array have a value in common (a la esri)"
+      ) { param =>
+        doPolicyTest(
+          param,
+          "arrayComparisonExample",
+          addArrayComparisonExampleRecords,
+          policyResponseForArrayComparisonAspect
+        )
+      }
+
       def doPolicyTest(
           param: FixtureParam,
           exampleId: String,
@@ -474,6 +485,41 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     )
   }
 
+  def addArrayComparisonExampleRecords(param: FixtureParam) {
+    addRecord(
+      param,
+      Record(
+        "allowArrayComparisonExample",
+        "allowArrayComparisonExample",
+        Map(
+          "arrayComparisonExample" -> JsObject(
+            "array" -> JsArray(
+              JsString("one"),
+              JsString("two")
+            )
+          )
+        ),
+        authnReadPolicyId = Some("arrayComparisonExample.policy")
+      )
+    )
+    addRecord(
+      param,
+      Record(
+        "denyArrayComparisonExample",
+        "denyArrayComparisonExample",
+        Map(
+          "arrayComparisonExample" -> JsObject(
+            "array" -> JsArray(
+              JsString("three"),
+              JsString("four")
+            )
+          )
+        ),
+        authnReadPolicyId = Some("arrayComparisonExample.policy")
+      )
+    )
+  }
+
   val policyResponseForStringExampleAspect = """
       {
         "result": {
@@ -739,4 +785,118 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       }
   """
 
+  val policyResponseForArrayComparisonAspect = """
+        {
+        "result": {
+          "queries": [
+            [
+              {
+                "index": 0,
+                "terms": [
+                    {
+                        "type": "ref",
+                        "value": [
+                            {
+                                "type": "var",
+                                "value": "eq"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "string",
+                        "value": "two"
+                    },
+                    {
+                        "type": "ref",
+                        "value": [
+                            {
+                                "type": "var",
+                                "value": "input"
+                            },
+                            {
+                                "type": "string",
+                                "value": "object"
+                            },
+                            {
+                                "type": "string",
+                                "value": "registry"
+                            },
+                            {
+                                "type": "string",
+                                "value": "record"
+                            },
+                            {
+                                "type": "string",
+                                "value": "arrayComparisonExample"
+                            },
+                            {
+                                "type": "string",
+                                "value": "array"
+                            },
+                            {
+                                "type": "var",
+                                "value": "$06"
+                            }
+                        ]
+                    }
+                ]
+              }
+            ],
+            [
+              {
+                  "index": 0,
+                  "terms": [
+                      {
+                          "type": "ref",
+                          "value": [
+                              {
+                                  "type": "var",
+                                  "value": "eq"
+                              }
+                          ]
+                      },
+                      {
+                          "type": "string",
+                          "value": "two"
+                      },
+                      {
+                          "type": "ref",
+                          "value": [
+                              {
+                                  "type": "var",
+                                  "value": "input"
+                              },
+                              {
+                                  "type": "string",
+                                  "value": "object"
+                              },
+                              {
+                                  "type": "string",
+                                  "value": "registry"
+                              },
+                              {
+                                  "type": "string",
+                                  "value": "record"
+                              },
+                              {
+                                  "type": "string",
+                                  "value": "esri-access-control"
+                              },
+                              {
+                                  "type": "string",
+                                  "value": "groups"
+                              },
+                              {
+                                  "type": "var",
+                                  "value": "$06"
+                              }
+                          ]
+                      }
+                  ]
+              }
+            ]
+          ]
+        }
+      }
+  """
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/AuthApiClient.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/AuthApiClient.scala
@@ -95,7 +95,7 @@ class AuthApiClient(authHttpFetcher: HttpFetcher)(
         headers
       )
       .flatMap(receiveOpaResponse[List[List[OpaQuery]]](_, policyId) { json =>
-        OpaParser.parseOpaResponse(json)
+        OpaParser.parseOpaResponse(json, policyId)
       })
   }
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/opa/OpaParser.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/opa/OpaParser.scala
@@ -11,6 +11,7 @@ import spray.json._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import au.csiro.data61.magda.client.AuthApiClient
+import java.util.regex.Pattern
 
 object OpaTypes {
   case class OpaQueryPair(policyId: String, queries: List[OpaQuery])
@@ -93,17 +94,18 @@ object RegoTerm {
   }
 }
 
-object OpaConsts {
-  val ANY_IN_ARRAY: String = "[_]"
-}
-
 object OpaParser {
+  val anyInArrayPattern = "(\\$\\d+)".r
+  println(anyInArrayPattern.findAllMatchIn("$06"))
 
-  def parseOpaResponse(json: JsValue): List[List[OpaQuery]] = {
+  def parseOpaResponse(json: JsValue, policy: String): List[List[OpaQuery]] = {
     val result = json.asJsObject.fields
       .get("result") match {
       case Some(aResult) => aResult
-      case None          => throw new Exception("Got no result for opa query")
+      case None =>
+        throw new Exception(
+          s"Got no result for opa query '$policy', instead got ${json}"
+        )
     }
 
     val rulesOpt: List[List[OpaQuery]] = result.asJsObject.fields
@@ -236,7 +238,8 @@ object OpaParser {
 
   private def regoRefPathToOpaRefPath(path: List[RegoTerm]): List[OpaRef] = {
     path.flatMap {
-      case RegoTermVar("input") => None
+      case RegoTermVar("input")              => None
+      case RegoTermVar(anyInArrayPattern(_)) => Some(OpaRefAnyInArray)
       case pathSegment: RegoTermString =>
         Some(OpaRefObjectKey(pathSegment.value))
       case e =>
@@ -244,7 +247,6 @@ object OpaParser {
     }
   }
 
-  private val anyInArrayPattern = "\\$.*".r
   private def parseRule(terms: JsValue): List[RegoTerm] = {
     // The terms may look like
     //


### PR DESCRIPTION
### What this PR does
Just realised that my last auth PR broke the integration tests 😬. Specifically it breaks the ESRI policy, which has a condition along the lines of `path.in.aspect.array[_] = other.array[_]`, which I specifically got rid of because I didn't think we needed it right now or that it worked, but we do and it did. So I found the code that made it work and brought it back over :).

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] This corrects a change that I shouldn't have made
