### PR TITLE
Issue/2928 Allow to configure webRoutes in a way of similar to routes (i.e. specify method, auth etc)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,8 @@ Gateway:
 -   Allow cookie option to be configured via helm chart
 -   Set cookie `secure` default value to `auto`
 -   Set dev site cookie `sameSite` attribute to `none`
+-   Allow to configure webRoutes in a way of similar to routes (i.e. specify method, auth etc)
+-   Make preview-map route configurable (through web route)
 
 Authorization:
 

--- a/deploy/helm/internal-charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/gateway/templates/deployment.yaml
@@ -88,7 +88,6 @@ spec:
             "--web", {{ .Values.web | default "http://web" | quote }},
             "--authorizationApi", "http://authorization-api/v0",
             "--tenantUrl", "http://tenant-api/v0",
-            "--previewMap", "http://preview-map:6110",
 {{- if .Values.global.openfaas.mainNamespace }}
             "--openfaasGatewayUrl", {{ include "magda.openfaasGatewayUrl" . | quote }},
             "--openfaasAllowAdminOnly", {{ .Values.global.openfaas.allowAdminOnly | quote }},

--- a/deploy/helm/internal-charts/gateway/values.yaml
+++ b/deploy/helm/internal-charts/gateway/values.yaml
@@ -28,6 +28,8 @@ resources:
   limits:
     cpu: 200m
 
+# Routes list here are available under `/api/v0/` path
+# See `Proxy Target Definition` below for route format
 defaultRoutes:
   search:
     to: http://search-api/v0
@@ -66,7 +68,24 @@ defaultRoutes:
     to: http://tenant-api/v0
     auth: true
 
-webRoutes: {}
+# extra web routes
+# See `Proxy Target Definition` below for route format
+webRoutes:
+  preview-map: http://preview-map:6110
+
+### Proxy Target Definition
+# A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
+# - `to`: target url
+# - `methods`: array of string. "all" means all methods
+# - `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
+# - `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
+# - `statusCheck`: check target's live status from the gateway
+# A proxy target be also specify in a simply string form, in which case, Gateway assumes a GET method, no auth proxy route is requested.
+
+# Default web route. 
+# This is the last route of the proxy
+# Main UI should be served from here
+web: http://web
 
 csp:
   browserSniff: false

--- a/magda-gateway/src/buildApp.ts
+++ b/magda-gateway/src/buildApp.ts
@@ -14,7 +14,7 @@ import {
     installStatusRouter,
     createServiceProbe
 } from "magda-typescript-common/src/express/status";
-import createApiRouter from "./createApiRouter";
+import createGenericProxyRouter from "./createGenericProxyRouter";
 import createAuthRouter from "./createAuthRouter";
 import createGenericProxy from "./createGenericProxy";
 import createCkanRedirectionRouter from "./createCkanRedirectionRouter";
@@ -22,7 +22,7 @@ import createHttpsRedirectionMiddleware from "./createHttpsRedirectionMiddleware
 import createOpenfaasGatewayProxy from "./createOpenfaasGatewayProxy";
 import Authenticator, { SessionCookieOptions } from "./Authenticator";
 import defaultConfig from "./defaultConfig";
-import { ProxyTarget } from "./createApiRouter";
+import { ProxyTarget } from "./createGenericProxyRouter";
 import setupTenantMode from "./setupTenantMode";
 import createPool from "./createPool";
 
@@ -230,12 +230,16 @@ export default function buildApp(app: express.Application, config: Config) {
         );
     }
 
-    app.use("/api/v0", createApiRouter(apiRouterOptions));
+    app.use("/api/v0", createGenericProxyRouter(apiRouterOptions));
 
     if (config.webProxyRoutesJson) {
-        _.forEach(config.webProxyRoutesJson, (value: string, key: string) => {
-            app.use("/" + key, createGenericProxy(value, apiRouterOptions));
-        });
+        app.use(
+            "/",
+            createGenericProxyRouter({
+                ...apiRouterOptions,
+                routes: config.webProxyRoutesJson
+            })
+        );
     }
 
     app.use(

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -7,7 +7,7 @@ import {
     MAGDA_TENANT_ID_HEADER,
     MAGDA_ADMIN_PORTAL_ID
 } from "magda-typescript-common/src/registry/TenantConsts";
-import { ApiRouterOptions } from "./createApiRouter";
+import { GenericProxyRouterOptions } from "./createGenericProxyRouter";
 
 const DO_NOT_PROXY_HEADERS = [
     "Proxy-Authorization",
@@ -24,7 +24,9 @@ const doNotProxyHeaderLookup = groupBy(
     (x: string) => x
 );
 
-export default function createBaseProxy(options: ApiRouterOptions): httpProxy {
+export default function createBaseProxy(
+    options: GenericProxyRouterOptions
+): httpProxy {
     const proxy = httpProxy.createProxyServer({
         prependUrl: false,
         changeOrigin: true

--- a/magda-gateway/src/createGenericProxy.ts
+++ b/magda-gateway/src/createGenericProxy.ts
@@ -1,10 +1,10 @@
 import express from "express";
 import createBaseProxy from "./createBaseProxy";
-import { ApiRouterOptions } from "./createApiRouter";
+import { GenericProxyRouterOptions } from "./createGenericProxyRouter";
 
 export default function createGenericProxy(
     target: string,
-    options: ApiRouterOptions
+    options: GenericProxyRouterOptions
 ): express.Router {
     const webRouter = express.Router();
     const proxy = createBaseProxy(options);

--- a/magda-gateway/src/createGenericProxyRouter.ts
+++ b/magda-gateway/src/createGenericProxyRouter.ts
@@ -123,10 +123,6 @@ export default function createGenericProxyRouter(
                 ? getDefaultProxyTargetDefinition(value)
                 : value;
 
-        // --- skip tenant api router if multiTenantsMode is off
-        if (key === "tenant" && !options.tenantMode.multiTenantsMode) {
-            return;
-        }
         proxyRoute(
             `/${key}`,
             target.to,

--- a/magda-gateway/src/createGenericProxyRouter.ts
+++ b/magda-gateway/src/createGenericProxyRouter.ts
@@ -24,7 +24,7 @@ export interface ProxyTarget {
     statusCheck?: boolean;
 }
 
-export interface ApiRouterOptions {
+export interface GenericProxyRouterOptions {
     authenticator: Authenticator;
     jwtSecret: string;
     routes: {
@@ -34,7 +34,9 @@ export interface ApiRouterOptions {
     defaultCacheControl?: string;
 }
 
-export default function createApiRouter(options: ApiRouterOptions): Router {
+export default function createGenericProxyRouter(
+    options: GenericProxyRouterOptions
+): Router {
     const proxy = createBaseProxy(options);
 
     const authenticator = options.authenticator;

--- a/magda-gateway/src/createOpenfaasGatewayProxy.ts
+++ b/magda-gateway/src/createOpenfaasGatewayProxy.ts
@@ -1,14 +1,14 @@
 import express from "express";
 import createBaseProxy from "./createBaseProxy";
 import { mustBeAdmin } from "magda-typescript-common/src/authorization-api/authMiddleware";
-import { ApiRouterOptions } from "./createApiRouter";
+import { GenericProxyRouterOptions } from "./createGenericProxyRouter";
 import buildJwt from "magda-typescript-common/src/session/buildJwt";
 
 interface OptionsType {
     gatewayUrl: string;
     baseAuthUrl: string;
     allowAdminOnly?: boolean;
-    apiRouterOptions: ApiRouterOptions;
+    apiRouterOptions: GenericProxyRouterOptions;
     jwtSecret: string;
 }
 

--- a/magda-gateway/src/defaultConfig.ts
+++ b/magda-gateway/src/defaultConfig.ts
@@ -27,6 +27,9 @@ export default {
             auth: true
         }
     },
+    extraWebRoutes: {
+        "preview-map": "http://localhost:6110"
+    },
     csp: {
         directives: {
             scriptSrc: ["'self'"],

--- a/magda-gateway/src/index.ts
+++ b/magda-gateway/src/index.ts
@@ -92,11 +92,6 @@ const argv = addJwtSecretFromEnvVar(
             type: "string",
             default: "http://localhost:6104/v0"
         })
-        .option("previewMap", {
-            describe: "The base URL of the preview map.",
-            type: "string",
-            default: "http://localhost:6110"
-        })
         .option("web", {
             describe: "The base URL of the web site.",
             type: "string",

--- a/magda-gateway/src/test/createGenericProxyRouter.spec.ts
+++ b/magda-gateway/src/test/createGenericProxyRouter.spec.ts
@@ -1,0 +1,143 @@
+import {} from "mocha";
+import sinon from "sinon";
+import express from "express";
+import nock from "nock";
+import _ from "lodash";
+import supertest from "supertest";
+
+import Authenticator from "../Authenticator";
+import setupTenantMode from "../setupTenantMode";
+
+import createGenericProxyRouter from "../createGenericProxyRouter";
+import { expect } from "chai";
+
+describe("createGenericProxyRouter", () => {
+    const defaultTenantMode = setupTenantMode({
+        enableMultiTenants: false
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it("should accept url string as target proxy definition item", async () => {
+        let isApplyToRouteCalled = false;
+
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        dummyAuthenticator.applyToRoute = () => {
+            isApplyToRouteCalled = true;
+        };
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route": "http://test-route.com"
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com").get("/").reply(200);
+
+        await supertest(app).get("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // by default no auth
+        expect(isApplyToRouteCalled).to.be.false;
+
+        // only `get` route is setup by default
+        scope.post("/", {}).reply(200);
+        await supertest(app).post("/test-route").expect(404);
+    });
+
+    it("should process complete target proxy definition item well", async () => {
+        let isApplyToRouteCalled = false;
+
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        dummyAuthenticator.applyToRoute = () => {
+            isApplyToRouteCalled = true;
+        };
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route": {
+                    to: "http://test-route.com",
+                    auth: true,
+                    methods: ["get", "post"]
+                }
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com").get("/").reply(200);
+
+        await supertest(app).get("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // Auth is on now
+        expect(isApplyToRouteCalled).to.be.true;
+
+        // only `post` route is also setup now
+        scope.post("/").reply(200);
+        await supertest(app).post("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+    });
+
+    it("should support `all` method", async () => {
+        let isApplyToRouteCalled = false;
+
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        dummyAuthenticator.applyToRoute = () => {
+            isApplyToRouteCalled = true;
+        };
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route": {
+                    to: "http://test-route.com",
+                    auth: false,
+                    methods: ["all"]
+                }
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com").get("/").reply(200);
+        await supertest(app).get("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // `post` route is also setup now (as it's `all`)
+        scope.post("/").reply(200);
+        await supertest(app).post("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // `put` route is also setup now (as it's `all`)
+        scope.put("/").reply(200);
+        await supertest(app).put("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // `delete` route is also setup now (as it's `all`)
+        scope.delete("/").reply(200);
+        await supertest(app).delete("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // Auth is off now
+        expect(isApplyToRouteCalled).to.be.false;
+    });
+});

--- a/magda-gateway/src/test/proxy.spec.ts
+++ b/magda-gateway/src/test/proxy.spec.ts
@@ -11,7 +11,7 @@ import { expect } from "chai";
 
 const PROXY_ROOTS = {
     "/api/v0/registry": "http://registry",
-    "/preview-map": "http://preview-map/",
+    "/preview-map": "http://preview-map",
     "/map/": "http://map/",
     "/other/foo/bar/": "http://otherplace/foo/bar"
 };
@@ -30,6 +30,7 @@ const defaultAppOptions = {
         }
     },
     webProxyRoutesJson: {
+        "preview-map": "http://preview-map",
         map: "http://map",
         other: "http://otherplace"
     },
@@ -42,7 +43,6 @@ const defaultAppOptions = {
     jwtSecret: "othersecret",
     userId: "b1fddd6f-e230-4068-bd2c-1a21844f1598",
     web: "https://127.0.0.1",
-    previewMap: "http://preview-map",
     tenantUrl: "http://tenant",
     defaultCacheControl: "DEFAULT CACHE CONTROL"
 };


### PR DESCRIPTION
### What this PR does

Fixes #2928 

This PR actually address the ticket in a more generic way:
- generalise the function of createApiRouter and rename it as createGenericProxyRouter
- Allow configuring webRoutes in a way of similar to routes (i.e. specify methods, auth etc)
  - Accept simple string value as target as well (which assume route `GET` method, no auth)
- Make preview-map route to be added via `webRoutes`
- Added more test cases

So now, you can either configure a route like:
```yaml
webRoutes:
  preview-map: http://preview-map:6110
```
in which case assume it's a GET only route that has no auth.

Or specify more details:
```yaml
webRoutes:
  preview-map: 
    to: http://preview-map:6110
    auth: false
    method:
      - get  # `all` means all methods
```


### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
