### PR TITLE
Make minio, by default, deploy with `Recreate` strategy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ Storage:
 -   Support multipart upload
 -   Fixed: minio chart will not be deployed if storage-api is not turned on
 -   Make MinIO a dependency of storage's helm chart
+-   Make minio, by default, deploy with `Recreate` strategy
 
 Gateway:
 

--- a/deploy/helm/internal-charts/storage-api/values.yaml
+++ b/deploy/helm/internal-charts/storage-api/values.yaml
@@ -12,3 +12,6 @@ minio:
   nameOverride: "magda-minio"
   fullnameOverride: "magda-minio"
   existingSecret: "storage-secrets"
+  DeploymentUpdate:
+    type: Recreate
+


### PR DESCRIPTION
### What this PR does

Make minio, by default, deploy with `Recreate` strategy
- By default, it's deployed with rolling update strategy which will cause issues (the newly created pod will log `Multi-attach` error), when redeploying to an existing release. 

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
