### PR TITLE
Issue/2870 Always set dataset publishing state to "published" no matter the approval flow is on / off

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ UI:
 -   Made files that are dropped get uploaded, if this is specified by the user
 -   Bugfix: Read raw value from CSV files
 -   Add a flag `placeholderWorkflowsOn` to hide UI components that are not complete yet
+-   Always set dataset publishing state to "published" no matter the approval flow is on / off
 
 Storage:
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -358,23 +358,22 @@ class NewDataset extends React.Component<Props, State> {
 
             this.setState((state) => ({
                 ...state,
-                isPublishing: true
+                isPublishing: true,
+                datasetPublishing: {
+                    ...state.datasetPublishing,
+                    state: "published"
+                }
             }));
 
-            // Setting datasets as approved if
-            // approval flow is turned off
-            if (!config.featureFlags.datasetApprovalWorkflowOn) {
-                this.setState((state) => ({
-                    ...state,
-                    datasetPublishing: {
-                        ...state.datasetPublishing,
-                        state: "published"
-                    }
-                }));
-            }
             await submitDatasetFromState(
                 datasetId,
-                this.state,
+                {
+                    ...this.state,
+                    datasetPublishing: {
+                        ...this.state.datasetPublishing,
+                        state: "published"
+                    }
+                },
                 this.setState.bind(this)
             );
 


### PR DESCRIPTION
### What this PR does

Fixes #2870


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
