### PR TITLE
Add OPA Neq parsing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,7 @@ Registry:
 
 -   Made events record the correct user id
 -   Fixed Registry History API Performance Issue when limit=1 & Updated Registry History API Document
+-   Fixed not support `Neg` operator in OPA policy
 
 Search:
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
@@ -154,6 +154,7 @@ object SqlHelper {
     else if (operation == Lt) SQLSyntax.createUnsafely("<")
     else if (operation == Gte) SQLSyntax.createUnsafely(">=")
     else if (operation == Lte) SQLSyntax.createUnsafely("<=")
+    else if (operation == Neq) SQLSyntax.createUnsafely("!=")
     else
       throw new Exception("Could not understand " + operation)
   }


### PR DESCRIPTION
(cherry picked from commit 96417fa2391e7a48c3f4bf962a45e5363eea66e3)

### What this PR does

Fixes #2933 

Add parsing OPA `Neq` operation into SQL `!=` operation.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
