### PR TITLE
Started recording user id against events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,7 +100,12 @@ Authorization:
 -   Added per-record authorization around the `/records/<recordid>/history` endpoint
 -   Added per-record authorization around the `/records/<recordid>/history/<eventId>` endpoint
 
-Search
+Registry:
+
+-   Made events record the correct user id
+-   Fixed Registry History API Performance Issue when limit=1 & Updated Registry History API Document
+
+Search:
 
 -   Began work on a NodeJS-based search API to replace the scala one
 -   Allow fetch region record by region id
@@ -108,7 +113,6 @@ Search
 Others:
 
 -   Use a "Year" column from a CSV file to extract a temporal extent
--   Fixed Registry History API Performance Issue when limit=1 & Updated Registry History API Document
 -   Added tentative documentation/scripting for building and running on microk8s.
 -   Added tentative documentation/scripting for building and running on k3d.
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/RegisterWebhook.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/external/registry/RegisterWebhook.scala
@@ -89,7 +89,6 @@ object RegisterWebhook {
         includeRecords = Some(true),
         dereference = Some(true)
       ),
-      userId = Some(0), // TODO: Will have to change this when it becomes important
       isWaitingForResponse = None,
       active = true
     )

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
@@ -96,7 +96,6 @@ class RegisterWebhookSpec extends BaseRegistryApiSpec with SprayJsonSupport {
               includeRecords = None,
               dereference = None
             ),
-            userId = Some(0),
             isWaitingForResponse = None,
             active = true
           )

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
@@ -37,7 +37,11 @@ class RegisterWebhookSpec extends BaseRegistryApiSpec with SprayJsonSupport {
               marshaller: ToEntityMarshaller[WebHook]
           ) => {
             // Forward the req to the registry api
-            expectAdminCheck(param.authFetcher, true)
+            expectAdminCheck(
+              param.authFetcher,
+              true,
+              TestActorSystem.AUTH_USER_ID
+            )
             val request = Post(url, webhook)(marshaller, param.api(Full).ec)
               .withHeaders(scala.collection.immutable.Seq.concat(headers))
 
@@ -121,7 +125,11 @@ class RegisterWebhookSpec extends BaseRegistryApiSpec with SprayJsonSupport {
               marshaller: ToEntityMarshaller[WebHook]
           ) => {
             // Forward the req to the registry api
-            expectAdminCheck(param.authFetcher, true)
+            expectAdminCheck(
+              param.authFetcher,
+              true,
+              TestActorSystem.AUTH_USER_ID
+            )
             val request = Put(url, webhook)(marshaller, param.api(Full).ec)
               .withHeaders(scala.collection.immutable.Seq.concat(headers))
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/RegisterWebhookSpec.scala
@@ -182,7 +182,7 @@ class RegisterWebhookSpec extends BaseRegistryApiSpec with SprayJsonSupport {
     }
 
     def expectWebHookGet(param: FixtureParam) {
-      expectAdminCheck(param.authFetcher, true)
+      expectAdminCheck(param.authFetcher, true, TestActorSystem.AUTH_USER_ID)
       (param.authFetcher
         .get(_: String, _: Seq[HttpHeader]))
         .expects(*, *)

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookDeleteDatasetsSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookDeleteDatasetsSpec.scala
@@ -43,7 +43,7 @@ class WebhookDeleteDatasetsSpec extends WebhookSpecBase {
                 id = None,
                 eventTime = None,
                 eventType = EventType.DeleteRecord,
-                userId = 0,
+                userId = Some("36bf34b8-7610-4fd3-8aab-0beaa318920a"),
                 data = JsObject("recordId" -> JsString(dataSet.identifier)),
                 tenantId = MAGDA_ADMIN_PORTAL_ID
               )

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIncludedRecordNotDeletedSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIncludedRecordNotDeletedSpec.scala
@@ -38,7 +38,7 @@ class WebhookIncludedRecordNotDeletedSpec extends WebhookSpecBase {
                 id = None,
                 eventTime = None,
                 eventType = EventType.DeleteRecord,
-                userId = 0,
+                userId = Some("36bf34b8-7610-4fd3-8aab-0beaa318920a"),
                 data = JsObject("recordId" -> JsString(dataSet.identifier)),
                 tenantId = 1
               )

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/TestActorSystem.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/TestActorSystem.scala
@@ -5,6 +5,8 @@ import com.typesafe.config.ConfigFactory
 import au.csiro.data61.magda.AppConfig
 
 object TestActorSystem {
+  val AUTH_USER_ID = "36bf34b8-7610-4fd3-8aab-0beaa318920a"
+
   // This has to be separated out to make overriding the config work for some stupid reason.
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = ERROR
@@ -33,7 +35,7 @@ object TestActorSystem {
       baseUrl = "http://localhost:8888/v0/opa/"
       testSessionId = "general-search-api-tests"
     }
-    auth.userId = "1"
+    auth.userId = "$AUTH_USER_ID"
   """).resolve().withFallback(AppConfig.conf())
 
   def actorSystem = ActorSystem("TestActorSystem", config)

--- a/magda-migrator-registry-db/sql/V2_4__Link_user_id_to_auth_db.sql
+++ b/magda-migrator-registry-db/sql/V2_4__Link_user_id_to_auth_db.sql
@@ -1,0 +1,18 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE events
+    DROP CONSTRAINT events_userid_fkey;
+
+ALTER TABLE webhooks
+	DROP CONSTRAINT webhooks_userid_fkey;
+
+DROP TABLE users;
+
+ALTER TABLE events
+    DROP COLUMN userid;
+
+ALTER TABLE webhooks
+    DROP COLUMN userid;
+
+ALTER TABLE events
+    ADD COLUMN userid uuid;

--- a/magda-minion-framework/src/registerWebhook.ts
+++ b/magda-minion-framework/src/registerWebhook.ts
@@ -15,10 +15,8 @@ export default async function registerNewWebhook(
 
     const webHookConfig = buildWebhookConfig(options);
 
-    const userId = "b1fddd6f-e230-4068-bd2c-1a21844f1598";
     const newWebHook: WebHook = {
         id: options.id,
-        userId,
         name: options.id,
         active: true,
         url: getWebhookUrl(options),

--- a/magda-minion-framework/src/test/registry.spec.ts
+++ b/magda-minion-framework/src/test/registry.spec.ts
@@ -237,7 +237,6 @@ function buildWebHook(
         name: id,
         url: `${internalUrl}/hook`,
         active: true,
-        userId,
         eventTypes: [
             "CreateRecord",
             "CreateAspectDefinition",

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
@@ -22,7 +22,7 @@ class AspectValidator(config: Config, recordPersistence: RecordPersistence) {
       implicit session: DBSession
   ) {
     if (shouldValidate()) {
-      AspectPersistence.getById(session, aspectId, tenantId) match {
+      AspectPersistence.getById(aspectId, tenantId) match {
         case Some(aspectDef) => validateWithDefinition(aspectDef, aspectData)
         case None =>
           throw new Exception(
@@ -67,7 +67,6 @@ class AspectValidator(config: Config, recordPersistence: RecordPersistence) {
       tenantId: TenantId
   )(implicit session: DBSession): Unit = {
     val originalAspect = (recordPersistence.getRecordAspectById(
-      session,
       tenantId,
       recordId,
       aspectId,

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
@@ -86,11 +86,11 @@ class AspectsService(
   )
   def create: Route = post {
     pathEnd {
-      requireIsAdmin(authClient)(system, config) { _ =>
+      requireIsAdmin(authClient)(system, config) { user =>
         requiresSpecifiedTenantId { tenantId =>
           entity(as[AspectDefinition]) { aspect =>
             val theResult = DB localTx { session =>
-              AspectPersistence.create(session, aspect, tenantId) match {
+              AspectPersistence.create(aspect, tenantId, user.id)(session) match {
                 case Success(result) =>
                   complete(result)
                 case Failure(exception) =>
@@ -178,11 +178,11 @@ class AspectsService(
   def putById: Route = put {
     path(Segment) { id: String =>
       {
-        requireIsAdmin(authClient)(system, config) { _ =>
+        requireIsAdmin(authClient)(system, config) { user =>
           requiresSpecifiedTenantId { tenantId =>
             entity(as[AspectDefinition]) { aspect =>
               val theResult = DB localTx { session =>
-                AspectPersistence.putById(session, id, aspect, tenantId) match {
+                AspectPersistence.putById(id, aspect, tenantId, user.id)(session) match {
                   case Success(result) =>
                     complete(result)
                   case Failure(exception) =>
@@ -270,12 +270,12 @@ class AspectsService(
   )
   def patchById: Route = patch {
     path(Segment) { id: String =>
-      requireIsAdmin(authClient)(system, config) { _ =>
+      requireIsAdmin(authClient)(system, config) { user =>
         requiresSpecifiedTenantId { tenantId =>
           entity(as[JsonPatch]) { aspectPatch =>
             val theResult = DB localTx { session =>
               AspectPersistence
-                .patchById(session, id, aspectPatch, tenantId) match {
+                .patchById(id, aspectPatch, tenantId, user.id)(session) match {
                 case Success(result) =>
                   complete(result)
                 case Failure(exception) =>

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
@@ -90,7 +90,8 @@ class AspectsService(
         requiresSpecifiedTenantId { tenantId =>
           entity(as[AspectDefinition]) { aspect =>
             val theResult = DB localTx { session =>
-              AspectPersistence.create(aspect, tenantId, user.id)(session) match {
+              AspectPersistence
+                .create(aspect, tenantId, user.id)(session) match {
                 case Success(result) =>
                   complete(result)
                 case Failure(exception) =>
@@ -182,7 +183,9 @@ class AspectsService(
           requiresSpecifiedTenantId { tenantId =>
             entity(as[AspectDefinition]) { aspect =>
               val theResult = DB localTx { session =>
-                AspectPersistence.putById(id, aspect, tenantId, user.id)(session) match {
+                AspectPersistence.putById(id, aspect, tenantId, user.id)(
+                  session
+                ) match {
                   case Success(result) =>
                     complete(result)
                   case Failure(exception) =>

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
@@ -67,7 +67,7 @@ class AspectsServiceRO(
       requiresTenantId { tenantId =>
         complete {
           DB readOnly { session =>
-            AspectPersistence.getAll( tenantId)(session)
+            AspectPersistence.getAll(tenantId)(session)
           }
         }
       }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsServiceRO.scala
@@ -67,7 +67,7 @@ class AspectsServiceRO(
       requiresTenantId { tenantId =>
         complete {
           DB readOnly { session =>
-            AspectPersistence.getAll(session, tenantId)
+            AspectPersistence.getAll( tenantId)(session)
           }
         }
       }
@@ -123,7 +123,7 @@ class AspectsServiceRO(
     path(Segment) { id: String =>
       requiresTenantId { tenantId =>
         DB readOnly { session =>
-          AspectPersistence.getById(session, id, tenantId) match {
+          AspectPersistence.getById(id, tenantId)(session) match {
             case Some(aspect) => complete(aspect)
             case None =>
               complete(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
@@ -67,9 +67,9 @@ object Directives extends Protocols with SprayJsonSupport {
       provide(None)
     } else {
       getJwt().flatMap { jwt =>
-        val recordPolicyIds = DB readOnly { session =>
+        val recordPolicyIds = DB readOnly { implicit session =>
           recordPersistence
-            .getPolicyIds(session, operationType, recordId.map(Set(_)))
+            .getPolicyIds(operationType, recordId.map(Set(_)))
         } get
 
         if (recordPolicyIds.isEmpty) {
@@ -141,14 +141,13 @@ object Directives extends Protocols with SprayJsonSupport {
       provide((None, None))
     } else {
       getJwt().flatMap { jwt =>
-        val recordPolicyIds = DB readOnly { session =>
+        val recordPolicyIds = DB readOnly { implicit session =>
           recordPersistence
-            .getPolicyIds(session, operationType, recordId.map(Set(_)))
+            .getPolicyIds(operationType, recordId.map(Set(_)))
         } get
 
-        val linkedRecordIds = DB readOnly { session =>
+        val linkedRecordIds = DB readOnly { implicit session =>
           recordPersistence.getLinkedRecordIds(
-            session,
             operationType,
             recordId,
             aspectIds
@@ -158,10 +157,9 @@ object Directives extends Protocols with SprayJsonSupport {
         val linkedRecordPolicyIds =
           if (linkedRecordIds.isEmpty) List()
           else
-            DB readOnly { session =>
+            DB readOnly { implicit session =>
               recordPersistence
                 .getPolicyIds(
-                  session,
                   operationType,
                   Some(linkedRecordIds.toSet)
                 )
@@ -236,9 +234,9 @@ object Directives extends Protocols with SprayJsonSupport {
           Some(recordId),
           notFoundResponse
         ) flatMap { recordQueries =>
-          DB readOnly { session =>
+          DB readOnly { implicit session =>
             recordPersistence
-              .getById(session, tenantId, recordQueries, recordId) match {
+              .getById(tenantId, recordQueries, recordId) match {
               case Some(record) => pass
               case None         => complete(notFoundResponse)
             }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsService.scala
@@ -124,17 +124,17 @@ class RecordAspectsService(
   def putById: Route = put {
     path(Segment / "aspects" / Segment) {
       (recordId: String, aspectId: String) =>
-        requireIsAdmin(authClient)(system, config) { _ =>
+        requireIsAdmin(authClient)(system, config) { user =>
           requiresSpecifiedTenantId { tenantId =>
             entity(as[JsObject]) { aspect =>
               val theResult = DB localTx { session =>
                 recordPersistence.putRecordAspectById(
-                  session,
                   tenantId,
                   recordId,
                   aspectId,
-                  aspect
-                ) match {
+                  aspect,
+                  user.id
+                )(session) match {
                   case Success(result) => complete(result)
                   case Failure(exception) =>
                     complete(
@@ -210,15 +210,15 @@ class RecordAspectsService(
   def deleteById: Route = delete {
     path(Segment / "aspects" / Segment) {
       (recordId: String, aspectId: String) =>
-        requireIsAdmin(authClient)(system, config) { _ =>
+        requireIsAdmin(authClient)(system, config) { user =>
           requiresSpecifiedTenantId { tenantId =>
             val theResult = DB localTx { session =>
               recordPersistence.deleteRecordAspect(
-                session,
                 tenantId,
                 recordId,
-                aspectId
-              ) match {
+                aspectId,
+                user.id
+              )(session) match {
                 case Success(result) => complete(DeleteResult(result))
                 case Failure(exception) =>
                   complete(
@@ -313,17 +313,17 @@ class RecordAspectsService(
   def patchById: Route = patch {
     path(Segment / "aspects" / Segment) {
       (recordId: String, aspectId: String) =>
-        requireIsAdmin(authClient)(system, config) { _ =>
+        requireIsAdmin(authClient)(system, config) { user =>
           requiresSpecifiedTenantId { tenantId =>
             entity(as[JsonPatch]) { aspectPatch =>
               val theResult = DB localTx { session =>
                 recordPersistence.patchRecordAspectById(
-                  session,
                   tenantId,
                   recordId,
                   aspectId,
-                  aspectPatch
-                ) match {
+                  aspectPatch,
+                  user.id
+                )(session) match {
                   case Success(result) => complete(result)
                   case Failure(exception) =>
                     complete(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordAspectsServiceRO.scala
@@ -118,10 +118,9 @@ class RecordAspectsServiceRO(
               materializer,
               system.dispatcher
             ) { opaQueries =>
-              DB readOnly { session =>
+              DB readOnly { implicit session =>
                 recordPersistence
                   .getRecordAspectById(
-                    session,
                     tenantId,
                     recordId,
                     aspectId,

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -113,9 +113,8 @@ class RecordHistoryService(
               ec
             ) {
               complete(
-                DB readOnly { session =>
+                DB readOnly { implicit session =>
                   eventPersistence.getEvents(
-                    session,
                     recordId = Some(id),
                     pageToken = pageToken,
                     start = start,

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -26,16 +26,14 @@ import com.typesafe.config.Config
 trait RecordPersistence {
 
   def getAll(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       pageToken: Option[String],
       start: Option[Int],
       limit: Option[Int]
-  ): RecordsPage[RecordSummary]
+  )(implicit session: DBSession): RecordsPage[RecordSummary]
 
   def getAllWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       optionalAspectIds: Iterable[String],
@@ -48,26 +46,23 @@ trait RecordPersistence {
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil,
       orderBy: Option[OrderByDef] = None
-  ): RecordsPage[Record]
+  )(implicit session: DBSession): RecordsPage[Record]
 
   def getCount(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       aspectIds: Iterable[String],
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil
-  ): Long
+  )(implicit session: DBSession): Long
 
   def getById(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       id: String
-  ): Option[RecordSummary]
+  )(implicit session: DBSession): Option[RecordSummary]
 
   def getByIdWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       id: String,
       recordOpaQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -75,10 +70,9 @@ trait RecordPersistence {
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): Option[Record]
+  )(implicit session: DBSession): Option[Record]
 
   def getByIdsWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       ids: Iterable[String],
       opaRecordQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -86,10 +80,9 @@ trait RecordPersistence {
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): RecordsPage[Record]
+  )(implicit session: DBSession): RecordsPage[Record]
 
   def getRecordsLinkingToRecordIds(
-      implicit session: DBSession,
       tenantId: TenantId,
       ids: Iterable[String],
       opaRecordQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -98,32 +91,30 @@ trait RecordPersistence {
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): RecordsPage[Record]
+  )(implicit session: DBSession): RecordsPage[Record]
 
   def getRecordAspectById(
-      implicit session: DBSession,
       tenantId: TenantId,
       recordId: String,
       aspectId: String,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]]
-  ): Option[JsObject]
+  )(implicit session: DBSession): Option[JsObject]
 
   def getPageTokens(
-      implicit session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       limit: Option[Int] = None,
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable()
-  ): List[String]
+  )(implicit session: DBSession): List[String]
 
   def putRecordById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       id: String,
       newRecord: Record,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record]
+  )(implicit session: DBSession): Try[Record]
 
   def processRecordPatchOperationsOnAspects[T](
       recordPatch: JsonPatch,
@@ -133,66 +124,67 @@ trait RecordPersistence {
   ): Iterable[T]
 
   def patchRecordById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       id: String,
       recordPatch: JsonPatch,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record]
+  )(implicit session: DBSession): Try[Record]
 
   def patchRecordAspectById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       aspectPatch: JsonPatch,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject]
+  )(implicit session: DBSession): Try[JsObject]
 
   def putRecordAspectById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       newAspect: JsObject,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject]
+  )(implicit session: DBSession): Try[JsObject]
 
   def createRecord(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       record: Record,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record]
+  )(implicit session: DBSession): Try[Record]
 
   def deleteRecord(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
-      recordId: String
-  ): Try[Boolean]
+      recordId: String,
+      userId: String
+  )(implicit session: DBSession): Try[Boolean]
 
   def trimRecordsBySource(
       tenantId: SpecifiedTenantId,
       sourceTagToPreserve: String,
       sourceId: String,
+      userId: String,
       logger: Option[LoggingAdapter] = None
   )(implicit session: DBSession): Try[Long]
 
   def createRecordAspect(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       aspect: JsObject,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject]
+  )(implicit session: DBSession): Try[JsObject]
 
   def deleteRecordAspect(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
-      aspectId: String
-  ): Try[Boolean]
+      aspectId: String,
+      userId: String
+  )(implicit session: DBSession): Try[Boolean]
 
   def reconstructRecordFromEvents(
       id: String,
@@ -207,18 +199,16 @@ trait RecordPersistence {
     * has a policy id of NULL.
     */
   def getPolicyIds(
-      implicit session: DBSession,
       operation: AuthOperations.OperationType,
       recordIds: Option[Set[String]] = None
-  ): Try[List[String]]
+  )(implicit session: DBSession): Try[List[String]]
 
   /** Given a record and aspects being requested, returns the ids of all records that the record/aspect id combinations link to */
   def getLinkedRecordIds(
-      implicit session: DBSession,
       operation: AuthOperations.OperationType,
       recordId: Option[String] = None,
       aspectIds: Iterable[String] = List()
-  ): Try[Iterable[String]]
+  )(implicit session: DBSession): Try[Iterable[String]]
 
   /**
     * Given a list of aspect ids, queries each of them to see if the aspects link to other aspects.
@@ -229,9 +219,8 @@ trait RecordPersistence {
     * @return a Map of aspect ids to the first field inside that aspect that links to another aspect.
     */
   def buildReferenceMap(
-      implicit session: DBSession,
       aspectIds: Iterable[String]
-  ): Map[String, PropertyWithLink]
+  )(implicit session: DBSession): Map[String, PropertyWithLink]
 }
 
 class DefaultRecordPersistence(config: Config)
@@ -248,14 +237,13 @@ class DefaultRecordPersistence(config: Config)
     else None
 
   def getAll(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       pageToken: Option[String],
       start: Option[Int],
       limit: Option[Int]
-  ): RecordsPage[RecordSummary] = {
-    this.getSummaries(session, tenantId, opaQueries, pageToken, start, limit)
+  )(implicit session: DBSession): RecordsPage[RecordSummary] = {
+    this.getSummaries(tenantId, opaQueries, pageToken, start, limit)
   }
 
   private def getSqlFromAspectQueries(
@@ -290,7 +278,6 @@ class DefaultRecordPersistence(config: Config)
   }
 
   def getAllWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       optionalAspectIds: Iterable[String],
@@ -303,7 +290,7 @@ class DefaultRecordPersistence(config: Config)
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil,
       orderBy: Option[OrderByDef] = None
-  ): RecordsPage[Record] = {
+  )(implicit session: DBSession): RecordsPage[Record] = {
 
     // --- make sure if orderBy is used, the involved aspectId is, at least, included in optionalAspectIds
     val notIncludedAspectIds = (orderBy
@@ -316,7 +303,6 @@ class DefaultRecordPersistence(config: Config)
     )
 
     this.getRecords(
-      session,
       tenantId,
       aspectIds,
       optionalAspectIds ++ notIncludedAspectIds,
@@ -335,20 +321,18 @@ class DefaultRecordPersistence(config: Config)
   // Is this what we want?
   // See ticket https://github.com/magda-io/magda/issues/2360
   def getCount(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       aspectIds: Iterable[String],
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil
-  ): Long = {
+  )(implicit session: DBSession): Long = {
 
     val selectors = Seq(
       getSqlFromAspectQueries(aspectQueries, aspectOrQueries)
     )
 
     this.getCountInner(
-      session,
       tenantId,
       opaQueries,
       aspectIds,
@@ -357,19 +341,17 @@ class DefaultRecordPersistence(config: Config)
   }
 
   def getById(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       id: String
-  ): Option[RecordSummary] = {
+  )(implicit session: DBSession): Option[RecordSummary] = {
     this
-      .getSummaries(session, tenantId, opaQueries, None, None, None, Some(id))
+      .getSummaries(tenantId, opaQueries, None, None, None, Some(id))
       .records
       .headOption
   }
 
   def getByIdWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       id: String,
       recordOpaQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -377,10 +359,9 @@ class DefaultRecordPersistence(config: Config)
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): Option[Record] = {
+  )(implicit session: DBSession): Option[Record] = {
     this
       .getRecords(
-        session,
         tenantId,
         aspectIds,
         optionalAspectIds,
@@ -397,7 +378,6 @@ class DefaultRecordPersistence(config: Config)
   }
 
   def getByIdsWithAspects(
-      implicit session: DBSession,
       tenantId: TenantId,
       ids: Iterable[String],
       opaRecordQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -405,12 +385,11 @@ class DefaultRecordPersistence(config: Config)
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): RecordsPage[Record] = {
+  )(implicit session: DBSession): RecordsPage[Record] = {
     if (ids.isEmpty)
       RecordsPage(hasMore = false, Some("0"), List())
     else
       this.getRecords(
-        session,
         tenantId,
         aspectIds,
         optionalAspectIds,
@@ -425,7 +404,6 @@ class DefaultRecordPersistence(config: Config)
   }
 
   def getRecordsLinkingToRecordIds(
-      implicit session: DBSession,
       tenantId: TenantId,
       ids: Iterable[String],
       opaRecordQueries: Option[List[(String, List[List[OpaQuery]])]],
@@ -434,9 +412,9 @@ class DefaultRecordPersistence(config: Config)
       aspectIds: Iterable[String] = Seq(),
       optionalAspectIds: Iterable[String] = Seq(),
       dereference: Option[Boolean] = None
-  ): RecordsPage[Record] = {
+  )(implicit session: DBSession): RecordsPage[Record] = {
     val linkAspects =
-      buildReferenceMap(session, List.concat(aspectIds, optionalAspectIds))
+      buildReferenceMap(List.concat(aspectIds, optionalAspectIds))
     if (linkAspects.isEmpty) {
       // There are no linking aspects, so there cannot be any records linking to these IDs.
       RecordsPage(hasMore = false, None, List())
@@ -461,7 +439,6 @@ class DefaultRecordPersistence(config: Config)
       )
 
       this.getRecords(
-        session,
         tenantId,
         aspectIds,
         optionalAspectIds,
@@ -477,12 +454,11 @@ class DefaultRecordPersistence(config: Config)
   }
 
   def getRecordAspectById(
-      implicit session: DBSession,
       tenantId: TenantId,
       recordId: String,
       aspectId: String,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]]
-  ): Option[JsObject] = {
+  )(implicit session: DBSession): Option[JsObject] = {
     val opaSql =
       getOpaConditions(opaQueries, AuthOperations.read, defaultOpaPolicyId)
 
@@ -503,13 +479,12 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def getPageTokens(
-      implicit session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       limit: Option[Int] = None,
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable()
-  ): List[String] = {
+  )(implicit session: DBSession): List[String] = {
     val recordsFilteredByTenantClause = filterRecordsByTenantClause(tenantId)
 
     val requiredAspectsAndOpaQueriesSelectors: Seq[Option[SQLSyntax]] =
@@ -544,12 +519,12 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def putRecordById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       id: String,
       newRecord: Record,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record] = {
+  )(implicit session: DBSession): Try[Record] = {
     val newRecordWithoutAspects = newRecord.copy(aspects = Map())
 
     for {
@@ -570,7 +545,6 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       }
 
       oldRecordWithoutAspects <- this.getByIdWithAspects(
-        session,
         tenantId,
         id,
         None,
@@ -583,7 +557,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
         // we don't end up with an extraneous record creation event in the database.
         case None =>
           // Check if record exists without any auth
-          this.getById(session, tenantId, None, id) match {
+          this.getById(tenantId, None, id) match {
             case Some(record) =>
               Failure(
                 // TODO: Return a better error code.
@@ -595,14 +569,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
               DB.localTx { nested =>
                 // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
                 // --- as the aspect data has been validated (unless not required) in the beginning of current method
-                createRecord(nested, tenantId, newRecord, true).map(
+                createRecord(tenantId, newRecord, userId, true)(nested).map(
                   _.copy(aspects = Map())
                 )
               } match {
                 case Success(record) => Success(record)
                 case Failure(e) =>
                   this.getByIdWithAspects(
-                    session,
                     tenantId,
                     id,
                     None,
@@ -627,10 +600,10 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
       // --- as the aspect data has been validated (unless not required) in the beginning of current method
       result <- patchRecordById(
-        session,
         tenantId,
         id,
         recordPatch,
+        userId,
         true
       )
       patchedAspects <- Try {
@@ -641,11 +614,11 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
               // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
               // --- as the aspect data has been validated (unless not required) in the beginning of current method
               this.putRecordAspectById(
-                session,
                 tenantId,
                 id,
                 aspectId,
                 data,
+                userId,
                 true
               )
             )
@@ -759,14 +732,14 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def patchRecordById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       id: String,
       recordPatch: JsonPatch,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record] = {
+  )(implicit session: DBSession): Try[Record] = {
     for {
-      record <- this.getByIdWithAspects(session, tenantId, id, None, None) match {
+      record <- this.getByIdWithAspects(tenantId, id, None, None) match {
         case Some(record) => Success(record)
         case None =>
           Failure(new RuntimeException("No record exists with that ID."))
@@ -812,7 +785,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
           val event =
             PatchRecordEvent(id, tenantId.tenantId, recordOnlyPatch).toJson.compactPrint
           val eventId =
-            sql"insert into Events (eventTypeId, userId, tenantId, data) values (${PatchRecordEvent.Id}, 0, ${tenantId.tenantId}, $event::json)"
+            sql"insert into Events (eventTypeId, userId, tenantId, data) values (${PatchRecordEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $event::json)"
               .updateAndReturnGeneratedKey()
               .apply()
           sql"""update Records set name = ${patchedRecord.name}, authnReadPolicyId = ${patchedRecord.authnReadPolicyId}, lastUpdate = $eventId
@@ -832,11 +805,11 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
             (
               aspectId,
               putRecordAspectById(
-                session,
                 tenantId,
                 id,
                 aspectId,
                 aspectData,
+                userId,
                 true
               )
             ),
@@ -844,16 +817,16 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
             (
               aspectId,
               patchRecordAspectById(
-                session,
                 tenantId,
                 id,
                 aspectId,
                 aspectPatch,
+                userId,
                 true
               )
             ),
           (aspectId: String) => {
-            deleteRecordAspect(session, tenantId, id, aspectId)
+            deleteRecordAspect(tenantId, id, aspectId, userId)
             (aspectId, Success(JsNull))
           }
         )
@@ -883,16 +856,15 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def patchRecordAspectById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       aspectPatch: JsonPatch,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject] = {
+  )(implicit session: DBSession): Try[JsObject] = {
     for {
       aspect <- (this.getRecordAspectById(
-        session,
         tenantId,
         recordId,
         aspectId,
@@ -932,7 +904,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
             aspectId,
             aspectPatch
           ).toJson.compactPrint
-          sql"insert into Events (eventTypeId, userId, tenantId, data) values (${PatchRecordAspectEvent.Id}, 0, ${tenantId.tenantId}, $event::json)"
+          sql"insert into Events (eventTypeId, userId, tenantId, data) values (${PatchRecordAspectEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $event::json)"
             .updateAndReturnGeneratedKey()
             .apply()
         } else {
@@ -943,10 +915,11 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       _ <- Try {
         if (testRecordAspectPatch.ops.nonEmpty) {
           val jsonString = patchedAspect.compactPrint
-          sql"""insert into RecordAspects (recordId, tenantId, aspectId, lastUpdate, data) values ($recordId, ${tenantId.tenantId}, $aspectId, $eventId, $jsonString::json)
-               on conflict (aspectId, recordId, tenantId) do update
-               set lastUpdate = $eventId, data = $jsonString::json
-               """.update.apply()
+          sql"""insert into RecordAspects (recordId, tenantId, aspectId, lastUpdate, data)
+              values ($recordId, ${tenantId.tenantId}, $aspectId, $eventId, $jsonString::json)
+              on conflict (aspectId, recordId, tenantId) do update
+              set lastUpdate = $eventId, data = $jsonString::json
+          """.update.apply()
         } else {
           0
         }
@@ -955,13 +928,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def putRecordAspectById(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       newAspect: JsObject,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject] = {
+  )(implicit session: DBSession): Try[JsObject] = {
     for {
       // --- validate Aspect data against JSON schema
       _ <- Try {
@@ -971,7 +944,6 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
           )
       }
       oldAspect <- this.getRecordAspectById(
-        session,
         tenantId,
         recordId,
         aspectId,
@@ -987,18 +959,17 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
             // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
             // --- as the aspect data has been validated (unless not required) in the beginning of current method
             createRecordAspect(
-              nested,
               tenantId,
               recordId,
               aspectId,
               newAspect,
+              userId,
               true
-            )
+            )(nested)
           } match {
             case Success(aspect) => Success(aspect)
             case Failure(e) =>
               this.getRecordAspectById(
-                session,
                 tenantId,
                 recordId,
                 aspectId,
@@ -1019,22 +990,22 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
       // --- as the aspect data has been validated (unless not required) in the beginning of current method
       result <- patchRecordAspectById(
-        session,
         tenantId,
         recordId,
         aspectId,
         recordAspectPatch,
+        userId,
         true
       )
     } yield result
   }
 
   def createRecord(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       record: Record,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[Record] = {
+  )(implicit session: DBSession): Try[Record] = {
     for {
 
       // --- validate aspects data against json schema
@@ -1053,7 +1024,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
             record.name,
             record.authnReadPolicyId
           ).toJson.compactPrint
-        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${CreateRecordEvent.Id}, 0, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
+        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${CreateRecordEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
           .apply()
       }
       _ <- Try {
@@ -1076,13 +1047,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
         .map(
           aspect =>
             createRecordAspect(
-              session,
               tenantId,
               record.id,
               aspect._1,
               aspect._2,
+              userId,
               true
-            )
+            )(session)
         )
         .find(_.isFailure) match {
         case Some(Failure(e)) => Failure(e)
@@ -1092,10 +1063,10 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def deleteRecord(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
-      recordId: String
-  ): Try[Boolean] = {
+      recordId: String,
+      userId: String
+  )(implicit session: DBSession): Try[Boolean] = {
     for {
       aspects <- Try {
         sql"select aspectId from RecordAspects where (recordId, tenantId)=($recordId, ${tenantId.tenantId})"
@@ -1105,7 +1076,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       }
       _ <- aspects
         .map(
-          aspectId => deleteRecordAspect(session, tenantId, recordId, aspectId)
+          aspectId => deleteRecordAspect(tenantId, recordId, aspectId, userId)
         )
         .find(_.isFailure) match {
         case Some(Failure(e)) => Failure(e)
@@ -1114,7 +1085,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       _ <- Try {
         val eventJson =
           DeleteRecordEvent(recordId, tenantId.tenantId).toJson.compactPrint
-        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${DeleteRecordEvent.Id}, 0, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
+        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${DeleteRecordEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
           .apply()
       }
       rowsDeleted <- Try {
@@ -1128,6 +1099,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       tenantId: SpecifiedTenantId,
       sourceTagToPreserve: String,
       sourceId: String,
+      userId: String,
       logger: Option[LoggingAdapter] = None
   )(implicit session: DBSession): Try[Long] = {
     val recordIds = Try {
@@ -1141,7 +1113,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       case Success(Nil) => Success(0L)
       case Success(ids) =>
         ids
-          .map(recordId => deleteRecord(session, tenantId, recordId))
+          .map(recordId => deleteRecord(tenantId, recordId, userId))
           .foldLeft[Try[Long]](Success(0L))(
             (trySoFar: Try[Long], thisTry: Try[Boolean]) =>
               (trySoFar, thisTry) match {
@@ -1170,13 +1142,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def createRecordAspect(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
       aspectId: String,
       aspect: JsObject,
+      userId: String,
       forceSkipAspectValidation: Boolean = false
-  ): Try[JsObject] = {
+  )(implicit session: DBSession): Try[JsObject] = {
     for {
 
       _ <- Try {
@@ -1191,7 +1163,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
           aspectId,
           aspect
         ).toJson.compactPrint
-        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${CreateRecordAspectEvent.Id}, 0, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
+        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${CreateRecordAspectEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
           .apply()
       }
       insertResult <- Try {
@@ -1213,16 +1185,16 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def deleteRecordAspect(
-      implicit session: DBSession,
       tenantId: SpecifiedTenantId,
       recordId: String,
-      aspectId: String
-  ): Try[Boolean] = {
+      aspectId: String,
+      userId: String
+  )(implicit session: DBSession): Try[Boolean] = {
     for {
       _ <- Try {
         val eventJson =
           DeleteRecordAspectEvent(recordId, tenantId.tenantId, aspectId).toJson.compactPrint
-        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${DeleteRecordAspectEvent.Id}, 0, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
+        sql"insert into Events (eventTypeId, userId, tenantId, data) values (${DeleteRecordAspectEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
           .apply()
       }
       rowsDeleted <- Try {
@@ -1298,10 +1270,9 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def getPolicyIds(
-      implicit session: DBSession,
       operation: AuthOperations.OperationType,
       recordIds: Option[Set[String]] = None
-  ): Try[List[String]] = {
+  )(implicit session: DBSession): Try[List[String]] = {
     val whereClause = recordIds match {
       case Some(recordIds) if !recordIds.isEmpty =>
         sqls"""WHERE ${SQLSyntax.joinWithOr(
@@ -1335,14 +1306,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def getLinkedRecordIds(
-      implicit session: DBSession,
       operation: AuthOperations.OperationType,
       recordId: Option[String] = None,
       aspectIds: Iterable[String] = List()
-  ): Try[Iterable[String]] = {
+  )(implicit session: DBSession): Try[Iterable[String]] = {
 
     /** For aspects that have links to other aspects, a map of the ids of those aspects to the location (first-level, not path) in their JSON where the link is  */
-    val referenceMap = this.buildReferenceMap(session, aspectIds)
+    val referenceMap = this.buildReferenceMap(aspectIds)
     val recordIdClause = recordId match {
       case Some(recordId) => sqls"AND recordId = ${recordId}"
       case none           => SQLSyntax.empty
@@ -1375,14 +1345,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   // Is this what we want?
   // See ticket https://github.com/magda-io/magda/issues/2359
   private def getSummaries(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       pageToken: Option[String],
       start: Option[Int],
       rawLimit: Option[Int],
       recordId: Option[String] = None
-  ): RecordsPage[RecordSummary] = {
+  )(implicit session: DBSession): RecordsPage[RecordSummary] = {
     val countWhereClauseParts =
       if (recordId.nonEmpty)
         Seq(
@@ -1440,7 +1409,6 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   private def getRecords(
-      implicit session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       optionalAspectIds: Iterable[String],
@@ -1452,7 +1420,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
       dereference: Option[Boolean] = None,
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable(),
       orderBy: Option[OrderByDef] = None
-  ): RecordsPage[Record] = {
+  )(implicit session: DBSession): RecordsPage[Record] = {
 
     if (orderBy.isDefined && pageToken.isDefined) {
       throw new Error(
@@ -1481,7 +1449,6 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
         .map(token => sqls"Records.sequence > $token")
 
     val aspectSelectors = aspectIdsToSelectClauses(
-      session,
       tenantId,
       List.concat(aspectIds, optionalAspectIds), // aspectIds must come before optionalAspectIds.
       AuthOperations.read,
@@ -1558,12 +1525,11 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   private def getCountInner(
-      implicit session: DBSession,
       tenantId: TenantId,
       opaQueries: Option[List[(String, List[List[OpaQuery]])]],
       aspectIds: Iterable[String],
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable()
-  ): Long = {
+  )(implicit session: DBSession): Long = {
     val recordsFilteredByTenantClause = filterRecordsByTenantClause(tenantId)
     val opaConditions =
       getOpaConditions(opaQueries, AuthOperations.read, defaultOpaPolicyId)
@@ -1657,9 +1623,8 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   def buildReferenceMap(
-      implicit session: DBSession,
       aspectIds: Iterable[String]
-  ): Map[String, PropertyWithLink] = {
+  )(implicit session: DBSession): Map[String, PropertyWithLink] = {
     if (aspectIds.isEmpty) {
       Map()
     } else {
@@ -1773,14 +1738,13 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
   }
 
   private def aspectIdsToSelectClauses(
-      session: DBSession,
       tenantId: TenantId,
       aspectIds: Iterable[String],
       operationType: AuthOperations.OperationType,
       recordOpaQueries: Option[List[(String, List[List[OpaQuery]])]],
       linkedRecordOpaQueries: Option[List[(String, List[List[OpaQuery]])]],
       dereference: Boolean = false
-  ): Iterable[scalikejdbc.SQLSyntax] = {
+  )(implicit session: DBSession): Iterable[scalikejdbc.SQLSyntax] = {
     val outerOpaConditions =
       getOpaConditions(recordOpaQueries, operationType, defaultOpaPolicyId)
     val linkedRecordOpaConditions =
@@ -1790,7 +1754,7 @@ where (RecordAspects.recordId, RecordAspects.aspectId)=($recordId, $aspectId) AN
         defaultOpaPolicyId
       )
     val referenceDetails =
-      buildReferenceMap(session, aspectIds.toSeq)
+      buildReferenceMap(aspectIds.toSeq)
 
     val result: Iterable[SQLSyntax] = aspectIds.zipWithIndex.map {
       case (aspectId, index) =>

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -289,9 +289,8 @@ class RecordsServiceRO(
                     )
                   } else {
                     complete {
-                      DB readOnly { session =>
+                      DB readOnly { implicit session =>
                         recordPersistence.getAllWithAspects(
-                          session,
                           tenantId,
                           aspects,
                           optionalAspects,
@@ -428,10 +427,9 @@ class RecordsServiceRO(
               ec
             ) { opaQueries =>
               complete {
-                DB readOnly { session =>
+                DB readOnly { implicit session =>
                   recordPersistence
                     .getAll(
-                      session,
                       tenantId,
                       opaQueries,
                       pageToken,
@@ -600,11 +598,10 @@ class RecordsServiceRO(
               ec
             ) { opaQueries =>
               complete {
-                DB readOnly { session =>
+                DB readOnly { implicit session =>
                   CountResponse(
                     recordPersistence
                       .getCount(
-                        session,
                         tenantId,
                         opaQueries,
                         aspects,
@@ -697,10 +694,9 @@ class RecordsServiceRO(
               ec
             ) { opaQueries =>
               complete {
-                DB readOnly { session =>
+                DB readOnly { implicit session =>
                   "0" :: recordPersistence
                     .getPageTokens(
-                      session,
                       tenantId,
                       aspect,
                       opaQueries,
@@ -823,9 +819,8 @@ class RecordsServiceRO(
             ) { opaQueries =>
               opaQueries match {
                 case (recordQueries, linkedRecordQueries) =>
-                  DB readOnly { session =>
+                  DB readOnly { implicit session =>
                     recordPersistence.getByIdWithAspects(
-                      session,
                       tenantId,
                       id,
                       recordQueries,
@@ -927,9 +922,9 @@ class RecordsServiceRO(
           materializer,
           ec
         ) { recordQueries =>
-          DB readOnly { session =>
+          DB readOnly { implicit session =>
             recordPersistence
-              .getById(session, tenantId, recordQueries, id) match {
+              .getById(tenantId, recordQueries, id) match {
               case Some(record) => complete(record)
               case None =>
                 complete(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
@@ -491,7 +491,6 @@ object WebHookActor {
             } else {
               val eventPage = DB readOnly { implicit session =>
                 eventPersistence.getEvents(
-                  session,
                   webHook.lastEvent,
                   None,
                   Some(config.getInt("webhooks.eventPageSize")),

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
@@ -92,7 +92,6 @@ class WebHookProcessor(
               .foldLeft[List[RecordsPage[Record]]](Nil)((pages, tenantId) => {
                 val recordIds = tenantRecordIdsMap(tenantId)
                 pages :+ recordPersistence.getByIdsWithAspects(
-                  session,
                   SpecifiedTenantId(tenantId),
                   recordIds,
                   None,
@@ -119,7 +118,6 @@ class WebHookProcessor(
                   tenantRecordIdsExcludedMap.getOrElse(tenantId, Nil)
                 val recordIds = tenantRecordIdsMap(tenantId)
                 pages :+ recordPersistence.getRecordsLinkingToRecordIds(
-                  session,
                   SpecifiedTenantId(tenantId),
                   recordIds,
                   None,
@@ -208,7 +206,7 @@ class WebHookProcessor(
         DB readOnly { implicit session =>
           Some(
             AspectPersistence
-              .getByIds(session, aspectDefinitionIds, AllTenantsId)
+              .getByIds(aspectDefinitionIds, AllTenantsId)
           )
         }
     }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
@@ -188,13 +188,17 @@ abstract class ApiSpec
     req.withHeaders(new RawHeader("X-Magda-Session", jws))
   }
 
-  def expectAdminCheck(httpFetcher: HttpFetcher, isAdmin: Boolean) {
-    val resFuture = Marshal(User(USER_ID, isAdmin))
+  def expectAdminCheck(
+      httpFetcher: HttpFetcher,
+      isAdmin: Boolean,
+      userId: String = USER_ID
+  ) {
+    val resFuture = Marshal(User(userId, isAdmin))
       .to[ResponseEntity]
       .map(user => HttpResponse(status = 200, entity = user))
 
     (httpFetcher.get _)
-      .expects("/v0/public/users/57c75a42-d037-47b9-81f5-247111c43434", *)
+      .expects(s"/v0/public/users/$userId", *)
       .returns(resFuture)
   }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
@@ -48,9 +48,12 @@ abstract class ApiSpec
     with SprayJsonSupport
     with MockFactory
     with AuthProtocols {
+
   override def beforeAll(): Unit = {
     Util.clearWebHookActorsCache()
   }
+
+  val USER_ID = "57c75a42-d037-47b9-81f5-247111c43434"
 
   val databaseUrl = Option(System.getenv("POSTGRES_URL"))
     .getOrElse("jdbc:postgresql://localhost:5432/postgres")
@@ -179,18 +182,20 @@ abstract class ApiSpec
     val jws = Authentication.signToken(
       Jwts
         .builder()
-        .claim("userId", "1"),
+        .claim("userId", USER_ID),
       system.log
     )
     req.withHeaders(new RawHeader("X-Magda-Session", jws))
   }
 
   def expectAdminCheck(httpFetcher: HttpFetcher, isAdmin: Boolean) {
-    val resFuture = Marshal(User("1", isAdmin))
+    val resFuture = Marshal(User(USER_ID, isAdmin))
       .to[ResponseEntity]
       .map(user => HttpResponse(status = 200, entity = user))
 
-    (httpFetcher.get _).expects("/v0/public/users/1", *).returns(resFuture)
+    (httpFetcher.get _)
+      .expects("/v0/public/users/57c75a42-d037-47b9-81f5-247111c43434", *)
+      .returns(resFuture)
   }
 
   def checkMustBeAdmin(role: Role)(fn: => HttpRequest) {

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectPersistenceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectPersistenceSpec.scala
@@ -11,6 +11,8 @@ import au.csiro.data61.magda.model.TenantId.SpecifiedTenantId
 import au.csiro.data61.magda.model.TenantId.AllTenantsId
 
 class AspectPersistenceSpec extends ApiSpec {
+  val userId = "2296943e-69d5-410a-8a86-88216984249c";
+
   it("Fetch aspects should be filtered by tenant id") { _ =>
     val aspectA = AspectDefinition(
       id = "aspect A",
@@ -28,13 +30,12 @@ class AspectPersistenceSpec extends ApiSpec {
     aspects.foreach(testAspect => {
       DB localTx { implicit session =>
         AspectPersistence
-          .create(session, testAspect, SpecifiedTenantId(TENANT_1))
+          .create(testAspect, SpecifiedTenantId(TENANT_1), userId)
       }
     })
 
     val tenant1Results = DB readOnly { implicit session =>
       AspectPersistence.getByIds(
-        session,
         aspectIds,
         SpecifiedTenantId(TENANT_1)
       )
@@ -43,7 +44,6 @@ class AspectPersistenceSpec extends ApiSpec {
 
     val allTenantsResults = DB readOnly { implicit session =>
       AspectPersistence.getByIds(
-        session,
         aspectIds,
         AllTenantsId
       )
@@ -53,7 +53,7 @@ class AspectPersistenceSpec extends ApiSpec {
     List(TENANT_2, MAGDA_ADMIN_PORTAL_ID).foreach(tenantId => {
       val result = DB readOnly { implicit session =>
         AspectPersistence
-          .getByIds(session, aspectIds, SpecifiedTenantId(tenantId))
+          .getByIds(aspectIds, SpecifiedTenantId(tenantId))
       }
       result shouldEqual Nil
     })

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -4293,7 +4293,7 @@ class RecordsServiceSpec extends ApiSpec {
           val eventsPage = responseAs[EventsPage]
           eventsPage.events.length shouldEqual 2
           eventsPage.events(1).userId shouldEqual Some(USER_ID)
-          eventsPage.events(1).eventType shouldEqual EventType.CreateRecord
+          eventsPage.events(1).eventType shouldEqual EventType.PatchRecord
           eventsPage
             .events(1)
             .data
@@ -4965,7 +4965,14 @@ class RecordsServiceSpec extends ApiSpec {
             status shouldEqual StatusCodes.OK
           }
 
-          Get(s"/v0/records/without/history") ~> addTenantIdHeader(
+          param.asAdmin(Delete("/v0/records/without")) ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(role).routes ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[DeleteResult].deleted shouldBe true
+          }
+
+          param.asAdmin(Get(s"/v0/records/without/history")) ~> addTenantIdHeader(
             TENANT_1
           ) ~> param
             .api(role)
@@ -4988,13 +4995,6 @@ class RecordsServiceSpec extends ApiSpec {
           ) ~> param.api(role).routes ~> check {
             status shouldEqual StatusCodes.OK
             responseAs[DeleteResult].deleted shouldBe false
-          }
-
-          param.asAdmin(Delete("/v0/records/without")) ~> addTenantIdHeader(
-            TENANT_1
-          ) ~> param.api(role).routes ~> check {
-            status shouldEqual StatusCodes.OK
-            responseAs[DeleteResult].deleted shouldBe true
           }
         }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookActorSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookActorSpec.scala
@@ -25,7 +25,6 @@ class WebHookActorSpec extends ApiSpec with BeforeAndAfterEach {
 
     val hook = WebHook(
       id = Some(hookId),
-      userId = None,
       name = "abc",
       active = true,
       lastEvent = None,
@@ -58,7 +57,6 @@ class WebHookActorSpec extends ApiSpec with BeforeAndAfterEach {
 
       val hook = WebHook(
         id = Some(hookId),
-        userId = None,
         name = "abc",
         active = true,
         lastEvent = None,
@@ -92,7 +90,6 @@ class WebHookActorSpec extends ApiSpec with BeforeAndAfterEach {
 
     val hook = WebHook(
       id = Some(hookId),
-      userId = None,
       name = "abc",
       active = true,
       lastEvent = None,

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -2638,7 +2638,6 @@ class WebHookProcessingSpec
 
   private val defaultWebHook = WebHook(
     id = Some("test"),
-    userId = None,
     name = "test",
     active = true,
     lastEvent = None,

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -80,7 +80,8 @@ object Registry
       id: Option[Long],
       eventTime: Option[OffsetDateTime],
       eventType: EventType,
-      userId: Int,
+      /** This is an option because although it's mandatory for new events, at versions 0.0.56 and below it wasn't set */
+      userId: Option[String],
       data: JsObject,
       tenantId: BigInt
   )
@@ -178,7 +179,6 @@ object Registry
 
   case class WebHook(
       id: Option[String] = None,
-      userId: Option[Int],
       name: String,
       active: Boolean,
       lastEvent: Option[Long] = None,
@@ -292,7 +292,7 @@ object Registry
   implicit val aspectFormat = jsonFormat3(Registry.AspectDefinition)
   implicit val webHookPayloadFormat = jsonFormat6(Registry.WebHookPayload)
   implicit val webHookConfigFormat = jsonFormat6(Registry.WebHookConfig)
-  implicit val webHookFormat = jsonFormat14(Registry.WebHook)
+  implicit val webHookFormat = jsonFormat13(Registry.WebHook)
   implicit val registryRecordsResponseFormat = jsonFormat3(
     Registry.RegistryRecordsResponse.apply
   )

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -151,14 +151,13 @@ export class RegistryEvent {
     "id": any;
     "eventTime": Date;
     "eventType": EventType;
-    "userId": number;
+    "userId": string;
     "data": JsObject;
     "tenantId": number;
 }
 
 export class WebHook {
     "id": string;
-    "userId": any;
     "name": string;
     "active": boolean;
     "lastEvent": any;


### PR DESCRIPTION
### What this PR does

Fixes #2866 

This makes it so that the user id is stored in the events table, and recorded against each event depending on who initiated the event.

This also:
- Refactors scala so that only the `DBSession` is an implicit parameter.
- Removes userIds from webhooks completely

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
