### PR TITLE
Added auth to the records/<recordId>/history endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Authorization:
 -   Added authorization inside links with dereferencing on or off, for the `/records` endpoint
 -   Added per-record authorization around the `/records/summary/<recordid>` endpoint matching the `/records/<id>` one.
 -   Added per-record authorization around the `/records/summary` endpoint matching the `/records` one.
+-   Added per-record authorization around the `/records/<recordid>/history` endpoint
 
 Others:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,9 +59,10 @@ Authorization:
 -   Added ability to set per-record authorization policies in the registry (for getting a single record)
 -   Added ability to set per-record authorization policies in the registry (for getting multiple records)
 -   Added ability to use OPA policies that use data types other than strings in the registry
--   Added authorization inside links with dereferencing on or off, for the `records/<id>` endpoint
--   Added authorization inside links with dereferencing on or off, for the `records` endpoint
--   Added per-record authorization around the `records/summary/<recordid>` endpoint matching the `records/<id>` one.
+-   Added authorization inside links with dereferencing on or off, for the `/records/<id>` endpoint
+-   Added authorization inside links with dereferencing on or off, for the `/records` endpoint
+-   Added per-record authorization around the `/records/summary/<recordid>` endpoint matching the `/records/<id>` one.
+-   Added per-record authorization around the `/records/summary` endpoint matching the `/records` one.
 
 Others:
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/TestActorSystem.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/TestActorSystem.scala
@@ -7,7 +7,7 @@ import au.csiro.data61.magda.AppConfig
 object TestActorSystem {
   // This has to be separated out to make overriding the config work for some stupid reason.
   val config = ConfigFactory.parseString(s"""
-    akka.loglevel = ${if (ContinuousIntegration.isCi) "WARNING" else "DEBUG"}
+    akka.loglevel = ERROR
     indexer.refreshInterval = -1
     akka.http.server.request-timeout = 30s
     maxResults = 100

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/CreateRecordEvent.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/CreateRecordEvent.scala
@@ -1,7 +1,11 @@
 package au.csiro.data61.magda.registry
 
-case class CreateRecordEvent(recordId: String, tenantId: BigInt, name: String)
-    extends RecordEvent
+case class CreateRecordEvent(
+    recordId: String,
+    tenantId: BigInt,
+    name: String,
+    authnReadPolicyId: Option[String]
+) extends RecordEvent
 
 object CreateRecordEvent {
   val Id = 0 // from EventTypes table

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer
-import au.csiro.data61.magda.directives.AuthDirectives
+import au.csiro.data61.magda.directives.AuthDirectives._
 import au.csiro.data61.magda.opa.OpaTypes._
 import com.typesafe.config.Config
 import scalikejdbc.DB
@@ -16,12 +16,27 @@ import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import au.csiro.data61.magda.client.AuthOperations.OperationType
 import au.csiro.data61.magda.model.TenantId
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import au.csiro.data61.magda.model.Auth.User
 
 object Directives extends Protocols with SprayJsonSupport {
-  private def skipOpaQuery(implicit config: Config) =
-    config.hasPath("authorization.skipOpaQuery") && config.getBoolean(
-      "authorization.skipOpaQuery"
-    )
+
+  /**
+    * Returns true if the configuration says to skip the opa query.
+    */
+  private def skipOpaQuery(implicit system: ActorSystem, config: Config) = {
+    val skip = config.hasPath("authorization.skipOpaQuery") && config
+      .getBoolean(
+        "authorization.skipOpaQuery"
+      )
+
+    if (skip) {
+      system.log.warning(
+        "WARNING: Skip OPA querying is turned on! This is fine for testing or playing around, but this should NOT BE TURNED ON FOR PRODUCTION!"
+      )
+    }
+
+    skip
+  }
 
   /**
     * Determines OPA policies that apply, queries OPA and parses the policies for translation to SQL or some other query language.
@@ -51,7 +66,7 @@ object Directives extends Protocols with SprayJsonSupport {
     if (skipOpaQuery) {
       provide(None)
     } else {
-      AuthDirectives.getJwt().flatMap { jwt =>
+      getJwt().flatMap { jwt =>
         val recordPolicyIds = DB readOnly { session =>
           recordPersistence
             .getPolicyIds(session, operationType, recordId.map(Set(_)))
@@ -125,7 +140,7 @@ object Directives extends Protocols with SprayJsonSupport {
     if (skipOpaQuery) {
       provide((None, None))
     } else {
-      AuthDirectives.getJwt().flatMap { jwt =>
+      getJwt().flatMap { jwt =>
         val recordPolicyIds = DB readOnly { session =>
           recordPersistence
             .getPolicyIds(session, operationType, recordId.map(Set(_)))
@@ -182,47 +197,53 @@ object Directives extends Protocols with SprayJsonSupport {
   }
 
   /**
-    * Checks whether the user making this call can actually access the passed record id. This will complete with a 404 if the user is
-    * not allowed to access the record, OR if the record simply doesn't exist at all.
+    * Checks whether the user making this call can access events for the provided record id.
+    *
+    * This will complete with 404 if:
+    *   - The record never existed OR
+    *   - The record existed and has been deleted, and the user is NOT an admin
+    *
+    * This will complete with 200 if:
+    *   - The record exists and the user is allowed to access it in its current form OR
+    *   - The record existed in the past and has been deleted, but the user is an admin
     *
     * @param recordPersistence A RecordPersistence instance to look up record policies etc through
     * @param authApiClient An auth api client to query OPA through
     * @param recordId The id of the record in question
-    * @param noPoliciesResponse What to respond with if there are no valid policies to query for (defaults to 404)
+    * @param notFoundResponse What to respond with if there are no valid policies to query for (defaults to 404)
     * @return If the record exists and the user is allowed to access it, will pass through, otherwise will complete with 404.
     */
-  def checkUserCanAccessRecord(
+  def checkUserCanAccessRecordEvents(
       recordPersistence: RecordPersistence,
       authApiClient: RegistryAuthApiClient,
       recordId: String,
       tenantId: au.csiro.data61.magda.model.TenantId.TenantId,
-      noPoliciesResponse: => ToResponseMarshallable = (
-        StatusCodes.NotFound,
-        ApiError(
-          "No record exists with that ID."
-        )
-      )
+      notFoundResponse: => ToResponseMarshallable
   )(
       implicit config: Config,
       system: ActorSystem,
       materializer: Materializer,
       ec: ExecutionContext
   ): Directive0 = {
-    withRecordOpaQuery(
-      AuthOperations.read,
-      recordPersistence,
-      authApiClient,
-      Some(recordId),
-      noPoliciesResponse
-    ).flatMap { recordQueries =>
-      DB readOnly { session =>
-        recordPersistence
-          .getById(session, tenantId, recordQueries, recordId) match {
-          case Some(record) => pass
-          case None =>
-            complete(noPoliciesResponse)
+    provideUser(authApiClient) flatMap {
+      // If the user is an admin, we should allow this even if they can't access the record
+      case Some(User(_, true)) => pass
+      case _ =>
+        withRecordOpaQuery(
+          AuthOperations.read,
+          recordPersistence,
+          authApiClient,
+          Some(recordId),
+          notFoundResponse
+        ) flatMap { recordQueries =>
+          DB readOnly { session =>
+            recordPersistence
+              .getById(session, tenantId, recordQueries, recordId) match {
+              case Some(record) => pass
+              case None         => complete(notFoundResponse)
+            }
+          }
         }
-      }
     }
   }
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -21,7 +21,7 @@ trait Protocols extends DiffsonProtocol {
   implicit val createAspectDefinitionEventFormat = jsonFormat4(
     CreateAspectDefinitionEvent.apply
   )
-  implicit val createRecordEventFormat = jsonFormat3(CreateRecordEvent.apply)
+  implicit val createRecordEventFormat = jsonFormat4(CreateRecordEvent.apply)
   implicit val createRecordAspectEventFormat = jsonFormat4(
     CreateRecordAspectEvent.apply
   )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -100,11 +100,12 @@ class RecordHistoryService(
       requiresTenantId { tenantId =>
         parameters('pageToken.as[Long].?, 'start.as[Int].?, 'limit.as[Int].?) {
           (pageToken, start, limit) =>
-            checkUserCanAccessRecord(
+            checkUserCanAccessRecordEvents(
               recordPersistence,
               authApiClient,
               id,
-              tenantId
+              tenantId,
+              EventsPage(false, None, Nil)
             )(
               config,
               system,

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -9,12 +9,17 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import au.csiro.data61.magda.directives.TenantDirectives.requiresTenantId
 import au.csiro.data61.magda.model.Registry._
+import au.csiro.data61.magda.registry.Directives._
+import au.csiro.data61.magda.client.AuthOperations
 import io.swagger.annotations._
 import javax.ws.rs.Path
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scalikejdbc.DB
+import com.typesafe.config.Config
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 /**
   * @apiGroup Registry Record History
@@ -24,6 +29,7 @@ import scalikejdbc.DB
   * @apiParam (query) {string} pageToken A token that identifies the start of a page of results. This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
   * @apiParam (query) {number} start The index of the first event to retrieve. Specify pageToken instead will result in better performance when access high offset. If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
   * @apiParam (query) {number} limit The maximum number of records to receive. The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
+  * @apiHeader {string} X-Magda-Session Magda internal session id
   * @apiSuccess (Success 200) {json} Response the event list
   * @apiSuccessExample {json} Response:
                         {
@@ -50,12 +56,16 @@ import scalikejdbc.DB
   produces = "application/json"
 )
 class RecordHistoryService(
+    authApiClient: RegistryAuthApiClient,
+    config: Config,
     system: ActorSystem,
     materializer: Materializer,
     recordPersistence: RecordPersistence,
     eventPersistence: EventPersistence
 ) extends Protocols
     with SprayJsonSupport {
+
+  implicit private val ec: ExecutionContext = system.dispatcher
 
   val route =
     history ~
@@ -90,17 +100,29 @@ class RecordHistoryService(
       requiresTenantId { tenantId =>
         parameters('pageToken.as[Long].?, 'start.as[Int].?, 'limit.as[Int].?) {
           (pageToken, start, limit) =>
-            complete {
-              DB readOnly { session =>
-                eventPersistence.getEvents(
-                  session,
-                  recordId = Some(id),
-                  pageToken = pageToken,
-                  start = start,
-                  limit = limit,
-                  tenantId = tenantId
-                )
-              }
+            checkUserCanAccessRecord(
+              recordPersistence,
+              authApiClient,
+              id,
+              tenantId
+            )(
+              config,
+              system,
+              materializer,
+              ec
+            ) {
+              complete(
+                DB readOnly { session =>
+                  eventPersistence.getEvents(
+                    session,
+                    recordId = Some(id),
+                    pageToken = pageToken,
+                    start = start,
+                    limit = limit,
+                    tenantId = tenantId
+                  )
+                }
+              )
             }
         }
       }
@@ -182,36 +204,34 @@ class RecordHistoryService(
   def version = get {
     path(Segment / "history" / Segment) { (id, version) =>
       requiresTenantId { tenantId =>
-        {
-          parameters('aspect.*, 'optionalAspect.*) {
-            (aspects: Iterable[String], optionalAspects: Iterable[String]) =>
-              DB readOnly { session =>
-                val events = eventPersistence.streamEventsUpTo(
-                  version.toLong,
-                  recordId = Some(id),
-                  tenantId = tenantId
+        parameters('aspect.*, 'optionalAspect.*) {
+          (aspects: Iterable[String], optionalAspects: Iterable[String]) =>
+            DB readOnly { session =>
+              val events = eventPersistence.streamEventsUpTo(
+                version.toLong,
+                recordId = Some(id),
+                tenantId = tenantId
+              )
+              val recordSource =
+                recordPersistence.reconstructRecordFromEvents(
+                  id,
+                  events,
+                  aspects,
+                  optionalAspects
                 )
-                val recordSource =
-                  recordPersistence.reconstructRecordFromEvents(
-                    id,
-                    events,
-                    aspects,
-                    optionalAspects
-                  )
-                val sink = Sink.head[Option[Record]]
-                val future = recordSource.runWith(sink)(materializer)
-                Await.result[Option[Record]](future, 5 seconds) match {
-                  case Some(record) => complete(record)
-                  case None =>
-                    complete(
-                      StatusCodes.NotFound,
-                      ApiError(
-                        "No record exists with that ID, it does not have a CreateRecord event, or it has been deleted."
-                      )
+              val sink = Sink.head[Option[Record]]
+              val future = recordSource.runWith(sink)(materializer)
+              Await.result[Option[Record]](future, 5 seconds) match {
+                case Some(record) => complete(record)
+                case None =>
+                  complete(
+                    StatusCodes.NotFound,
+                    ApiError(
+                      "No record exists with that ID, it does not have a CreateRecord event, or it has been deleted."
                     )
-                }
+                  )
               }
-          }
+            }
         }
       }
     }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -987,7 +987,12 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
 
       eventId <- Try {
         val eventJson =
-          CreateRecordEvent(record.id, tenantId.tenantId, record.name).toJson.compactPrint
+          CreateRecordEvent(
+            record.id,
+            tenantId.tenantId,
+            record.name,
+            record.authnReadPolicyId
+          ).toJson.compactPrint
         sql"insert into Events (eventTypeId, userId, tenantId, data) values (${CreateRecordEvent.Id}, 0, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
           .apply()
       }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -747,6 +747,8 @@ class RecordsServiceRO(
         recordPersistence
       ).route ~
       new RecordHistoryService(
+        authApiClient,
+        config,
         system,
         materializer,
         recordPersistence,

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
@@ -42,8 +42,8 @@ abstract class ApiWithOpa
     with AuthProtocols {
   override def testConfigSource: String =
     super.testConfigSource + s"""
-      |opa.recordPolicyId="object.registry.record.esri_owner_groups"
-      |akka.loglevel = ERROR
+                                |opa.recordPolicyId="object.registry.record.esri_owner_groups"
+                                |akka.loglevel = ERROR
     """.stripMargin
 
   implicit def default(implicit system: ActorSystem): RouteTestTimeout =

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/ApiWithOpa.scala
@@ -42,7 +42,8 @@ abstract class ApiWithOpa
     with AuthProtocols {
   override def testConfigSource: String =
     super.testConfigSource + s"""
-                                |opa.recordPolicyId="object.registry.record.esri_owner_groups"
+      |opa.recordPolicyId="object.registry.record.esri_owner_groups"
+      |akka.loglevel = ERROR
     """.stripMargin
 
   implicit def default(implicit system: ActorSystem): RouteTestTimeout =

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
@@ -92,7 +92,7 @@ abstract class ApiSpec
        |db.default.url = "${databaseUrl}?currentSchema=test"
        |authorization.skip = false
        |authorization.skipOpaQuery = true
-       |akka.loglevel = debug
+       |akka.loglevel = ERROR
        |authApi.baseUrl = "http://localhost:6104"
        |webhooks.actorTickRate=0
        |webhooks.eventPageSize=10
@@ -186,7 +186,7 @@ abstract class ApiSpec
   }
 
   def expectAdminCheck(httpFetcher: HttpFetcher, isAdmin: Boolean) {
-    val resFuture = Marshal(User(isAdmin))
+    val resFuture = Marshal(User("1", isAdmin))
       .to[ResponseEntity]
       .map(user => HttpResponse(status = 200, entity = user))
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
@@ -44,11 +44,11 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     it(
       "allows access to an aspect-less record if policy resolves to unconditionally allow access"
     ) { param =>
-      setupNoAspectRecord(
+      setupRecord(
         param,
         recordPolicy,
         expectedReadPolicy,
-        """{ "queries": [[]] }"""
+        policyResponseForUnconditionallyAllowed
       )
 
       Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -64,7 +64,12 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     it(
       "disallows access to an aspect-less record if policy resolves to unconditionally disallow access"
     ) { param =>
-      setupNoAspectRecord(param, recordPolicy, expectedReadPolicy, """{}""")
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForUnconditionallyDisallowed
+      )
 
       Get(s"/v0/records/foo") ~> addTenantIdHeader(
         TENANT_1
@@ -77,25 +82,37 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       "allows access to an record if record matches policy"
     ) { param =>
       addExampleAspectDef(param)
-      val recordId = "foo"
-      addRecord(
-        param,
-        Record(
-          recordId,
-          "foo",
-          Map(
-            "stringExample" -> JsObject(
-              "nested" -> JsObject("public" -> JsString("true"))
-            )
-          ),
-          authnReadPolicyId = recordPolicy
-        )
-      )
+      // val recordId = "foo"
+      // addRecord(
+      //   param,
+      //   Record(
+      //     recordId,
+      //     "foo",
+      //     Map(
+      //       "stringExample" -> JsObject(
+      //         "nested" -> JsObject("public" -> JsString("true"))
+      //       )
+      //     ),
+      //     authnReadPolicyId = recordPolicy
+      //   )
+      // )
 
-      expectOpaQueryForPolicy(
+      // expectOpaQueryForPolicy(
+      //   param,
+      //   expectedReadPolicy,
+      //   policyResponseForStringExampleAspect
+      // )
+
+      setupRecord(
         param,
+        recordPolicy,
         expectedReadPolicy,
-        policyResponseForStringExampleAspect
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("true"))
+          )
+        )
       )
 
       Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -109,25 +126,37 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       "does not allow access to an record if record does not match policy"
     ) { param =>
       addExampleAspectDef(param)
-      val recordId = "foo"
-      addRecord(
-        param,
-        Record(
-          recordId,
-          "foo",
-          Map(
-            "stringExample" -> JsObject(
-              "nested" -> JsObject("public" -> JsString("false"))
-            )
-          ),
-          authnReadPolicyId = recordPolicy
-        )
-      )
+      // val recordId = "foo"
+      // addRecord(
+      //   param,
+      //   Record(
+      //     recordId,
+      //     "foo",
+      //     Map(
+      //       "stringExample" -> JsObject(
+      //         "nested" -> JsObject("public" -> JsString("false"))
+      //       )
+      //     ),
+      //     authnReadPolicyId = recordPolicy
+      //   )
+      // )
 
-      expectOpaQueryForPolicy(
+      // expectOpaQueryForPolicy(
+      //   param,
+      //   expectedReadPolicy,
+      //   policyResponseForStringExampleAspect
+      // )
+
+      setupRecord(
         param,
+        recordPolicy,
         expectedReadPolicy,
-        policyResponseForStringExampleAspect
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("false"))
+          )
+        )
       )
 
       Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -287,11 +316,11 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     it(
       "allows access to an aspect-less record if policy resolves to unconditionally allow access"
     ) { param =>
-      setupNoAspectRecord(
+      setupRecord(
         param,
         recordPolicy,
         expectedReadPolicy,
-        """{ "queries": [[]] }"""
+        policyResponseForUnconditionallyAllowed
       )
 
       Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
@@ -307,7 +336,12 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     it(
       "disallows access to an aspect-less record if policy resolves to unconditionally disallow access"
     ) { param =>
-      setupNoAspectRecord(param, recordPolicy, expectedReadPolicy, """{}""")
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForUnconditionallyDisallowed
+      )
 
       Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
         TENANT_1
@@ -320,25 +354,37 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       "allows access to an record if record matches policy"
     ) { param =>
       addExampleAspectDef(param)
-      val recordId = "foo"
-      addRecord(
-        param,
-        Record(
-          recordId,
-          "foo",
-          Map(
-            "stringExample" -> JsObject(
-              "nested" -> JsObject("public" -> JsString("true"))
-            )
-          ),
-          authnReadPolicyId = recordPolicy
-        )
-      )
+      // val recordId = "foo"
+      // addRecord(
+      //   param,
+      //   Record(
+      //     recordId,
+      //     "foo",
+      //     Map(
+      //       "stringExample" -> JsObject(
+      //         "nested" -> JsObject("public" -> JsString("true"))
+      //       )
+      //     ),
+      //     authnReadPolicyId = recordPolicy
+      //   )
+      // )
 
-      expectOpaQueryForPolicy(
+      // expectOpaQueryForPolicy(
+      //   param,
+      //   expectedReadPolicy,
+      //   policyResponseForStringExampleAspect
+      // )
+
+      setupRecord(
         param,
+        recordPolicy,
         expectedReadPolicy,
-        policyResponseForStringExampleAspect
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("true"))
+          )
+        )
       )
 
       Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
@@ -352,25 +398,37 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       "does not allow access to an record if record does not match policy"
     ) { param =>
       addExampleAspectDef(param)
-      val recordId = "foo"
-      addRecord(
-        param,
-        Record(
-          recordId,
-          "foo",
-          Map(
-            "stringExample" -> JsObject(
-              "nested" -> JsObject("public" -> JsString("false"))
-            )
-          ),
-          authnReadPolicyId = recordPolicy
-        )
-      )
+      // val recordId = "foo"
+      // addRecord(
+      //   param,
+      //   Record(
+      //     recordId,
+      //     "foo",
+      //     Map(
+      //       "stringExample" -> JsObject(
+      //         "nested" -> JsObject("public" -> JsString("false"))
+      //       )
+      //     ),
+      //     authnReadPolicyId = recordPolicy
+      //   )
+      // )
 
-      expectOpaQueryForPolicy(
+      // expectOpaQueryForPolicy(
+      //   param,
+      //   expectedReadPolicy,
+      //   policyResponseForStringExampleAspect
+      // )
+
+      setupRecord(
         param,
+        recordPolicy,
         expectedReadPolicy,
-        policyResponseForStringExampleAspect
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("false"))
+          )
+        )
       )
 
       Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
@@ -507,27 +565,268 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
     }
   }
 
-  def setupNoAspectRecord(
+  /**
+    * Performs tests for auth on the history endpoint (/records/history/${recordId}) that should be done under
+    * three sets of conditions:
+    * 1. The record being requested has no policy set, and there is a default policy (default policy should be used)
+    *    (defaultPolicy=Some, recordHasPolicy=false)
+    * 2. The record being requested has a policy set, and there is ALSO a default policy (record policy should be used)
+    *    (defaultPolicy=Some, recordHasPolicy=true)
+    * 3. The record being requested has a policy set, and there is NO default policy (record policy should be used)
+    *    (defaultPolicy=None, recordHasPolicy=true)
+    *
+    * @param defaultPolicy The default policy that's been set in settings, or None if no policy has been set
+    * @param recordHasPolicy Whether a policy should be set on the record
+    */
+  def commonRecordHistoryTests(
+      defaultPolicy: Option[String],
+      recordHasPolicy: Boolean
+  ) = {
+    val recordPolicy = if (recordHasPolicy) Some("nonDefaultPolicy") else None
+    val expectedReadPolicy = recordPolicy.orElse(defaultPolicy).get + ".read"
+
+    it(
+      "allows access to all events of an aspect-less record if policy resolves to unconditionally allow access"
+    ) { param =>
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForUnconditionallyAllowed
+      )
+
+      Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val resRecord = responseAs[EventsPage]
+
+        resRecord.events.length shouldBe 1
+        resRecord.events.head.id shouldBe "foo"
+      }
+    }
+
+    it(
+      "returns 404 for events on an aspect-less record if policy resolves to unconditionally disallow access"
+    ) { param =>
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForUnconditionallyDisallowed
+      )
+
+      Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "allows access to an record if record matches policy"
+    ) { param =>
+      addExampleAspectDef(param)
+
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("true"))
+          )
+        )
+      )
+
+      Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.OK
+
+        val resRecord = responseAs[EventsPage]
+        resRecord.events.length shouldBe 1
+        resRecord.events.head.id shouldBe "foo"
+      }
+    }
+
+    it(
+      "does not allow access to an record if record does not match policy"
+    ) { param =>
+      addExampleAspectDef(param)
+
+      setupRecord(
+        param,
+        recordPolicy,
+        expectedReadPolicy,
+        policyResponseForStringExampleAspect,
+        Map(
+          "stringExample" -> JsObject(
+            "nested" -> JsObject("public" -> JsString("false"))
+          )
+        )
+      )
+
+      Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+
+    describe("policies successfully allow and deny for") {
+      it("a string-based policy") { param =>
+        doPolicyTestForHistory(
+          param,
+          "stringExample",
+          addStringExampleRecords(recordPolicy),
+          policyResponseForStringExampleAspect
+        )
+      }
+
+      it("a boolean-based policy") { param =>
+        doPolicyTestForHistory(
+          param,
+          "booleanExample",
+          addBooleanExampleRecords(recordPolicy),
+          policyResponseForBooleanExampleAspect
+        )
+      }
+
+      it("a numeric-based policy") { param =>
+        doPolicyTestForHistory(
+          param,
+          "numericExample",
+          addNumericExampleRecords(recordPolicy),
+          policyResponseForNumericExampleAspect
+        )
+      }
+
+      it("a policy that tests for the existence of an aspect") { param =>
+        doPolicyTestForHistory(
+          param,
+          "aspectExistenceExample",
+          addAspectExistenceExampleRecords(recordPolicy),
+          policyResponseForAspectExistenceExampleAspect
+        )
+      }
+
+      it(
+        "a policy that tests for the existence of a field within an aspect"
+      ) { param =>
+        doPolicyTestForHistory(
+          param,
+          "existenceExample",
+          addExistenceExampleRecords(recordPolicy),
+          policyResponseForExistenceExampleAspect
+        )
+      }
+
+      it(
+        "a policy that involves checking if one array and another array have a value in common (a la esri)"
+      ) { param =>
+        doPolicyTestForHistory(
+          param,
+          "arrayComparisonExample",
+          addArrayComparisonExampleRecords(recordPolicy),
+          policyResponseForArrayComparisonAspect
+        )
+      }
+
+      def doPolicyTestForHistory(
+          param: FixtureParam,
+          exampleId: String,
+          addRecords: FixtureParam => Unit,
+          policyResponse: String
+      ) = {
+        val PascalCaseId = exampleId.charAt(0).toUpper + exampleId
+          .substring(1)
+        val camelCaseId = exampleId.charAt(0).toLower + exampleId.substring(
+          1
+        )
+
+        addAspectDef(param, camelCaseId)
+        addRecords(param)
+
+        expectOpaQueryForPolicy(
+          param,
+          expectedReadPolicy,
+          policyResponse
+        ).twice()
+
+        Get(s"/v0/records/allow$PascalCaseId/history") ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get(s"/v0/records/deny$PascalCaseId/history") ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.NotFound
+        }
+      }
+    }
+
+    it("if OPA responds with an error, registry should respond with an error") {
+      param =>
+        addExampleAspectDef(param)
+        val recordId = "foo"
+        addRecord(
+          param,
+          Record(
+            recordId,
+            "foo",
+            Map(
+              "stringExample" -> JsObject(
+                "nested" -> JsObject("public" -> JsString("true"))
+              )
+            ),
+            authnReadPolicyId = recordPolicy
+          )
+        )
+
+        expectOpaQueryForPolicy(
+          param,
+          expectedReadPolicy,
+          "ERROR: Not found",
+          StatusCodes.InternalServerError
+        )
+
+        Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.InternalServerError
+        }
+    }
+  }
+
+  /**
+    * Adds a record with the supplied record policy and aspects,
+    * and returns the provided result from OPA when it's requested
+    * for the supplied expectedReadPolicy
+    */
+  def setupRecord(
       param: FixtureParam,
       recordPolicy: Option[String],
       expectedReadPolicy: String,
-      result: String
+      opaResult: String,
+      aspects: Map[String, JsObject] = Map()
   ) = {
     addRecord(
       param,
       Record(
         "foo",
         "foo",
-        Map(),
+        aspects,
         authnReadPolicyId = recordPolicy
       )
     )
     expectOpaQueryForPolicy(
       param,
       expectedReadPolicy,
-      s"""{
-            "result": ${result}
-          }"""
+      opaResult
     )
   }
 
@@ -2223,6 +2522,20 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
       )
     )
   }
+
+  val policyResponseForUnconditionallyAllowed = """
+    {
+      "result": {
+        "queries": [[]]
+      }
+    }
+  """
+
+  val policyResponseForUnconditionallyDisallowed = """
+    {
+      "result": {}
+    }
+  """
 
   val policyResponseForStringExampleAspect = """
       {

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
@@ -601,8 +601,10 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
         status shouldEqual StatusCodes.OK
         val resRecord = responseAs[EventsPage]
 
-        resRecord.events.length shouldBe 1
-        resRecord.events.head.id shouldBe "foo"
+        resRecord.events.length shouldBe 1 // one event for record creation
+        resRecord.events.head.data.fields("recordId") shouldEqual JsString(
+          "foo"
+        )
       }
     }
 
@@ -646,8 +648,10 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
         status shouldEqual StatusCodes.OK
 
         val resRecord = responseAs[EventsPage]
-        resRecord.events.length shouldBe 1
-        resRecord.events.head.id shouldBe "foo"
+        resRecord.events.length shouldBe 2 // one each for record and aspect creation
+        resRecord.events.head.data.fields("recordId") shouldEqual JsString(
+          "foo"
+        )
       }
     }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/JsonSchemaValidationSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/JsonSchemaValidationSpec.scala
@@ -15,7 +15,7 @@ class JsonSchemaValidationSpec extends ApiSpec {
        |db.default.url = "${databaseUrl}?currentSchema=test"
        |authorization.skip = false
        |authorization.skipOpaQuery = true
-       |akka.loglevel = debug
+       |akka.loglevel = ERROR
        |authApi.baseUrl = "http://localhost:6104"
        |webhooks.actorTickRate=0
        |webhooks.eventPageSize=10

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceAuthSpec.scala
@@ -35,22 +35,6 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
         it(
           "if there's no default or specific policy in place, it should deny all access"
         ) { param =>
-          addExampleAspectDef(param)
-          val recordId = "foo"
-          addRecord(
-            param,
-            Record(
-              recordId,
-              "foo",
-              Map(
-                "stringExample" -> JsObject(
-                  "nested" -> JsObject("public" -> JsString("true"))
-                )
-              ),
-              authnReadPolicyId = None
-            )
-          )
-
           Get(s"/v0/records/foo") ~> addTenantIdHeader(
             TENANT_1
           ) ~> param.api(Full).routes ~> check {
@@ -65,21 +49,23 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
         it(
           "if there's no default or specific policy in place, it should deny all access"
         ) { param =>
-          addExampleAspectDef(param)
-          val recordId = "foo"
-          addRecord(
-            param,
-            Record(
-              recordId,
-              "foo",
-              Map(
-                "stringExample" -> JsObject(
-                  "nested" -> JsObject("public" -> JsString("true"))
-                )
-              ),
-              authnReadPolicyId = None
-            )
-          )
+          setupNullPolicyRecord(param)
+
+          Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.NotFound
+          }
+        }
+      }
+
+      describe("for record history") {
+        commonRecordHistoryTests(None, true)
+
+        it(
+          "if there's no default or specific policy in place, it should deny all access"
+        ) { param =>
+          setupNullPolicyRecord(param)
 
           Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
             TENANT_1
@@ -190,6 +176,20 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
 
         }
 
+        it(
+          "if there's no default or specific policy in place, it should deny all access"
+        ) { param =>
+          setupNullPolicyRecord(param)
+
+          Get(s"/v0/records") ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val resPage = responseAs[RecordsPage[Record]]
+            resPage.records.length shouldBe 0
+          }
+        }
+
         doLinkTestsOnRecordsEndpoint(Some("a"), Some("b"), "a.read", "b.read")
       }
 
@@ -283,6 +283,39 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
             status shouldEqual StatusCodes.InternalServerError
           }
         }
+
+        it(
+          "if there's no default or specific policy in place, it should deny all access"
+        ) { param =>
+          setupNullPolicyRecord(param)
+
+          Get(s"/v0/records") ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val resPage = responseAs[RecordsPage[RecordSummary]]
+            resPage.records.length shouldBe 0
+          }
+        }
+      }
+
+      /** Creates a record with no policy */
+      def setupNullPolicyRecord(param: FixtureParam) = {
+        addExampleAspectDef(param)
+        val recordId = "foo"
+        addRecord(
+          param,
+          Record(
+            recordId,
+            "foo",
+            Map(
+              "stringExample" -> JsObject(
+                "nested" -> JsObject("public" -> JsString("true"))
+              )
+            ),
+            authnReadPolicyId = None
+          )
+        )
       }
 
       /** Sets up 5 public records with no aspects */
@@ -331,9 +364,7 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
         expectOpaQueryForPolicy(
           param,
           "not.default.policyid.read",
-          """{
-            "result": {}
-          }"""
+          policyResponseForUnconditionallyDisallowed
         )
       }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceAuthSpec.scala
@@ -25,6 +25,7 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
        |db.default.url = "${databaseUrl}?currentSchema=test"
        |authorization.skip = false
        |authorization.skipOpaQuery = false
+       |akka.loglevel = ERROR
     """.stripMargin
 
   describe("without a default policy set") {
@@ -67,10 +68,12 @@ class RecordsServiceAuthSpec extends BaseRecordsServiceAuthSpec {
         ) { param =>
           setupNullPolicyRecord(param)
 
-          Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+          Get(s"/v0/records/foo/history") ~> addTenantIdHeader(
             TENANT_1
           ) ~> param.api(Full).routes ~> check {
-            status shouldEqual StatusCodes.NotFound
+            status shouldEqual StatusCodes.OK
+            val resRecord = responseAs[EventsPage]
+            resRecord.events.length shouldBe 0
           }
         }
       }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -3131,7 +3131,8 @@ class RecordsServiceSpec extends ApiSpec {
         Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_2) ~> param
           .api(role)
           .routes ~> check {
-          status shouldEqual StatusCodes.NotFound
+          status shouldEqual StatusCodes.OK
+          responseAs[EventsPage].events.length shouldEqual 0
         }
 
         val newRecord = record.copy(sourceTag = Some("tag2"))
@@ -4291,7 +4292,7 @@ class RecordsServiceSpec extends ApiSpec {
                 status shouldEqual StatusCodes.NotFound
               }
 
-              Get(s"/v0/records/$recordId/history") ~> addTenantIdHeader(
+              param.asAdmin(Get(s"/v0/records/$recordId/history")) ~> addTenantIdHeader(
                 TENANT_1
               ) ~> param.api(role).routes ~> check {
                 status shouldEqual StatusCodes.OK

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -3131,8 +3131,7 @@ class RecordsServiceSpec extends ApiSpec {
         Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_2) ~> param
           .api(role)
           .routes ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[EventsPage].events.length shouldEqual 0
+          status shouldEqual StatusCodes.NotFound
         }
 
         val newRecord = record.copy(sourceTag = Some("tag2"))

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WithDefaultPolicyRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WithDefaultPolicyRecordsServiceAuthSpec.scala
@@ -42,16 +42,23 @@ class WithDefaultPolicyRecordsServiceAuthSpec
           it(
             "allows access to an aspect-less record if default policy resolves to unconditionally allow access"
           ) { param =>
-            val recordId = "foo"
-            addRecord(param, Record(recordId, "foo", Map(), None))
-            expectOpaQueryForPolicy(
+            //   val recordId = "foo"
+            //   addRecord(param, Record(recordId, "foo", Map(), None))
+            //   expectOpaQueryForPolicy(
+            //     param,
+            //     "default.policy.read",
+            //     """{
+            //   "result": {
+            //       "queries": [[]]
+            //   }
+            // }"""
+            //   )
+
+            setupRecord(
               param,
+              None,
               "default.policy.read",
-              """{
-            "result": {
-                "queries": [[]]
-            }
-          }"""
+              policyResponseForUnconditionallyAllowed
             )
 
             Get(s"/v0/records/foo") ~> addTenantIdHeader(
@@ -68,12 +75,18 @@ class WithDefaultPolicyRecordsServiceAuthSpec
           it(
             "disallows access to an aspect-less record if default policy resolves to unconditionally disallow access"
           ) { param =>
-            val recordId = "foo"
+            //   val recordId = "foo"
 
-            addRecord(param, Record(recordId, "foo", Map(), None))
-            expectOpaQueryForPolicy(param, "default.policy.read", """{
-            "result": {}
-          }""")
+            //   addRecord(param, Record(recordId, "foo", Map(), None))
+            //   expectOpaQueryForPolicy(param, "default.policy.read", """{
+            //   "result": {}
+            // }""")
+            setupRecord(
+              param,
+              None,
+              "default.policy.read",
+              policyResponseForUnconditionallyDisallowed
+            )
 
             Get(s"/v0/records/foo") ~> addTenantIdHeader(
               TENANT_1
@@ -203,6 +216,152 @@ class WithDefaultPolicyRecordsServiceAuthSpec
 
         describe("with no policy set on the record") {
           commonSingleRecordSummaryTests(Some("default.policy"), false)
+
+          it(
+            "allows access to an aspect-less record if default policy resolves to unconditionally allow access"
+          ) { param =>
+            val recordId = "foo"
+            addRecord(param, Record(recordId, "foo", Map(), None))
+            expectOpaQueryForPolicy(
+              param,
+              "default.policy.read",
+              """{
+              "result": {
+                  "queries": [[]]
+              }
+            }"""
+            )
+
+            Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+              TENANT_1
+            ) ~> param.api(Full).routes ~> check {
+              status shouldEqual StatusCodes.OK
+              val resRecord = responseAs[RecordSummary]
+
+              resRecord.id shouldBe "foo"
+            }
+          }
+
+          it(
+            "disallows access to an aspect-less record if default policy resolves to unconditionally disallow access"
+          ) { param =>
+            val recordId = "foo"
+
+            addRecord(param, Record(recordId, "foo", Map(), None))
+            expectOpaQueryForPolicy(param, "default.policy.read", """{
+              "result": {}
+            }""")
+
+            Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+              TENANT_1
+            ) ~> param.api(Full).routes ~> check {
+              status shouldEqual StatusCodes.NotFound
+            }
+          }
+
+          describe("based on the value in an aspect") {
+            it(
+              "allows access to an record if policy resolves true"
+            ) { param =>
+              addExampleAspectDef(param)
+              val recordId = "foo"
+              addRecord(
+                param,
+                Record(
+                  recordId,
+                  "foo",
+                  Map(
+                    "stringExample" -> JsObject(
+                      "nested" -> JsObject("public" -> JsString("true"))
+                    )
+                  ),
+                  None
+                )
+              )
+
+              expectOpaQueryForPolicy(
+                param,
+                "default.policy.read",
+                policyResponseForStringExampleAspect
+              )
+
+              Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+                TENANT_1
+              ) ~> param.api(Full).routes ~> check {
+                status shouldEqual StatusCodes.OK
+                val summary = responseAs[RecordSummary]
+                summary.aspects shouldEqual List("stringExample")
+              }
+            }
+
+            it(
+              "denies access to an record if policy resolves false"
+            ) { param =>
+              addExampleAspectDef(param)
+              val recordId = "foo"
+              addRecord(
+                param,
+                Record(
+                  recordId,
+                  "foo",
+                  Map(
+                    "stringExample" -> JsObject(
+                      "nested" -> JsObject("public" -> JsString("false"))
+                    )
+                  ),
+                  None
+                )
+              )
+              expectOpaQueryForPolicy(
+                param,
+                "default.policy.read",
+                policyResponseForStringExampleAspect
+              )
+
+              Get(s"/v0/records/summary/foo") ~> addTenantIdHeader(
+                TENANT_1
+              ) ~> param.api(Full).routes ~> check {
+                status shouldEqual StatusCodes.NotFound
+              }
+            }
+
+            it(
+              "denies access to an record if required aspect is not present"
+            ) { param =>
+              addExampleAspectDef(param)
+              val recordId = "foo"
+              addRecord(
+                param,
+                Record(
+                  recordId,
+                  "foo",
+                  Map(),
+                  None
+                )
+              )
+              expectOpaQueryForPolicy(
+                param,
+                "default.policy.read",
+                policyResponseForStringExampleAspect
+              )
+
+              Get(s"/v0/records/foo") ~> addTenantIdHeader(
+                TENANT_1
+              ) ~> param.api(Full).routes ~> check {
+                status shouldEqual StatusCodes.NotFound
+              }
+            }
+          }
+        }
+      }
+
+      describe("for record history") {
+        describe("with a policy set on the record") {
+          commonRecordHistoryTests(Some("default.policy"), true)
+        }
+
+        describe("with no policy set on the record") {
+          commonRecordHistoryTests(Some("default.policy"), false)
 
           it(
             "allows access to an aspect-less record if default policy resolves to unconditionally allow access"

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Auth.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Auth.scala
@@ -3,9 +3,9 @@ package au.csiro.data61.magda.model
 import spray.json.DefaultJsonProtocol
 
 object Auth {
-  case class User(isAdmin: Boolean)
+  case class User(userId: String, isAdmin: Boolean)
 
   trait AuthProtocols extends DefaultJsonProtocol {
-    implicit val userFormat = jsonFormat1(User)
+    implicit val userFormat = jsonFormat2(User)
   }
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Auth.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Auth.scala
@@ -3,7 +3,10 @@ package au.csiro.data61.magda.model
 import spray.json.DefaultJsonProtocol
 
 object Auth {
-  case class User(userId: String, isAdmin: Boolean)
+  case class User(
+      id: String,
+      isAdmin: Boolean
+  )
 
   trait AuthProtocols extends DefaultJsonProtocol {
     implicit val userFormat = jsonFormat2(User)


### PR DESCRIPTION
(branches off https://github.com/magda-io/magda/pull/2787, merge that first!)

### What this PR does

Fixes #2376 

This adds authorization to the records/<recordId>/history endpoint. This mostly follows the same logic as the record endpoint and the record summary endpoint, with a few exceptions:
- Current behaviour is that if a record can't be found, rather than return 404 the endpoint returns 200 with `events: []`, so if a user doesn't have access to a record, this is what's returned.
- If a record has been deleted, users will no longer be able to see any events from the record unless they're an admin - this is so that:
    - If sensitive data gets added accidentally, there's a quick and simple way to hide it
    - It avoids having to implement really complex logic around how else we could solve this problem... e.g. possibly we could figure out the record's last state and use that to determine whether the user should be allowed to see it, but then what if you want to change the policy to hide the history after that? You'd have to undelete it somehow, change the policy and then redelete it?
        - We might have to revisit this later but I don't anticipate that will be soon

#### To Test
There are 3 records in https://issues-2376-record-history-auth.dev.magda.io/:
- `record-public`should have its history viewable by anyone
- `record-private` should only be available to those who match the policy
- `record-deleted` was originally public, but has been deleted, so should only be viewable by admins.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
