### PR TITLE
Incorrect dates from csv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ UI:
 -   Make `add dataset page` save state data to registry (unless in preview mode) rather than localStorage
 -   Change search text to say "Search for data" instead of "Search for open data"
 -   Set flag `previewAddDataset` to `false` by default
+-   Bugfix: Read raw value from CSV files
 
 Storage:
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetFile.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetFile.tsx
@@ -35,7 +35,9 @@ function FileInProgress({
 }) {
     const progress = file._progress ? file._progress : 0;
     let width = Math.ceil((progress / 100) * 330);
-    if (width < 5) width = 5;
+    if (width < 5) {
+        width = 5;
+    }
     return (
         <div className="dataset-file-root">
             <div className="file-in-progress">
@@ -72,8 +74,8 @@ function FileInProgress({
                         </div>
                     </div>
                     <div className="file-status">
-                        {distributionStateToText(file._state)} -{" "}
-                        {file._progress}% complete
+                        {distributionStateToText(file._state)} - {progress}%
+                        complete
                     </div>
                 </div>
             </div>

--- a/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetLinkItem.tsx
@@ -116,7 +116,9 @@ const DatasetLinkItemProcessing = (props: ProcessingProps) => {
 
     const progress = distribution._progress ? distribution._progress : 0;
     let width = Math.ceil((progress / 100) * 330);
-    if (width < 5) width = 5;
+    if (width < 5) {
+        width = 5;
+    }
 
     return (
         <div className="processing-item">
@@ -154,7 +156,7 @@ const DatasetLinkItemProcessing = (props: ProcessingProps) => {
                         </div>
                     </div>
                     <div className="distribution-status">
-                        Reviewing service - {distribution._progress}% complete
+                        Reviewing service - {progress}% complete
                     </div>
                 </div>
             </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.tsx
@@ -504,7 +504,7 @@ async function processFile(thisFile: any, update: Function) {
     update({ _state: DistributionState.Ready });
 }
 
-function mapStateToProps(state, old) {
+function mapStateToProps(_state, old) {
     let dataset = old.match.params.datasetId;
     return {
         dataset

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
@@ -30,7 +30,7 @@ export function extractExtents(input, output) {
             }
 
             output.temporalCoverage = {
-                intervals: [aggregateDates(rows, headers)].filter(i => i)
+                intervals: [aggregateDates(rows, headers)]
             };
             output.spatialCoverage = calculateSpatialExtent(rows, headers);
         }

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
@@ -15,7 +15,7 @@ export function extractExtents(input, output) {
         // what if it has multiple sheets?
         const worksheet = input.workbook.Sheets[input.workbook.SheetNames[0]];
 
-        const rows = XLSX.utils.sheet_to_json(worksheet, { raw: false });
+        const rows = XLSX.utils.sheet_to_json(worksheet, { raw: true });
         if (rows.length) {
             const headersSet = new Set<string>();
             for (let row of rows) {

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractExtents.ts
@@ -106,8 +106,8 @@ function aggregateDates(rows: any[], headers: string[]) {
     let earliestDate = maxDate;
     let latestDate = minDate;
 
-    startDateHeadersInOrder.forEach(header => {
-        rows.forEach(row => {
+    rows.forEach(row => {
+        startDateHeadersInOrder.forEach(header => {
             var dateStr: string = row[header].toString();
             var parsedDate: Moment = moment.utc(dateStr, dateFormats);
             if (parsedDate) {
@@ -117,10 +117,8 @@ function aggregateDates(rows: any[], headers: string[]) {
                 }
             }
         });
-    });
 
-    endDateHeadersInOrder.forEach(header => {
-        rows.forEach(row => {
+        endDateHeadersInOrder.forEach(header => {
             var dateStr: string = row[header].toString();
             var parsedDate: Moment = moment.utc(dateStr, dateFormats);
             if (parsedDate) {

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractText.js
@@ -39,10 +39,11 @@ export async function extractText(input, output) {
  * Extracts data/metadata from various spreadsheet formats. Refer to
  * https://github.com/SheetJS/js-xlsx for more details
  */
-async function extractSpreadsheetFile(input, output, bookType = "xlsx") {
+async function extractSpreadsheetFile(input, output) {
     input.workbook = XLSX.read(input.array, {
         type: "array",
-        cellDates: true
+        cellDates: true,
+        raw: true
     });
 
     // excel files can have embedded properties; extract those
@@ -72,7 +73,7 @@ async function extractSpreadsheetFile(input, output, bookType = "xlsx") {
         input.text = Object.values(input.workbook.Sheets)
             .map(worksheet => {
                 return XLSX.utils
-                    .sheet_to_json(worksheet)
+                    .sheet_to_json(worksheet, { raw: true })
                     .map(row => Object.values(row).join(","))
                     .join("\n");
             })

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/index.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/index.ts
@@ -27,23 +27,20 @@ function delay(time) {
 }
 
 export async function runExtractors(input: ExtractorInput, update: any) {
-    for (const extractor of extractors) {
-        const index = extractors.indexOf(extractor);
+    const numExtractors = extractors.length;
+    extractors.forEach((extractor: Extractor, index: number) => {
         try {
-            console.log("Processing", index + 1, "of", extractors.length);
+            console.log("Processing", index + 1, "of", numExtractors);
             const output: any = {};
-            output._progress =
-                ((extractors.indexOf(extractor) + 0.1) / extractors.length) *
-                100;
+            output._progress = ((index + 0.1) * 100) / numExtractors;
             update(output);
-            await extractor(input, output);
-            output._progress =
-                ((extractors.indexOf(extractor) + 1) / extractors.length) * 100;
+            extractor(input, output);
+            output._progress = ((index + 1) * 100) / numExtractors;
             update(output);
-            await delay(100);
+            delay(100);
         } catch (e) {
             // even if one of the modules fail, we keep going
             console.error(e);
         }
-    }
+    });
 }

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/index.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/index.ts
@@ -22,10 +22,6 @@ export const extractors: Extractor[] = [
     extractKeywords
 ];
 
-function delay(time) {
-    return new Promise(resolve => setTimeout(resolve, time));
-}
-
 export async function runExtractors(input: ExtractorInput, update: any) {
     const numExtractors = extractors.length;
     extractors.forEach((extractor: Extractor, index: number) => {
@@ -37,7 +33,6 @@ export async function runExtractors(input: ExtractorInput, update: any) {
             extractor(input, output);
             output._progress = ((index + 1) * 100) / numExtractors;
             update(output);
-            delay(100);
         } catch (e) {
             // even if one of the modules fail, we keep going
             console.error(e);


### PR DESCRIPTION
### What this PR does

Fixes #2831 

Reads raw data from spreadsheets so that dates are not interpreted incorrectly.

## Optimization

In current master (ad93d91), to ingest the dataset at https://data.gov.au/dataset/ds-nsw-d3d51a4f-0efb-434d-b42c-90a35280ecb7/details?q=nsw%20covid%2019, it takes about 1 m 37s (on 5 June 2020, it was around 486,000 lines of CSV).

In this branch, it takes about 1 m 30 s.

I changed the order of some loops, made some small tweaks here and there.

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
-   [x] Test that the optimization actually works
