### PR TITLE
Stopped querying with a 255,000 clause SQL query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,7 @@ Authorization:
 -   Added per-record authorization around the `/records/summary` endpoint matching the `/records` one.
 -   Added per-record authorization around the `/records/<recordid>/history` endpoint
 -   Added per-record authorization around the `/records/<recordid>/history/<eventId>` endpoint
+-   Fixed a bug where the registry would attempt to query for policies against every single record id in the registry all at once.
 
 Registry:
 

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -78,4 +78,4 @@ dependencies:
   repository: file://../internal-charts/ingress
   version: 0.0.57-0
 digest: sha256:e11f9dd597d72666d34c82c57b0d5dfc34f20d9201c9243482ffbc853ed927ef
-generated: "2020-06-09T17:05:39.075233+10:00"
+generated: "2020-07-06T14:48:45.723033326+10:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -125,5 +125,5 @@ dependencies:
 - name: magda-esri-portal-connector
   repository: https://charts.magda.io
   version: 0.0.57-0
-digest: sha256:1c3d2c4dea577a2395b4cd166505d33959a814c638fbb692c3aa3aab5fdca098
-generated: "2020-05-22T09:52:04.158024088+10:00"
+digest: sha256:8eb2f7169154a537bd42d3e6691aa31c97850daaee3d7e7c16e50530d6d09c15
+generated: "2020-07-06T14:49:16.255172752+10:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -49,7 +49,6 @@ dependencies:
     version: 0.0.57-0
     repository: https://charts.magda.io
     tags:
-      - minions
       - minion-ckan-exporter
 
   - name: magda-ckan-connector

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -546,7 +546,7 @@ object Generators {
       derivedFrom <- Gen.option(
         Gen.listOf(
           Generators.textGen
-            .map(text => ProvenanceRecord(id = Some(List(text.take(50).trim))))
+            .map(text => ProvenanceRecord(id = Some(text.take(50).trim)))
         )
       )
       affiliatedOrganizationIds <- Gen.option(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
@@ -146,24 +146,25 @@ object Directives extends Protocols with SprayJsonSupport {
             .getPolicyIds(operationType, recordId.map(Set(_)))
         } get
 
-        val linkedRecordIds = DB readOnly { implicit session =>
-          recordPersistence.getLinkedRecordIds(
-            operationType,
-            recordId,
-            aspectIds
-          )
-        } get
+        val linkedRecordIds = recordId.map(
+          innerRecordId =>
+            DB readOnly { implicit session =>
+              recordPersistence.getLinkedRecordIds(
+                operationType,
+                innerRecordId,
+                aspectIds
+              )
+            } get
+        )
 
         val linkedRecordPolicyIds =
-          if (linkedRecordIds.isEmpty) List()
-          else
-            DB readOnly { implicit session =>
-              recordPersistence
-                .getPolicyIds(
-                  operationType,
-                  Some(linkedRecordIds.toSet)
-                )
-            } get
+          DB readOnly { implicit session =>
+            recordPersistence
+              .getPolicyIds(
+                operationType,
+                linkedRecordIds.map(_.toSet)
+              )
+          } get
 
         val allPolicyIds = recordPolicyIds.toSet ++ linkedRecordPolicyIds
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/BaseRecordsServiceAuthSpec.scala
@@ -1391,6 +1391,15 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
           )
         )
 
+        // Should not have access to the outer record
+        Get(
+          s"/v0/records/record-2?aspect=aspect-with-link&dereference=false"
+        ) ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          status shouldEqual StatusCodes.NotFound
+        }
+
         // Make sure we have access to the inner record (thus expect an extra call for inner policy)
         expectOpaQueryForPolicy(
           param,
@@ -1403,14 +1412,6 @@ abstract class BaseRecordsServiceAuthSpec extends ApiSpec {
           TENANT_1
         ) ~> param.api(Full).routes ~> check {
           status shouldEqual StatusCodes.OK
-        }
-
-        Get(
-          s"/v0/records/record-2?aspect=aspect-with-link&dereference=false"
-        ) ~> addTenantIdHeader(
-          TENANT_1
-        ) ~> param.api(Full).routes ~> check {
-          status shouldEqual StatusCodes.NotFound
         }
 
         // Call again with dereference=true, this means more calls to OPA

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -60,7 +60,7 @@ package misc {
   )
 
   case class ProvenanceRecord(
-      id: Option[Seq[String]],
+      id: Option[String],
       name: Option[String] = None
   )
 

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1175,10 +1175,18 @@ export class RecordHistoryApi {
      *
      * @param xMagdaTenantId 0
      * @param recordId ID of the record for which to fetch history.
+     * @param xMagdaSession Magda internal session id
+     * @param pageToken A token that identifies the start of a page of events.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
+     * @param start The index of the first event to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
+     * @param limit The maximum number of events to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
      */
     public history(
         xMagdaTenantId: number,
-        recordId: string
+        recordId: string,
+        xMagdaSession: string,
+        pageToken?: string,
+        start?: number,
+        limit?: number
     ): Promise<{ response: http.IncomingMessage; body: EventsPage }> {
         const localVarPath =
             this.basePath +
@@ -1204,7 +1212,28 @@ export class RecordHistoryApi {
             );
         }
 
+        // verify required parameter 'xMagdaSession' is not null or undefined
+        if (xMagdaSession === null || xMagdaSession === undefined) {
+            throw new Error(
+                "Required parameter xMagdaSession was null or undefined when calling history."
+            );
+        }
+
+        if (pageToken !== undefined) {
+            queryParameters["pageToken"] = pageToken;
+        }
+
+        if (start !== undefined) {
+            queryParameters["start"] = start;
+        }
+
+        if (limit !== undefined) {
+            queryParameters["limit"] = limit;
+        }
+
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
 
         let useFormData = false;
 


### PR DESCRIPTION
### What this PR does

Currently in the registry we're seeing massive broken sql queries. This is happening because of an attempted optimisation - before querying for what policies are present in the database, we try to narrow it down by the records that are being requested, and the records that they link to. However, if no record id is passed, it narrows down records linked to to every single record in the database.

This corrects this by making requests without a record id not attempt to narrow down the policy query by either record id or linked record id.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
