### PR TITLE
fixed CI pipeline: `sbt-prebuild` & `check-scala-formatting` require `builders-and-yarn` to run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ builders-and-yarn:
 # Make sure sbt depenencies, plugins are in place, cached (only for this job) and pass to following stage as artifacts
 sbt-prebuild:
   stage: sbt-prebuild
-  needs: []
+  needs: ["builders-and-yarn"]
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
@@ -73,7 +73,7 @@ sbt-prebuild:
 check-scala-formatting:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  needs: []
+  needs: ["builders-and-yarn"]
   script:
     - sbt scalafmtCheckAll
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -858,8 +858,8 @@ Publish NPM Packages:
   cache: {}
   script:
     # Setup NPM token
-    - yarn run in-submodules -f categories.npmPackage=true run npm-setup
-    - yarn run in-submodules -f categories.npmPackage=true run release
+    - npm run in-submodules -f categories.npmPackage=true run npm-setup
+    - npm run in-submodules -f categories.npmPackage=true run release
 
 Publish Helm Chart:
   stage: release

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -185,20 +185,7 @@ yarn update-all-charts
 helm upgrade --install --timeout 9999s --wait -f deploy/helm/docker-desktop-windows.yml -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
 ```
 
-If you want to deploy the packed & production ready helm chart in our helm repo:
-
-```bash
-# update magda helm repo
-helm repo update
-# deploy the local magda chart
-helm upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda magda-io/magda
-```
-
-**Please Note:**
-
--   By default, helm will install the latest production version. This excludes development versions (e.g. 0.0.57-0)
--   If you need the latest version (including the development version), please add a `--devel` switch to the `helm upgrade` command above.
--   Alternatively, you can use `--version` to specify a specific version. e.g. `--version 0.0.57-0`
+If you want to deploy the packed & production ready helm chart in our helm repo, please check out this sample [config repo](https://github.com/magda-io/magda-config).
 
 ### Crawl Data
 


### PR DESCRIPTION
### What this PR does

Fixes #2936 
- fixed CI pipeline: `sbt-prebuild` & `check-scala-formatting` require `builders-and-yarn` to run
- Updated readme.md as `helm upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda magda-io/magda` wiil not work unless we provide a different value file after [this pr](https://github.com/magda-io/magda/pull/2917)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
