### PR TITLE
Use IBM Plex Sans font

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ UI:
 -   Use a new "All done!" screen at the end of the dataset flow
 -   Added Error Screen for adding distributions from URL feature & allow manually create distributions
 -   Added the support of processing ESRI REST API URL
+-   Use IBM Plex Sans font
 
 Storage:
 

--- a/magda-web-client/public/index.html
+++ b/magda-web-client/public/index.html
@@ -9,6 +9,7 @@
             content="nV420NeaH-ckqtpFS1CwE8eFRaJHRD1gT6t4NX9-W0A"
         />
         <meta name="theme-color" content="#320e3b" />
+        <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&display=swap" rel="stylesheet">
         <link
             rel="shortcut icon"
             href="%PUBLIC_URL%/api/v0/content/favicon.ico"

--- a/magda-web-client/src/AppContainer.scss
+++ b/magda-web-client/src/AppContainer.scss
@@ -1,7 +1,7 @@
 @import "_variables";
 
 #root {
-    font-family: inherit;
+    font-family: $AU-font;
 }
 
 .wrapper {

--- a/magda-web-client/src/Components/Common/DataPreviewTextBox.scss
+++ b/magda-web-client/src/Components/Common/DataPreviewTextBox.scss
@@ -1,5 +1,5 @@
 .data-preview-text-box {
-    font-family: Courier;
+    font-family: inherit;
     margin: 15px auto;
     pre {
         background: #fff;

--- a/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/SpatialAreaInput/index.scss
@@ -70,7 +70,7 @@
             width: 139.9px;
             height: 20px;
             text-align: center;
-            font-family: Helvetica;
+            font-family: inherit;
             font-size: 12px;
             font-weight: normal;
             font-style: normal;

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -1,5 +1,7 @@
 @import "fns";
 
+$AU-font: "IBM Plex Sans", sans-serif;
+
 $magda-color-primary: #320e3b;
 $magda-color-secondary: #ffffff;
 

--- a/magda-web-client/src/assets/au-govt-logo-mobile.svg
+++ b/magda-web-client/src/assets/au-govt-logo-mobile.svg
@@ -41,7 +41,9 @@
      inkscape:current-layer="Layer_1" /><metadata
      id="metadata395"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><style
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata>
+<style type="text/css">@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans');</style>           
+<style
      id="style3"
      type="text/css">
 	.st0{fill:#FFFFFF;}
@@ -898,7 +900,7 @@
      font-size="40px"
      y="-139.53755"
      x="348.25876"
-     font-family="Sans"
+     font-family="&quot;IBM Plex Sans&quot;, sans-serif"
      line-height="125%"
      fill="#000000"><tspan
        id="tspan4464"

--- a/magda-web-client/src/assets/upload-section.svg
+++ b/magda-web-client/src/assets/upload-section.svg
@@ -3,9 +3,12 @@
   <defs>
     <path id="a" d="M21.5 14.5v6h-6v2h6v6h2v-6h6v-2h-6v-6z"/>
   </defs>
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans');</style>
+  </defs>
   <g fill="none" fill-rule="evenodd">
     <path fill="#F4F4F4" stroke="#979797" stroke-dasharray="10,10" stroke-width="2" d="M6 1h1110a5 5 0 0 1 5 5v167a5 5 0 0 1-5 5H6a5 5 0 0 1-5-5V6a5 5 0 0 1 5-5z"/>
-    <text fill="#484848" font-family="-apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;" font-size="18" letter-spacing="-.3" transform="translate(1 1)">
+    <text fill="#484848" font-family="&quot;IBM Plex Sans&quot;, sans-serif" font-size="18" letter-spacing="-.3" transform="translate(1 1)">
       <tspan x="546.406" y="117.858">Drag your files here</tspan>
     </text>
     <g transform="translate(46.492 70)">


### PR DESCRIPTION
### What this PR does

Fixes #2780

Use IBM Plex Sans font
- Load the font remotely from google API (fonts.googleapis.com) rather than include it as part our source code (if we want it included as our source, please let me know)
- Have to add `<defs> / <style>` tags in SVG to make the font load in SVG (if you know a better way please let me know)



### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
