### PR TITLE
use magda-auth-arcgis auth plugin instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 -   Replace internal auth provider with auth plugin [magda-auth-internal](https://github.com/magda-io/magda-auth-internal)
 -   Remove Google, CKAN & internal auth provider code from Gateway codebase
 -   Publish docker image utils as a seperate NPM package @magda/docker-utils
+-   Use magda-auth-arcgis auth plugin instead
 
 ## 0.0.57
 

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -11,6 +11,9 @@ dependencies:
 - name: magda-auth-internal
   repository: https://charts.magda.io
   version: 1.0.0
+- name: magda-auth-arcgis
+  repository: https://charts.magda.io
+  version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
   version: 0.0.57-0
@@ -110,5 +113,5 @@ dependencies:
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 0.0.57-0
-digest: sha256:fb4c7cf78ef729f4a65d90eafdbfeb2ac52b08b17f22508678213b6c06d7bf66
-generated: "2020-10-29T23:33:52.796811+11:00"
+digest: sha256:ad7aff27bf67e0b74c29fb62730c49a3e24641bb768f71d240ef922bfea79ecf
+generated: "2020-11-02T13:58:38.706939+11:00"

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -29,6 +29,13 @@ dependencies:
       - all
       - magda-auth-internal
 
+  - name: magda-auth-arcgis
+    version: 1.0.0
+    repository: https://charts.magda.io
+    tags:
+      - all
+      - magda-auth-arcgis
+
   ## Data.gov.au connector to provide some initial data. Remove this if you
   ## don't want any data.gov.au connector
   - name: magda-ckan-connector

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -66,7 +66,6 @@ magda:
       enableHttpsRedirection: true
       auth:
         facebookClientId: "173073926555600"
-        arcgisClientId: "d0MgVUbbg5Z6vmWo"
         vanguardWsFedIdpUrl: https://thirdparty.authentication.business.gov.au/fas/v2/wsfed12/authenticate
         vanguardWsFedRealm: https://environment.magda.io/integration-test-2
       authPlugins:
@@ -76,6 +75,8 @@ magda:
         baseUrl: http://magda-auth-ckan
       - key: internal
         baseUrl: http://magda-auth-internal
+      - key: arcgis
+        baseUrl: http://magda-auth-arcgis
       cors:
         credentials: true
         origin: true
@@ -192,6 +193,12 @@ magda-auth-ckan:
 magda-auth-internal:
   authPluginConfig:
     loginFormExtraInfoContent: "Forgot your password? Email [magda-test@googlegroups.com](magda-test@googlegroups.com)"
+  image:
+    tag: 1.0.0
+    repository: docker.io/data61
+
+magda-auth-arcgis:
+  arcgisClientId: "d0MgVUbbg5Z6vmWo"
   image:
     tag: 1.0.0
     repository: docker.io/data61

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -68,7 +68,6 @@ magda:
         origin: true
       auth:
         facebookClientId: "173073926555600"
-        arcgisClientId: "d0MgVUbbg5Z6vmWo"
       authPlugins:
       - key: google
         baseUrl: http://magda-auth-google
@@ -76,6 +75,8 @@ magda:
         baseUrl: http://magda-auth-ckan
       - key: internal
         baseUrl: http://magda-auth-internal
+      - key: arcgis
+        baseUrl: http://magda-auth-arcgis
 
     registry-api:
       skipAuthorization: false
@@ -161,6 +162,12 @@ magda-auth-ckan:
 magda-auth-internal:
   authPluginConfig:
     loginFormExtraInfoContent: "Forgot your password? Email [magda-test@googlegroups.com](magda-test@googlegroups.com)"
+  image:
+    tag: 1.0.0
+    repository: docker.io/data61
+
+magda-auth-arcgis:
+  arcgisClientId: "d0MgVUbbg5Z6vmWo"
   image:
     tag: 1.0.0
     repository: docker.io/data61

--- a/deploy/helm/preview-multi-tenant.yml
+++ b/deploy/helm/preview-multi-tenant.yml
@@ -64,6 +64,8 @@ magda:
         baseUrl: http://magda-auth-ckan
       - key: internal
         baseUrl: http://magda-auth-internal
+      - key: arcgis
+        baseUrl: http://magda-auth-arcgis
       autoscaler:
         enabled: false
       helmet:
@@ -164,6 +166,12 @@ magda-auth-ckan:
 magda-auth-internal:
   authPluginConfig:
     loginFormExtraInfoContent: "Forgot your password? Email [magda-test@googlegroups.com](magda-test@googlegroups.com)"
+  image:
+    tag: 1.0.0
+    repository: docker.io/data61
+
+magda-auth-arcgis:
+  arcgisClientId: "d0MgVUbbg5Z6vmWo"
   image:
     tag: 1.0.0
     repository: docker.io/data61

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -50,7 +50,6 @@ magda:
       enableHttpsRedirection: true
       auth:
         facebookClientId: "173073926555600"
-        arcgisClientId: "d0MgVUbbg5Z6vmWo"
         vanguardWsFedIdpUrl: https://thirdparty.authentication.business.gov.au/fas/v2/wsfed12/authenticate
         vanguardWsFedRealm: https://environment.magda.io/integration-test-2
       authPlugins:
@@ -60,6 +59,8 @@ magda:
         baseUrl: http://magda-auth-ckan
       - key: internal
         baseUrl: http://magda-auth-internal
+      - key: arcgis
+        baseUrl: http://magda-auth-arcgis
       autoscaler:
         enabled: false
       helmet:
@@ -166,6 +167,12 @@ magda-auth-ckan:
 magda-auth-internal:
   authPluginConfig:
     loginFormExtraInfoContent: "Forgot your password? Email [magda-test@googlegroups.com](magda-test@googlegroups.com)"
+  image:
+    tag: 1.0.0
+    repository: docker.io/data61
+
+magda-auth-arcgis:
+  arcgisClientId: "d0MgVUbbg5Z6vmWo"
   image:
     tag: 1.0.0
     repository: docker.io/data61


### PR DESCRIPTION
### What this PR does

Related #3020 
- use magda-auth-arcgis auth plugin instead. 
- didn't remove origin arcgis provider from gateway code base so that it won't stop digital twin projects from upgrading to this version without removing their auth provider usage

Tested locally with QLD dev credentials 

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
