### PR TITLE
Stop apidoc from using -x instead of -c for config

### DIFF
--- a/scripts/generate-api-documentation.js
+++ b/scripts/generate-api-documentation.js
@@ -45,7 +45,7 @@ const input = fs
 
 const output = `-o ${argv.output}`;
 
-const config = `-x ${argv.config}`;
+const config = `-c ${argv.config}`;
 
 childProcess.execSync(
     `apidoc ${input} -f ".*\.scala$" -f ".*\.ts$" -f ".*\.js$" ${output} ${config}`,


### PR DESCRIPTION
### What this PR does

See https://spectrum.chat/magda/general/yarn-install-yarn-run-build-failed~333d2e09-49fd-4b47-be16-b90e8875c306

For some reason our apidocs script uses `-x apidoc.json` to specify the config file. `-x` isn't a thing. I don't think it has ever been a thing. It's not in the apidocs code. I have no idea where it came from or why it works or how. The proper flag is `-c`. In any case, for poor old was there it stopped working pretty spectacularly. So we should fix it.