### PR TITLE
Issue/2974 Be able to disable the store to storage API option on Add dataset page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 -   Added Documentation for Magda Helm Charts (generated using [helm-docs](https://github.com/norwoodj/helm-docs))
 -   Upgrade papaParse to 5.3.0 for the [Regular Expression Denial of Service (ReDos) vulnerability](https://github.com/magda-io/magda/network/alert/magda-web-client/package.json/papaparse/open)
 -   Fixed papaParse's chunk data loading HTTP 416 Error (on our forked repo)
+-   On dataset page, display an alert box when the dataset is superseded or retired
 
 ## 0.0.57
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 -   Upgrade papaParse to 5.3.0 for the [Regular Expression Denial of Service (ReDos) vulnerability](https://github.com/magda-io/magda/network/alert/magda-web-client/package.json/papaparse/open)
 -   Fixed papaParse's chunk data loading HTTP 416 Error (on our forked repo)
 -   On dataset page, display an alert box when the dataset is superseded or retired
+-   Added Helm chart option to disable "use internal storage to store file" option in metadata creation tool UI
 
 ## 0.0.57
 

--- a/deploy/helm/internal-charts/web-server/README.md
+++ b/deploy/helm/internal-charts/web-server/README.md
@@ -35,11 +35,12 @@ Kubernetes: `>= 1.14.0-0`
 | dateConfig.dateRegexes.startDateRegex | string | `"(start|st).*(date|dt|year|decade)"` |  |
 | defaultContactEmail | string | `"mail@example.com"` |  |
 | disableAuthenticationFeatures | bool | `false` |  |
-| featureFlags.cataloguing | bool | `false` |  |
-| featureFlags.datasetApprovalWorkflowOn | bool | `true` |  |
-| featureFlags.placeholderWorkflowsOn | bool | `false` |  |
-| featureFlags.previewAddDataset | bool | `false` |  |
-| featureFlags.publishToDga | bool | `false` |  |
+| featureFlags.cataloguing | bool | `false` | turn on / off metadata creation tool.  If this option is `false`, user won't be able to access the dataset add / edit UI  |
+| featureFlags.datasetApprovalWorkflowOn | bool | `true` | turn on / off dataset approval note step |
+| featureFlags.placeholderWorkflowsOn | bool | `false` | turn on / off some metadata creation tool questions that are still under development |
+| featureFlags.previewAddDataset | bool | `false` | turn on / off the preview mode of metadata creation tool. Under preview mode, user can play with the metadata creation tool without requiring admin permission. No data will be saved under this mode. |
+| featureFlags.publishToDga | bool | `false` | turn on / off the UI switch that allow user to select whether to auto push dataset data to a CKAN instance |
+| featureFlags.useStorageApi | bool | `true` | turn on / off the UI option to use Magda internal storage for file storage. |
 | image | object | `{}` |  |
 | keywordsBlackList[0] | string | `"Mr"` |  |
 | keywordsBlackList[10] | string | `"Mr."` |  |

--- a/deploy/helm/internal-charts/web-server/values.yaml
+++ b/deploy/helm/internal-charts/web-server/values.yaml
@@ -33,7 +33,7 @@ featureFlags:
   # featureFlags.datasetApprovalWorkflowOn -- turn on / off dataset approval note step
   datasetApprovalWorkflowOn: true
   # featureFlags.useStorageApi -- turn on / off the UI option to use Magda internal storage for file storage.
-  useStorageApi: 
+  useStorageApi: true
 
 
 # The base url where the UI serves at. If not specify (or empty string), it assumes the UI serves at '/'.

--- a/deploy/helm/internal-charts/web-server/values.yaml
+++ b/deploy/helm/internal-charts/web-server/values.yaml
@@ -19,11 +19,22 @@ service: {}
 useLocalStyleSheet: false
 contentApiBaseUrlInternal: "http://content-api/v0/"
 featureFlags:
- cataloguing: false
- previewAddDataset: false
- publishToDga: false
- placeholderWorkflowsOn: false
- datasetApprovalWorkflowOn: true
+  # featureFlags.cataloguing -- turn on / off metadata creation tool. 
+  # If this option is `false`, user won't be able to access the dataset add / edit UI 
+  cataloguing: false
+  # featureFlags.previewAddDataset -- turn on / off the preview mode of metadata creation tool.
+  # Under preview mode, user can play with the metadata creation tool without requiring admin permission.
+  # No data will be saved under this mode.
+  previewAddDataset: false
+  # featureFlags.publishToDga -- turn on / off the UI switch that allow user to select whether to auto push dataset data to a CKAN instance
+  publishToDga: false
+  # featureFlags.placeholderWorkflowsOn -- turn on / off some metadata creation tool questions that are still under development
+  placeholderWorkflowsOn: false
+  # featureFlags.datasetApprovalWorkflowOn -- turn on / off dataset approval note step
+  datasetApprovalWorkflowOn: true
+  # featureFlags.useStorageApi -- turn on / off the UI option to use Magda internal storage for file storage.
+  useStorageApi: 
+
 
 # The base url where the UI serves at. If not specify (or empty string), it assumes the UI serves at '/'.
 # it should have a leading slash, but no trailing slash

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -145,6 +145,7 @@ magda:
         publishToDga: true
         placeholderWorkflowsOn: false
         datasetApprovalWorkflowOn: true
+        useStorageApi: true
       vocabularyApiEndpoints:
         - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
         - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -87,6 +87,7 @@ magda:
         publishToDga: true
         placeholderWorkflowsOn: true
         datasetApprovalWorkflowOn: true
+        useStorageApi: true
       dateConfig:
         dateFormats:
           - YYYY

--- a/deploy/helm/preview-multi-tenant.yml
+++ b/deploy/helm/preview-multi-tenant.yml
@@ -121,6 +121,7 @@ magda:
         publishToDga: true
         placeholderWorkflowsOn: false
         datasetApprovalWorkflowOn: true
+        useStorageApi: true
 
     correspondence-api:
       alwaysSendToDefaultRecipient: true

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -114,6 +114,7 @@ magda:
         publishToDga: true
         placeholderWorkflowsOn: false
         datasetApprovalWorkflowOn: true
+        useStorageApi: true
       vocabularyApiEndpoints:
         - "https://vocabs.ands.org.au/repository/api/lda/abares/australian-land-use-and-management-classification/version-8/concept.json"
         - "https://vocabs.ands.org.au/repository/api/lda/neii/australian-landscape-water-balance/version-1/concept.json"

--- a/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/AddDatasetLinkSection.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/AddDatasetLinkSection.scss
@@ -1,6 +1,6 @@
 .dataset-add-file-page {
     .add-dataset-link-section {
-        margin-top: 100px;
+        margin-top: 50px;
 
         .section-heading {
             font-size: 38px;

--- a/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.scss
@@ -1,6 +1,6 @@
 .dataset-add-file-page {
     .top-area-row {
-        padding-bottom: 61px;
+        padding-bottom: 0px;
         position: relative;
     }
     .top-text-area {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/AddFiles/index.tsx
@@ -190,7 +190,6 @@ class AddFilesPage extends React.Component<Props> {
 
                 <div className="row add-files-heading">
                     <div className="col-xs-12">
-                        <h3>Storage and location</h3>
                         {this.renderStorageOption()}
                     </div>
 

--- a/magda-web-client/src/Components/Dataset/Add/StorageOptionsSection.scss
+++ b/magda-web-client/src/Components/Dataset/Add/StorageOptionsSection.scss
@@ -1,4 +1,4 @@
-.dataset-add-file-page .storage-options-section {
+.dataset-add-file-page .storage-options-section.storage-api-on {
     margin-bottom: 15px;
 
     .storage-option-heading,
@@ -74,5 +74,11 @@
             border-radius: 2px;
             background-color: #042330;
         }
+    }
+}
+
+.dataset-add-file-page .storage-options-section.storage-api-off {
+    h3 {
+        margin-bottom: 45px !important;
     }
 }

--- a/magda-web-client/src/Components/Dataset/Add/StorageOptionsSection.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/StorageOptionsSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./StorageOptionsSection.scss";
 import { Distribution } from "./DatasetAddCommon";
-
+import { config } from "config";
 import ToolTip from "./ToolTip";
 import { AlwaysEditor } from "Components/Editing/AlwaysEditor";
 import { codelistRadioEditor } from "Components/Editing/Editors/codelistEditor";
@@ -17,53 +17,71 @@ type Props = {
 
 const StorageOptionsSection = (props: Props) => {
     const shouldDisableInput = props.files.length > 0 ? true : false;
+    const useStorageApi =
+        typeof config?.featureFlags?.["useStorageApi"] === "boolean"
+            ? config.featureFlags["useStorageApi"]
+            : true;
 
     return (
-        <div className="row storage-options-section">
+        <div
+            className={`row storage-options-section ${
+                useStorageApi ? "storage-api-on" : "storage-api-off"
+            }`}
+        >
             <div className="col-sm-12">
-                <div className="storage-option-heading">
-                    Would you like a copy of the files in this dataset to be
-                    stored by Magda?
-                </div>
-                <ToolTip>
-                    Select yes if you would like to store a copy of this file on
-                    Magda’s servers. This will allow your users to download the
-                    file directly from Magda without having to locate the file
-                    on your internal storage system or shared drive .{" "}
-                </ToolTip>
-
-                <div className="storage-option-input-area">
-                    {shouldDisableInput ? (
-                        <div className="tooltip-container">
-                            <div className="triangle">&nbsp;</div>
-                            <div>
-                                In order to change this selection, please remove
-                                the files you have already uploaded, change this
-                                selection and re-upload them.
-                            </div>
+                <h3>Storage and location</h3>
+                {useStorageApi ? (
+                    <>
+                        <div className="storage-option-heading">
+                            Would you like a copy of the files in this dataset
+                            to be stored by Magda?
                         </div>
-                    ) : null}
-                    <AlwaysEditor
-                        value={
-                            props.shouldUploadToStorageApi ? "true" : "false"
-                        }
-                        onChange={value =>
-                            props.setShouldUploadToStorageApi(
-                                value === "true" ? true : false
-                            )
-                        }
-                        editor={codelistRadioEditor(
-                            "file-storage-option-selection",
-                            {
-                                true: "Yes, store a copy of this file on Magda",
-                                false:
-                                    "No, I want to use my existing shared drive or storage systems"
-                            },
-                            false,
-                            shouldDisableInput
-                        )}
-                    />
-                </div>
+                        <ToolTip>
+                            Select yes if you would like to store a copy of this
+                            file on Magda’s servers. This will allow your users
+                            to download the file directly from Magda without
+                            having to locate the file on your internal storage
+                            system or shared drive .{" "}
+                        </ToolTip>
+
+                        <div className="storage-option-input-area">
+                            {shouldDisableInput ? (
+                                <div className="tooltip-container">
+                                    <div className="triangle">&nbsp;</div>
+                                    <div>
+                                        In order to change this selection,
+                                        please remove the files you have already
+                                        uploaded, change this selection and
+                                        re-upload them.
+                                    </div>
+                                </div>
+                            ) : null}
+                            <AlwaysEditor
+                                value={
+                                    props.shouldUploadToStorageApi
+                                        ? "true"
+                                        : "false"
+                                }
+                                onChange={(value) =>
+                                    props.setShouldUploadToStorageApi(
+                                        value === "true" ? true : false
+                                    )
+                                }
+                                editor={codelistRadioEditor(
+                                    "file-storage-option-selection",
+                                    {
+                                        true:
+                                            "Yes, store a copy of this file on Magda",
+                                        false:
+                                            "No, I want to use my existing shared drive or storage systems"
+                                    },
+                                    false,
+                                    shouldDisableInput
+                                )}
+                            />
+                        </div>
+                    </>
+                ) : null}
 
                 {props.shouldUploadToStorageApi ? null : (
                     <div className="access-location-area">

--- a/magda-web-client/src/Components/Dataset/CurrencyAlert.scss
+++ b/magda-web-client/src/Components/Dataset/CurrencyAlert.scss
@@ -1,0 +1,14 @@
+.currency-alert {
+    p {
+        div {
+            padding-top: 10px;
+            padding-left: 20px;
+        }
+        ul {
+            margin-top: 0px !important;
+            li {
+                margin-top: 0px !important;
+            }
+        }
+    }
+}

--- a/magda-web-client/src/Components/Dataset/CurrencyAlert.tsx
+++ b/magda-web-client/src/Components/Dataset/CurrencyAlert.tsx
@@ -1,0 +1,110 @@
+import React, { FunctionComponent } from "react";
+import { ParsedDataset } from "helpers/record";
+import { useAsync } from "react-async-hook";
+import { fetchRecord } from "api-clients/RegistryApis";
+import CommonLink from "Components/Common/CommonLink";
+import "./CurrencyAlert.scss";
+
+type PropsType = {
+    dataset: ParsedDataset;
+};
+
+const CurrencyAlert: FunctionComponent<PropsType> = (props) => {
+    const status = props.dataset?.currency?.status;
+    const retireReason = props.dataset?.currency?.retireReason;
+    const supersededBy = props.dataset?.currency?.supersededBy;
+
+    const { result, loading, error } = useAsync(
+        async (status, supersededBy): Promise<any[]> => {
+            if (status !== "SUPERSEDED" || !supersededBy?.length) {
+                return [];
+            } else {
+                return await Promise.all(
+                    supersededBy
+                        .filter((item) => item?.id?.length || item?.name)
+                        .map(async (item) => {
+                            if (item?.id?.length) {
+                                try {
+                                    const record = await fetchRecord(
+                                        item.id[0],
+                                        ["dcat-dataset-strings"],
+                                        [],
+                                        false
+                                    );
+                                    const name = record?.aspects?.[
+                                        "dcat-dataset-strings"
+                                    ]?.title
+                                        ? record.aspects["dcat-dataset-strings"]
+                                              .title
+                                        : record.name;
+                                    return {
+                                        name,
+                                        id: item.id[0]
+                                    };
+                                } catch (e) {
+                                    console.error(
+                                        "Failed to fetch dataset name: ",
+                                        e
+                                    );
+                                    return {
+                                        id: item.id[0]
+                                    };
+                                }
+                            } else {
+                                return {
+                                    name: item.name
+                                };
+                            }
+                        })
+                );
+            }
+        },
+        [status, supersededBy]
+    );
+
+    if (status === "CURRENT") {
+        return null;
+    } else if (status === "RETIRED") {
+        return (
+            <div className="currency-alert au-page-alerts au-page-alerts--warning">
+                <h3>Retired Dataset</h3>
+                <p>This dataset is retired.</p>
+                {retireReason ? <p>Retired Reason: {retireReason}</p> : null}
+            </div>
+        );
+    } else if (status === "SUPERSEDED") {
+        return (
+            <div className="currency-alert au-page-alerts au-page-alerts--warning">
+                <h3>Superseded Dataset</h3>
+                <p>
+                    <div>This dataset has been superseded by:</div>
+                    {loading || !result ? (
+                        <div>Loading...</div>
+                    ) : error ? (
+                        <div>Error: {error}...</div>
+                    ) : (
+                        <ul>
+                            {result.map((item, idx) => (
+                                <li key={idx}>
+                                    {item?.id ? (
+                                        <CommonLink
+                                            href={`/dataset/${item.id}/details`}
+                                        >
+                                            {item?.name ? item.name : item.id}
+                                        </CommonLink>
+                                    ) : (
+                                        <>{item.name}</>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </p>
+            </div>
+        );
+    } else {
+        return null;
+    }
+};
+
+export default CurrencyAlert;

--- a/magda-web-client/src/Components/Dataset/DatasetPage.tsx
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.tsx
@@ -19,6 +19,7 @@ import SecClassification, {
     Sensitivity
 } from "Components/Common/SecClassification";
 import CommonLink from "Components/Common/CommonLink";
+import CurrencyAlert from "./CurrencyAlert";
 
 interface PropsType {
     history: History;
@@ -65,6 +66,9 @@ const DatasetPage: FunctionComponent<PropsType> = (props) => {
                     </p>
                 </div>
             ) : null}
+
+            <CurrencyAlert dataset={dataset} />
+
             <div className="row">
                 <div className="col-sm-8">
                     <h1 itemProp="name">{dataset?.title}</h1>
@@ -148,9 +152,6 @@ const DatasetPage: FunctionComponent<PropsType> = (props) => {
                         ) : (
                             <></>
                         )}
-                        {dataset.currencyStatus ? (
-                            <div>Currency: {dataset.currencyStatus}</div>
-                        ) : null}
                         {dataset.accrualPeriodicity ? (
                             <div>Updated: {dataset.accrualPeriodicity}</div>
                         ) : null}

--- a/magda-web-client/src/Components/Dataset/Edit/Pages/EditFiles/index.scss
+++ b/magda-web-client/src/Components/Dataset/Edit/Pages/EditFiles/index.scss
@@ -12,20 +12,19 @@
 
     .add-files-heading {
         h3 {
-            margin-top: 60px;
-            margin-bottom: 30px;
-            font-size: 38px;
-            font-weight: normal;
-            font-style: normal;
-            font-stretch: normal;
-            line-height: 1.61;
-            letter-spacing: normal;
-            color: #484848;
-            border: none !important;
+            margin-top: 12px;
+            margin-bottom: 65px;
+            color: #30384d;
+            font-size: 29px;
+            letter-spacing: -0.5px;
+            line-height: 30px;
+            padding-bottom: 18px;
+            border-bottom: 1px solid #cccaca;
         }
     }
 
     h4.dataset-contents-heading {
+        margin-top: 45px;
         margin-bottom: 50px;
     }
 

--- a/magda-web-client/src/Components/Dataset/Edit/Pages/EditFiles/index.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/Pages/EditFiles/index.tsx
@@ -231,12 +231,14 @@ const EditFilesPage: FunctionComponent<Props> = (props) => {
 
                 <ErrorMessageBox error={error} scrollIntoView={true} />
 
-                <div className="row add-files-heading">
-                    <div className="col-xs-12">
-                        <h3>Your files and distributions</h3>
-                        <h4>Storage and location</h4>
-                        {renderStorageOption()}
+                <div className="row top-area-row">
+                    <div className="col-xs-12 top-text-area">
+                        <h1>Your files and distributions</h1>
                     </div>
+                </div>
+
+                <div className="row add-files-heading">
+                    <div className="col-xs-12">{renderStorageOption()}</div>
                 </div>
 
                 <h4 className="dataset-contents-heading">Dataset contents</h4>

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -54,6 +54,15 @@ export type VersionItem = {
     title: string;
 };
 
+export type CurrencyData = {
+    status: "CURRENT" | "SUPERSEDED" | "RETIRED";
+    retireReason?: string;
+    supersededBy?: {
+        id?: string[];
+        name?: string;
+    }[];
+};
+
 export type VersionAspectData = {
     currentVersionNumber: number;
     versions: VersionItem[];

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -43,7 +43,8 @@ const DEV_FEATURE_FLAGS = {
     publishToDga: true,
     previewAddDataset: false,
     placeholderWorkflowsOn: false,
-    datasetApprovalWorkflowOn: false
+    datasetApprovalWorkflowOn: false,
+    useStorageApi: true
 };
 
 const homePageConfig: {

--- a/magda-web-client/src/helpers/record.ts
+++ b/magda-web-client/src/helpers/record.ts
@@ -2,7 +2,11 @@ import getDateString from "./getDateString";
 import { isSupportedFormat as isSupportedMapPreviewFormat } from "../Components/Common/DataPreviewMap";
 import { FetchError } from "../types";
 import weightedMean from "weighted-mean";
-import { Record, VersionAspectData } from "api-clients/RegistryApis";
+import {
+    Record,
+    VersionAspectData,
+    CurrencyData
+} from "api-clients/RegistryApis";
 import { config } from "config";
 
 export type RecordAction = {
@@ -160,6 +164,7 @@ export type RawDataset = {
         access: Access;
         version?: VersionAspectData;
         "dataset-draft"?: DatasetDraft;
+        currency?: CurrencyData;
     };
 };
 
@@ -202,7 +207,7 @@ export type ParsedDataset = {
     title: string;
     accrualPeriodicity?: string;
     accrualPeriodicityRecurrenceRule?: string;
-    currencyStatus?: "CURRENT" | "SUPERSEDED" | "RETIRED";
+    currency?: CurrencyData;
     issuedDate?: string;
     updatedDate?: string;
     landingPage: string;
@@ -456,7 +461,6 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
         : defaultDatasetAspects;
     const identifier = dataset && dataset.id;
     const accessControl = aspects["dataset-access-control"];
-    const currencyStatus = aspects["currency"]?.status;
     const datasetInfo = aspects["dcat-dataset-strings"];
     const distribution = aspects["dataset-distributions"];
     const temporalCoverage = aspects["temporal-coverage"] || { intervals: [] };
@@ -576,7 +580,7 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
         error,
         linkedDataRating,
         hasQuality,
-        currencyStatus,
+        currency: aspects?.["currency"],
         themes: datasetInfo["themes"],
         sourceDetails: aspects["source"],
         provenance: {


### PR DESCRIPTION
### What this PR does

Included PR: https://github.com/magda-io/magda/pull/2973

Fixes #2974 Be able to disable the store to storage API option on Add dataset page

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
