### PR TITLE
Fixed 3031

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -301,6 +301,7 @@ buildtest:typescript-apis-stateless:
     paths:
       - "*/dist"
       - "packages/*/dist"
+      - "packages/*/bin"
     expire_in: 30 days
 
 buildtest:typescript-apis-with-pg:


### PR DESCRIPTION
### What this PR does

Fixes #3031 

- add "packages/*/bin" as artifacts path in CI


### Checklist

-   [x] unit tests aren't applicable
