### PR TITLE
Some improvement on openfaas deployment + fixes documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -703,7 +703,7 @@ inttest:registryAuth:
 (UI) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.secrets.authSecrets=false,global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda.magda-core.web-server.baseUrl=https://dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda.magda-core.web-server.baseUrl=https://dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 (UI - Auto) Run As Preview:
@@ -713,7 +713,7 @@ inttest:registryAuth:
     variables:
       - $CI_COMMIT_MESSAGE =~ /#deploy-ui-preview/
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.secrets.authSecrets=false,global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda.magda-core.web-server.baseUrl=https://dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,magda.magda-core.web-server.baseUrl=https://dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 (No Data) Run As Preview:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@ General:
 -   Set pwgen to `0.1.6` (was `^0.1.6`)
 -   Remove ESRI-portal related code from deployment charts
 -   Allow admin users to download history report of a dataset
+-   Fixed `building-and-running` doc: instruct users to update helm charts with `yarn update-all-charts`
+-   Added Docs of supplying custom policy files
+-   Openfaas should be turn on / of via condition field `global.openfaas.enabled` instead of `tags`.
+-   When `global.openfaas.enabled` is false, all openfaas dependent objects will either report error to users or be skiped for creation.
 
 UI:
 

--- a/deploy/helm/local-auth-test.yml
+++ b/deploy/helm/local-auth-test.yml
@@ -10,6 +10,8 @@ global:
   useCloudSql: false
   useCombinedDb: true
   enablePriorityClass: false
+  openfaas:
+    enabled: false
 
 tags:
   all: false

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -77,5 +77,5 @@ dependencies:
 - name: ingress
   repository: file://../internal-charts/ingress
   version: 0.0.57-0
-digest: sha256:e11f9dd597d72666d34c82c57b0d5dfc34f20d9201c9243482ffbc853ed927ef
-generated: "2020-07-06T14:48:45.723033326+10:00"
+digest: sha256:1836ae127f8fcee4946e2189b5d43033231426ca8a09cd98845512ee3fb6a389
+generated: "2020-08-14T10:29:10.243231+10:00"

--- a/deploy/helm/magda-core/Chart.yaml
+++ b/deploy/helm/magda-core/Chart.yaml
@@ -149,9 +149,11 @@ dependencies:
   - name: openfaas
     version: 5.5.5-magda
     repository: file://../openfaas
-    tags:
-      - all
-      - openfaas
+    # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
+    # Due to a limitation of helm, the value of tags is not available in chart template.
+    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
+    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
+    condition: global.openfaas.enabled
 
 # K8s misc
   - name: priorities

--- a/deploy/helm/magda-core/values.yaml
+++ b/deploy/helm/magda-core/values.yaml
@@ -16,6 +16,10 @@ global:
   gapiIds: []
   enablePriorityClass: false
   openfaas:
+    # turn on / off openfaas
+    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
+    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
+    enabled: true 
     namespacePrefix: ""
     functionNamespace: openfaas-fn  # Default namespace for functions
     mainNamespace: openfaas # Default namespace for gateway and other core modules
@@ -41,6 +45,7 @@ openfaas:
     dryRun: false
 
 tags:
+  # to turn on/off openfaas, please set value to `global.openfaas.enabled`
   priorities: true
   all: true
   apidocs-server: false

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -27,4 +27,4 @@ dependencies:
   repository: https://charts.magda.io
   version: 0.0.57-0
 digest: sha256:e662e0b91671fe7f9a314b84401e31de25eee68ae57d1aaed4fa130847b49ba0
-generated: "2020-08-04T16:13:34.741659+10:00"
+generated: "2020-08-14T14:08:35.200419+10:00"

--- a/deploy/helm/magda/templates/openfaas-fn-auth-secrets.yaml
+++ b/deploy/helm/magda/templates/openfaas-fn-auth-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.openfaas.secrets.authSecrets }}
+{{- if and (eq .Values.global.openfaas.enabled true) (eq .Values.global.openfaas.secrets.authSecrets true) }}
 {{- $namespacePrefix := .Values.global.openfaas.namespacePrefix | default .Release.Namespace -}}
 {{- $functionNamespace := .Values.global.openfaas.functionNamespace | default "openfaas-fn" -}}
 apiVersion: v1

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -12,6 +12,7 @@ global:
     includeInitialJobs: false
     includeCronJobs: true
   openfaas:
+    enabled: true
     namespacePrefix: ""
     functionNamespace: openfaas-fn  # Default namespace for functions
     mainNamespace: openfaas # Default namespace for gateway and other core modules

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -14,6 +14,10 @@ global:
   defaultContactEmail: "magda@mailinator.com"
   enableMultiTenants: false
   openfaas:
+    # turn on / off openfaas
+    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
+    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
+    enabled: true
     # turn off auth over openfass gateway for ease of debugging
     allowAdminOnly: false
   

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -180,9 +180,7 @@ If you're using Docker Desktop on Windows, add `-f deploy/helm/docker-desktop-wi
 # update magda helm repo
 helm repo update
 # update magda chart dependencies
-helm dep build deploy/helm/internal-charts/storage-api
-helm dep build deploy/helm/magda-core
-helm dep build deploy/helm/magda
+yarn update-all-charts
 # deploy the magda chart from magda helm repo
 helm upgrade --install --timeout 9999s --wait -f deploy/helm/docker-desktop-windows.yml -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
 ```

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -165,9 +165,7 @@ Note: If using docker desktop for Windows older than version 19, change the valu
 helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 # update magda chart dependencies
-helm dep build deploy/helm/internal-charts/storage-api
-helm dep build deploy/helm/magda-core
-helm dep build deploy/helm/magda
+yarn update-all-charts
 # deploy the magda chart from magda helm repo
 helm upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
 ```

--- a/docs/docs/how-to-add-custom-opa-policies.md
+++ b/docs/docs/how-to-add-custom-opa-policies.md
@@ -1,0 +1,69 @@
+# How to Add Custom OPA Policy Files
+
+Magda comes with a policy engine (Open Policy Agent) for authorisation usage.
+
+You can supply your own set of policy files to implment additional logic or replace existing build-in policy files.
+
+### Encode Your Policy Files Directory into ConfigMap
+
+To supply your own policy files, you need to create one or more (in case files are too big for one) configMap that contains your policy file directory.
+
+A helm chart template [magda.filesToJson](https://github.com/magda-io/magda/blob/21499b75c7a7ee00d68886338713217d83ccb91f/deploy/helm/magda-core/templates/_helpers.tpl#L244) is provided to load files with directory structure into a k8s configMap.
+
+This template support 2 parameters:
+
+-   `filePattern`: Glob file search pattern string. All files (and their dir path) match the `Glob` pattern will be encoded and included in the configMap.
+-   `pathPrefix` : Optional. Add `pathPrefix` to all file path generated in configMap JSON.
+
+Example Usage:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: "my-default-files"
+data:
+    my_default_files.json:
+        {
+            {
+                include "magda.filesToJson" (dict "root" . "filePattern" "my_dir/**/*" ),
+            },
+        }
+```
+
+Or with `pathPrefix`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: "my-default-files"
+data:
+    my_default_files.json:
+        {
+            {
+                include "magda.filesToJson" (dict "root" . "filePattern" "my_dir/**/*" "pathPrefix" "test/" ),
+            },
+        }
+```
+
+### Deployment Chart
+
+To pass the configMap to OPA, you need to create a deployment chart to deploy your application:
+
+-   Your policy files directory should be put inside your chart directory.
+-   The configMap template should be put into your chart template directory.
+-   You can supply your custom policy file configMap by set the `customPolicyConfigMaps` value of opa sub chart. e.g.:
+
+```yaml
+magda:
+    magda-core:
+        opa:
+            customPolicyConfigMaps:
+                - my-extra-policy-files-1
+                - my-extra-policy-files-2
+```
+
+A complete example can be found from:
+
+https://github.com/magda-io/magda/tree/9339dde1c30a43cec44646aea5aeda1391275931/deploy/helm/local-deployment


### PR DESCRIPTION
### What this PR does

Fixed: #2930 

-   Fixed `building-and-running` doc: instruct users to update helm charts with `yarn update-all-charts`
-   Added Docs of supplying custom policy files
-   Openfaas should be turn on / of via condition field `global.openfaas.enabled` instead of `tags`.
-   When `global.openfaas.enabled` is false, all openfaas dependent objects will either report the error to users or be skipped for creation (e.g. secret place holder in function namespace).

The error will look like this:

> Error: UPGRADE FAILED: template: magda-local-deployment/charts/magda/charts/ckan-connector-functions/templates/functionDataUrlProcessor.yaml:4:4: executing "magda-local-deployment/charts/magda/charts/ckan-connector-functions/templates/functionDataUrlProcessor.yaml" at <fail "`ckan-connector-functions` requires `magda-core`.`openfaas` to deploy. Please turn of openfaas by setting `global.openfaas.enabled` to `true` or turn off `ckan-connector-functions` to avoid this error.">: error calling fail: `ckan-connector-functions` requires `magda-core`.`openfaas` to deploy. Please turn of openfaas by setting `global.openfaas.enabled` to `true` or turn off `ckan-connector-functions` to avoid this error.


#### Test

Test site: https://issue-2930.dev.magda.io/

Tested No data Deployment & UI Only preview as well

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
