### PR TITLE
Issue/3013 Make `Add a dataset` link on Homepage (admin user only) go to metadata creation tool directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 -   Remove Google, CKAN & internal auth provider code from Gateway codebase
 -   Publish docker image utils as a seperate NPM package @magda/docker-utils
 -   Use magda-auth-arcgis auth plugin instead
+-   Make `Add a dataset` link on Homepage (admin user only) go to metadata creation tool directly
 
 ## 0.0.57
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddPage.tsx
@@ -146,7 +146,7 @@ class AddDataset extends React.Component<any, any> {
                                     heading="No files to upload?"
                                     icon={iconDataEntry}
                                     blurb="Manually add the dataset record and the metadata."
-                                    href="/dataset/add/metadata/-/0"
+                                    href="/dataset/add/metadata"
                                     secondary
                                 />
                                 <Choice

--- a/magda-web-client/src/Components/Home/MyDatasetSectionComponents/SideNavigation.tsx
+++ b/magda-web-client/src/Components/Home/MyDatasetSectionComponents/SideNavigation.tsx
@@ -12,7 +12,7 @@ const SideNavigation: FunctionComponent<PropsType> = (props) => {
                 <a className="icon-my-data active">
                     <span>My data sets</span>
                 </a>
-                <Link to="/dataset/add" className="icon-add-dataset">
+                <Link to="/dataset/add/metadata" className="icon-add-dataset">
                     <span>Add a data set</span>
                 </Link>
             </div>


### PR DESCRIPTION
### What this PR does

Fixes #3013 
- Make `Add a dataset` link on Homepage (admin user only) go to metadata creation tool directly
- Also, correct the link on add dataset landing page (we may not need it for now but still keep it just in case we need it in future)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
