### PR TITLE
Protected or above security classification is an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@ UI:
 -   Fix magda & ckan login options are missing
 -   Always set dataset publishing state to "published" no matter the approval flow is on / off
 -   Fix a sheet file contains date would cause blank screen during processing
+-   Set an error if security classification is at PROTECTED or above
 
 Storage:
 

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
@@ -76,6 +76,15 @@ const classificationValidator: CustomValidatorType = (
     state,
     validationItem
 ) => {
+    if (value === "PROTECTED" || value === "SECRET" || value === "TOP SECRET") {
+        return {
+            valid: false,
+            validationMessage:
+                "Cannot proceed with this dataset. A dataset with security classification " +
+                "of PROTECTED or above cannot be stored in MAGDA."
+        };
+    }
+
     if (
         !ValidationManager.shouldValidate(
             "$.datasetPublishing.publishAsOpenData.dga"

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
@@ -76,7 +76,12 @@ const classificationValidator: CustomValidatorType = (
     state,
     validationItem
 ) => {
-    if (value === "PROTECTED" || value === "SECRET" || value === "TOP SECRET") {
+    const valueUpper = value.toUpperCase();
+    if (
+        valueUpper === "PROTECTED" ||
+        valueUpper === "SECRET" ||
+        valueUpper === "TOP SECRET"
+    ) {
         return {
             valid: false,
             validationMessage:

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/index.tsx
@@ -86,7 +86,7 @@ const classificationValidator: CustomValidatorType = (
             valid: false,
             validationMessage:
                 "Cannot proceed with this dataset. A dataset with security classification " +
-                "of PROTECTED or above cannot be stored in MAGDA."
+                "of PROTECTED or above cannot be stored in Magda."
         };
     }
 


### PR DESCRIPTION
### What this PR does

Fixes #2888 

If dataset security clearance is PROTECTED or above, it doesn't let the user proceed and sets an error.

### Checklist

-   [x] ~There are unit tests to verify my changes are correct~ Unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
