### PR TITLE
Auto Versioning update script for Helm Chart

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -654,7 +654,6 @@ inttest:registryAuth:
     - branches
   except:
     - master
-    - /^v.*RC.*$/
   dependencies:
     - buildtest:helm-charts
   cache:
@@ -728,9 +727,13 @@ inttest:registryAuth:
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 Update scripts:
-  stage: preview
+  stage: release
   only:
-    - /^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/
+    # Strict Semvar validation
+    - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
+  except:
+    - branches
+    - triggers
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
   before_script:
     - yarn global add pkg
@@ -758,7 +761,6 @@ Stop Preview: &stopPreview
     - branches
   except:
     - master
-    - /^v.*RC.*$/
   dependencies: []
   cache:
     paths: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -798,7 +798,8 @@ Deploy Master To Dev:
 Release Tags To Docker Hub:
   stage: release
   only:
-    - /^v.*\..*\..*$/
+    # Strict Semvar validation
+    - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
   except:
     - branches
     - triggers
@@ -819,7 +820,8 @@ Release Tags To Docker Hub:
 Publish NPM Packages:
   stage: release
   only:
-    - /^v.*\..*\..*$/
+    # Strict Semvar validation
+    - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
   except:
     - branches
     - triggers
@@ -841,7 +843,8 @@ Publish NPM Packages:
 Publish Helm Chart:
   stage: release
   only:
-    - /^v.*\..*\..*$/
+    # Strict Semvar validation
+    - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
   except:
     - branches
     - triggers

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,10 @@
         "magda-web-client/**/*.css": true
     },
     "eslint.enable": true,
-    "files.associations": { "*.json": "jsonc" }
+    "files.associations": {
+        "*.json": "jsonc"
+    },
+    "files.watcherExclude": {
+        "**/target": true
+    }
 }

--- a/deploy/helm/internal-charts/admin-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/admin-api/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             "--dockerRepo", {{ .Values.global.image.repository | quote }},
             "--authApiUrl", "http://authorization-api/v0",
             "--registryApiUrl", "http://registry-api/v0",
-            "--imageTag", {{ .Values.image.tag | default .Values.global.image.tag }},
+            "--imageTag", {{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }},
             "--pullPolicy", {{ .Values.global.image.pullPolicy }},
             "--kubernetesApiType", "cluster",
             "--userId", {{ .Values.global.defaultAdminUserId | quote }},

--- a/deploy/helm/internal-charts/authorization-db/templates/migration.yaml
+++ b/deploy/helm/internal-charts/authorization-db/templates/migration.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: authorization-db-migrator
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-authorization-db:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-authorization-db:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         env:
         - name: DB_HOST

--- a/deploy/helm/internal-charts/content-api/templates/configmap.yaml
+++ b/deploy/helm/internal-charts/content-api/templates/configmap.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: "scss-compiler-config"
 data:
-  image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-scss-compiler:{{ .Values.image.tag | default .Values.global.image.tag }}"
+  image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-scss-compiler:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
   scssVars: {{ .Values.scssVars | quote }}

--- a/deploy/helm/internal-charts/content-api/templates/init-scss-compiler.yaml
+++ b/deploy/helm/internal-charts/content-api/templates/init-scss-compiler.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: init-scss-compiler
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-scss-compiler:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-scss-compiler:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: [
             "node",

--- a/deploy/helm/internal-charts/content-db/templates/migration.yaml
+++ b/deploy/helm/internal-charts/content-db/templates/migration.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: content-db-migrator
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-content-db:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-content-db:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         env:
         - name: DB_HOST

--- a/deploy/helm/internal-charts/registry-db/templates/migration.yaml
+++ b/deploy/helm/internal-charts/registry-db/templates/migration.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: registry-db-migrator
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-registry-db:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-registry-db:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         env: 
         - name: DB_HOST

--- a/deploy/helm/internal-charts/session-db/templates/migration.yaml
+++ b/deploy/helm/internal-charts/session-db/templates/migration.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: session-db-migrator
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-session-db:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-session-db:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         env: 
         - name: DB_HOST

--- a/deploy/helm/internal-charts/tenant-db/templates/migration.yaml
+++ b/deploy/helm/internal-charts/tenant-db/templates/migration.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: tenant-db-migrator
-        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-tenant-db:{{ .Values.image.tag | default .Values.global.image.tag }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository }}/magda-migrator-tenant-db:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         env:
         - name: DB_HOST

--- a/deploy/helm/magda-core/templates/_helpers.tpl
+++ b/deploy/helm/magda-core/templates/_helpers.tpl
@@ -16,11 +16,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "dockerimage" -}}
-"{{ .Values.image.repository | default .Values.global.image.repository }}/magda-{{ .Chart.Name }}:{{ .Values.image.tag | default .Values.global.image.tag }}"
+"{{ .Values.image.repository | default .Values.global.image.repository }}/magda-{{ .Chart.Name }}:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
 {{- end -}}
 
 {{- define "postgres" -}}
-"{{ .Values.image.repository | default .Values.global.image.repository }}/magda-postgres:{{ .Values.image.tag | default .Values.global.image.tag }}"
+"{{ .Values.image.repository | default .Values.global.image.repository }}/magda-postgres:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
 {{- end -}}
 
 {{- define "magda.postgres-client-env" -}}
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
         - name: connector-{{ .jobConfig.id }}
-          image: "{{ .jobConfig.image.repository | default .root.Values.image.repository | default .root.Values.global.image.repository }}/{{ .jobConfig.image.name }}:{{ .jobConfig.image.tag | default .root.Values.image.tag | default .root.Values.global.image.tag }}"
+          image: "{{ .jobConfig.image.repository | default .root.Values.image.repository | default .root.Values.global.image.repository }}/{{ .jobConfig.image.name }}:{{ .jobConfig.image.tag | default .root.Values.image.tag | default .root.Values.global.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .jobConfig.image.pullPolicy | default .root.Values.image.pullPolicy | default .root.Values.global.image.pullPolicy }}
           command:
             - "node"

--- a/deploy/helm/magda-core/values.yaml
+++ b/deploy/helm/magda-core/values.yaml
@@ -6,7 +6,9 @@ global:
     maxUnavailable: 0
   exposeNodePorts: false
   image:
-    tag: 0.0.57-0
+    # When we don't specify tag here, .Chart.version will be used --- which is easier for versioning
+    # You still can specify a tag here to override the default `.Chart.version` value (e.g. for local debugging)
+    # tag: xxxxxxx
     repository: "data61"
     pullPolicy: IfNotPresent
   defaultAdminUserId: "00000000-0000-4000-8000-000000000000"

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -30,5 +30,13 @@
     "generate-registry-typescript": "generate-registry-typescript.js",
     "create-docker-context-for-node-component": "create-docker-context-for-node-component.js",
     "generate-connector-jobs": "generate-connector-jobs.js"
-  }
+  },
+  "versionUpdateExclude": [
+      "openfaas",
+      "magda-cert-issuer",
+      "magda-nginx-ingress-controller",
+      "nginx-ingress-controller",
+      "default-http-backend",
+      "magda-cert-issuer"
+  ]
 }

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -8,7 +8,14 @@
     "generate-connector-jobs-local": "generate-connector-jobs --in ./connector-config --out ./kubernetes/generated/local --local",
     "generate-connector-jobs-dev": "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
     "generate-connector-jobs-prod": "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
-    "create-config-configmap": "kubectl delete configmap config --ignore-not-found && kubectl create configmap config --from-file ./kubernetes/config/"
+    "create-config-configmap": "kubectl delete configmap config --ignore-not-found && kubectl create configmap config --from-file ./kubernetes/config/",
+    "update-magda-core-chart": "helm dep up helm/internal-charts/storage-api && helm dep up helm/magda-core",
+    "update-magda-chart": "yarn update-magda-core-chart && helm dep up helm/magda",
+    "update-local-deployment-chart": "yarn update-magda-chart && helm dep up helm/local-deployment",
+    "update-all-charts": "yarn clean-up-all-charts && yarn update-local-deployment-chart",
+    "clean-up-all-charts": "rm -rf helm/internal-charts/storage-api/charts helm/magda-core/charts helm/magda/charts helm/local-deployment/charts",
+    "add-all-chart-version-changes": "git ls-files -m | grep Chart.yaml | xargs git add && git ls-files -m | grep Chart.lock | xargs git add",
+    "version": "yarn update-helm-chart-version && yarn update-all-charts && yarn add-all-chart-version-changes"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/docs/docs/installing-docker-k8s.md
+++ b/docs/docs/installing-docker-k8s.md
@@ -10,7 +10,7 @@ Make sure you get the EDGE client - as of the time of writing Kubernetes isn't i
 
 ## Setup
 
-Start up Docker for Mac. Find the icon in the top-right hand corner of the screen and open "Preferences". Then navigate to "Advanced" and set the resources so your cluster has 2 processors and 4gb of RAM.
+Start up Docker for Mac. Find the icon in the top-right hand corner of the screen and open "Preferences". Then navigate to "Advanced" and set the resources so your cluster has at least 2 processors and 6gb of RAM.
 
 ![Advanced Tab Screenshot](./screenshots/set-resources-docker-macos.png)
 

--- a/docs/docs/installing-minikube.md
+++ b/docs/docs/installing-minikube.md
@@ -9,16 +9,16 @@ You'll need to download and install:
 
 ## Setup
 
-Run the following to give your VM enough juice to run Magda and start it up:
+Run the following to give your VM enough juice (Magda requires at least 6GB ram to deploy all modules) to run Magda and start it up:
 
 ```bash
-minikube config set memory 4096
+minikube config set memory 6144
 minikube config set cpus 2
 minikube config set vm-driver virtualbox
 minikube start
 ```
 
-This reserves 4 GB of RAM for Minikube and starts it up. If you're low on RAM and only intend to run the databases on Minikube, you can likely get away with a smaller number, like 2048.
+This reserves 6 GB of RAM for Minikube and starts it up. If you're low on RAM and only intend to run the databases on Minikube, you can likely get away with a smaller number, like 2048.
 
 More detailed instructions for setting up Minikube can be found [here](https://github.com/kubernetes/minikube) if that doesn't work.
 

--- a/package.json
+++ b/package.json
@@ -41,11 +41,7 @@
     "start-opa": "opa run deploy/helm/internal-charts/opa/policies",
     "test-opa": "opa test deploy/helm/internal-charts/opa/policies -v",
     "clean": "rm -rf pancake magda-web-client/src/pancake; rm -rf ./node_modules; for dir in magda-*; do echo \"Removing node_modules from $dir\"; rm -rf $dir/node_modules; done",
-    "update-magda-core-chart": "helm dep up deploy/helm/internal-charts/storage-api && helm dep up deploy/helm/magda-core",
-    "update-magda-chart": "yarn update-magda-core-chart && helm dep up deploy/helm/magda",
-    "update-local-deployment-chart": "yarn update-magda-chart && helm dep up deploy/helm/local-deployment",
-    "update-all-charts": "yarn clean-up-all-charts && yarn update-local-deployment-chart",
-    "clean-up-all-charts": "rm -rf deploy/helm/internal-charts/storage-api/charts deploy/helm/magda-core/charts deploy/helm/magda/charts deploy/helm/local-deployment/charts"
+    "update-all-charts": "cd deploy && yarn update-all-charts && cd .."
   },
   "pancake": {
     "auto-save": true,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "start-opa": "opa run deploy/helm/internal-charts/opa/policies",
     "test-opa": "opa test deploy/helm/internal-charts/opa/policies -v",
     "clean": "rm -rf pancake magda-web-client/src/pancake; rm -rf ./node_modules; for dir in magda-*; do echo \"Removing node_modules from $dir\"; rm -rf $dir/node_modules; done",
-    "update-all-charts": "cd deploy && yarn update-all-charts && cd .."
+    "update-all-charts": "cd deploy && yarn update-all-charts && cd ..",
+    "set-version": "lerna version --no-push --force-publish"
   },
   "pancake": {
     "auto-save": true,

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,11 +18,11 @@
     "org-tree": "org-tree/index.js",
     "acs-cmd": "acs-cmd/index.js",
     "set-user-password": "set-user-password.js",
-    "create-api-key": "create-api-key.js"
+    "create-api-key": "create-api-key.js",
+    "update-helm-chart-version": "update-helm-chart-version.js"
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "npm-setup": "echo \"//registry.npmjs.org/:_authToken=${NPM_TOKEN}\" > .npmrc",
     "release": "npm publish || echo \"Skip releasing npm package @magda/scripts.\""
   },
   "devDependencies": {
@@ -42,6 +42,7 @@
     "bcrypt": "^5.0.0",
     "chalk": "^2.4.1",
     "clear": "^0.1.0",
+    "cli-cursor": "^3.1.0",
     "commander": "^2.17.0",
     "configstore": "^4.0.0",
     "fs-extra": "^2.1.2",
@@ -70,7 +71,7 @@
     "tsconfig-paths": "^3.9.0",
     "typescript": "^3.7.2",
     "uniqid": "^5.0.3",
-    "cli-cursor": "^3.1.0",
+    "yaml": "^1.10.0",
     "yargs": "^12.0.5"
   },
   "keywords": [

--- a/scripts/update-helm-chart-version.js
+++ b/scripts/update-helm-chart-version.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+const path = require("path");
+const recursive = require("recursive-readdir");
+const fse = require("fs-extra");
+const YAML = require("yaml");
+
+const cwdPath = process.cwd();
+const pkg = fse.readJsonSync(path.join(cwdPath, "package.json"));
+if (!pkg || !pkg["version"]) {
+    console.err("Cannot find package.json at: " + cwdPath);
+    process.exit(-1);
+}
+
+const pkgVersion = pkg["version"];
+
+function updateChartVersion(chartFilePath) {
+    try {
+        const chartDir = path.dirname(chartFilePath);
+        const chartFileContent = fse.readFileSync(chartFilePath, {
+            encoding: "utf8"
+        });
+        if (!chartFileContent) {
+            throw new Error("Failed to read Chart.yaml");
+        }
+        const chart = YAML.parseDocument(chartFileContent);
+        const chartVersion = chart.getIn(["version"], true);
+        if (chartVersion) {
+            chartVersion.value = pkgVersion;
+        } else {
+            chart.setIn(["version"], pkgVersion);
+        }
+        const deps = chart.getIn(["dependencies"]);
+        if (deps && deps.items && deps.items.length) {
+            for (let i = 0; i < deps.items.length; i++) {
+                const repoStr = chart.getIn(["dependencies", i, "repository"]);
+                if (
+                    typeof repoStr === "string" &&
+                    repoStr.indexOf("file://") === 0
+                ) {
+                    const version = chart.getIn(
+                        ["dependencies", i, "version"],
+                        true
+                    );
+                    if (version) {
+                        version.value = pkgVersion;
+                    } else {
+                        chart.setIn(["dependencies", i, "version"], pkgVersion);
+                    }
+                }
+            }
+        }
+        fse.writeFileSync(chartFilePath, chart.toString(), {
+            encoding: "utf8"
+        });
+    } catch (e) {
+        console.err(`Failed to process ${chartFilePath}: ${e}`);
+        process.exit(-1);
+    }
+}
+
+recursive(
+    cwdPath,
+    [
+        (file, stats) =>
+            stats.isDirectory() ||
+            path.basename(file).toLowerCase() === "chart.yaml"
+                ? false
+                : true
+    ],
+    function (err, files) {
+        if (err) {
+            console.err(err);
+            process.exit(-1);
+        }
+        files.forEach(updateChartVersion);
+    }
+);

--- a/scripts/update-helm-chart-version.js
+++ b/scripts/update-helm-chart-version.js
@@ -44,9 +44,12 @@ function updateChartVersion(chartFilePath) {
         if (deps && deps.items && deps.items.length) {
             for (let i = 0; i < deps.items.length; i++) {
                 const repoStr = chart.getIn(["dependencies", i, "repository"]);
+                const nameStr = chart.getIn(["dependencies", i, "name"]);
                 if (
                     typeof repoStr === "string" &&
-                    repoStr.indexOf("file://") === 0
+                    repoStr.indexOf("file://") === 0 &&
+                    excludedCharts.length &&
+                    excludedCharts.indexOf(nameStr) === -1
                 ) {
                     const version = chart.getIn(
                         ["dependencies", i, "version"],

--- a/scripts/update-helm-chart-version.js
+++ b/scripts/update-helm-chart-version.js
@@ -12,6 +12,11 @@ if (!pkg || !pkg["version"]) {
 }
 
 const pkgVersion = pkg["version"];
+// a list of helm chart that we want to exclude from auto update version
+const excludedCharts =
+    pkg["versionUpdateExclude"] && pkg["versionUpdateExclude"].length
+        ? pkg["versionUpdateExclude"]
+        : [];
 
 function updateChartVersion(chartFilePath) {
     try {
@@ -23,6 +28,12 @@ function updateChartVersion(chartFilePath) {
             throw new Error("Failed to read Chart.yaml");
         }
         const chart = YAML.parseDocument(chartFileContent);
+        const chartName = chart.getIn(["name"]);
+        if (excludedCharts.length && excludedCharts.indexOf(chartName) !== -1) {
+            // skip update version of excluded charts
+            return;
+        }
+
         const chartVersion = chart.getIn(["version"], true);
         if (chartVersion) {
             chartVersion.value = pkgVersion;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21559,7 +21559,7 @@ yaml-front-matter@^4.0.0:
     commander "^2.14.1"
     js-yaml "^3.10.0"
 
-yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
### What this PR does

Fixes #2946 #2948 #2950 
- Script to auto-update version of local Helm charts (and its dependencies) according to package.json's version
  - The script will be called as part of `version` hook and will be triggered by `lerna version` command
  - Helm dep update will be called to update lock files
  - All file changed will be added git staging area during version hook call so they will be included as git version tag 
- A root-level script `yarn set-version` to update version (via `lerna version` & version hook) of all local modules (and any referenced dependencies)
  - For local helm charts, this script will:
    - Update all local charts versions according to `deploy/package.json` version (unless it's explicitly excluded in `versionUpdateExclude` field of `deploy/package.json`)
    - Update dependencies version
    - Update Chart.lock file
  - All version bump related change will be committed (but not pushed, so you still can examine locally) and tagged.
- Make CI pipeline supports strict [Semantic Versioning](https://semver.org/)
- All Helm Chart by default uses `.Chart.version` for the docker image version
- create-secrets update job not triggered in CI

### Checklist

-   [x]  unit tests aren't applicable
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
