### PR TITLE
Bumped search index version to cope with new acronym feature

### DIFF
--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -89,7 +89,7 @@ object IndexDefinition extends DefaultJsonProtocol {
 
   val dataSets: IndexDefinition = new IndexDefinition(
     name = "datasets",
-    version = 45,
+    version = 46,
     indicesIndex = Indices.DataSetsIndex,
     definition = (indices, config) => {
       val baseDefinition =
@@ -353,7 +353,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val publishers: IndexDefinition =
     new IndexDefinition(
       name = "publishers",
-      version = 4,
+      version = 5,
       indicesIndex = Indices.PublishersIndex,
       definition = (indices, config) =>
         createIndex(indices.getIndex(config, Indices.PublishersIndex))


### PR DESCRIPTION
### What this PR does

Dev search is currently broken because the new acronym feature has slightly changed the structure of search documents. This'll force everything to be reindexed.
