### PR TITLE
Tests for auth on /records/summaries API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,9 +59,10 @@ Authorization:
 -   Added ability to set per-record authorization policies in the registry (for getting a single record)
 -   Added ability to set per-record authorization policies in the registry (for getting multiple records)
 -   Added ability to use OPA policies that use data types other than strings in the registry
--   Added authorization inside links with dereferencing on or off, for the `records/<id>` endpoint
--   Added authorization inside links with dereferencing on or off, for the `records` endpoint
--   Added per-record authorization around the `records/summary/<recordid>` endpoint matching the `records/<id>` one.
+-   Added authorization inside links with dereferencing on or off, for the `/records/<id>` endpoint
+-   Added authorization inside links with dereferencing on or off, for the `/records` endpoint
+-   Added per-record authorization around the `/records/summary/<recordid>` endpoint matching the `/records/<id>` one.
+-   Added per-record authorization around the `/records/summary` endpoint matching the `/records` one.
 
 Others:
 


### PR DESCRIPTION
WARNING: Follows on from #2782, merge that first!

### What this PR does

Fixes #2374 

The issue is to add auth for the summaries API, but that already works so this is just tests.

#### To test:
- Go to https://issues-2374-authorisation-on-summaries-plural.dev.magda.io/api/v0/registry/records/summary
- There's `record-private`, which has an `owner_orgunit` policy, and `record-public`, which is public
- If you're logged in and have access to `record-private`, you should be able to see both, if you're logged out you should only be able to see one.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
