### PR TITLE
Issue/2921 On dataset page, display an alert box when the dataset is superseded or retired

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 -   Added Documentation for Magda Helm Charts (generated using [helm-docs](https://github.com/norwoodj/helm-docs))
 -   Upgrade papaParse to 5.3.0 for the [Regular Expression Denial of Service (ReDos) vulnerability](https://github.com/magda-io/magda/network/alert/magda-web-client/package.json/papaparse/open)
 -   Fixed papaParse's chunk data loading HTTP 416 Error (on our forked repo)
+-   On dataset page, display an alert box when the dataset is superseded or retired
 
 ## 0.0.57
 

--- a/magda-web-client/src/Components/Dataset/CurrencyAlert.scss
+++ b/magda-web-client/src/Components/Dataset/CurrencyAlert.scss
@@ -1,0 +1,14 @@
+.currency-alert {
+    p {
+        div {
+            padding-top: 10px;
+            padding-left: 20px;
+        }
+        ul {
+            margin-top: 0px !important;
+            li {
+                margin-top: 0px !important;
+            }
+        }
+    }
+}

--- a/magda-web-client/src/Components/Dataset/CurrencyAlert.tsx
+++ b/magda-web-client/src/Components/Dataset/CurrencyAlert.tsx
@@ -1,0 +1,110 @@
+import React, { FunctionComponent } from "react";
+import { ParsedDataset } from "helpers/record";
+import { useAsync } from "react-async-hook";
+import { fetchRecord } from "api-clients/RegistryApis";
+import CommonLink from "Components/Common/CommonLink";
+import "./CurrencyAlert.scss";
+
+type PropsType = {
+    dataset: ParsedDataset;
+};
+
+const CurrencyAlert: FunctionComponent<PropsType> = (props) => {
+    const status = props.dataset?.currency?.status;
+    const retireReason = props.dataset?.currency?.retireReason;
+    const supersededBy = props.dataset?.currency?.supersededBy;
+
+    const { result, loading, error } = useAsync(
+        async (status, supersededBy): Promise<any[]> => {
+            if (status !== "SUPERSEDED" || !supersededBy?.length) {
+                return [];
+            } else {
+                return await Promise.all(
+                    supersededBy
+                        .filter((item) => item?.id?.length || item?.name)
+                        .map(async (item) => {
+                            if (item?.id?.length) {
+                                try {
+                                    const record = await fetchRecord(
+                                        item.id[0],
+                                        ["dcat-dataset-strings"],
+                                        [],
+                                        false
+                                    );
+                                    const name = record?.aspects?.[
+                                        "dcat-dataset-strings"
+                                    ]?.title
+                                        ? record.aspects["dcat-dataset-strings"]
+                                              .title
+                                        : record.name;
+                                    return {
+                                        name,
+                                        id: item.id[0]
+                                    };
+                                } catch (e) {
+                                    console.error(
+                                        "Failed to fetch dataset name: ",
+                                        e
+                                    );
+                                    return {
+                                        id: item.id[0]
+                                    };
+                                }
+                            } else {
+                                return {
+                                    name: item.name
+                                };
+                            }
+                        })
+                );
+            }
+        },
+        [status, supersededBy]
+    );
+
+    if (status === "CURRENT") {
+        return null;
+    } else if (status === "RETIRED") {
+        return (
+            <div className="currency-alert au-page-alerts au-page-alerts--warning">
+                <h3>Retired Dataset</h3>
+                <p>This dataset is retired.</p>
+                {retireReason ? <p>Retired Reason: {retireReason}</p> : null}
+            </div>
+        );
+    } else if (status === "SUPERSEDED") {
+        return (
+            <div className="currency-alert au-page-alerts au-page-alerts--warning">
+                <h3>Superseded Dataset</h3>
+                <p>
+                    <div>This dataset has been superseded by:</div>
+                    {loading || !result ? (
+                        <div>Loading...</div>
+                    ) : error ? (
+                        <div>Error: {error}...</div>
+                    ) : (
+                        <ul>
+                            {result.map((item, idx) => (
+                                <li key={idx}>
+                                    {item?.id ? (
+                                        <CommonLink
+                                            href={`/dataset/${item.id}/details`}
+                                        >
+                                            {item?.name ? item.name : item.id}
+                                        </CommonLink>
+                                    ) : (
+                                        <>{item.name}</>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </p>
+            </div>
+        );
+    } else {
+        return null;
+    }
+};
+
+export default CurrencyAlert;

--- a/magda-web-client/src/Components/Dataset/DatasetPage.tsx
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.tsx
@@ -19,6 +19,7 @@ import SecClassification, {
     Sensitivity
 } from "Components/Common/SecClassification";
 import CommonLink from "Components/Common/CommonLink";
+import CurrencyAlert from "./CurrencyAlert";
 
 interface PropsType {
     history: History;
@@ -65,6 +66,9 @@ const DatasetPage: FunctionComponent<PropsType> = (props) => {
                     </p>
                 </div>
             ) : null}
+
+            <CurrencyAlert dataset={dataset} />
+
             <div className="row">
                 <div className="col-sm-8">
                     <h1 itemProp="name">{dataset?.title}</h1>
@@ -148,9 +152,6 @@ const DatasetPage: FunctionComponent<PropsType> = (props) => {
                         ) : (
                             <></>
                         )}
-                        {dataset.currencyStatus ? (
-                            <div>Currency: {dataset.currencyStatus}</div>
-                        ) : null}
                         {dataset.accrualPeriodicity ? (
                             <div>Updated: {dataset.accrualPeriodicity}</div>
                         ) : null}

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -54,6 +54,15 @@ export type VersionItem = {
     title: string;
 };
 
+export type CurrencyData = {
+    status: "CURRENT" | "SUPERSEDED" | "RETIRED";
+    retireReason?: string;
+    supersededBy?: {
+        id?: string[];
+        name?: string;
+    }[];
+};
+
 export type VersionAspectData = {
     currentVersionNumber: number;
     versions: VersionItem[];

--- a/magda-web-client/src/helpers/record.ts
+++ b/magda-web-client/src/helpers/record.ts
@@ -2,7 +2,11 @@ import getDateString from "./getDateString";
 import { isSupportedFormat as isSupportedMapPreviewFormat } from "../Components/Common/DataPreviewMap";
 import { FetchError } from "../types";
 import weightedMean from "weighted-mean";
-import { Record, VersionAspectData } from "api-clients/RegistryApis";
+import {
+    Record,
+    VersionAspectData,
+    CurrencyData
+} from "api-clients/RegistryApis";
 import { config } from "config";
 
 export type RecordAction = {
@@ -160,6 +164,7 @@ export type RawDataset = {
         access: Access;
         version?: VersionAspectData;
         "dataset-draft"?: DatasetDraft;
+        currency?: CurrencyData;
     };
 };
 
@@ -202,7 +207,7 @@ export type ParsedDataset = {
     title: string;
     accrualPeriodicity?: string;
     accrualPeriodicityRecurrenceRule?: string;
-    currencyStatus?: "CURRENT" | "SUPERSEDED" | "RETIRED";
+    currency?: CurrencyData;
     issuedDate?: string;
     updatedDate?: string;
     landingPage: string;
@@ -456,7 +461,6 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
         : defaultDatasetAspects;
     const identifier = dataset && dataset.id;
     const accessControl = aspects["dataset-access-control"];
-    const currencyStatus = aspects["currency"]?.status;
     const datasetInfo = aspects["dcat-dataset-strings"];
     const distribution = aspects["dataset-distributions"];
     const temporalCoverage = aspects["temporal-coverage"] || { intervals: [] };
@@ -576,7 +580,7 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
         error,
         linkedDataRating,
         hasQuality,
-        currencyStatus,
+        currency: aspects?.["currency"],
         themes: datasetInfo["themes"],
         sourceDetails: aspects["source"],
         provenance: {


### PR DESCRIPTION
### What this PR does

Fixes #2921

On dataset page, display an alert box when the dataset is superseded or retired

Examples:

![image](https://user-images.githubusercontent.com/674387/93761409-19958000-fc51-11ea-95f4-b8582a5033cb.png)

![image](https://user-images.githubusercontent.com/674387/93761431-1f8b6100-fc51-11ea-800e-473a80fda572.png)


### Checklist

-   [x]  unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
