### PR TITLE
Fixed patch ckan-export request trigger 400 error when the aspect doesn't exist at all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,7 @@ UI:
 -   Add revised edit flow for adding/deleting/superceding existing distributions
 -   Show extra metadata on the dataset page
 -   Fixed ckan-export aspect's fields should be only changed via JSON patch from the frontend (#2887)
+-   Fixed patch ckan-export request trigger 400 error when the aspect doesn't exist at all
 
 Storage:
 


### PR DESCRIPTION
### What this PR does

Fixed patch ckan-export request trigger 400 error when the aspect doesn't exist at all. (Related PR: https://github.com/magda-io/magda/pull/2903)

- `Add` operation works no matter the key exists or not but will still give you 400 error if the aspect doesn’t exist at all.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
