### PR TITLE
CI Optimization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,9 +13,9 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Click on '....'
+1. Scroll down to '....'
+1. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -700,6 +700,12 @@ inttest:registryAuth:
 
 (UI) Run As Preview:
   <<: *runAsPreview
+  script:
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda-core.web-server.baseUrl=https://dev.magda.io,magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
+
+(UI - Auto) Run As Preview:
+  <<: *runAsPreview
   when: always
   only:
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,6 +462,13 @@ dockerize:scala:
   stage: dockerize
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
+  needs: [
+    "registry-typescript-api",
+    "sbt-prebuild",
+    "buildtest:registry",
+    "buildtest:search-no-index-cache",
+    "buildtest:search-with-index-cache"
+  ]
   dependencies:
     - registry-typescript-api
     - sbt-prebuild

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,10 +231,6 @@ buildtest:ui:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   retry: 1
   needs: ["builders-and-yarn"]
-  only:
-    changes:
-      - magda-web-client/**/**
-      - magda-web-server/**/**
   dependencies:
     - builders-and-yarn
   cache:
@@ -533,10 +529,6 @@ dockerize:ui:
     "registry-typescript-api",
     "buildtest:ui"
   ]
-  only:
-    changes:
-      - magda-web-server/**/**
-      - magda-web-cient/**/**
   dependencies:
     - builders-and-yarn
     - registry-typescript-api

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,8 +91,8 @@ registry-typescript-api:
 buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  retry: 2
-  parallel: 2
+  retry: 3
+  timeout: 18 minutes
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"
@@ -157,8 +157,8 @@ buildtest:search-with-index-cache:
 buildtest:search-no-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  retry: 2
-  parallel: 2
+  retry: 3
+  timeout: 18 minutes
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -564,7 +564,6 @@ dockerize:migrators:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
-  needs: ["registry-typescript-api"]
   cache:
     paths: []
   services:
@@ -577,7 +576,6 @@ dockerize:dockerExtensions:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
-  needs: ["registry-typescript-api"]
   cache:
     paths: []
   services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -534,8 +534,8 @@ dockerize:ui:
   ]
   only:
     changes:
-      - magda-web-server/*
-      - magda-web-cient/*
+      - magda-web-server/**/*
+      - magda-web-cient/**/*
   dependencies:
     - builders-and-yarn
     - registry-typescript-api

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,8 +233,8 @@ buildtest:ui:
   needs: ["builders-and-yarn"]
   only:
     changes:
-      - magda-web-server/*
-      - magda-web-cient/*
+      - magda-web-server/**/*
+      - magda-web-cient/**/*
   dependencies:
     - builders-and-yarn
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ registry-typescript-api:
 buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  retry: 3
+  retry: 2
   timeout: 18 minutes
   needs: [
     "builders-and-yarn",
@@ -157,7 +157,7 @@ buildtest:search-with-index-cache:
 buildtest:search-no-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  retry: 3
+  retry: 2
   timeout: 18 minutes
   needs: [
     "builders-and-yarn",

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
-  parallel: 4
+  parallel: 2
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"
@@ -158,7 +158,7 @@ buildtest:search-no-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
-  parallel: 4
+  parallel: 2
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ builders-and-yarn:
 # Make sure sbt depenencies, plugins are in place, cached (only for this job) and pass to following stage as artifacts
 sbt-prebuild:
   stage: sbt-prebuild
+  needs: []
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
@@ -71,12 +72,14 @@ sbt-prebuild:
 check-scala-formatting:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  needs: []
   script:
     - sbt scalafmtCheckAll
 
 registry-typescript-api:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  needs: ["check-scala-formatting"]
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
@@ -430,6 +433,7 @@ buildtest:helm-charts:
   stage: buildtest
   image: dtzar/helm-kubectl:3.1.1
   dependencies: []
+  needs: []
   cache:
     paths: []
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,12 +248,13 @@ buildtest:ui:
 
 buildtest:registry:
   stage: buildtest
-  retry: 1
+  retry: 2
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"
   ]
+  timeout: 30 minutes
   dependencies:
     - builders-and-yarn
     - sbt-prebuild

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,7 @@ buildtest:search-no-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
+  parallel: 4
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,6 +231,10 @@ buildtest:ui:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   retry: 1
   needs: ["builders-and-yarn"]
+  only:
+    changes:
+      - magda-web-server/*
+      - magda-web-cient/*
   dependencies:
     - builders-and-yarn
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -700,6 +700,10 @@ inttest:registryAuth:
 
 (UI) Run As Preview:
   <<: *runAsPreview
+  when: always
+  only:
+    variables:
+      - $CI_COMMIT_MESSAGE =~ /#deploy-ui-preview/
   script:
     - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/magda --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda-core.web-server.baseUrl=https://dev.magda.io,magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
@@ -737,6 +741,7 @@ Update scripts:
     - git config --global user.name "magdabot"
     - git commit -m "Update create-secrets scripts `date`"
     - git push "https://x-access-token:$GITHUB_ACCESS_TOKEN@github.com/magda-io/magda-config" master
+
 
 Stop Preview: &stopPreview
   stage: preview

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -532,6 +532,10 @@ dockerize:ui:
     "registry-typescript-api",
     "buildtest:ui"
   ]
+  only:
+    changes:
+      - magda-web-server/*
+      - magda-web-cient/*
   dependencies:
     - builders-and-yarn
     - registry-typescript-api

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ check-scala-formatting:
 registry-typescript-api:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  needs: []
+  needs: ["builders-and-yarn"]
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,7 @@ buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
+  parallel: 4
   needs: [
     "builders-and-yarn",
     "sbt-prebuild"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ builders-and-yarn:
   stage: builders
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:master
   retry: 1
+  needs: []
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:
@@ -95,6 +96,9 @@ buildtest:search-with-index-cache:
     "builders-and-yarn",
     "sbt-prebuild"
   ]
+  dependencies:
+    - builders-and-yarn
+    - sbt-prebuild
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -157,6 +161,9 @@ buildtest:search-no-index-cache:
     "builders-and-yarn",
     "sbt-prebuild"
   ]
+  dependencies:
+    - builders-and-yarn
+    - sbt-prebuild
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -222,6 +229,8 @@ buildtest:ui:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   retry: 1
   needs: ["builders-and-yarn"]
+  dependencies:
+    - builders-and-yarn
   cache:
     paths: []
   variables:
@@ -245,6 +254,9 @@ buildtest:registry:
     "builders-and-yarn",
     "sbt-prebuild"
   ]
+  dependencies:
+    - builders-and-yarn
+    - sbt-prebuild
   services:
   # postgres 9.6.17 (published on 15th Feb 2020) introduced an issue see here (https://gitlab.com/gitlab-com/support-forum/issues/5199)
     - postgres:9.6.16
@@ -273,6 +285,9 @@ buildtest:typescript-apis-stateless:
     "builders-and-yarn",
     "registry-typescript-api"
   ]
+  dependencies:
+    - builders-and-yarn
+    - registry-typescript-api
   script:
     - cd magda-typescript-common && yarn build && yarn test && cd ..
     - cd magda-minion-framework && yarn build && yarn test && cd ..
@@ -294,6 +309,9 @@ buildtest:typescript-apis-with-pg:
     "builders-and-yarn",
     "registry-typescript-api"
   ]
+  dependencies:
+    - builders-and-yarn
+    - registry-typescript-api
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -341,6 +359,8 @@ buildtest:typescript-apis-with-es:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
   needs: ["builders-and-yarn"]
+  dependencies:
+    - builders-and-yarn
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -387,6 +407,9 @@ buildtest:storage-api:
     "builders-and-yarn",
     "registry-typescript-api"
   ]
+  dependencies:
+    - builders-and-yarn
+    - registry-typescript-api
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -425,6 +448,8 @@ buildtest:opa-policies:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 1
   needs: ["builders-and-yarn"]
+  dependencies:
+    - builders-and-yarn
   cache:
     paths: []
   services:
@@ -475,6 +500,12 @@ dockerize:scala:
     "buildtest:search-no-index-cache",
     "buildtest:search-with-index-cache"
   ]
+  dependencies:
+    - registry-typescript-api
+    - sbt-prebuild
+    - buildtest:registry
+    - buildtest:search-no-index-cache
+    - buildtest:search-with-index-cache
   services:
     - docker:dind
   script:
@@ -494,6 +525,10 @@ dockerize:ui:
     "registry-typescript-api",
     "buildtest:ui"
   ]
+  dependencies:
+    - builders-and-yarn
+    - registry-typescript-api
+    - buildtest:ui
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.ui=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
@@ -514,6 +549,13 @@ dockerize:typescript-apis:
     "buildtest:typescript-apis-with-es",
     "buildtest:storage-api"
   ]
+  dependencies:
+    - builders-and-yarn
+    - registry-typescript-api
+    - buildtest:typescript-apis-stateless
+    - buildtest:typescript-apis-with-pg
+    - buildtest:typescript-apis-with-es
+    - buildtest:storage-api
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.api=true -f language=typescript -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
@@ -522,6 +564,7 @@ dockerize:migrators:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
+  needs: []
   cache:
     paths: []
   services:
@@ -534,6 +577,7 @@ dockerize:dockerExtensions:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
+  needs: []
   cache:
     paths: []
   services:
@@ -556,6 +600,11 @@ inttest:registryAuth:
     "buildtest:registry",
     "buildtest:helm-charts"
   ]
+  dependencies:
+    - sbt-prebuild
+    - builders-and-yarn
+    - buildtest:registry
+    - buildtest:helm-charts
   services:
     - docker:dind
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,6 @@ check-scala-formatting:
 registry-typescript-api:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  needs: ["check-scala-formatting"]
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,12 +469,12 @@ dockerize:scala:
     "buildtest:search-no-index-cache",
     "buildtest:search-with-index-cache"
   ]
-  dependencies:
-    - registry-typescript-api
-    - sbt-prebuild
-    - buildtest:registry
-    - buildtest:search-no-index-cache
-    - buildtest:search-with-index-cache
+  # dependencies:
+  #   - registry-typescript-api
+  #   - sbt-prebuild
+  #   - buildtest:registry
+  #   - buildtest:search-no-index-cache
+  #   - buildtest:search-with-index-cache
   services:
     - docker:dind
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -490,6 +490,8 @@ buildtest:helm-charts:
 
     - echo "helm lint magda chart using preview-multi-tenant.yml"
     - helm lint -f deploy/helm/preview-multi-tenant.yml deploy/helm/magda
+
+    - ls; pwd; echo "lmao"
   artifacts:
     paths:
       - "deploy/helm/magda/charts"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,7 @@ check-scala-formatting:
 registry-typescript-api:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  needs: []
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,8 +233,8 @@ buildtest:ui:
   needs: ["builders-and-yarn"]
   only:
     changes:
-      - magda-web-server/**/*
-      - magda-web-cient/**/*
+      - magda-web-client/**/**
+      - magda-web-server/**/**
   dependencies:
     - builders-and-yarn
   cache:
@@ -491,7 +491,6 @@ buildtest:helm-charts:
     - echo "helm lint magda chart using preview-multi-tenant.yml"
     - helm lint -f deploy/helm/preview-multi-tenant.yml deploy/helm/magda
 
-    - ls; pwd; echo "lmao"
   artifacts:
     paths:
       - "deploy/helm/magda/charts"
@@ -536,8 +535,8 @@ dockerize:ui:
   ]
   only:
     changes:
-      - magda-web-server/**/*
-      - magda-web-cient/**/*
+      - magda-web-server/**/**
+      - magda-web-cient/**/**
   dependencies:
     - builders-and-yarn
     - registry-typescript-api
@@ -596,8 +595,6 @@ dockerize:dockerExtensions:
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.dockerExtension=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
-
-
 
 inttest:registryAuth:
   # https://github.com/kind-ci/examples/blob/master/.gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,9 +90,10 @@ buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
-  dependencies:
-    - builders-and-yarn
-    - sbt-prebuild
+  needs: [
+    "builders-and-yarn",
+    "sbt-prebuild"
+  ]
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -151,9 +152,10 @@ buildtest:search-no-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   retry: 2
-  dependencies:
-    - builders-and-yarn
-    - sbt-prebuild
+  needs: [
+    "builders-and-yarn",
+    "sbt-prebuild"
+  ]
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -218,8 +220,7 @@ buildtest:ui:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   retry: 1
-  dependencies:
-    - builders-and-yarn
+  needs: ["builders-and-yarn"]
   cache:
     paths: []
   variables:
@@ -239,9 +240,10 @@ buildtest:registry:
   stage: buildtest
   retry: 1
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  dependencies:
-    - builders-and-yarn
-    - sbt-prebuild
+  needs: [
+    "builders-and-yarn",
+    "sbt-prebuild"
+  ]
   services:
   # postgres 9.6.17 (published on 15th Feb 2020) introduced an issue see here (https://gitlab.com/gitlab-com/support-forum/issues/5199)
     - postgres:9.6.16
@@ -266,9 +268,10 @@ buildtest:typescript-apis-stateless:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   retry: 1
-  dependencies:
-    - builders-and-yarn
-    - registry-typescript-api
+  needs: [
+    "builders-and-yarn",
+    "registry-typescript-api"
+  ]
   script:
     - cd magda-typescript-common && yarn build && yarn test && cd ..
     - cd magda-minion-framework && yarn build && yarn test && cd ..
@@ -286,9 +289,10 @@ buildtest:typescript-apis-with-pg:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 1
-  dependencies:
-    - builders-and-yarn
-    - registry-typescript-api
+  needs: [
+    "builders-and-yarn",
+    "registry-typescript-api"
+  ]
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -335,8 +339,7 @@ buildtest:typescript-apis-with-es:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
-  dependencies:
-    - builders-and-yarn
+  needs: ["builders-and-yarn"]
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -379,9 +382,10 @@ buildtest:storage-api:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 1
-  dependencies:
-    - builders-and-yarn
-    - registry-typescript-api
+  needs: [
+    "builders-and-yarn",
+    "registry-typescript-api"
+  ]
   before_script:
     - |
       if [ -z "$DOCKER_HOST" -a "$KUBERNETES_PORT" ]; then
@@ -419,8 +423,7 @@ buildtest:opa-policies:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 1
-  dependencies:
-    - builders-and-yarn
+  needs: ["builders-and-yarn"]
   cache:
     paths: []
   services:
@@ -431,7 +434,6 @@ buildtest:opa-policies:
 buildtest:helm-charts:
   stage: buildtest
   image: dtzar/helm-kubectl:3.1.1
-  dependencies: []
   needs: []
   cache:
     paths: []
@@ -472,12 +474,6 @@ dockerize:scala:
     "buildtest:search-no-index-cache",
     "buildtest:search-with-index-cache"
   ]
-  # dependencies:
-  #   - registry-typescript-api
-  #   - sbt-prebuild
-  #   - buildtest:registry
-  #   - buildtest:search-no-index-cache
-  #   - buildtest:search-with-index-cache
   services:
     - docker:dind
   script:
@@ -492,10 +488,11 @@ dockerize:ui:
     paths: []
   services:
     - docker:dind
-  dependencies:
-    - builders-and-yarn
-    - registry-typescript-api
-    - buildtest:ui
+  needs: [
+    "builders-and-yarn",
+    "registry-typescript-api",
+    "buildtest:ui"
+  ]
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.ui=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
@@ -508,13 +505,14 @@ dockerize:typescript-apis:
     paths: []
   services:
     - docker:dind
-  dependencies:
-    - builders-and-yarn
-    - registry-typescript-api
-    - buildtest:typescript-apis-stateless
-    - buildtest:typescript-apis-with-pg
-    - buildtest:typescript-apis-with-es
-    - buildtest:storage-api
+  needs: [
+    "builders-and-yarn",
+    "registry-typescript-api",
+    "buildtest:typescript-apis-stateless",
+    "buildtest:typescript-apis-with-pg",
+    "buildtest:typescript-apis-with-es",
+    "buildtest:storage-api"
+  ]
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.api=true -f language=typescript -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
@@ -551,11 +549,12 @@ inttest:registryAuth:
   retry: 1
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   allow_failure: true
-  dependencies:
-    - sbt-prebuild
-    - builders-and-yarn
-    - buildtest:registry
-    - buildtest:helm-charts
+  needs: [
+    "sbt-prebuild",
+    "builders-and-yarn",
+    "buildtest:registry",
+    "buildtest:helm-charts"
+  ]
   services:
     - docker:dind
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -564,7 +564,7 @@ dockerize:migrators:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
-  needs: []
+  needs: ["registry-typescript-api"]
   cache:
     paths: []
   services:
@@ -577,7 +577,7 @@ dockerize:dockerExtensions:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:$CI_COMMIT_REF_SLUG
   retry: 2
-  needs: []
+  needs: ["registry-typescript-api"]
   cache:
     paths: []
   services:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,10 @@ Minions:
 
 -   Added a minion for publishing to CKAN
 
+CI/CD:
+
+-   Use Acyclic Directed Graph in Gitlab CI
+
 Others:
 
 -   Use a "Year" column from a CSV file to extract a temporal extent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,7 +123,7 @@ Minions:
 
 CI/CD:
 
--   Use Acyclic Directed Graph in Gitlab CI
+-   Use Directed Acyclic Graph in Gitlab CI
 
 Others:
 

--- a/magda-web-client/src/Components/Account/AccountLoginPage.tsx
+++ b/magda-web-client/src/Components/Account/AccountLoginPage.tsx
@@ -190,7 +190,7 @@ export default function Login(props) {
             )}
             {isProvidersLoading ? (
                 <div className="col-xs-12">
-                    <p>Loading available authentication providers...</p>
+                    <p>Loading all available authentication providers...</p>
                 </div>
             ) : null}
             {!isProvidersLoading && providersLoadingError ? (

--- a/magda-web-client/src/Components/Account/AccountLoginPage.tsx
+++ b/magda-web-client/src/Components/Account/AccountLoginPage.tsx
@@ -190,7 +190,7 @@ export default function Login(props) {
             )}
             {isProvidersLoading ? (
                 <div className="col-xs-12">
-                    <p>Loading all available authentication providers...</p>
+                    <p>Loading available authentication providers...</p>
                 </div>
             ) : null}
             {!isProvidersLoading && providersLoadingError ? (

--- a/magda-web-client/src/Components/Account/AccountLoginPage.tsx
+++ b/magda-web-client/src/Components/Account/AccountLoginPage.tsx
@@ -190,7 +190,7 @@ export default function Login(props) {
             )}
             {isProvidersLoading ? (
                 <div className="col-xs-12">
-                    <p>Loading available authentication providers... </p>
+                    <p>Loading available authentication providers...</p>
                 </div>
             ) : null}
             {!isProvidersLoading && providersLoadingError ? (

--- a/magda-web-client/src/Components/Account/AccountLoginPage.tsx
+++ b/magda-web-client/src/Components/Account/AccountLoginPage.tsx
@@ -190,7 +190,7 @@ export default function Login(props) {
             )}
             {isProvidersLoading ? (
                 <div className="col-xs-12">
-                    <p>Loading available authentication providers...</p>
+                    <p>Loading available authentication providers... </p>
                 </div>
             ) : null}
             {!isProvidersLoading && providersLoadingError ? (


### PR DESCRIPTION
### What this PR does

Helps #2726 

- Uses Gitlab's Acyclic Directed Graph to trigger jobs as soon as they can be triggered
2020-07-08: `git push` to :heavy_check_mark: takes about 35 minutes now.
- Not exactly CI, but uses Github flavored markdown for bug report
- Adds quick retries for search index tests 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
