### PR TITLE
Issue/2751 Added Error Screen for adding distributions from URL feature & allow manually create distributions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ UI:
 -   Added UI for "Publish as Open Data to data.gov.au"
 -   Refactor view dataset page & remove the edit function from the page
 -   Clarify tooltip text
+-   Added Error Screen for adding distributions from URL feature & allow manually create distributions
 
 Storage:
 

--- a/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.scss
+++ b/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.scss
@@ -44,6 +44,21 @@
             background-color: #30384d;
         }
 
+        button.manual-enter-metadata-button {
+            margin-left: 15px;
+            border-radius: 10px;
+            border: solid 2px #30384d;
+
+            font-size: 16px;
+            font-weight: 300;
+            font-stretch: normal;
+            font-style: normal;
+            line-height: 1.5;
+            letter-spacing: -0.2px;
+            text-align: center;
+            color: #30384d;
+        }
+
         h4.url-input-heading {
             font-size: 16px;
             font-weight: normal;
@@ -56,6 +71,41 @@
 
         .au-error-text {
             padding-left: 5px;
+        }
+
+        .process-url-error-message {
+            h3 {
+                margin-top: 40px;
+                font-size: 25px;
+                font-weight: normal;
+                font-stretch: normal;
+                font-style: normal;
+                line-height: normal;
+                letter-spacing: normal;
+                color: #042330;
+            }
+            .heading {
+                margin-top: 33px;
+                padding-left: 5px;
+                font-size: 17px;
+                font-weight: 300;
+                font-stretch: normal;
+                font-style: normal;
+                line-height: 1.88;
+                letter-spacing: normal;
+                color: #484848;
+            }
+            ul {
+                margin-top: 0px;
+                padding-left: 35px;
+                font-size: 17px;
+                font-weight: 300;
+                font-stretch: normal;
+                font-style: normal;
+                line-height: 1.88;
+                letter-spacing: normal;
+                color: #484848;
+            }
         }
     }
 }

--- a/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.tsx
@@ -51,7 +51,7 @@ const AddDatasetLinkSection = (props: Props) => {
         }
     };
 
-    const manaulCreate = () => {
+    const manualCreate = () => {
         if (!isUrl(url)) {
             setValidationErrorMessage("Please input an valid URL!");
         } else {
@@ -176,7 +176,7 @@ const AddDatasetLinkSection = (props: Props) => {
                 {processingErrorMessage ? (
                     <button
                         className="au-btn au-btn--secondary manual-enter-metadata-button"
-                        onClick={manaulCreate}
+                        onClick={manualCreate}
                     >
                         Manually enter metadata
                     </button>

--- a/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/AddDatasetLinkSection.tsx
@@ -3,6 +3,7 @@ import {
     Distribution,
     DistributionState,
     DistributionSource,
+    DistributionCreationMethod,
     createId
 } from "Components/Dataset/Add/DatasetAddCommon";
 import "./AddDatasetLinkSection.scss";
@@ -24,6 +25,7 @@ const AddDatasetLinkSection = (props: Props) => {
     const { type } = props;
     const [url, setUrl] = useState("");
     const [validationErrorMessage, setValidationErrorMessage] = useState("");
+    const [processingErrorMessage, setProcessingErrorMessage] = useState("");
     const distributions = props.distributions
         .map((item, idx) => ({ distribution: item, idx }))
         .filter(item => item.distribution.creationSource === props.type);
@@ -33,16 +35,38 @@ const AddDatasetLinkSection = (props: Props) => {
             setValidationErrorMessage("Please input an valid URL!");
         } else {
             setValidationErrorMessage("");
+            setProcessingErrorMessage("");
 
             props.addDistribution({
                 id: createId("dist"),
                 downloadURL: url,
                 creationSource: type,
+                creationMethod: DistributionCreationMethod.Auto,
                 title: url,
                 modified: new Date(),
                 format: "",
                 _state: DistributionState.Processing,
                 _progress: 50
+            });
+        }
+    };
+
+    const manaulCreate = () => {
+        if (!isUrl(url)) {
+            setValidationErrorMessage("Please input an valid URL!");
+        } else {
+            setValidationErrorMessage("");
+            setProcessingErrorMessage("");
+
+            props.addDistribution({
+                id: createId("dist"),
+                downloadURL: url,
+                creationSource: type,
+                creationMethod: DistributionCreationMethod.Manual,
+                title: url,
+                modified: new Date(),
+                format: "",
+                _state: DistributionState.Drafting
             });
 
             setUrl("");
@@ -79,6 +103,9 @@ const AddDatasetLinkSection = (props: Props) => {
                                         deleteDistribution={props.deleteDistribution(
                                             item.idx
                                         )}
+                                        setProcessingErrorMessage={
+                                            setProcessingErrorMessage
+                                        }
                                     />
                                 ))}
                             </div>
@@ -94,6 +121,33 @@ const AddDatasetLinkSection = (props: Props) => {
                         </div>
                     </>
                 ) : null}
+
+                {processingErrorMessage ? (
+                    <div className="process-url-error-message au-body au-page-alerts au-page-alerts--warning">
+                        <h3>{processingErrorMessage}</h3>
+                        <div className="heading">Here’s what you can do:</div>
+                        <ul>
+                            <li>
+                                Double check the URL below is correct and
+                                without any typos. If you need to edit the URL,
+                                do so below and press ‘Fetch’ again
+                            </li>
+                            <li>
+                                If the URL looks correct, it’s possible we can’t
+                                connect to the service or extract any meaningful
+                                metadata from it. You may want to try again
+                                later
+                            </li>
+                            <li>
+                                If you want to continue using this URL you can,
+                                however you’ll need to manually enter the
+                                dataset metadata. Use the ‘Manually enter
+                                metadata’ button below
+                            </li>
+                        </ul>
+                    </div>
+                ) : null}
+
                 <h4 className="url-input-heading">What is the URL?</h4>
 
                 <div>
@@ -119,6 +173,14 @@ const AddDatasetLinkSection = (props: Props) => {
                 <button className="au-btn fetch-button" onClick={fetchUrl}>
                     Fetch
                 </button>
+                {processingErrorMessage ? (
+                    <button
+                        className="au-btn au-btn--secondary manual-enter-metadata-button"
+                        onClick={manaulCreate}
+                    >
+                        Manually enter metadata
+                    </button>
+                ) : null}
             </div>
         </div>
     );

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -72,6 +72,7 @@ export type Distribution = {
     // --- An UUID for identify a file during the processing. array index is not a reliable id.
     id?: string;
     creationSource?: DistributionSource;
+    creationMethod?: DistributionCreationMethod;
     _state: DistributionState;
     _progress?: number;
 };
@@ -82,11 +83,17 @@ export enum DistributionSource {
     Api
 }
 
+export enum DistributionCreationMethod {
+    Manual,
+    Auto
+}
+
 export enum DistributionState {
     Added,
     Reading,
     Processing,
-    Ready
+    Ready,
+    Drafting
 }
 
 export function distributionStateToText(state: DistributionState) {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.scss
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.scss
@@ -188,6 +188,17 @@
                 border: solid 1px #cccaca;
             }
 
+            .SlimTextInputWithValidation {
+                .edit-icon {
+                    right: 6px;
+                    top: 7px;
+                }
+                input {
+                    padding-right: 32px;
+                    padding-left: 8px;
+                }
+            }
+
             .link-item-save-button {
                 position: absolute;
                 z-index: 1;

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, Dispatch, SetStateAction } from "react";
 import { useAsync } from "react-async-hook";
 import moment from "moment";
 import uuid from "uuid";
@@ -7,7 +7,8 @@ import { config } from "config";
 import {
     Distribution,
     DistributionState,
-    DistributionSource
+    DistributionSource,
+    DistributionCreationMethod
 } from "Components/Dataset/Add/DatasetAddCommon";
 import "./DatasetLinkItem.scss";
 
@@ -32,6 +33,7 @@ type Props = {
     ) => void;
     deleteDistribution: () => void;
     className?: string;
+    setProcessingErrorMessage: Dispatch<SetStateAction<string>>;
 };
 
 type ProcessingProps = {
@@ -270,7 +272,20 @@ const DatasetLinkItemEditing = (props: EditViewProps) => {
  *
  * @returns
  */
-async function getAllDataUrlProcessorsFromOpenfaasGateway() {
+async function getAllDataUrlProcessorsFromOpenfaasGateway(
+    type?: DistributionSource
+) {
+    if (
+        type !== DistributionSource.Api &&
+        type !== DistributionSource.DatasetUrl
+    ) {
+        throw new Error("Unknown distribution url type!");
+    }
+
+    const magdaFuncType =
+        type == DistributionSource.DatasetUrl
+            ? "data-url-processor"
+            : "api-url-processor";
     const res = await fetch(
         `${config.openfaasBaseUrl}/system/functions`,
         config.fetchOptions
@@ -285,7 +300,7 @@ async function getAllDataUrlProcessorsFromOpenfaasGateway() {
         return [];
     }
     return data.filter(
-        item => item.labels && item.labels.magdaType === "data-url-processor"
+        item => item.labels && item.labels.magdaType === magdaFuncType
     );
 }
 
@@ -294,17 +309,24 @@ interface UrlProcessingError extends Error {
 }
 
 const DatasetLinkItem = (props: Props) => {
-    const [editMode, setEditMode] = useState(false);
+    const [editMode, setEditMode] = useState(
+        props.distribution?.creationMethod ==
+            DistributionCreationMethod.Manual &&
+            props.distribution?._state == DistributionState.Drafting
+    );
 
     useAsync(async () => {
         try {
             if (props.distribution._state !== DistributionState.Processing) {
                 return;
             }
-            const processors = await getAllDataUrlProcessorsFromOpenfaasGateway();
+
+            const processors = await getAllDataUrlProcessorsFromOpenfaasGateway(
+                props.distribution.creationSource
+            );
             if (!processors || !processors.length) {
                 throw new Error(
-                    "There is no data url processor has been deployed and available for service."
+                    "There is no required url processor has been deployed or available for service."
                 );
             }
 
@@ -326,6 +348,7 @@ const DatasetLinkItem = (props: Props) => {
                                 (await res.text())
                         );
                         e.unableProcessUrl = true;
+                        throw e;
                     }
 
                     const data = await res.json();
@@ -355,18 +378,19 @@ const DatasetLinkItem = (props: Props) => {
                 })
             ).catch(e => {
                 console.log(e);
-                if (e && e.length) {
+                const error = e?.length ? e[0] : e;
+                if (error) {
                     // --- only deal with the first error
-                    if (e.UrlProcessingError === true) {
+                    if (error.unableProcessUrl === true) {
                         // --- We simplify the url processing error message here
                         // --- Different data sources might fail to recognise the url for different technical reasons but those info may be too technical to the user.
                         throw new Error(
-                            "System cannot recognise or process the URL."
+                            "We weren't able to extract any information from the URL"
                         );
                     } else {
                         // --- notify the user the `post processing` error as it'd be more `relevant` message (as at least the url has been recognised now).
                         // --- i.e. url is recognised and processed but meta data is not valid or insufficient (e.g. no distributions)
-                        throw e;
+                        throw error;
                     }
                 }
             });
@@ -395,11 +419,14 @@ const DatasetLinkItem = (props: Props) => {
             }
         } catch (e) {
             props.deleteDistribution();
-            alert("" + e);
+            props.setProcessingErrorMessage("" + (e.message ? e.message : e));
         }
     }, [props.distribution.id]);
 
-    if (props.distribution._state !== DistributionState.Ready) {
+    if (
+        props.distribution._state !== DistributionState.Ready &&
+        props.distribution._state !== DistributionState.Drafting
+    ) {
         return (
             <div
                 className={`dataset-link-item-container ${

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
@@ -197,6 +197,15 @@ const DatasetLinkItemEditing = (props: EditViewProps) => {
                         ])
                     ) {
                         setEditMode(!editMode);
+                        if (
+                            distribution?._progress ===
+                            DistributionState.Drafting
+                        ) {
+                            editDistribution(distribution => ({
+                                ...distribution,
+                                _progress: DistributionState.Ready
+                            }));
+                        }
                     }
                 }}
             >

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
@@ -198,12 +198,11 @@ const DatasetLinkItemEditing = (props: EditViewProps) => {
                     ) {
                         setEditMode(!editMode);
                         if (
-                            distribution?._progress ===
-                            DistributionState.Drafting
+                            distribution?._progress !== DistributionState.Ready
                         ) {
                             editDistribution(distribution => ({
                                 ...distribution,
-                                _progress: DistributionState.Ready
+                                _state: DistributionState.Ready
                             }));
                         }
                     }

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
@@ -333,9 +333,7 @@ const DatasetLinkItem = (props: Props) => {
                 props.distribution.creationSource
             );
             if (!processors || !processors.length) {
-                throw new Error(
-                    "There is no required url processor has been deployed or available for service."
-                );
+                throw new Error("No url processor available.");
             }
 
             const data = await promiseAny(

--- a/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/codelistEditor.tsx
@@ -1,5 +1,6 @@
 import React, { RefObject } from "react";
 import Editor from "./Editor";
+import "../Style.scss";
 import uuidv4 from "uuid/v4";
 import { ListMultiItemEditor } from "./multiItem";
 

--- a/magda-web-client/src/Components/Editing/Editors/contactEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/contactEditor.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Editor from "./Editor";
+import "../Style.scss";
 
 import "./contactEditor.scss";
 import editIcon from "assets/edit.svg";

--- a/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/multiItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Editor from "./Editor";
+import "../Style.scss";
 import "./multiItem.scss";
 
 export abstract class MultiItemEditor<V> extends React.Component<

--- a/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
+++ b/magda-web-client/src/Components/Editing/Editors/textEditor.tsx
@@ -1,5 +1,6 @@
 import React, { ReactEventHandler, FunctionComponent } from "react";
 import Editor from "./Editor";
+import "../Style.scss";
 import editIcon from "assets/edit.svg";
 import uuidv4 from "uuid/v4";
 import { ListMultiItemEditor } from "./multiItem";


### PR DESCRIPTION
### What this PR does

Fixes #2751 

Changes Summary:
- Added Error Screen
- Allow manually create distributions
- Make it works for `(and/or) Link to an API or web service` as well
  - Now if you click the fetch button, it gonna tries to query all functions with label `magdaType=api-url-processor`. If no function with that labels deployed, the error screen will be shown as the screenshot below.
  - This makes sure #2810, #2809, #2808 don't need to do any frontend changes (as long as they stick to `magdaType=api-url-processor` label)
- Fixed an edit control styling regression issue:
  - One common stylesheet (`Components/Editing/Style.scss`) is actually indirectly imported through `Components/Editing/ToggleEditor.tsx` ONLY 😢 . The ToggleEditor is not used as we removed the edit function from view dataset page.


![image](https://user-images.githubusercontent.com/674387/80057910-1c3d5d80-856b-11ea-9cb6-b3036d9873b7.png)

![image](https://user-images.githubusercontent.com/674387/80058492-b8b42f80-856c-11ea-90af-ef71faf74ced.png)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
