### PR TITLE
Acronym alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,7 @@ Search
 
 -   Began work on a NodeJS-based search API to replace the scala one
 -   Allow fetch region record by region id
+-   Use a list of acronyms for publishers that have a 'Department of' in their name
 
 Others:
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
@@ -256,7 +256,11 @@ class DataSetSearchSpec extends BaseSearchApiSpec {
         def dataSetToQuery(dataSet: DataSet) = {
           dataSet.publisher
             .flatMap(d => getAcronymFromPublisherName(d.name))
-            .map(acronyms => Generators.randomCaseGen(acronyms(random.nextInt(acronyms.length)))) match {
+            .map(
+              acronyms =>
+                Generators
+                  .randomCaseGen(acronyms(random.nextInt(acronyms.length)))
+            ) match {
             case Some(randomCaseAcronymGen) =>
               randomCaseAcronymGen.flatMap(
                 acronym => Query(freeText = Some(acronym))

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
@@ -253,7 +253,7 @@ class DataSetSearchSpec extends BaseSearchApiSpec {
         def dataSetToQuery(dataSet: DataSet) = {
           dataSet.publisher
             .flatMap(d => getAcronymFromPublisherName(d.name))
-            .map(acronym => Generators.randomCaseGen(acronym)) match {
+            .map(acronyms => Generators.randomCaseGen(acronyms.head)) match {
             case Some(randomCaseAcronymGen) =>
               randomCaseAcronymGen.flatMap(
                 acronym => Query(freeText = Some(acronym))

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
@@ -32,6 +32,8 @@ import org.locationtech.jts.geom.GeometryFactory
 import org.scalacheck.Arbitrary.{arbString, arbitrary}
 import org.scalacheck.{Gen, Shrink}
 
+import scala.util.Random
+
 class DataSetSearchSpec extends BaseSearchApiSpec {
 
   blockUntilNotRed()
@@ -250,10 +252,11 @@ class DataSetSearchSpec extends BaseSearchApiSpec {
       }
 
       it("for auto-generated publishers") {
+        val random = new Random
         def dataSetToQuery(dataSet: DataSet) = {
           dataSet.publisher
             .flatMap(d => getAcronymFromPublisherName(d.name))
-            .map(acronyms => Generators.randomCaseGen(acronyms.head)) match {
+            .map(acronyms => Generators.randomCaseGen(acronyms(random.nextInt(acronyms.length)))) match {
             case Some(randomCaseAcronymGen) =>
               randomCaseAcronymGen.flatMap(
                 acronym => Query(freeText = Some(acronym))

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -46,7 +46,7 @@ object Generators {
   // reason - if there's time later on it'd be good to find out exactly what ES can accept because
   // right now we're only testing english characters.
   val textCharGen =
-    Gen.frequency((9, Gen.alphaNumChar), (1, Gen.oneOf('-', '.', ''', ' ')))
+    Gen.frequency((9, Gen.alphaNumChar), (1, Gen.oneOf('-', '.', '\'', ' ')))
 
   val nonEmptyTextGen = for {
     before <- listSizeBetween(0, 50, textCharGen).map(_.mkString.trim)

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -138,7 +138,7 @@ package misc {
       identifier: Option[String] = None,
       name: Option[String] = None,
       description: Option[String] = None,
-      acronym: Option[String] = None,
+      acronym: Option[Seq[String]] = None,
       jurisdiction: Option[String] = None,
       aggKeywords: Option[String] = None,
       email: Option[String] = None,

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -330,17 +330,32 @@ object Registry
 
   def getAcronymFromPublisherName(
       publisherName: Option[String]
-  ): Option[String] = {
+  ): Option[List[String]] = {
     publisherName
       .map("""[^a-zA-Z\s]""".r.replaceAllIn(_, ""))
-      .map(
-        """\s""".r
-          .split(_)
+      .map { nameStr =>
+        val nameStrParts = """\s""".r
+          .split(nameStr)
           .map(_.trim.toUpperCase)
-          .filter(!List("", "AND", "THE", "OF").contains(_))
-          .map(_.take(1))
-          .mkString
-      )
+
+        List(
+          Some(
+            nameStrParts
+              .filter(!List("", "AND", "THE", "OF").contains(_))
+              .map(_.take(1))
+              .mkString
+          ),
+          (if (nameStrParts(0) == "DEPARTMENT")
+             Some(
+               nameStrParts
+                 .drop(1)
+                 .filter(!List("", "AND", "THE", "OF").contains(_))
+                 .map(_.take(1))
+                 .mkString
+             )
+           else None)
+        ).filter(_.isDefined).map(_.get)
+      }
   }
 
   def convertPublisher(publisher: Registry.Record): Agent = {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/OrganisationAutocomplete.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/OrganisationAutocomplete.tsx
@@ -57,7 +57,7 @@ export default function OrganisationAutocomplete(props: Props) {
         async (term: string) => {
             const apiResult = await autocompletePublishers({}, term);
 
-            return apiResult.options.map(option => ({
+            return apiResult.options.map((option) => ({
                 existingId: option.identifier,
                 value: option.identifier,
                 label: option.value
@@ -71,7 +71,7 @@ export default function OrganisationAutocomplete(props: Props) {
             className="react-select"
             isMulti={props.multi}
             isSearchable={true}
-            onChange={(rawValue, action) => {
+            onChange={(rawValue, _action) => {
                 if (!rawValue) {
                     props.onOrgSelected(undefined);
                 } else if (props.multi) {


### PR DESCRIPTION
### What this PR does

Fixes #2868 

If a publisher/organisation has 'Department of' in its name, then two acronyms will be created for it (one with, and one without the 'Department').

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
