### PR TITLE
Issue/2750 Improve the build & run document a bit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ General:
 -   Release [npm packages](https://www.npmjs.com/search?q=%40magda) for building `connectors` & `minions` without depending on main repo
 -   Upgrade charts to use with Helm 3, Kubernetes 1.17 and Minikube 1.7.2
 -   Make recompiling and updating create secrets scripts an action in the CI
+-   Update build & run document to provide more information regarding running local build connector & minion docker images
 
 UI:
 

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -16,6 +16,21 @@ global:
   connectors:
     includeInitialJobs: true
     includeCronJobs: false
+    # Remove the image section to make connectors pull your test docker images from your local docker registry
+    # Make sure you build & push the connector docker images to your local docker registry
+    image:
+      repository: docker.io/data61
+      tag: 0.0.57-0
+      pullPolicy: IfNotPresent
+      imagePullSecret: false
+  minions:
+    # Remove the image section to make minions pull your test docker images from local docker registry
+    # Make sure you build & push the connector docker images to your local docker registry
+    image:
+      repository: docker.io/data61
+      tag: 0.0.57-0
+      pullPolicy: IfNotPresent
+      imagePullSecret: false
 
 magda-core:
   gateway:

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -93,6 +93,29 @@ eval $(minikube docker-env) # (If you haven't run this already)
 lerna run docker-build-local --stream --concurrency=4 --include-filtered-dependencies
 ```
 
+### Build Connector and Minion local docker images
+
+As of v0.0.57, Magda official connectors & minions live outside the core repository. You can find connector & minions repositories at [here](https://github.com/magda-io?q=connector+OR++minion).
+
+You don't have to build connector & minions docker images as the default config value file [minikube-dev.yml](https://github.com/magda-io/magda/blob/master/deploy/helm/minikube-dev.yml#L20) specifically set to use official production-ready docker image from docker hub repository.
+
+If you do want to use local build connector & minion docker images for testing & development purpose, you need to:
+
+1. Clone the relevant connector or minion repository
+2. Build & Push docker image to a local docker registry.
+
+Run the following commands from the cloned folder:
+
+```bash
+yarn install
+yarn run build
+eval $(minikube docker-env)
+yarn run docker-build-local
+```
+
+3. Modify `minikube-dev.yml`, remove the `global.connectors.image` & `global.minions.image` section.
+4. Deploy Magda with helm using the instructions provided by the [Install Magda on your minikube/docker-desktop cluster section](#install-magda-on-your-minikubedocker-desktop-cluster) below.
+
 ### Create the necessary secrets with the secret creation script
 
 ```bash
@@ -109,25 +132,6 @@ kubectl apply -f deploy/kubernetes/local-storage-volume.yaml
 ```
 
 Note: If using docker desktop for Windows older than version 19, change the value from "docker-desktop" to "docker-for-desktop" in nodeAffinity in file deploy/kubernetes/local-storage-volume.yaml
-
-### Install the CKAN connector
-
-The Magda CKAN connector (as of v0.0.57) lives outside of the core repository, at https://github.com/magda-io/magda-ckan-connector.
-
-This is necessary if you want your magda instance already populated with an initial
-set of datasets from [data.gov.au](data.gov.au). If you don't want to get datasets from
-data.gov.au, then you can skip this and set `global.connectors.includeInitialJobs` to `false`.
-
-To get the CKAN connector running,
-
-```bash
-git clone https://github.com/magda-io/magda-ckan-connector
-cd magda-ckan-connector
-yarn install
-yarn run build
-eval $(minikube docker-env)
-yarn run docker-build-local
-```
 
 ### Install Magda on your minikube/docker-desktop cluster
 


### PR DESCRIPTION
### What this PR does

Fixes #2750

It looks like we already a paragraph that talks about building connector image locally.

I think it might be easier for the user to make the build docker image step optional in order to run magda.

So I made the following changes:
- Update `minikube-dev.yaml` make connectors & minions use docker hub images by default
- Update document accordingly  

Please help to review the document and let me know if you got a better idea.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
