### PR TITLE
Issue/2844 Make add dataset page save state data into registy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@ UI:
 -   Use IBM Plex Sans font
 -   Fixed: error notification no longer has a white background
 -   Added `add dataset review page`
+-   Make `add dataset page` save state data to registry (unless in preview mode) rather than localStorage
 
 Storage:
 

--- a/deploy/helm/internal-charts/opa/policies/object/registry/record/owner_only.rego
+++ b/deploy/helm/internal-charts/opa/policies/object/registry/record/owner_only.rego
@@ -1,0 +1,14 @@
+package object.registry.record.owner_only
+
+import data.object.registry.record.owner
+import data.object.registry.record.admin_role
+import data.object.registry.record.has_permission
+
+read {
+    admin_role
+}
+
+read {
+    has_permission.read
+    owner
+}

--- a/deploy/helm/internal-charts/opa/policies/object/registry/record/owner_only_test.rego
+++ b/deploy/helm/internal-charts/opa/policies/object/registry/record/owner_only_test.rego
@@ -1,0 +1,67 @@
+package object.registry.record.owner_only
+
+test_allow_read_if_user_has_admin_role {
+    read with input as {
+        "user": {
+            "roles": ["00000000-0000-0003-0000-000000000000"]
+        }
+    }
+}
+
+test_allow_read_if_owner_and_permission_are_correct_regardless_orgunit {
+    read with input as {
+        "user": {
+            "id": "personA",
+            "permissions": [
+                {
+                   "operations": [
+                       {
+                           "uri": "object/registry/record/read"
+                       }
+                   ]
+                }
+            ],
+            "managingOrgUnitIds": []
+        },
+
+        "object": {
+            "registry": {
+                "record": {
+                    "dataset-access-control": {
+                        "ownerId": "personA",
+                        "orgUnitOwnerId": "3"
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_deny_read_if_owner_and_permission_are_incorrect {
+    not read with input as {
+        "user": {
+            "id": "personA",
+            "permissions": [
+                {
+                   "operations": [
+                       {
+                           "uri": "object/registry/record/read"
+                       }
+                   ]
+                }
+            ],
+            "managingOrgUnitIds": ["3"]
+        },
+
+        "object": {
+            "registry": {
+                "record": {
+                    "dataset-access-control": {
+                        "ownerId": "personB",
+                        "orgUnitOwnerId": "3"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/magda-registry-aspects/dataset-draft.schema.json
+++ b/magda-registry-aspects/dataset-draft.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Dataset Draft Data Storage Aspect",
+    "description": "Store the datatset draft data before submit",
+    "type": "object",
+    "properties": {
+        "data": {
+            "description": "a json string represents the dataset authoring tool state data.",
+            "format": "json",
+            "type": "string"
+        },
+        "timestamp": {
+            "title": "The timestamp when the draft data is generated. In `date-time` (ISO 8601) format",
+            "format": "date-time",
+            "type": "string"
+        }
+    },
+    "required": ["data", "timestamp"]
+}

--- a/magda-web-client/src/Components/Common/AsyncButton.tsx
+++ b/magda-web-client/src/Components/Common/AsyncButton.tsx
@@ -1,17 +1,24 @@
 import React, {
     FunctionComponent,
     ButtonHTMLAttributes,
-    useState
+    useState,
+    MouseEvent
 } from "react";
+
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+type PropsType = Overwrite<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    {
+        onClick: (e: MouseEvent<HTMLButtonElement>) => Promise<any>;
+    }
+>;
 
 /**
  * A button will auto add `...` to button content until onClick is resolved
  *
  * @param props support all buttom element's attributes
  */
-const AsyncButton: FunctionComponent<ButtonHTMLAttributes<
-    HTMLButtonElement
->> = props => {
+const AsyncButton: FunctionComponent<PropsType> = props => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const newProps = { ...props };
 

--- a/magda-web-client/src/Components/Common/AsyncButton.tsx
+++ b/magda-web-client/src/Components/Common/AsyncButton.tsx
@@ -1,0 +1,42 @@
+import React, {
+    FunctionComponent,
+    ButtonHTMLAttributes,
+    useState
+} from "react";
+
+/**
+ * A button will auto add `...` to button content until onClick is resolved
+ *
+ * @param props support all buttom element's attributes
+ */
+const AsyncButton: FunctionComponent<ButtonHTMLAttributes<
+    HTMLButtonElement
+>> = props => {
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const newProps = { ...props };
+
+    if (props.children) {
+        const frag = <>{props.children}</>;
+        newProps.children = (
+            <>
+                {frag}
+                {isLoading ? "..." : null}
+            </>
+        );
+    }
+
+    newProps.disabled = isLoading;
+
+    if (props.onClick && typeof props.onClick === "function") {
+        newProps.onClick = async (...args) => {
+            setIsLoading(true);
+            // --- await `result` will be resolved to the `result`
+            await props.onClick?.apply(null, args);
+            setIsLoading(false);
+        };
+    }
+
+    return <button {...newProps} />;
+};
+
+export default AsyncButton;

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -466,8 +466,11 @@ function populateDistributions(data: RawDataset, state: State) {
     }
 }
 
-export async function rawDatasetDataToState(data: RawDataset): Promise<State> {
-    const state = createBlankState();
+export async function rawDatasetDataToState(
+    data: RawDataset,
+    user: User
+): Promise<State> {
+    const state = createBlankState(user);
 
     populateDcatDatasetStringAspect(data, state);
     populateDatasetPublisherAspect(data, state);
@@ -512,7 +515,7 @@ export async function rawDatasetDataToState(data: RawDataset): Promise<State> {
     return state;
 }
 
-export function createBlankState(user?: User): State {
+export function createBlankState(user: User): State {
     return {
         distributions: [],
         processing: false,
@@ -560,7 +563,7 @@ export function createBlankState(user?: User): State {
 
 export async function loadStateFromLocalStorage(
     id: string,
-    user?: User
+    user: User
 ): Promise<State> {
     const stateString = localStorage[id];
     let state: State;
@@ -595,7 +598,7 @@ export async function loadStateFromLocalStorage(
 
 export async function loadStateFromRegistry(
     id: string,
-    user?: User
+    user: User
 ): Promise<State> {
     let record: RawDataset | undefined;
     try {
@@ -645,7 +648,7 @@ export async function loadStateFromRegistry(
     return state;
 }
 
-export async function loadState(id: string, user?: User): Promise<State> {
+export async function loadState(id: string, user: User): Promise<State> {
     if (config?.featureFlags?.previewAddDataset) {
         // --- in preview mode, still save to local storage
         return await loadStateFromLocalStorage(id, user);

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -528,7 +528,8 @@ export function createBlankState(user?: User): State {
 export async function loadState(id: string, user?: User): Promise<State> {
     let record: RawDataset | undefined;
     try {
-        record = await fetchRecord(id, ["dataset-draft"], [], false);
+        // --- we turned off cache here
+        record = await fetchRecord(id, ["dataset-draft"], [], false, true);
     } catch (e) {
         if (e! instanceof ServerError || e.statusCode !== 404) {
             // --- mute 404 error as we're gonna create blank status if can't find an existing one
@@ -562,7 +563,8 @@ export async function loadState(id: string, user?: User): Promise<State> {
         !state.dataset.publisher &&
         typeof config.defaultOrganizationId !== "undefined"
     ) {
-        const org = await fetchOrganization(config.defaultOrganizationId);
+        // --- we turned off cache here
+        const org = await fetchOrganization(config.defaultOrganizationId, true);
         state.dataset.publisher = {
             name: org.name,
             existingId: org.id
@@ -581,7 +583,8 @@ export async function saveState(state: State, id = createId()) {
 
     let record: RawDataset | undefined;
     try {
-        record = await fetchRecord(id, ["dataset-draft"], [], false);
+        // --- we turned off cache here
+        record = await fetchRecord(id, ["dataset-draft"], [], false, true);
     } catch (e) {
         if (e! instanceof ServerError || e.statusCode !== 404) {
             // --- mute 404 error as we're gonna create one if can't find an existing one
@@ -629,7 +632,8 @@ async function ensureBlankDatasetIsSavedToRegistry(
     name: string
 ) {
     try {
-        await fetchRecord(id, [], [], false);
+        // --- we turned off cache here
+        await fetchRecord(id, [], [], false, true);
     } catch (e) {
         if (e.statusCode !== 404) {
             throw e;
@@ -954,7 +958,8 @@ export async function submitDatasetFromState(
 ) {
     let recordExist: boolean = false;
     try {
-        if (await fetchRecord(datasetId, [], [], false)) {
+        // --- turned off cache
+        if (await fetchRecord(datasetId, [], [], false, true)) {
             recordExist = true;
         }
     } catch (e) {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -598,12 +598,27 @@ export async function saveState(state: State, id = createId()) {
     };
 
     if (!record) {
+        const { dataset, datasetPublishing } = state;
         await createDataset(
             {
                 id,
                 name: "",
                 aspects: {
-                    "dataset-draft": datasetDraftAspectData
+                    "dataset-draft": datasetDraftAspectData,
+                    publishing: {
+                        ...datasetPublishing,
+                        state: "draft",
+                        publishAsOpenData: {}
+                    },
+                    "dataset-access-control": {
+                        orgUnitOwnerId: dataset.owningOrgUnitId
+                            ? dataset.owningOrgUnitId
+                            : undefined,
+                        custodianOrgUnitId: dataset.custodianOrgUnitId
+                            ? dataset.custodianOrgUnitId
+                            : undefined
+                    },
+                    source: getInternalDatasetSourceAspectData()
                 }
             },
             []

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -654,17 +654,18 @@ export async function loadState(id: string, user?: User): Promise<State> {
     }
 }
 
-export async function saveState(state: State, id = createId()) {
+export function saveStateToLocalStorage(state: State, id: string) {
     state = Object.assign({}, state);
-
     state._lastModifiedDate = new Date();
 
-    if (config?.featureFlags?.previewAddDataset) {
-        // --- in preview mode, still save to local storage
-        const dataset = JSON.stringify(state);
-        localStorage[id] = dataset;
-        return id;
-    }
+    const dataset = JSON.stringify(state);
+    localStorage[id] = dataset;
+    return id;
+}
+
+export async function saveStateToRegistry(state: State, id: string) {
+    state = Object.assign({}, state);
+    state._lastModifiedDate = new Date();
 
     const dataset = JSON.stringify(state);
     const timestamp = state._lastModifiedDate.toISOString();
@@ -712,6 +713,15 @@ export async function saveState(state: State, id = createId()) {
     }
 
     return id;
+}
+
+export async function saveState(state: State, id = createId()) {
+    if (config?.featureFlags?.previewAddDataset) {
+        // --- in preview mode, still save to local storage
+        return saveStateToLocalStorage(state, id);
+    } else {
+        return await saveStateToRegistry(state, id);
+    }
 }
 
 export function createId(type = "ds") {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -260,7 +260,7 @@ class NewDataset extends React.Component<Props, State> {
     async saveAndExit() {
         try {
             await this.resetError();
-            saveState(this.state, this.props.datasetId);
+            await saveState(this.state, this.props.datasetId);
             this.props.history.push(`/dataset/list`);
         } catch (e) {
             this.props.createNewDatasetError(e);
@@ -271,7 +271,7 @@ class NewDataset extends React.Component<Props, State> {
         try {
             await this.resetError();
             if (ValidationManager.validateAll()) {
-                saveState(this.state, this.props.datasetId);
+                await saveState(this.state, this.props.datasetId);
                 this.props.history.push(
                     "/dataset/add/metadata/" + this.props.datasetId + "/" + step
                 );
@@ -314,7 +314,7 @@ class NewDataset extends React.Component<Props, State> {
         try {
             await this.resetError();
 
-            saveState(this.state, this.props.datasetId);
+            await saveState(this.state, this.props.datasetId);
 
             this.setState(state => ({
                 ...state,

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -145,7 +145,8 @@ class NewDataset extends React.Component<Props, State> {
             if (step === 5) {
                 // --- review page
                 if (this.state.isPublishing) {
-                    return "Publishing as draft...";
+                    // --- AsyncButton will add extra "..." when loading
+                    return "Publishing as draft";
                 } else {
                     return "Publish draft dataset";
                 }

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -265,7 +265,16 @@ class NewDataset extends React.Component<Props, State> {
         try {
             await this.resetError();
             await saveState(this.state, this.props.datasetId);
-            this.props.history.push(`/`);
+
+            if (config?.featureFlags?.previewAddDataset) {
+                // --- still redirect to dataset list page in preview wmdoe
+                this.props.history.push(`/dataset/list`);
+            } else {
+                // --- redirect to home page for my dataset section
+                // --- set nocache flag so that the my dataset section know to disable cache when query registry
+                // --- otherwise, the recent created dataset may not be list in my dataset
+                this.props.history.push(`/?nocache`);
+            }
         } catch (e) {
             this.props.createNewDatasetError(e);
         }

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -282,6 +282,10 @@ class NewDataset extends React.Component<Props, State> {
 
     async gotoStep(step) {
         try {
+            /**
+             * await here is for fixing a weird bug that causing input ctrl with validation error can't be moved into viewport
+             * Until we find the root cause of this problem, resetError() must be called with await
+             */
             await this.resetError();
             if (ValidationManager.validateAll()) {
                 await saveState(this.state, this.props.datasetId);

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -3,6 +3,7 @@ import { withRouter } from "react-router";
 import { MultilineTextEditor } from "Components/Editing/Editors/textEditor";
 
 import ToolTip from "Components/Dataset/Add/ToolTip";
+import AsyncButton from "Components/Common/AsyncButton";
 
 import {
     createNewDatasetReset,
@@ -157,13 +158,13 @@ class NewDataset extends React.Component<Props, State> {
             }
         };
 
-        const nextButtonOnClick = () => {
+        const nextButtonOnClick = async () => {
             if (step === 5) {
                 // --- review page
                 if (config.featureFlags.previewAddDataset) {
-                    this.gotoStep(step + 1);
+                    await this.gotoStep(step + 1);
                 } else {
-                    this.performPublishDataset();
+                    await this.performPublishDataset();
                 }
             } else if (step === 6) {
                 // --- all done or preview mode feedback page
@@ -173,7 +174,7 @@ class NewDataset extends React.Component<Props, State> {
                         "mailto:magda@csiro.au?subject=Add Dataset Feedback";
                 }
             } else {
-                this.gotoStep(step + 1);
+                await this.gotoStep(step + 1);
             }
         };
 
@@ -216,17 +217,19 @@ class NewDataset extends React.Component<Props, State> {
                         <div className="row next-save-button-row">
                             <div className="col-sm-12">
                                 {this.props.isBackToReview ? (
-                                    <button
+                                    <AsyncButton
                                         className="au-btn back-to-review-button"
-                                        onClick={() =>
-                                            this.gotoStep(this.steps.length - 2)
+                                        onClick={async () =>
+                                            await this.gotoStep(
+                                                this.steps.length - 2
+                                            )
                                         }
                                     >
                                         Return to Review
-                                    </button>
+                                    </AsyncButton>
                                 ) : null}
 
-                                <button
+                                <AsyncButton
                                     className={`au-btn ${
                                         this.props.isBackToReview
                                             ? "au-btn--secondary save-button"
@@ -236,14 +239,14 @@ class NewDataset extends React.Component<Props, State> {
                                     disabled={this.state.isPublishing}
                                 >
                                     {nextButtonCaption()}
-                                </button>
+                                </AsyncButton>
                                 {hideExitButton ? null : (
-                                    <button
+                                    <AsyncButton
                                         className="au-btn au-btn--secondary save-button"
                                         onClick={this.saveAndExit.bind(this)}
                                     >
                                         Save and exit
-                                    </button>
+                                    </AsyncButton>
                                 )}
                             </div>
                         </div>

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -17,7 +17,7 @@ import {
     State,
     saveState,
     DistributionState,
-    createDatasetFromState
+    submitDatasetFromState
 } from "./DatasetAddCommon";
 import DetailsAndContents from "./Pages/DetailsAndContents";
 import DatasetAddPeoplePage from "./Pages/People/DatasetAddPeoplePage";
@@ -261,7 +261,7 @@ class NewDataset extends React.Component<Props, State> {
         try {
             await this.resetError();
             await saveState(this.state, this.props.datasetId);
-            this.props.history.push(`/dataset/list`);
+            this.props.history.push(`/`);
         } catch (e) {
             this.props.createNewDatasetError(e);
         }
@@ -312,24 +312,22 @@ class NewDataset extends React.Component<Props, State> {
 
     async performPublishDataset() {
         try {
-            await this.resetError();
+            const datasetId = this.props.datasetId;
 
-            await saveState(this.state, this.props.datasetId);
+            await this.resetError();
 
             this.setState(state => ({
                 ...state,
                 isPublishing: true
             }));
 
-            await createDatasetFromState(
-                this.props.datasetId,
+            await submitDatasetFromState(
+                datasetId,
                 this.state,
                 this.setState.bind(this)
             );
 
-            this.props.history.push(
-                `/dataset/add/metadata/${this.props.datasetId}/6`
-            );
+            this.props.history.push(`/dataset/add/metadata/${datasetId}/6`);
         } catch (e) {
             this.setState({
                 isPublishing: false

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAutocomplete.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAutocomplete.tsx
@@ -4,7 +4,7 @@ import debouncePromise from "debounce-promise";
 import { searchDatasets } from "api-clients/SearchApis";
 import {
     DatasetAutocompleteChoice,
-    saveState,
+    createId,
     createBlankState
 } from "../../DatasetAddCommon";
 import ASyncSelect, { Async } from "react-select/async";
@@ -132,11 +132,8 @@ export default function DatasetAutocomplete(props: Props) {
                             label: `Add new: "${term}"`,
                             isCustomItem: true,
                             itemSelectHandler: () => {
-                                const newDatasetState = createBlankState(
-                                    props.user
-                                );
-                                newDatasetState.dataset.title = term;
-                                const newDatasetId = saveState(newDatasetState);
+                                // --- only generate id here will create datasets when submit
+                                const newDatasetId = createId();
 
                                 addChoice({
                                     existingId: newDatasetId,

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAutocomplete.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAutocomplete.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import debouncePromise from "debounce-promise";
 
 import { searchDatasets } from "api-clients/SearchApis";
-import {
-    DatasetAutocompleteChoice,
-    createId,
-    createBlankState
-} from "../../DatasetAddCommon";
+import { DatasetAutocompleteChoice, createId } from "../../DatasetAddCommon";
 import ASyncSelect, { Async } from "react-select/async";
 import ReactSelectStyles from "Components/Common/react-select/ReactSelectStyles";
 import { OptionProps } from "react-select/src/components/Option";

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { RouterProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 
 import { loadState, State } from "./DatasetAddCommon";
 import { User } from "reducers/userManagementReducer";
 import { config } from "config";
+import { useAsync } from "react-async-hook";
 
 type Props = { initialState: State; user: User } & RouterProps;
 
@@ -17,20 +18,23 @@ function mapStateToProps(state: any) {
 
 export default <T extends Props>(Component: React.ComponentType<T>) => {
     const withAddDatasetState = (props: T) => {
-        const [state, updateData] = useState<State | undefined>(undefined);
-
         const isDisabled =
             !config.featureFlags.previewAddDataset &&
             (!props.user ||
                 props.user.id === "" ||
                 props.user.isAdmin !== true);
 
-        useEffect(() => {
-            // Once redux has finished getting a logged in user, load the state (we need to pass the current user in to populate default state)
-            loadState(props.match.params.datasetId, props.user).then(state => {
-                updateData(state);
-            });
-        }, [props.user]);
+        const [state, updateData] = useState<State | undefined>(undefined);
+        const { loading, error } = useAsync(
+            async (isDisabled, datasetId, user) => {
+                if (isDisabled || !datasetId) {
+                    return;
+                }
+                const datasetState = await loadState(datasetId, user);
+                updateData(datasetState);
+            },
+            [isDisabled, props.match.params.datasetId, props.user]
+        );
 
         if (props.isFetchingWhoAmI) {
             return <div>Loading...</div>;
@@ -45,8 +49,10 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
                     </span>
                 </div>
             );
-        } else if (!state) {
+        } else if ((!state || loading) && !error) {
             return <div>Loading...</div>;
+        } else if (error) {
+            return <div>Failed to load dataset data: {"" + error}</div>;
         } else {
             return <Component {...props} initialState={state} />;
         }

--- a/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { withRouter } from "react-router";
 import { MultilineTextEditor } from "Components/Editing/Editors/textEditor";
-
+import AsyncButton from "Components/Common/AsyncButton";
 import ToolTip from "Components/Dataset/Add/ToolTip";
 
 import {
@@ -201,17 +201,19 @@ class EditDataset extends React.Component<Props, State> {
                         <div className="row next-save-button-row">
                             <div className="col-sm-12">
                                 {this.props.isBackToReview ? (
-                                    <button
+                                    <AsyncButton
                                         className="au-btn back-to-review-button"
-                                        onClick={() =>
-                                            this.gotoStep(this.steps.length - 2)
+                                        onClick={async () =>
+                                            await this.gotoStep(
+                                                this.steps.length - 2
+                                            )
                                         }
                                     >
                                         Return to Review
-                                    </button>
+                                    </AsyncButton>
                                 ) : null}
 
-                                <button
+                                <AsyncButton
                                     className={`au-btn ${
                                         this.props.isBackToReview
                                             ? "au-btn--secondary save-button"
@@ -221,16 +223,18 @@ class EditDataset extends React.Component<Props, State> {
                                     disabled={this.state.isPublishing}
                                 >
                                     {nextButtonCaption()}
-                                </button>
+                                </AsyncButton>
                                 {hideExitButton ? null : (
-                                    <button
+                                    <AsyncButton
                                         className="au-btn au-btn--secondary save-button"
-                                        onClick={() =>
-                                            this.gotoStep(this.steps.length - 2)
+                                        onClick={async () =>
+                                            await this.gotoStep(
+                                                this.steps.length - 2
+                                            )
                                         }
                                     >
                                         Review &amp; Save
-                                    </button>
+                                    </AsyncButton>
                                 )}
                             </div>
                         </div>

--- a/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
@@ -133,18 +133,15 @@ class EditDataset extends React.Component<Props, State> {
 
         step = Math.max(Math.min(step, this.steps.length - 1), 0);
 
-        const hideExitButton = config.featureFlags.previewAddDataset
-            ? step >= 4
-            : step >= 5;
+        const hideExitButton =
+            this.props.isBackToReview ||
+            (config.featureFlags.previewAddDataset ? step >= 4 : step >= 5);
 
         const nextButtonCaption = () => {
             if (step === 5) {
                 // --- review page
-                if (this.state.isPublishing) {
-                    return "Submit dataset changes...";
-                } else {
-                    return "Submit dataset changes";
-                }
+                // --- loading status is handled by AsynButton now
+                return "Submit dataset changes";
             } else if (step === 6) {
                 // --- all done or preview mode feedback page
                 // --- All done page has no button to show
@@ -154,13 +151,13 @@ class EditDataset extends React.Component<Props, State> {
             }
         };
 
-        const nextButtonOnClick = () => {
+        const nextButtonOnClick = async () => {
             if (step === 5) {
                 // --- review page
                 if (config.featureFlags.previewAddDataset) {
-                    this.gotoStep(step + 1);
+                    await this.gotoStep(step + 1);
                 } else {
-                    this.performPublishDataset();
+                    await this.performPublishDataset();
                 }
             } else if (step === 6) {
                 // --- all done or preview mode feedback page
@@ -170,7 +167,7 @@ class EditDataset extends React.Component<Props, State> {
                         "mailto:magda@csiro.au?subject=Add Dataset Feedback";
                 }
             } else {
-                this.gotoStep(step + 1);
+                await this.gotoStep(step + 1);
             }
         };
 
@@ -233,7 +230,7 @@ class EditDataset extends React.Component<Props, State> {
                                             )
                                         }
                                     >
-                                        Review &amp; Save
+                                        Review &amp; Publish
                                     </AsyncButton>
                                 )}
                             </div>

--- a/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
@@ -247,6 +247,10 @@ class EditDataset extends React.Component<Props, State> {
 
     async gotoStep(step) {
         try {
+            /**
+             * await here is for fixing a weird bug that causing input ctrl with validation error can't be moved into viewport
+             * Until we find the root cause of this problem, resetError() must be called with await
+             */
             await this.resetError();
             if (ValidationManager.validateAll()) {
                 this.props.history.push(

--- a/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/DatasetEditMetadataPage.tsx
@@ -16,7 +16,7 @@ import { editSteps as ProgressMeterStepsConfig } from "../../Common/AddDatasetPr
 import {
     State,
     DistributionState,
-    updateDatasetFromState
+    submitDatasetFromState
 } from "../Add/DatasetAddCommon";
 import DetailsAndContents from "../Add/Pages/DetailsAndContents";
 import DatasetAddPeoplePage from "../Add/Pages/People/DatasetAddPeoplePage";
@@ -294,7 +294,7 @@ class EditDataset extends React.Component<Props, State> {
                 isPublishing: true
             });
 
-            await updateDatasetFromState(
+            await submitDatasetFromState(
                 this.props.datasetId,
                 this.state,
                 this.setState.bind(this)

--- a/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
@@ -25,22 +25,25 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
                 props.user.id === "" ||
                 props.user.isAdmin !== true);
 
-        const { loading, error } = useAsync(async () => {
-            if (isDisabled || !props.match.params.datasetId) {
-                return;
-            }
-            // --- turn off cache
-            const data = await fetchRecord(
-                props.match.params.datasetId,
-                undefined,
-                undefined,
-                true,
-                true
-            );
-            const loadedStateData = await rawDatasetDataToState(data);
+        const { loading, error } = useAsync(
+            async (isDisabled, datasetId, user) => {
+                if (isDisabled || !datasetId) {
+                    return;
+                }
+                // --- turn off cache
+                const data = await fetchRecord(
+                    datasetId,
+                    undefined,
+                    undefined,
+                    true,
+                    true
+                );
+                const loadedStateData = await rawDatasetDataToState(data, user);
 
-            updateData(loadedStateData);
-        }, [isDisabled, props.match.params.datasetId]);
+                updateData(loadedStateData);
+            },
+            [isDisabled, props.match.params.datasetId, props.user]
+        );
 
         if (props.isFetchingWhoAmI) {
             return <div>Loading...</div>;

--- a/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
@@ -29,7 +29,14 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
             if (isDisabled || !props.match.params.datasetId) {
                 return;
             }
-            const data = await fetchRecord(props.match.params.datasetId);
+            // --- turn off cache
+            const data = await fetchRecord(
+                props.match.params.datasetId,
+                undefined,
+                undefined,
+                true,
+                false
+            );
             const loadedStateData = await rawDatasetDataToState(data);
 
             updateData(loadedStateData);

--- a/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
@@ -35,7 +35,7 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
                 undefined,
                 undefined,
                 true,
-                false
+                true
             );
             const loadedStateData = await rawDatasetDataToState(data);
 

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -166,6 +166,16 @@ export async function fetchRecord(
     }
 }
 
+export async function deleteRecordAspect(
+    recordId: string,
+    aspectId: string
+): Promise<void> {
+    await request(
+        "DELETE",
+        `${config.registryFullApiUrl}records/${recordId}/aspects/${aspectId}`
+    );
+}
+
 export async function doesRecordExist(id: string) {
     try {
         await fetchRecord(id, [], [], false);

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -207,6 +207,7 @@ export async function doesRecordExist(id: string) {
 export type Record = {
     id: string;
     name: string;
+    authnReadPolicyId?: string;
     aspects: { [aspectId: string]: any };
 };
 

--- a/magda-web-client/src/api-clients/createNoCacheFetchOptions.ts
+++ b/magda-web-client/src/api-clients/createNoCacheFetchOptions.ts
@@ -1,0 +1,10 @@
+export function createNoCacheFetchOptions(fetchOptions: RequestInit = {}) {
+    const options = { ...fetchOptions };
+    if (!options.headers) {
+        options.headers = {};
+    }
+    options.headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+    options.headers["Pragma"] = "no-cache";
+    options.headers["Expires"] = "0";
+    return options;
+}


### PR DESCRIPTION
### What this PR does

Fixes #2844 
- Save state data to registry (`dataset-draft` aspect) 
  - In preview mode, still save to localStorage
- `Save & Exit` button will redirect user to home page (for future My Dataset section)
  - In preview mode, still redirect to dataset listing page
  - Dataset listing page is not deleted as it's still mentioned by Preview End Page message. But only send users to it in preview mode
- refactor create/update dataset `createDataset` / `updateDataset`
  - you don't need to provide a list of json schema that is needed to ensure exists --- both function can auto figure out from supplied dataset data to avoid mistakes
- refactor ensureAspect to avoid aspect def being saved multiple times
- Allow disabled registry cache when fetch data from the registry (Functions in registry API now support an extra `noCache` parameter). Disable cache when necessary.
- Add an `AsyncButton` to auto control UI status during ajax calls. 
  - Make sure all onClick function are async function because of it
- Add a new opa policy `object.registry.record.owner_only`
  - Has to be a new name due to the package name conflict of existing `owner` policy
  - Set policy id of created datasets to it

### Test Site

You need to setup a no data preview site as it comes with backend (opa policy) changes

### Checklist

-   [x] There are unit tests to verify my changes are correct (for OPA)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
