### PR TITLE
Fix missing cloud SQL proxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ General:
 -   Make Magda charts helm v3 charts
 -   Add migration document for migrating Magda release v0.0.56-RC6 or eariler to v0.0.57-0
 -   Add internal authentication provider allow user to be authenticated locally
+-   Add missing `cloud-sql-proxy` dependecy to `magda-core` chart
 
 UI:
 

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: authorization-db
   repository: file://../internal-charts/authorization-db
   version: 0.0.57-0
+- name: cloud-sql-proxy
+  repository: file://../internal-charts/cloud-sql-proxy
+  version: 0.0.57-0
 - name: combined-db
   repository: file://../internal-charts/combined-db
   version: 0.0.57-0
@@ -74,5 +77,5 @@ dependencies:
 - name: ingress
   repository: file://../internal-charts/ingress
   version: 0.0.57-0
-digest: sha256:c8888dfe8edb6b92b28348d88211077fa59f36ab3461bc1bc81b44ab1eb05641
-generated: "2020-05-01T14:20:15.040205+10:00"
+digest: sha256:e11f9dd597d72666d34c82c57b0d5dfc34f20d9201c9243482ffbc853ed927ef
+generated: "2020-06-09T17:05:39.075233+10:00"

--- a/deploy/helm/magda-core/Chart.yaml
+++ b/deploy/helm/magda-core/Chart.yaml
@@ -24,6 +24,12 @@ dependencies:
     tags:
       - all
       - authorization-db
+  - name: cloud-sql-proxy
+    version: 0.0.57-0
+    repository: file://../internal-charts/cloud-sql-proxy
+    tags:
+      - all
+      - cloud-sql-proxy
   - name: combined-db
     version: 0.0.57-0
     repository: file://../internal-charts/combined-db


### PR DESCRIPTION
### What this PR does

It turns out we never add cloud SQL proxy to `requirements.yaml`.
It worked before because we used to put all charts in `charts` folder and access it locally (rather than build it from `dependencies` ).
After we re-structured our charts, we never deploy an instance using cloud SQL. Thus, only encounter it today 😭 

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
