### PR TITLE
Accept either userId and jwtSecret or jwt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## 0.0.58
-
-typescript-common
-
--   The constructor of AuthorizedRegistryClient also accepts a customised jwt token.
-
 ## 0.0.57
 
 General:
@@ -35,6 +29,7 @@ General:
 -   Add missing `cloud-sql-proxy` dependecy to `magda-core` chart
 -   Add more operators to Registry /records & records/count API `aspectOrQuery`
 -   Add `aspectOrQuery`, `orderBy`, `orderByDir` & `orderNullFirst` parameters to Registry API /records & records/count
+-   Make the constructor of AuthorizedRegistryClient also accepts a customised jwt token.
 
 UI:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.0.58
+
+typescript-common
+
+-   The constructor of AuthorizedRegistryClient also accepts a customised jwt token.
+
 ## 0.0.57
 
 General:

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -40,11 +40,11 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             throw Error("A tenant id must be defined.");
         }
 
-        if (options.userId && options.jwtSecret === null) {
-            throw Error("JWT secret can not be null.");
-        }
-
-        if (options.jwt !== undefined && options.jwt === null) {
+        if (options.userId !== undefined) {
+            if (options.userId === null || options.jwtSecret === null) {
+                throw Error("userId or jwtSecret can not be null.");
+            }
+        } else if (options.jwt === null) {
             throw Error("jwt can not be null.");
         }
 

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -32,7 +32,6 @@ export type AuthorizedRegistryOptions =
     | AuthorizedRegistryJwtOptions;
 
 export default class AuthorizedRegistryClient extends RegistryClient {
-    protected options: AuthorizedRegistryOptions;
     protected jwt: string;
 
     constructor(options: AuthorizedRegistryOptions) {
@@ -43,13 +42,12 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         if (!options.jwt) {
             if (!options.userId || !options.jwtSecret) {
                 throw Error(
-                    "userId or jwtSecret must be both provided when jwt doesn't present!"
+                    "Either jwt or userId and jwtSecret must have values."
                 );
             }
         }
 
         super(options);
-        this.options = options;
         this.jwt = options.jwt
             ? options.jwt
             : buildJwt(options.jwtSecret, options.userId);

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -41,11 +41,19 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         }
 
         if (options.userId !== undefined) {
-            if (options.userId === null || options.jwtSecret === null) {
-                throw Error("userId or jwtSecret can not be null.");
+            // jwtSecret must have a value. Pure spaces are allowed.
+            if (
+                options.userId === null ||
+                options.userId.trim().length === 0 ||
+                options.jwtSecret === null ||
+                options.jwtSecret === ""
+            ) {
+                throw Error(
+                    "userId or jwtSecret can not be null, pure spaces or empty."
+                );
             }
-        } else if (options.jwt === null) {
-            throw Error("jwt can not be null.");
+        } else if (options.jwt === null || options.jwt.trim() === "") {
+            throw Error("jwt can not be null, empty or pure spaces.");
         }
 
         super(options);

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -33,26 +33,22 @@ export type AuthorizedRegistryOptions =
 
 export default class AuthorizedRegistryClient extends RegistryClient {
     protected options: AuthorizedRegistryOptions;
-    protected jwt: string | undefined;
+    protected jwt: string;
 
     constructor(options: AuthorizedRegistryOptions) {
         if (options.tenantId === undefined || options.tenantId === null) {
             throw Error("A tenant id must be defined.");
         }
 
-        if (
-            options.userId &&
-            (options.jwtSecret === undefined || options.jwtSecret === null)
-        ) {
-            throw Error("JWT secret must be defined.");
+        if (options.userId && options.jwtSecret === null) {
+            throw Error("JWT secret can not be null.");
         }
+
         super(options);
         this.options = options;
         this.jwt = options.jwt
             ? options.jwt
-            : options.userId
-            ? buildJwt(options.jwtSecret, options.userId)
-            : undefined;
+            : buildJwt(options.jwtSecret, options.userId);
     }
 
     putAspectDefinition(

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -40,20 +40,12 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             throw Error("A tenant id must be defined.");
         }
 
-        if (options.userId !== undefined) {
-            // jwtSecret must have a value. Pure spaces are allowed.
-            if (
-                options.userId === null ||
-                options.userId.trim().length === 0 ||
-                options.jwtSecret === null ||
-                options.jwtSecret === ""
-            ) {
+        if (!options.jwt) {
+            if (!options.userId || !options.jwtSecret) {
                 throw Error(
-                    "userId or jwtSecret can not be null, pure spaces or empty."
+                    "userId or jwtSecret must be both provided when jwt doesn't present!"
                 );
             }
-        } else if (options.jwt === null || options.jwt.trim() === "") {
-            throw Error("jwt can not be null, empty or pure spaces.");
         }
 
         super(options);

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -44,6 +44,10 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             throw Error("JWT secret can not be null.");
         }
 
+        if (options.jwt !== undefined && options.jwt === null) {
+            throw Error("jwt can not be null.");
+        }
+
         super(options);
         this.options = options;
         this.jwt = options.jwt

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -22,7 +22,16 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
-    it("rejects null jwt secret if userId is defined", async function () {
+    it("rejects null userId or jwtSecret", async function () {
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                userId: null,
+                jwtSecret: "top secret",
+                tenantId: 0
+            });
+        }).to.throw(Error, "userId or jwtSecret can not be null.");
+
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
@@ -30,7 +39,16 @@ describe("Test AuthorizedRegistryClient.ts", function () {
                 jwtSecret: null,
                 tenantId: 0
             });
-        }).to.throw(Error, "JWT secret can not be null.");
+        }).to.throw(Error, "userId or jwtSecret can not be null.");
+
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                userId: null,
+                jwtSecret: null,
+                tenantId: 0
+            });
+        }).to.throw(Error, "userId or jwtSecret can not be null.");
     });
 
     it("accepts jwt", async function () {

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -22,6 +22,17 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
+    it("rejects null jwt secret if userId is defined", async function () {
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                userId: "some.user",
+                jwtSecret: null,
+                tenantId: 0
+            });
+        }).to.throw(Error, "JWT secret can not be null.");
+    });
+
     it("accepts optional jwt", async function () {
         const registry = new AuthorizedRegistryClient({
             baseUrl: "some.where",

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -32,7 +32,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret can not be null, pure spaces or empty."
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
         );
 
         expect(function () {
@@ -44,7 +44,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret can not be null, pure spaces or empty."
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
         );
 
         expect(function () {
@@ -56,7 +56,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret can not be null, pure spaces or empty."
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
         );
 
         expect(function () {
@@ -68,7 +68,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret can not be null, pure spaces or empty."
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
         );
     });
 
@@ -81,21 +81,16 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
-    it("rejects null, empty or pure spaces jwt", async function () {
+    it("rejects null, empty jwt", async function () {
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
                 jwt: null,
                 tenantId: 0
             });
-        }).to.throw(Error, "jwt can not be null, empty or pure spaces.");
-
-        expect(function () {
-            new AuthorizedRegistryClient({
-                baseUrl: "some.where",
-                jwt: "  ",
-                tenantId: 0
-            });
-        }).to.throw(Error, "jwt can not be null, empty or pure spaces.");
+        }).to.throw(
+            Error,
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
+        );
     });
 });

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -12,7 +12,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         nock.cleanAll();
     });
 
-    it("accepts optional userId and jwtSecret", async function () {
+    it("accepts userId and jwtSecret", async function () {
         const registry = new AuthorizedRegistryClient({
             baseUrl: "some.where",
             userId: "some.user",
@@ -33,12 +33,22 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         }).to.throw(Error, "JWT secret can not be null.");
     });
 
-    it("accepts optional jwt", async function () {
+    it("accepts jwt", async function () {
         const registry = new AuthorizedRegistryClient({
             baseUrl: "some.where",
             jwt: "some.jwt.token",
             tenantId: 0
         });
         expect(registry !== undefined);
+    });
+
+    it("rejects null jwt", async function () {
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                jwt: null,
+                tenantId: 0
+            });
+        }).to.throw(Error, "jwt can not be null.");
     });
 });

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -1,0 +1,33 @@
+import {} from "mocha";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import nock from "nock";
+import AuthorizedRegistryClient from "magda-typescript-common/src/registry/AuthorizedRegistryClient";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe("Test AuthorizedRegistryClient.ts", function () {
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it("accepts optional userId and jwtSecret", async function () {
+        const registry = new AuthorizedRegistryClient({
+            baseUrl: "some.where",
+            userId: "some.user",
+            jwtSecret: "some.jwt.token",
+            tenantId: 0
+        });
+        expect(registry !== undefined);
+    });
+
+    it("accepts optional jwt", async function () {
+        const registry = new AuthorizedRegistryClient({
+            baseUrl: "some.where",
+            jwt: "some.jwt.token",
+            tenantId: 0
+        });
+        expect(registry !== undefined);
+    });
+});

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -32,7 +32,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
 
         expect(function () {
@@ -44,7 +44,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
 
         expect(function () {
@@ -56,7 +56,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
 
         expect(function () {
@@ -68,7 +68,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
     });
 
@@ -90,7 +90,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
 
         expect(function () {
@@ -101,7 +101,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
             });
         }).to.throw(
             Error,
-            "userId or jwtSecret must be both provided when jwt doesn't present!"
+            "Either jwt or userId and jwtSecret must have values."
         );
     });
 });

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -16,13 +16,13 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         const registry = new AuthorizedRegistryClient({
             baseUrl: "some.where",
             userId: "some.user",
-            jwtSecret: "some.jwt.token",
+            jwtSecret: "top secret",
             tenantId: 0
         });
         expect(registry !== undefined);
     });
 
-    it("rejects null, empty or pure spaces of userId and jwtSecret", async function () {
+    it("rejects null or empty of userId and jwtSecret", async function () {
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
@@ -81,11 +81,22 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
-    it("rejects null, empty jwt", async function () {
+    it("rejects null or empty jwt", async function () {
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
                 jwt: null,
+                tenantId: 0
+            });
+        }).to.throw(
+            Error,
+            "userId or jwtSecret must be both provided when jwt doesn't present!"
+        );
+
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                jwt: "",
                 tenantId: 0
             });
         }).to.throw(

--- a/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
+++ b/magda-typescript-common/src/test/registry/buildAuthorizedClient.spec.ts
@@ -22,7 +22,7 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
-    it("rejects null userId or jwtSecret", async function () {
+    it("rejects null, empty or pure spaces of userId and jwtSecret", async function () {
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
@@ -30,7 +30,10 @@ describe("Test AuthorizedRegistryClient.ts", function () {
                 jwtSecret: "top secret",
                 tenantId: 0
             });
-        }).to.throw(Error, "userId or jwtSecret can not be null.");
+        }).to.throw(
+            Error,
+            "userId or jwtSecret can not be null, pure spaces or empty."
+        );
 
         expect(function () {
             new AuthorizedRegistryClient({
@@ -39,7 +42,10 @@ describe("Test AuthorizedRegistryClient.ts", function () {
                 jwtSecret: null,
                 tenantId: 0
             });
-        }).to.throw(Error, "userId or jwtSecret can not be null.");
+        }).to.throw(
+            Error,
+            "userId or jwtSecret can not be null, pure spaces or empty."
+        );
 
         expect(function () {
             new AuthorizedRegistryClient({
@@ -48,7 +54,22 @@ describe("Test AuthorizedRegistryClient.ts", function () {
                 jwtSecret: null,
                 tenantId: 0
             });
-        }).to.throw(Error, "userId or jwtSecret can not be null.");
+        }).to.throw(
+            Error,
+            "userId or jwtSecret can not be null, pure spaces or empty."
+        );
+
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                userId: "some.user",
+                jwtSecret: "",
+                tenantId: 0
+            });
+        }).to.throw(
+            Error,
+            "userId or jwtSecret can not be null, pure spaces or empty."
+        );
     });
 
     it("accepts jwt", async function () {
@@ -60,13 +81,21 @@ describe("Test AuthorizedRegistryClient.ts", function () {
         expect(registry !== undefined);
     });
 
-    it("rejects null jwt", async function () {
+    it("rejects null, empty or pure spaces jwt", async function () {
         expect(function () {
             new AuthorizedRegistryClient({
                 baseUrl: "some.where",
                 jwt: null,
                 tenantId: 0
             });
-        }).to.throw(Error, "jwt can not be null.");
+        }).to.throw(Error, "jwt can not be null, empty or pure spaces.");
+
+        expect(function () {
+            new AuthorizedRegistryClient({
+                baseUrl: "some.where",
+                jwt: "  ",
+                tenantId: 0
+            });
+        }).to.throw(Error, "jwt can not be null, empty or pure spaces.");
     });
 });


### PR DESCRIPTION
### What this PR does

Fixes #2892 
AuthorizedRegistryClient constuctor accepts either `userId` and `jwtSecret` or a customised `jwt`. One of the use cases for customised `jwt` is that it carries extra info.

When `userId` is defined, `jwtSecret` must also be defined. When `jwt` is defined, `jwtSecret` should not be defined. Those rules are inforced at compile time.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
