### PR TITLE
Issue/3003 Turn off Open In National Map Button for Internal Storage data file Link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 -   Keep tracking superseded data files in versions to avoid superseded data files being deleted #2981
 -   UI Changes that allow user to access the distribution page of different versions #2982
 -   Use pseudo url for data file stored in storage api #3000
+-   Turn off `Open In National Map` Button for Internal Storage data file Link
+-   Use [magda-preview-map](https://github.com/magda-io/magda-preview-map) v0.0.58
 
 ## 0.0.57
 

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -34,7 +34,7 @@ dependencies:
   version: 0.0.58-alpha.0
 - name: magda-preview-map
   repository: https://charts.magda.io
-  version: 0.0.57-0
+  version: 0.0.58
 - name: registry-api
   repository: file://../internal-charts/registry-api
   version: 0.0.58-alpha.0
@@ -77,5 +77,5 @@ dependencies:
 - name: ingress
   repository: file://../internal-charts/ingress
   version: 0.0.58-alpha.0
-digest: sha256:b0bf1ba018cac7f6ab226aaa1ca4c31a46b505eb2c707a60c1be3cb242330c93
-generated: "2020-10-02T15:48:21.552178+10:00"
+digest: sha256:3d5b13822fb9c48cf0df63133da0a9212fbbe46f756f5233a9b4617006b45138
+generated: "2020-10-14T22:52:33.73458+11:00"

--- a/deploy/helm/magda-core/Chart.yaml
+++ b/deploy/helm/magda-core/Chart.yaml
@@ -75,7 +75,7 @@ dependencies:
       - all
       - indexer
   - name: magda-preview-map
-    version: 0.0.57-0
+    version: 0.0.58
     alias: preview-map
     repository: https://charts.magda.io
     tags:

--- a/deploy/helm/magda-core/README.md
+++ b/deploy/helm/magda-core/README.md
@@ -41,7 +41,7 @@ Kubernetes: `>= 1.14.0-0`
 | file://../internal-charts/tenant-db | tenant-db | 0.0.58-alpha.0 |
 | file://../internal-charts/web-server | web-server | 0.0.58-alpha.0 |
 | file://../openfaas | openfaas | 5.5.5-magda |
-| https://charts.magda.io | magda-preview-map | 0.0.57-0 |
+| https://charts.magda.io | magda-preview-map | 0.0.58 |
 
 ## Values
 

--- a/magda-web-client/src/Components/Common/DataPreviewMap.tsx
+++ b/magda-web-client/src/Components/Common/DataPreviewMap.tsx
@@ -13,6 +13,8 @@ import {
     FileSizeCheckResult
 } from "helpers/DistributionPreviewUtils";
 import DataPreviewSizeWarning from "./DataPreviewSizeWarning";
+import urijs from "urijs";
+import isStorageApiUrl from "helpers/isStorageApiUrl";
 
 const DATA_SOURCE_PREFERENCE = [
     {
@@ -240,6 +242,7 @@ class DataPreviewMapTerria extends Component<
                             name: selectedDistribution.title,
                             type: "magda-item",
                             url: config.baseUrl,
+                            storageApiUrl: config.storageApiUrl,
                             distributionId: selectedDistribution.identifier,
                             // --- default internal storage bucket name
                             defaultBucket: DATASETS_BUCKET,
@@ -253,7 +256,8 @@ class DataPreviewMapTerria extends Component<
                         east: 158,
                         south: -45,
                         west: 109
-                    }
+                    },
+                    corsDomains: [urijs(config.baseExternalUrl).hostname()]
                 }
             ]
         };
@@ -283,6 +287,10 @@ class DataPreviewMapTerria extends Component<
     };
 
     render() {
+        const shouldHideOpenNationalMapButton =
+            this.props.distribution.downloadURL &&
+            isStorageApiUrl(this.props.distribution.downloadURL);
+
         return (
             <div
                 className="data-preview-map"
@@ -290,15 +298,17 @@ class DataPreviewMapTerria extends Component<
                 onMouseLeave={this.handleMapMouseLeave}
             >
                 {!this.state.loaded && <Spinner width="100%" height="420px" />}
-                <DataPreviewMapOpenInNationalMapButton
-                    distribution={this.props.distribution}
-                    buttonText="Open in NationalMap"
-                    style={{
-                        position: "absolute",
-                        right: "10px",
-                        top: "10px"
-                    }}
-                />
+                {shouldHideOpenNationalMapButton ? null : (
+                    <DataPreviewMapOpenInNationalMapButton
+                        distribution={this.props.distribution}
+                        buttonText="Open in NationalMap"
+                        style={{
+                            position: "absolute",
+                            right: "10px",
+                            top: "10px"
+                        }}
+                    />
+                )}
                 {this.props.distribution.identifier != null && (
                     <iframe
                         key={this.props.distribution.identifier}


### PR DESCRIPTION
### What this PR does

Fixes #3003 

-   Turn off `Open In National Map` Button for Internal Storage data file Link
-   Use [magda-preview-map](https://github.com/magda-io/magda-preview-map) v0.0.58

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
