### PR TITLE
Update V1_4__add_roles_to_existing_users.sql

### DIFF
--- a/magda-migrator-authorization-db/sql/V1_4__add_roles_to_existing_users.sql
+++ b/magda-migrator-authorization-db/sql/V1_4__add_roles_to_existing_users.sql
@@ -8,7 +8,7 @@ INSERT INTO user_roles
 	WHERE u.id NOT IN (SELECT user_roles.user_id FROM user_roles WHERE user_roles.role_id = '00000000-0000-0002-0000-000000000000'::uuid) 
 );
 
--- Add default Authenticated Users role to existing admin users
+-- Add default Admin Users role to existing admin users
 INSERT INTO user_roles 
 (id, user_id, role_id)
 (


### PR DESCRIPTION
minor tweak to mismatched comment

### What this PR does

Fixes a confusing comment in https://github.com/magda-io/magda/blob/master/magda-migrator-authorization-db/sql/V1_4__add_roles_to_existing_users.sql

### Checklist

-   [x] n/a There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] n/a I've updated CHANGES.md with what I changed. 
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
