### PR TITLE
Made event SQL use eventId for order again

### DIFF
--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -188,7 +188,7 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
             aspectSql.or(dereferenceSql)
           case (Some(aspectSql), None)      => aspectSql
           case (None, Some(dereferenceSql)) => dereferenceSql
-          case (None, None)                 => sqls"1=1"
+          case (None, None)                 => sqls"true"
         })
         .and(eventTypesFilter)
     )
@@ -204,7 +204,8 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
             tenantId
           from Events
           $whereClause
-          order by eventTime asc
+      ${/* for some reason if you LIMIT 1 and ORDER BY eventId, postgres chooses a weird query plan, so use eventTime in that case*/ sqls""}
+          order by ${if (limit != Some(1)) sqls"eventId" else sqls"eventTime"} asc 
           offset ${start.getOrElse(0)}
           limit ${limit.getOrElse(1000)}"""
         .map(rs => {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -217,6 +217,14 @@ trait RecordPersistence {
       aspectIds: Iterable[String] = List()
   ): Try[Iterable[String]]
 
+  /**
+    * Given a list of aspect ids, queries each of them to see if the aspects link to other aspects.
+    *
+    * Note that currently, links can only be at the first level of an aspect, and only one is supported
+    * per aspect.
+    *
+    * @return a Map of aspect ids to the first field inside that aspect that links to another aspect.
+    */
   def buildReferenceMap(
       implicit session: DBSession,
       aspectIds: Iterable[String]
@@ -1578,15 +1586,6 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
     JsonParser(rs.string("data")).asJsObject
   }
 
-  /**
-    * Given a list of aspect ids, queries each of them to see if the aspects link to other aspects.
-    *
-    * Note that currently, links can only be at the first level of an aspect, and only one is supported
-    * per aspect.
-    *
-    * @return a Map of aspect ids to the first field inside that aspect that links to another aspect.
-    *
-    */
   def buildReferenceMap(
       implicit session: DBSession,
       aspectIds: Iterable[String]


### PR DESCRIPTION
### What this PR does

Fixes #2840 

So turns out that even though ordering by `eventTime` instead of `eventId` looks OK in the query planner, it burns a lot more CPU. Putting it back to the way it was and deploying that to dev pretty much instantly took the CPU from max down to 300m.

Unfortunately even with `ORDER BY eventId` the query is still pretty bad, but I couldn't figure out a better way to do it within the 24 hour timebox I gave myself, so this'll do for now.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed (this still fits with the same changelog entry as when we changed eventId to eventTime)
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
