### PR TITLE
Fixed: function is incorrectly turned on for UI only preview

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ General:
 -   Update `building and running` documents: replace `npx` with `yarn` in all commands & replace keywords `npm dependecies` with `dependecies`
 -   Update `building and running` documents: remove `lerna` & `pancake` from `prerequisites` list
 -   New: Extract metadata from data portal URLs
+-   Fixed function is incorrectly deployed for UI only deployment
 
 UI:
 

--- a/deploy/helm/magda/requirements.yaml
+++ b/deploy/helm/magda/requirements.yaml
@@ -11,6 +11,7 @@ dependencies:
     version: 0.0.57-0
     repository: https://charts.magda.io
     tags:
+      - minions
       - minion-broken-link
 
   - name: magda-minion-format
@@ -18,6 +19,7 @@ dependencies:
     version: 0.0.57-0
     repository: https://charts.magda.io
     tags:
+      - minions
       - minion-format
 
   - name: magda-minion-linked-data-rating
@@ -25,6 +27,7 @@ dependencies:
     version: 0.0.57-0
     repository: https://charts.magda.io
     tags:
+      - minions
       - minion-linked-data-rating
 
   - name: magda-minion-visualization
@@ -32,6 +35,7 @@ dependencies:
     version: 0.0.57-0
     repository: https://charts.magda.io
     tags:
+      - minions
       - minion-visualization
 
   - name: magda-ckan-connector
@@ -39,6 +43,8 @@ dependencies:
     alias: ckan-connector-functions
     repository: https://charts.magda.io
     tags:
+      - all
+      - url-processors
       - ckan-connector-functions
 
   - name: magda-ckan-connector


### PR DESCRIPTION
### What this PR does

Fixed: function is incorrectly turned on for UI only preview

There seems be a bug with helm that:
if the followings present in value file:
```yaml
module-a:
  value-a: xxxx
```
Then dependency `module-a` with tag:
```
- module-a
```
will be turned on even if you didn't set `tags.module-a=ture`.

The documented behaviour are:
> Tags are evaluated as 'if any of the chart's tags are true then enable the chart'.

#### Test

Deploy a UI only preview should work now

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
