### PR TITLE
Upgrade to bcrypt 5.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
     -Dsbt.ivy.home=$CI_PROJECT_DIR/sbt-cache/ivy
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button`
-  CACHE_VERSION: ts-11-scala-5
+  CACHE_VERSION: ts-12-scala-5
 
 stages:
   - builders

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ General:
 -   Add missing `cloud-sql-proxy` dependecy to `magda-core` chart
 -   Add more operators to Registry /records & records/count API `aspectOrQuery`
 -   Add `aspectOrQuery`, `orderBy`, `orderByDir` & `orderNullFirst` parameters to Registry API /records & records/count
+-   Upgrade [bcrypt](https://www.npmjs.com/package/bcrypt) to 5.0.0
 
 UI:
 

--- a/magda-gateway/Dockerfile
+++ b/magda-gateway/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app
-# Reinstall bcrypt to pull correct binary for linux (npm build won't help due to a node-gyp path issue)
-RUN rm -Rf /usr/src/app/node_modules/bcrypt && cd /usr/src/app/component && npm install bcrypt
+# Reinstall bcrypt to pull correct binary for linux
+RUN rm -Rf /usr/src/app/node_modules/bcrypt/lib && cd /usr/src/app/component/node_modules/bcrypt && /usr/src/app/node_modules/node-pre-gyp/bin/node-pre-gyp install --update-binary --fallback-to-build
 WORKDIR /usr/src/app/component
 ENTRYPOINT [ "node", "/usr/src/app/component/dist/index.js" ]

--- a/magda-gateway/Dockerfile
+++ b/magda-gateway/Dockerfile
@@ -2,6 +2,6 @@ FROM node:10
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app
 # Reinstall bcrypt to pull correct binary for linux
-RUN rm -Rf /usr/src/app/node_modules/bcrypt/lib && cd /usr/src/app/component/node_modules/bcrypt && /usr/src/app/node_modules/node-pre-gyp/bin/node-pre-gyp install --update-binary --fallback-to-build
+RUN rm -Rf /usr/src/app/node_modules/bcrypt/lib && cd /usr/src/app/node_modules/bcrypt && /usr/src/app/node_modules/node-pre-gyp/bin/node-pre-gyp install --update-binary --fallback-to-build
 WORKDIR /usr/src/app/component
 ENTRYPOINT [ "node", "/usr/src/app/component/dist/index.js" ]

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@magda/tenant-api": "^0.0.57-0",
     "@magda/typescript-common": "^0.0.57-0",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.0",
     "body-parser": "^1.13.2",
     "cheerio": "^0.22.0",
     "compression": "^1.7.2",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "ansi-styles": "^3.2.1",
     "apidoc": "https://github.com/magda-io/apidoc",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.0",
     "chalk": "^2.4.1",
     "clear": "^0.1.0",
     "commander": "^2.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5033,6 +5033,14 @@ bcrypt@^4.0.1:
     node-addon-api "^2.0.0"
     node-pre-gyp "0.14.0"
 
+bcrypt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.0.tgz#051407c7cd5ffbfb773d541ca3760ea0754e37e2"
+  integrity sha512-jB0yCBl4W/kVHM2whjfyqnxTmOHkCX4kHEa5nYKSoGeYe8YrjTYTc87/6bwt1g8cmV0QrbhKriETg9jWtcREhg==
+  dependencies:
+    node-addon-api "^3.0.0"
+    node-pre-gyp "0.15.0"
+
 before-after-hook@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
@@ -13698,7 +13706,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
+needle@^2.2.1, needle@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.0.tgz#e6fc4b3cc6c25caed7554bd613a5cf0bac8c31c0"
   integrity sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==
@@ -13789,6 +13797,11 @@ node-addon-api@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.1.tgz#4fd0931bf6d7e48b219ff3e6abc73cbb0252b7a3"
   integrity sha512-2WVfwRfIr1AVn3dRq4yRc2Hn35ND+mPJH6inC6bjpYCZVrpXPB4j3T6i//OGVfqVsR1t/X/axRulDsheq4F0LQ==
+
+node-addon-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
+  integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
 
 node-ensure@^0.0.0:
   version "0.0.0"
@@ -13925,6 +13938,22 @@ node-pre-gyp@0.14.0:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
     needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
+
+node-pre-gyp@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz#c2fc383276b74c7ffa842925241553e8b40f1087"
+  integrity sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,14 +5025,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-4.0.1.tgz#06e21e749a061020e4ff1283c1faa93187ac57fe"
-  integrity sha512-hSIZHkUxIDS5zA2o00Kf2O5RfVbQ888n54xQoF/eIaquU4uaLxK8vhhBdktd0B3n2MjkcAWzv4mnhogykBKOUQ==
-  dependencies:
-    node-addon-api "^2.0.0"
-    node-pre-gyp "0.14.0"
-
 bcrypt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.0.tgz#051407c7cd5ffbfb773d541ca3760ea0754e37e2"
@@ -13706,7 +13698,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1, needle@^2.5.0:
+needle@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.0.tgz#e6fc4b3cc6c25caed7554bd613a5cf0bac8c31c0"
   integrity sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==
@@ -13792,11 +13784,6 @@ nock@^9.0.14, nock@^9.1.6, nock@^9.2.5:
     propagate "^1.0.0"
     qs "^6.5.1"
     semver "^5.5.0"
-
-node-addon-api@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.1.tgz#4fd0931bf6d7e48b219ff3e6abc73cbb0252b7a3"
-  integrity sha512-2WVfwRfIr1AVn3dRq4yRc2Hn35ND+mPJH6inC6bjpYCZVrpXPB4j3T6i//OGVfqVsR1t/X/axRulDsheq4F0LQ==
 
 node-addon-api@^3.0.0:
   version "3.0.0"
@@ -13929,22 +13916,6 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-pre-gyp@0.15.0:
   version "0.15.0"


### PR DESCRIPTION
### What this PR does

pgrade [bcrypt](https://www.npmjs.com/package/bcrypt) to 5.0.0 for issues:
    - https://github.com/kelektiv/node.bcrypt.js/issues/776
    - https://github.com/kelektiv/node.bcrypt.js/issues/774


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
