### PR TITLE
Issue/2967 Helm charts Documentation 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -492,6 +492,32 @@ buildtest:helm-charts:
       - "deploy/helm/local-auth-test-deployment/charts"
     expire_in: 7 days
 
+buildtest:helm-docs-check:
+  stage: buildtest
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:master
+  needs: []
+  cache:
+    paths: []
+  services:
+    - docker:dind
+  script:
+    - code=0
+    - docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest || code=$?;
+      if [ "$code" != "0" ]; then 
+        echo "Failed to run helm-docs!";
+        exit 1;
+      fi;
+    - cd deploy
+    - code=0
+    - git ls-files -m | grep -i readme.md || code=$?;
+      if [ "$code" == "0" ]; then
+        echo -e "Some of helm chart docs are required to be updated using the [helm-docs](https://github.com/norwoodj/helm-docs) tool. \n
+        Please run helm-docs at project root, review & commit docs changes and push a new commit.";
+        exit 1;
+      else 
+        echo -e "helm docs check passed. helm docs update is not required.";
+      fi;
+
 dockerize:scala:
   stage: dockerize
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG

--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -1,0 +1,4 @@
+deploy/helm/local-auth-test-deployment
+deploy/helm/local-deployment
+deploy/helm/magda-nginx-ingress-controller
+deploy/helm/openfaas

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v0.15.0
+    hooks:
+      - id: helm-docs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.0.58
 
+-   Added Documentation for Magda Helm Charts (generated using [helm-docs](https://github.com/norwoodj/helm-docs))
+
 ## 0.0.57
 
 General:

--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ Email us at contact@magda.io.
 ## Want to contribute?
 
 Great! Take a look at https://github.com/magda-io/magda/blob/master/.github/CONTRIBUTING.md :).
+
+## Documentation links
+
+-   [Magda API Reference](https://demo.dev.magda.io/api/v0/apidocs/index.html)
+-   [Magda Helm Chart Reference](docs/docs/helm-charts-docs-index.md)
+-   [Other documentations](docs/docs/index.md)

--- a/deploy/helm/internal-charts/admin-api/README.md
+++ b/deploy/helm/internal-charts/admin-api/README.md
@@ -1,0 +1,17 @@
+# admin-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image | object | `{}` |  |
+| resources.requests.cpu | string | `"50m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |

--- a/deploy/helm/internal-charts/apidocs-server/README.md
+++ b/deploy/helm/internal-charts/apidocs-server/README.md
@@ -1,0 +1,18 @@
+# apidocs-server
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"20m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"10Mi"` |  |

--- a/deploy/helm/internal-charts/authorization-api/README.md
+++ b/deploy/helm/internal-charts/authorization-api/README.md
@@ -1,0 +1,22 @@
+# authorization-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |

--- a/deploy/helm/internal-charts/authorization-db/README.md
+++ b/deploy/helm/internal-charts/authorization-db/README.md
@@ -1,0 +1,17 @@
+# authorization-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| image | object | `{}` |  |
+| resources | object | `{}` |  |

--- a/deploy/helm/internal-charts/cloud-sql-proxy/README.md
+++ b/deploy/helm/internal-charts/cloud-sql-proxy/README.md
@@ -1,0 +1,16 @@
+# cloud-sql-proxy
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"10Mi"` |  |

--- a/deploy/helm/internal-charts/combined-db/README.md
+++ b/deploy/helm/internal-charts/combined-db/README.md
@@ -1,0 +1,20 @@
+# combined-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| debug | bool | `false` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.requests.cpu | string | `"200m"` |  |
+| resources.requests.memory | string | `"500Mi"` |  |

--- a/deploy/helm/internal-charts/content-api/README.md
+++ b/deploy/helm/internal-charts/content-api/README.md
@@ -1,0 +1,23 @@
+# content-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"30Mi"` |  |
+| scssVars | string | `"{}"` |  |

--- a/deploy/helm/internal-charts/content-db/README.md
+++ b/deploy/helm/internal-charts/content-db/README.md
@@ -1,0 +1,17 @@
+# content-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| image | object | `{}` |  |
+| resources | object | `{}` |  |

--- a/deploy/helm/internal-charts/correspondence-api/README.md
+++ b/deploy/helm/internal-charts/correspondence-api/README.md
@@ -1,0 +1,22 @@
+# correspondence-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| alwaysSendToDefaultRecipient | bool | `false` |  |
+| defaultRecipient | string | `"mail@example.com"` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"60Mi"` |  |
+| smtpHostname | string | `"example.com"` |  |
+| smtpPort | int | `587` |  |

--- a/deploy/helm/internal-charts/elasticsearch/README.md
+++ b/deploy/helm/internal-charts/elasticsearch/README.md
@@ -1,0 +1,33 @@
+# elasticsearch
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| backup.googleApplicationCreds | object | `{}` |  |
+| client.heapSize | string | `"256m"` |  |
+| client.pluginsInstall | string | `""` |  |
+| client.replicas | int | `1` |  |
+| client.resources.limits.cpu | string | `"100m"` |  |
+| client.resources.requests.cpu | string | `"50m"` |  |
+| client.resources.requests.memory | string | `"500Mi"` |  |
+| data.heapSize | string | `"256m"` |  |
+| data.pluginsInstall | string | `""` |  |
+| data.resources.limits.cpu | string | `"500m"` |  |
+| data.resources.requests.cpu | string | `"200m"` |  |
+| data.resources.requests.memory | string | `"500Mi"` |  |
+| data.storage | string | `"50Gi"` |  |
+| image | object | `{}` |  |
+| master.pluginsInstall | string | `""` |  |
+| master.resources.limits.cpu | string | `"100m"` |  |
+| master.resources.requests.cpu | string | `"50m"` |  |
+| master.resources.requests.memory | string | `"900Mi"` |  |
+| production | bool | `false` |  |

--- a/deploy/helm/internal-charts/gateway/Chart.yaml
+++ b/deploy/helm/internal-charts/gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart for Kubernetes
+description: The Gateway Component of Magda that routes incoming requets to other magda components.
 name: gateway
 version: 0.0.58-alpha.0
 kubeVersion: ">= 1.14.0-0"

--- a/deploy/helm/internal-charts/gateway/README.md
+++ b/deploy/helm/internal-charts/gateway/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
 
-A Helm chart for Kubernetes
+The Gateway Component of Magda that routes incoming requets to other magda components.
 
 ## Requirements
 
@@ -10,14 +10,26 @@ Kubernetes: `>= 1.14.0-0`
 
 ## Values
 
+##### Proxy Target Definition
+
+A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
+- `to`: target url
+- `methods`: array of string. "all" means all methods
+- `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
+- `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
+- `statusCheck`: check target's live status from the gateway
+A proxy target be also specify in a simply string form, in which case, Gateway assumes a GET method, no auth proxy route is requested.
+
+##### Cookie Settings
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.enableInternalAuthProvider | bool | `true` |  |
+| auth.enableInternalAuthProvider | bool | `true` | Whether enable magda internal authentication provider.  @default true |
 | autoscaler.enabled | bool | `false` |  |
 | autoscaler.maxReplicas | int | `3` |  |
 | autoscaler.minReplicas | int | `1` |  |
 | autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
-| cookie.sameSite | string | `"lax"` |  |
+| cookie | object | `{"sameSite":"lax"}` | Session cookie settings. Default value will be used if any options are left with blank. More info: https://github.com/expressjs/session#cookie Supported options are:  - `expires`: A fix cookie expire date. The expires option should not be set directly; instead only use the maxAge option. - `httpOnly`: Default: true. - `maxAge`: Default: 7 * 60 * 60 * 1000. - `path`: Default: '/'. - `sameSite`: Default: false (not set). - `secure1: Default: false (not set). |
 | cors.exposedHeaders[0] | string | `"Content-Range"` |  |
 | cors.exposedHeaders[1] | string | `"X-Content-Range"` |  |
 | csp.browserSniff | bool | `false` |  |
@@ -28,31 +40,8 @@ Kubernetes: `>= 1.14.0-0`
 | csp.directives.scriptSrc[3] | string | `"blob:"` |  |
 | csp.directives.workerSrc[0] | string | `"''self''"` |  |
 | csp.directives.workerSrc[1] | string | `"blob:"` |  |
-| defaultCacheControl | string | `"public, max-age=60"` |  |
-| defaultRoutes.admin.auth | bool | `true` |  |
-| defaultRoutes.admin.to | string | `"http://admin-api/v0"` |  |
-| defaultRoutes.apidocs.redirectTrailingSlash | bool | `true` |  |
-| defaultRoutes.apidocs.to | string | `"http://apidocs-server/"` |  |
-| defaultRoutes.auth.auth | bool | `true` |  |
-| defaultRoutes.auth.to | string | `"http://authorization-api/v0/public"` |  |
-| defaultRoutes.content.auth | bool | `true` |  |
-| defaultRoutes.content.to | string | `"http://content-api/v0"` |  |
-| defaultRoutes.correspondence.to | string | `"http://correspondence-api/v0/public"` |  |
-| defaultRoutes.opa.auth | bool | `true` |  |
-| defaultRoutes.opa.statusCheck | bool | `false` |  |
-| defaultRoutes.opa.to | string | `"http://authorization-api/v0/opa"` |  |
-| defaultRoutes.registry-auth.auth | bool | `true` |  |
-| defaultRoutes.registry-auth.to | string | `"http://registry-api/v0"` |  |
-| defaultRoutes.registry-read-only.auth | bool | `true` |  |
-| defaultRoutes.registry-read-only.to | string | `"http://registry-api-read-only/v0"` |  |
-| defaultRoutes.registry.auth | bool | `true` |  |
-| defaultRoutes.registry.to | string | `"http://registry-api/v0"` |  |
-| defaultRoutes.search.auth | bool | `true` |  |
-| defaultRoutes.search.to | string | `"http://search-api/v0"` |  |
-| defaultRoutes.storage.auth | bool | `true` |  |
-| defaultRoutes.storage.to | string | `"http://storage-api/v0"` |  |
-| defaultRoutes.tenant.auth | bool | `true` |  |
-| defaultRoutes.tenant.to | string | `"http://tenant-api/v0"` |  |
+| defaultCacheControl | string | `"public, max-age=60"` | If a response that goes through the gateway doesn't set Cache-Control, it'll be set to this value. Set to null to disable. |
+| defaultRoutes | object | `{"admin":{"auth":true,"to":"http://admin-api/v0"},"apidocs":{"redirectTrailingSlash":true,"to":"http://apidocs-server/"},"auth":{"auth":true,"to":"http://authorization-api/v0/public"},"content":{"auth":true,"to":"http://content-api/v0"},"correspondence":{"to":"http://correspondence-api/v0/public"},"opa":{"auth":true,"statusCheck":false,"to":"http://authorization-api/v0/opa"},"registry":{"auth":true,"to":"http://registry-api/v0"},"registry-auth":{"auth":true,"to":"http://registry-api/v0"},"registry-read-only":{"auth":true,"to":"http://registry-api-read-only/v0"},"search":{"auth":true,"to":"http://search-api/v0"},"storage":{"auth":true,"to":"http://storage-api/v0"},"tenant":{"auth":true,"to":"http://tenant-api/v0"}}` | Routes list here are available under `/api/v0/` path. See `Proxy Target Definition` for route format. |
 | enableAuthEndpoint | bool | `false` |  |
 | enableCkanRedirection | bool | `false` |  |
 | enableWebAccessControl | bool | `false` |  |
@@ -64,5 +53,5 @@ Kubernetes: `>= 1.14.0-0`
 | service.externalPort | int | `80` |  |
 | service.internalPort | int | `80` |  |
 | service.type | string | `"NodePort"` |  |
-| web | string | `"http://web"` |  |
-| webRoutes.preview-map | string | `"http://preview-map:6110"` |  |
+| web | string | `"http://web"` | Default web route.  This is the last route of the proxy. Main UI should be served from here. |
+| webRoutes | object | `{"preview-map":"http://preview-map:6110"}` | extra web routes. See `Proxy Target Definition` for route format. |

--- a/deploy/helm/internal-charts/gateway/README.md
+++ b/deploy/helm/internal-charts/gateway/README.md
@@ -1,0 +1,68 @@
+# gateway
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| auth.enableInternalAuthProvider | bool | `true` |  |
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| cookie.sameSite | string | `"lax"` |  |
+| cors.exposedHeaders[0] | string | `"Content-Range"` |  |
+| cors.exposedHeaders[1] | string | `"X-Content-Range"` |  |
+| csp.browserSniff | bool | `false` |  |
+| csp.directives.objectSrc[0] | string | `"''none''"` |  |
+| csp.directives.scriptSrc[0] | string | `"''self''"` |  |
+| csp.directives.scriptSrc[1] | string | `"''unsafe-inline''"` |  |
+| csp.directives.scriptSrc[2] | string | `"browser-update.org"` |  |
+| csp.directives.scriptSrc[3] | string | `"blob:"` |  |
+| csp.directives.workerSrc[0] | string | `"''self''"` |  |
+| csp.directives.workerSrc[1] | string | `"blob:"` |  |
+| defaultCacheControl | string | `"public, max-age=60"` |  |
+| defaultRoutes.admin.auth | bool | `true` |  |
+| defaultRoutes.admin.to | string | `"http://admin-api/v0"` |  |
+| defaultRoutes.apidocs.redirectTrailingSlash | bool | `true` |  |
+| defaultRoutes.apidocs.to | string | `"http://apidocs-server/"` |  |
+| defaultRoutes.auth.auth | bool | `true` |  |
+| defaultRoutes.auth.to | string | `"http://authorization-api/v0/public"` |  |
+| defaultRoutes.content.auth | bool | `true` |  |
+| defaultRoutes.content.to | string | `"http://content-api/v0"` |  |
+| defaultRoutes.correspondence.to | string | `"http://correspondence-api/v0/public"` |  |
+| defaultRoutes.opa.auth | bool | `true` |  |
+| defaultRoutes.opa.statusCheck | bool | `false` |  |
+| defaultRoutes.opa.to | string | `"http://authorization-api/v0/opa"` |  |
+| defaultRoutes.registry-auth.auth | bool | `true` |  |
+| defaultRoutes.registry-auth.to | string | `"http://registry-api/v0"` |  |
+| defaultRoutes.registry-read-only.auth | bool | `true` |  |
+| defaultRoutes.registry-read-only.to | string | `"http://registry-api-read-only/v0"` |  |
+| defaultRoutes.registry.auth | bool | `true` |  |
+| defaultRoutes.registry.to | string | `"http://registry-api/v0"` |  |
+| defaultRoutes.search.auth | bool | `true` |  |
+| defaultRoutes.search.to | string | `"http://search-api/v0"` |  |
+| defaultRoutes.storage.auth | bool | `true` |  |
+| defaultRoutes.storage.to | string | `"http://storage-api/v0"` |  |
+| defaultRoutes.tenant.auth | bool | `true` |  |
+| defaultRoutes.tenant.to | string | `"http://tenant-api/v0"` |  |
+| enableAuthEndpoint | bool | `false` |  |
+| enableCkanRedirection | bool | `false` |  |
+| enableWebAccessControl | bool | `false` |  |
+| helmet.frameguard | bool | `false` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"200m"` |  |
+| resources.requests.cpu | string | `"50m"` |  |
+| resources.requests.memory | string | `"40Mi"` |  |
+| service.externalPort | int | `80` |  |
+| service.internalPort | int | `80` |  |
+| service.type | string | `"NodePort"` |  |
+| web | string | `"http://web"` |  |
+| webRoutes.preview-map | string | `"http://preview-map:6110"` |  |

--- a/deploy/helm/internal-charts/gateway/README.md.gotmpl
+++ b/deploy/helm/internal-charts/gateway/README.md.gotmpl
@@ -1,0 +1,32 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesHeader" . }}
+
+##### Proxy Target Definition
+
+A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
+- `to`: target url
+- `methods`: array of string. "all" means all methods
+- `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
+- `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
+- `statusCheck`: check target's live status from the gateway
+A proxy target be also specify in a simply string form, in which case, Gateway assumes a GET method, no auth proxy route is requested.
+
+##### Cookie Settings
+
+
+
+{{ template "chart.valuesTable" . }}

--- a/deploy/helm/internal-charts/gateway/values.yaml
+++ b/deploy/helm/internal-charts/gateway/values.yaml
@@ -15,7 +15,8 @@ enableWebAccessControl: false
 enableCkanRedirection: false
 
 auth:
-  # Whether enable magda internal authentication provider. Default to true
+  # auth.enableInternalAuthProvider -- Whether enable magda internal authentication provider. 
+  # @default true
   enableInternalAuthProvider: true
 
 helmet:
@@ -28,8 +29,8 @@ resources:
   limits:
     cpu: 200m
 
-# Routes list here are available under `/api/v0/` path
-# See `Proxy Target Definition` below for route format
+# defaultRoutes -- Routes list here are available under `/api/v0/` path.
+# See `Proxy Target Definition` for route format.
 defaultRoutes:
   search:
     to: http://search-api/v0
@@ -68,23 +69,14 @@ defaultRoutes:
     to: http://tenant-api/v0
     auth: true
 
-# extra web routes
-# See `Proxy Target Definition` below for route format
+# webRoutes -- extra web routes.
+# See `Proxy Target Definition` for route format.
 webRoutes:
   preview-map: http://preview-map:6110
 
-### Proxy Target Definition
-# A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
-# - `to`: target url
-# - `methods`: array of string. "all" means all methods
-# - `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
-# - `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
-# - `statusCheck`: check target's live status from the gateway
-# A proxy target be also specify in a simply string form, in which case, Gateway assumes a GET method, no auth proxy route is requested.
-
-# Default web route. 
-# This is the last route of the proxy
-# Main UI should be served from here
+# web -- Default web route. 
+# This is the last route of the proxy.
+# Main UI should be served from here.
 web: http://web
 
 csp:
@@ -106,19 +98,18 @@ cors:
   - "Content-Range"
   - "X-Content-Range"
 
-# Session cookie settings
-# Default value will be used if any options are left with blank
-# Supported options are: 
-# - domain: By default, no domain is set, and most clients will consider the cookie to apply to only the current domain.
-# - expires: A fix cookie expire date. The expires option should not be set directly; instead only use the maxAge option.
-# - httpOnly: Default: true
-# - maxAge: Default: 7 * 60 * 60 * 1000
-# - path: Default: '/'
-# - sameSite: Default: false (not set)
-# - secure: Default: false (not set)
+# cookie -- Session cookie settings.
+# Default value will be used if any options are left with blank.
 # More info: https://github.com/expressjs/session#cookie
+# Supported options are: 
+# - `expires`: A fix cookie expire date. The expires option should not be set directly; instead only use the maxAge option.
+# - `httpOnly`: Default: true.
+# - `maxAge`: Default: 7 * 60 * 60 * 1000.
+# - `path`: Default: '/'.
+# - `sameSite`: Default: false (not set).
+# - `secure1: Default: false (not set).
 cookie:
   sameSite: "lax"
 
-# If a response that goes through the gateway doesn't set Cache-Control, it'll be set to this value. Set to null to disable.
+# defaultCacheControl -- If a response that goes through the gateway doesn't set Cache-Control, it'll be set to this value. Set to null to disable.
 defaultCacheControl: "public, max-age=60"

--- a/deploy/helm/internal-charts/indexer/README.md
+++ b/deploy/helm/internal-charts/indexer/README.md
@@ -1,0 +1,23 @@
+# indexer
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| elasticsearch.replicas | int | `0` |  |
+| elasticsearch.shards | int | `1` |  |
+| elasticsearch.useGcsSnapshots | bool | `false` |  |
+| image | object | `{}` |  |
+| makeSnapshots | bool | `false` |  |
+| readSnapshots | bool | `false` |  |
+| resources.limits.cpu | string | `"250m"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"250Mi"` |  |

--- a/deploy/helm/internal-charts/ingress/README.md
+++ b/deploy/helm/internal-charts/ingress/README.md
@@ -1,0 +1,16 @@
+# ingress
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| enableTls | bool | `false` |  |
+| useDefaultCertificate | bool | `false` |  |

--- a/deploy/helm/internal-charts/opa/Chart.yaml
+++ b/deploy/helm/internal-charts/opa/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart for Kubernetes
+description: Magda's Access Control Policy Engine ([Open Policy Agent](https://www.openpolicyagent.org/))
 name: opa
 version: 0.0.58-alpha.0
 kubeVersion: ">= 1.14.0-0"

--- a/deploy/helm/internal-charts/opa/README.md
+++ b/deploy/helm/internal-charts/opa/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
 
-A Helm chart for Kubernetes
+Magda's Access Control Policy Engine ([Open Policy Agent](https://www.openpolicyagent.org/))
 
 ## Requirements
 

--- a/deploy/helm/internal-charts/opa/README.md
+++ b/deploy/helm/internal-charts/opa/README.md
@@ -1,0 +1,28 @@
+# opa
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| customPolicyConfigMaps | list | `[]` | a list of names of the configMaps that contains custom policy files. the configMap must be created using magda helm chart template: [magda.filesToJson](https://github.com/magda-io/magda/blob/21499b75c7a7ee00d68886338713217d83ccb91f/deploy/helm/magda-core/templates/_helpers.tpl#L244). More info see [here](https://github.com/magda-io/magda-configmap-dir-loader). |
+| image | object | `{}` |  |
+| loaderImage.imagePullSecret | bool | `false` |  |
+| loaderImage.pullPolicy | string | `"IfNotPresent"` |  |
+| loaderImage.repository | string | `"docker.io/data61"` |  |
+| loaderImage.tag | string | `"0.0.57-0"` |  |
+| replicas | int | `1` |  |
+| resources.limits.cpu | string | `"100m"` |  |
+| resources.requests.cpu | string | `"20m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |

--- a/deploy/helm/internal-charts/opa/values.yaml
+++ b/deploy/helm/internal-charts/opa/values.yaml
@@ -17,4 +17,7 @@ resources:
     memory: 50Mi
   limits:
     cpu: 100m
+# customPolicyConfigMaps -- a list of names of the configMaps that contains custom policy files.
+# the configMap must be created using magda helm chart template: [magda.filesToJson](https://github.com/magda-io/magda/blob/21499b75c7a7ee00d68886338713217d83ccb91f/deploy/helm/magda-core/templates/_helpers.tpl#L244).
+# More info see [here](https://github.com/magda-io/magda-configmap-dir-loader).
 customPolicyConfigMaps: []

--- a/deploy/helm/internal-charts/registry-api/README.md
+++ b/deploy/helm/internal-charts/registry-api/README.md
@@ -1,0 +1,27 @@
+# registry-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| db | object | `{}` |  |
+| deployments.full | object | `{}` |  |
+| deployments.readOnly.enable | bool | `false` |  |
+| image | object | `{}` |  |
+| livenessProbe | object | `{}` |  |
+| resources.limits.cpu | string | `"750m"` |  |
+| resources.requests.cpu | string | `"250m"` |  |
+| resources.requests.memory | string | `"500Mi"` |  |
+| validateJsonSchema | bool | `true` |  |

--- a/deploy/helm/internal-charts/registry-db/README.md
+++ b/deploy/helm/internal-charts/registry-db/README.md
@@ -1,0 +1,17 @@
+# registry-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| image | object | `{}` |  |
+| resources | object | `{}` |  |

--- a/deploy/helm/internal-charts/search-api-node/README.md
+++ b/deploy/helm/internal-charts/search-api-node/README.md
@@ -1,0 +1,22 @@
+# search-api-node
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"60Mi"` |  |

--- a/deploy/helm/internal-charts/search-api/README.md
+++ b/deploy/helm/internal-charts/search-api/README.md
@@ -1,0 +1,22 @@
+# search-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"200m"` |  |
+| resources.requests.cpu | string | `"50m"` |  |
+| resources.requests.memory | string | `"300Mi"` |  |

--- a/deploy/helm/internal-charts/session-db/README.md
+++ b/deploy/helm/internal-charts/session-db/README.md
@@ -1,0 +1,17 @@
+# session-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| image | object | `{}` |  |
+| resources | object | `{}` |  |

--- a/deploy/helm/internal-charts/storage-api/README.md
+++ b/deploy/helm/internal-charts/storage-api/README.md
@@ -1,0 +1,28 @@
+# storage-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://kubernetes-charts.storage.googleapis.com | minio | 5.0.18 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image | object | `{}` |  |
+| minio.DeploymentUpdate.type | string | `"Recreate"` |  |
+| minio.existingSecret | string | `"storage-secrets"` |  |
+| minio.fullnameOverride | string | `"magda-minio"` |  |
+| minio.host | string | `"minio"` |  |
+| minio.nameOverride | string | `"magda-minio"` |  |
+| minio.port | int | `9000` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"30Mi"` |  |

--- a/deploy/helm/internal-charts/tenant-api/README.md
+++ b/deploy/helm/internal-charts/tenant-api/README.md
@@ -1,0 +1,18 @@
+# tenant-api
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image | object | `{}` |  |
+| resources.limits.cpu | string | `"50m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |

--- a/deploy/helm/internal-charts/tenant-db/README.md
+++ b/deploy/helm/internal-charts/tenant-db/README.md
@@ -1,0 +1,17 @@
+# tenant-db
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| data.storage | string | `"200Gi"` |  |
+| image | object | `{}` |  |
+| resources | object | `{}` |  |

--- a/deploy/helm/internal-charts/web-server/README.md
+++ b/deploy/helm/internal-charts/web-server/README.md
@@ -1,0 +1,86 @@
+# web-server
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaler.enabled | bool | `false` |  |
+| autoscaler.maxReplicas | int | `3` |  |
+| autoscaler.minReplicas | int | `1` |  |
+| autoscaler.targetCPUUtilizationPercentage | int | `80` |  |
+| contentApiBaseUrlInternal | string | `"http://content-api/v0/"` |  |
+| csvLoaderChunkSize | int | `2097152` |  |
+| custodianOrgLevel | int | `2` |  |
+| datasetThemes | list | `[]` |  |
+| dateConfig.dateFormats[0] | string | `"YYYY"` |  |
+| dateConfig.dateFormats[1] | string | `"YYYY-MM"` |  |
+| dateConfig.dateFormats[2] | string | `"DD-MM-YYYY"` |  |
+| dateConfig.dateFormats[3] | string | `"MM-DD-YYYY"` |  |
+| dateConfig.dateFormats[4] | string | `"YYYY-MM-DD"` |  |
+| dateConfig.dateFormats[5] | string | `"YYYY-MM-DDThh:mmTZD"` |  |
+| dateConfig.dateFormats[6] | string | `"YYYY-MM-DDThh:mm:ssTZD"` |  |
+| dateConfig.dateFormats[7] | string | `"YYYY-MM-DDThh:mm:ss.sTZD"` |  |
+| dateConfig.dateFormats[8] | string | `"DD-MMM-YYYY"` |  |
+| dateConfig.dateFormats[9] | string | `"MMM-DD-YYYY"` |  |
+| dateConfig.dateRegexes.dateRegex | string | `"(date|dt|year|decade)"` |  |
+| dateConfig.dateRegexes.endDateRegex | string | `"(end).*(date|dt|year|decade)"` |  |
+| dateConfig.dateRegexes.startDateRegex | string | `"(start|st).*(date|dt|year|decade)"` |  |
+| defaultContactEmail | string | `"mail@example.com"` |  |
+| disableAuthenticationFeatures | bool | `false` |  |
+| featureFlags.cataloguing | bool | `false` |  |
+| featureFlags.datasetApprovalWorkflowOn | bool | `true` |  |
+| featureFlags.placeholderWorkflowsOn | bool | `false` |  |
+| featureFlags.previewAddDataset | bool | `false` |  |
+| featureFlags.publishToDga | bool | `false` |  |
+| image | object | `{}` |  |
+| keywordsBlackList[0] | string | `"Mr"` |  |
+| keywordsBlackList[10] | string | `"Mr."` |  |
+| keywordsBlackList[11] | string | `"Ms."` |  |
+| keywordsBlackList[12] | string | `"Mrs."` |  |
+| keywordsBlackList[13] | string | `"Miss."` |  |
+| keywordsBlackList[14] | string | `"Dr."` |  |
+| keywordsBlackList[15] | string | `"Hon."` |  |
+| keywordsBlackList[16] | string | `"Jr."` |  |
+| keywordsBlackList[17] | string | `"Prof."` |  |
+| keywordsBlackList[18] | string | `"Sr."` |  |
+| keywordsBlackList[19] | string | `"St."` |  |
+| keywordsBlackList[1] | string | `"Ms"` |  |
+| keywordsBlackList[2] | string | `"Mrs"` |  |
+| keywordsBlackList[3] | string | `"Miss"` |  |
+| keywordsBlackList[4] | string | `"Dr"` |  |
+| keywordsBlackList[5] | string | `"Hon"` |  |
+| keywordsBlackList[6] | string | `"Jr"` |  |
+| keywordsBlackList[7] | string | `"Prof"` |  |
+| keywordsBlackList[8] | string | `"Sr"` |  |
+| keywordsBlackList[9] | string | `"St"` |  |
+| mandatoryFields[0] | string | `"dataset.title"` |  |
+| mandatoryFields[10] | string | `"informationSecurity.disseminationLimits"` |  |
+| mandatoryFields[11] | string | `"publishToDga"` |  |
+| mandatoryFields[1] | string | `"dataset.description"` |  |
+| mandatoryFields[2] | string | `"dataset.defaultLicense"` |  |
+| mandatoryFields[3] | string | `"distributions.title"` |  |
+| mandatoryFields[4] | string | `"distributions.format"` |  |
+| mandatoryFields[5] | string | `"distributions.license"` |  |
+| mandatoryFields[6] | string | `"dataset.publisher"` |  |
+| mandatoryFields[7] | string | `"licenseLevel"` |  |
+| mandatoryFields[8] | string | `"dataset.defaultLicense"` |  |
+| mandatoryFields[9] | string | `"informationSecurity.classification"` |  |
+| maxChartProcessingRows | int | `20000` |  |
+| maxTableProcessingRows | int | `200` |  |
+| noManualKeywords | bool | `false` |  |
+| noManualThemes | bool | `false` |  |
+| resources.limits.cpu | string | `"100m"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"30Mi"` |  |
+| service | object | `{}` |  |
+| showNotificationBanner | bool | `false` |  |
+| useLocalStyleSheet | bool | `false` |  |
+| vocabularyApiEndpoints | list | `[]` |  |

--- a/deploy/helm/magda-cert-issuer/README.md
+++ b/deploy/helm/magda-cert-issuer/README.md
@@ -1,0 +1,53 @@
+Before you install this chart install `cert-manager`:
+
+```
+helm install \
+    --name cert-manager \
+    --namespace cert-manager \
+    stable/cert-manager \
+```
+
+This requires you to create a secret for the route 53 credentials in the right namespace:
+
+```
+kubectl create secret generic prod-route53-credentials-secret --from-literal=secret-access-key=CHANGEME --namespace cert-manager
+```
+
+For route53 it also requires you to create the right IAM policy:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "route53:GetChange",
+            "Resource": "arn:aws:route53:::change/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "route53:ChangeResourceRecordSets",
+            "Resource": "arn:aws:route53:::hostedzone/*"
+        }
+    ]
+}
+```
+
+Also don't forget to specify `hostedZoneID` (the hosted zone for the domain) and `accessKeyID` (the access key for the user with the above IAM policy).
+
+Then finally install:
+
+```
+helm install --name cert-issuer --namespace cert-issuer deploy/helm/magda-cert-issuer --set hostedZoneID=CHANGEME,accessKeyID=CHANGEME,acmeEmail=CHANGEME,useStaging=SHOULDIUSESTAGING
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| accessKeyID | string | `nil` |  |
+| acmeEmail | string | `nil` |  |
+| hostedZoneID | string | `nil` |  |
+| secretAccessKeySecretRef.key | string | `"secret-access-key"` |  |
+| secretAccessKeySecretRef.name | string | `"prod-route53-credentials-secret"` |  |
+| useStaging | bool | `true` |  |

--- a/deploy/helm/magda-cert-issuer/README.md.gotmpl
+++ b/deploy/helm/magda-cert-issuer/README.md.gotmpl
@@ -40,3 +40,5 @@ Then finally install:
 ```
 helm install --name cert-issuer --namespace cert-issuer deploy/helm/magda-cert-issuer --set hostedZoneID=CHANGEME,accessKeyID=CHANGEME,acmeEmail=CHANGEME,useStaging=SHOULDIUSESTAGING
 ```
+
+{{ template "chart.valuesSection" . }}

--- a/deploy/helm/magda-core/README.md
+++ b/deploy/helm/magda-core/README.md
@@ -1,0 +1,104 @@
+# magda-core
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A complete solution for managing, publishing and discovering government data, private and open. This chart includes all core magda modules.
+
+**Homepage:** <https://github.com/magda-io/magda>
+
+## Source Code
+
+* <https://github.com/magda-io/magda>
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../internal-charts/admin-api | admin-api | 0.0.58-alpha.0 |
+| file://../internal-charts/apidocs-server | apidocs-server | 0.0.58-alpha.0 |
+| file://../internal-charts/authorization-api | authorization-api | 0.0.58-alpha.0 |
+| file://../internal-charts/authorization-db | authorization-db | 0.0.58-alpha.0 |
+| file://../internal-charts/cloud-sql-proxy | cloud-sql-proxy | 0.0.58-alpha.0 |
+| file://../internal-charts/combined-db | combined-db | 0.0.58-alpha.0 |
+| file://../internal-charts/content-api | content-api | 0.0.58-alpha.0 |
+| file://../internal-charts/content-db | content-db | 0.0.58-alpha.0 |
+| file://../internal-charts/correspondence-api | correspondence-api | 0.0.58-alpha.0 |
+| file://../internal-charts/elasticsearch | elasticsearch | 0.0.58-alpha.0 |
+| file://../internal-charts/gateway | gateway | 0.0.58-alpha.0 |
+| file://../internal-charts/indexer | indexer | 0.0.58-alpha.0 |
+| file://../internal-charts/ingress | ingress | 0.0.58-alpha.0 |
+| file://../internal-charts/opa | opa | 0.0.58-alpha.0 |
+| file://../internal-charts/priorities | priorities | 0.0.58-alpha.0 |
+| file://../internal-charts/registry-api | registry-api | 0.0.58-alpha.0 |
+| file://../internal-charts/registry-db | registry-db | 0.0.58-alpha.0 |
+| file://../internal-charts/search-api-node | search-api-node | 0.0.58-alpha.0 |
+| file://../internal-charts/search-api | search-api | 0.0.58-alpha.0 |
+| file://../internal-charts/session-db | session-db | 0.0.58-alpha.0 |
+| file://../internal-charts/storage-api | storage-api | 0.0.58-alpha.0 |
+| file://../internal-charts/tenant-api | tenant-api | 0.0.58-alpha.0 |
+| file://../internal-charts/tenant-db | tenant-db | 0.0.58-alpha.0 |
+| file://../internal-charts/web-server | web-server | 0.0.58-alpha.0 |
+| file://../openfaas | openfaas | 5.5.5-magda |
+| https://charts.magda.io | magda-preview-map | 0.0.57-0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.defaultAdminUserId | string | `"00000000-0000-4000-8000-000000000000"` |  |
+| global.enablePriorityClass | bool | `false` |  |
+| global.exposeNodePorts | bool | `false` |  |
+| global.externalUrl | string | `"http://localhost:6100"` |  |
+| global.gapiIds | list | `[]` |  |
+| global.image.pullPolicy | string | `"IfNotPresent"` |  |
+| global.image.repository | string | `"data61"` |  |
+| global.logLevel | string | `"INFO"` |  |
+| global.namespace | string | `"default"` |  |
+| global.noDbAuth | bool | `false` |  |
+| global.openfaas.allowAdminOnly | bool | `true` |  |
+| global.openfaas.enabled | bool | `true` |  |
+| global.openfaas.functionNamespace | string | `"openfaas-fn"` |  |
+| global.openfaas.mainNamespace | string | `"openfaas"` |  |
+| global.openfaas.namespacePrefix | string | `""` |  |
+| global.rollingUpdate.maxUnavailable | int | `0` |  |
+| global.useCloudSql | bool | `false` |  |
+| global.useCombinedDb | bool | `true` |  |
+| openfaas.basic_auth | bool | `false` |  |
+| openfaas.faasIdler.dryRun | bool | `false` |  |
+| openfaas.faasnetes.imagePullPolicy | string | `"IfNotPresent"` |  |
+| openfaas.faasnetes.readTimeout | string | `"120s"` |  |
+| openfaas.faasnetes.writeTimeout | string | `"120s"` |  |
+| openfaas.gateway.readTimeout | string | `"125s"` |  |
+| openfaas.gateway.scaleFromZero | bool | `true` |  |
+| openfaas.gateway.upstreamTimeout | string | `"120s"` |  |
+| openfaas.gateway.writeTimeout | string | `"125s"` |  |
+| openfaas.ingress.enabled | bool | `false` |  |
+| openfaas.operator.create | bool | `true` |  |
+| openfaas.serviceType | string | `"ClusterIP"` |  |
+| tags.admin-api | bool | `false` |  |
+| tags.all | bool | `true` |  |
+| tags.apidocs-server | bool | `false` |  |
+| tags.authorization-api | bool | `false` |  |
+| tags.authorization-db | bool | `false` |  |
+| tags.combined-db | bool | `false` |  |
+| tags.content-api | bool | `false` |  |
+| tags.content-db | bool | `false` |  |
+| tags.correspondence-api | bool | `false` |  |
+| tags.elasticsearch | bool | `false` |  |
+| tags.gateway | bool | `false` |  |
+| tags.indexer | bool | `false` |  |
+| tags.ingress | bool | `false` |  |
+| tags.opa | bool | `false` |  |
+| tags.preview-map | bool | `false` |  |
+| tags.priorities | bool | `true` |  |
+| tags.registry-api | bool | `false` |  |
+| tags.registry-db | bool | `false` |  |
+| tags.search-api | bool | `false` |  |
+| tags.search-api-node | bool | `false` |  |
+| tags.session-db | bool | `false` |  |
+| tags.storage-api | bool | `false` |  |
+| tags.tenant-api | bool | `false` |  |
+| tags.tenant-db | bool | `false` |  |
+| tags.web-server | bool | `false` |  |

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -1,0 +1,51 @@
+# magda
+
+![Version: 0.0.58-alpha.0](https://img.shields.io/badge/Version-0.0.58-alpha.0-informational?style=flat-square)
+
+A complete solution for managing, publishing and discovering government data, private and open. This chart includes the magda default deployment.
+
+**Homepage:** <https://github.com/magda-io/magda>
+
+## Source Code
+
+* <https://github.com/magda-io/magda>
+
+## Requirements
+
+Kubernetes: `>= 1.14.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../magda-core | magda-core | 0.0.58-alpha.0 |
+| https://charts.magda.io | magda-ckan-connector | 0.0.57-0 |
+| https://charts.magda.io | magda-function-esri-url-processor | 0.0.57-0 |
+| https://charts.magda.io | magda-function-history-report | 0.0.57-0 |
+| https://charts.magda.io | magda-minion-broken-link | 0.0.57-0 |
+| https://charts.magda.io | magda-minion-ckan-exporter | 0.0.57-0 |
+| https://charts.magda.io | magda-minion-format | 0.0.57-0 |
+| https://charts.magda.io | magda-minion-linked-data-rating | 0.0.57-0 |
+| https://charts.magda.io | magda-minion-visualization | 0.0.57-0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ckan-connector-functions.createConfigMap | bool | `false` |  |
+| ckan-connector-functions.createFunction | bool | `true` |  |
+| ckan-connector-functions.includeCronJobs | bool | `false` |  |
+| ckan-connector-functions.includeInitialJobs | bool | `false` |  |
+| global.connectors.includeCronJobs | bool | `true` |  |
+| global.connectors.includeInitialJobs | bool | `false` |  |
+| global.openfaas.allowAdminOnly | bool | `true` |  |
+| global.openfaas.enabled | bool | `true` |  |
+| global.openfaas.functionNamespace | string | `"openfaas-fn"` |  |
+| global.openfaas.mainNamespace | string | `"openfaas"` |  |
+| global.openfaas.namespacePrefix | string | `""` |  |
+| global.openfaas.secrets.authSecrets | bool | `true` |  |
+| tags.all | bool | `true` |  |
+| tags.connectors | bool | `false` |  |
+| tags.minion-broken-link | bool | `false` |  |
+| tags.minion-ckan-exporter | bool | `false` |  |
+| tags.minion-format | bool | `false` |  |
+| tags.minion-linked-data-rating | bool | `false` |  |
+| tags.minion-visualization | bool | `false` |  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -173,7 +173,8 @@ We welcome new contributors too! please check out our [Contributor's Guide](http
 ## Important links
 
 -   [Our Github](https://github.com/magda-io/magda)
--   [Our documentation](/docs)
--   [Magda API](https://demo.dev.magda.io/api/v0/apidocs/index.html)
+-   [Magda API Reference](https://demo.dev.magda.io/api/v0/apidocs/index.html)
+-   [Magda Helm Chart Reference](/docs/helm-chart-docs-index)
+-   [Other documentations](/docs)
 
 The project was started by CSIRO's [Data61](https://data61.csiro.au/) and Australia's [Department of Prime Minister and Cabinet](https://www.pmc.gov.au/). It's progressing thanks to Data61, the [Digital Transformation Agency](https://www.dta.gov.au/), the [Department of Agriculture](http://www.agriculture.gov.au/), the [Department of the Environment and Energy](https://www.environment.gov.au/) and [CSIRO Land and Water](https://www.csiro.au/en/Research/LWF).

--- a/docs/docs/helm-charts-docs-index.md
+++ b/docs/docs/helm-charts-docs-index.md
@@ -1,0 +1,55 @@
+# Magda Helm Chart Reference
+
+Magda use [Helm](https://helm.sh/) to pack our microservice components as reusable packages --- [helm charts](https://helm.sh/docs/topics/charts/). You can customise Magda (even create your own app) by declaring different sets of Magda helm charts as [dependencies](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/). Each of Helm chart supports customisable configuration options via [values files](https://helm.sh/docs/chart_template_guide/values_files/) that allow you to further customise its functions. This document provides the basic info of Magda Helm chart repository and the documentation links of all released Magda Helm Charts.
+
+# Magda Helm Chart Repository
+
+Our helm charts are published at [helm chart repository](https://helm.sh/docs/helm/helm_repo_add/): `https://charts.magda.io/`
+
+You can add Magda's Helm chart repo by:
+
+```bash
+helm repo add magda-io https://charts.magda.io
+```
+
+To search Magda's chart repo, you can:
+
+```bash
+helm search repo magda-io --devel
+```
+
+Here `--devel` means includes development versions.
+
+# Magda Helm Chart Documentation Index
+
+> Please note: the links belew are pointing to Master branch of our Github Repository. If you want to check the documentation of an older version of Magda Helm Chart, please switch to the [tags](https://github.com/magda-io/magda/tags) of your version.
+
+> We use [helm-docs](https://github.com/norwoodj/helm-docs) to auto generate docs from Helm Chart values files. You can use it to generate documentation for older version of Magda helm charts as well.
+
+> The quality of the document depends on the comments we add to the values files. We will keep making improvement in this area.
+
+-   [magda](https://github.com/magda-io/magda/blob/master/deploy/helm/magda/README.md): Includes all built-in components. This is the default package to choose unless you want to customise Magda.
+-   [magda-core](https://github.com/magda-io/magda/blob/master/deploy/helm/magda-core/README.md): Includes only core components. You may choose to use this package when you only need basic functionality or build your own app.
+-   Internal Magda Helm Charts / Components:
+    -   [admin-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/admin-api/README.md)
+    -   [apidocs-server](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/apidocs-server/README.md)
+    -   [authorization-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/authorization-api/README.md)
+    -   [authorization-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/authorization-db/README.md)
+    -   [cloud-sql-proxy](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/cloud-sql-proxy/README.md)
+    -   [combined-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/combined-db/README.md)
+    -   [content-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/content-api/README.md)
+    -   [content-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/content-db/README.md)
+    -   [correspondence-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/correspondence-api/README.md)
+    -   [elasticsearch](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/elasticsearch/README.md)
+    -   [gateway](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/gateway/README.md)
+    -   [indexer](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/indexer/README.md)
+    -   [ingress](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/ingress/README.md)
+    -   [opa](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/opa/README.md)
+    -   [registry-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/registry-api/README.md)
+    -   [registry-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/registry-db/README.md)
+    -   [search-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/search-api/README.md)
+    -   [session-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/session-db/README.md)
+    -   [storage-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/storage-api/README.md)
+    -   [tenant-api](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/tenant-api/README.md)
+    -   [tenant-db](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/tenant-db/README.md)
+    -   [web-server](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/web-server/README.md)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,12 +1,18 @@
 # Magda Documentation
 
+-   [How to build and run](/docs/building-and-running)
+-   [Deploy Magda with helm charts release](https://github.com/magda-io/magda-config)
+-   [Magda Helm Chart Reference](/docs/helm-charts-docs-index)
 -   [How to use APIs](/docs/using-api)
 -   [How to document APIs](/docs/api-documentation-howto)
--   [How to build and run](/docs/building-and-running)
+-   [How to create API key](/docs/how-to-create-api-key)
+-   [How to create local users](/docs/how-to-create-local-users)
 -   [Guide to Magda internals](/docs/architecture/guide-to-magda-internals)
--   [How to design and maintain connectors for external systems](/docs/connector-howto)
+-   [How to build your own connectors / minions](/docs/how-to-build-your-own-connectors-minions)
 -   [How to deploy an HA, production deployment on GKE](/docs/deploying-for-production-on-gke)
 -   [Ports used when running locally](/docs/local-ports)
 -   [Regression test](/docs/regression-test)
 -   [Roadmap](/docs/roadmap)
 -   [Mike's Windows Setup Instructions](/docs/windows-instructions)
+
+More documentation, please check [here](https://github.com/magda-io/magda/tree/master/docs/docs)


### PR DESCRIPTION
### What this PR does

Fixes #2967 
- Generated Helm charts Documentation using [helm-docs](https://github.com/norwoodj/helm-docs)
- Set up `helm-docs` & [pre-commit](https://pre-commit.com/) config
  - Add `helm-docs` to git pre-commit hook will slow down git operation a bit. If you want to turn on the hook, please:
    - install [pre-commit](https://pre-commit.com/) and run `pre-commit install`
  - Otherwise, without relying on pre-commit hooks, you can simply run `helm-docs` (after install helm-docs) at project root to auto-refresh all docs
- CI pipeline will check if any helm document are required to update (e.g. due to values files changes)
- Add the helm chart document link to magda.io

### Checklist

-   [x]  unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
