### PR TITLE
Post message in terria v8 format.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.0.59
 
+-   Post message to NationalMap in terriajs v8 format.
+
 ## 0.0.58
 
 -   Added Documentation for Magda Helm Charts (generated using [helm-docs](https://github.com/norwoodj/helm-docs))

--- a/magda-web-client/src/Components/Common/DataPreviewMapOpenInNationalMapButton.js
+++ b/magda-web-client/src/Components/Common/DataPreviewMapOpenInNationalMapButton.js
@@ -26,18 +26,23 @@ class DataPreviewMapOpenInNationalMapButton extends Component {
     }
 
     createCatalogItemFromDistribution(withoutBaseMap = false) {
+        const dga_id_prefix = "data.gov.au-postMessage-";
         const catConfig = {
             initSources: [
                 {
                     catalog: [
                         {
                             name: this.props.distribution.title,
-                            type: "magda-item",
-                            distributionId: this.props.distribution.identifier,
+                            type: "magda",
+                            recordId: this.props.distribution.identifier,
                             url: config.baseExternalUrl,
-                            isEnabled: true,
-                            zoomOnEnable: true
+                            id:
+                                dga_id_prefix +
+                                this.props.distribution.identifier
                         }
+                    ],
+                    workbench: [
+                        dga_id_prefix + this.props.distribution.identifier
                     ]
                 }
             ]


### PR DESCRIPTION
### What this PR does

Fixes #3019 

This PR should only be deployed after NationalMap is upgraded to terriajs v8. That is, this PR is blocked by https://github.com/TerriaJS/nationalmap/issues/968.

Before the `NationalMap` is upgraded to v8 `terriajs`, this [site](https://nationalmap.dev.saas.terria.io) can be used for testing.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
