### PR TITLE
Issue/2966 Speedup CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,15 +91,13 @@ registry-typescript-api:
 
 buildtest:search-with-index-cache:
   stage: buildtest
-  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:master
   retry: 2
   timeout: 18 minutes
   needs: [
-    "builders-and-yarn",
     "sbt-prebuild"
   ]
   dependencies:
-    - builders-and-yarn
     - sbt-prebuild
   before_script:
     - |
@@ -157,15 +155,13 @@ buildtest:search-with-index-cache:
 
 buildtest:search-no-index-cache:
   stage: buildtest
-  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:master
   retry: 2
   timeout: 18 minutes
   needs: [
-    "builders-and-yarn",
     "sbt-prebuild"
   ]
   dependencies:
-    - builders-and-yarn
     - sbt-prebuild
   before_script:
     - |
@@ -252,14 +248,12 @@ buildtest:ui:
 buildtest:registry:
   stage: buildtest
   retry: 2
-  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:master
   needs: [
-    "builders-and-yarn",
     "sbt-prebuild"
   ]
   timeout: 30 minutes
   dependencies:
-    - builders-and-yarn
     - sbt-prebuild
   services:
   # postgres 9.6.17 (published on 15th Feb 2020) introduced an issue see here (https://gitlab.com/gitlab-com/support-forum/issues/5199)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,8 @@ builders-and-yarn:
 # Make sure sbt depenencies, plugins are in place, cached (only for this job) and pass to following stage as artifacts
 sbt-prebuild:
   stage: sbt-prebuild
-  needs: ["builders-and-yarn"]
-  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
+  needs: []
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:master
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:
@@ -73,8 +73,8 @@ sbt-prebuild:
 
 check-scala-formatting:
   stage: prebuild
-  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  needs: ["builders-and-yarn"]
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:master
+  needs: []
   script:
     - sbt scalafmtCheckAll
 


### PR DESCRIPTION
### What this PR does

Fixes #2966 

Since we have no way to avoid using `master` docker image for `builders-and-yarn`, it should be fair to make `sbt-prebuild` & `check-scala-formatting` to use `master` docker image as well for the trade-off of speed.

the same applies to scala related test case tasks --- they can start to run after `sbt-prebuild` and don't need to wait for `builders-and-yarn`

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
