### PR TITLE
Issue/3024 Make Gateway should proxy all GET requests to registry-read-only pods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 -   Make PUT /auth/users/:userId API accept other user field rather then `isAdmin` field only
 -   Release `acs-cmd` & `org-tree` as separate NPM packages
 -   Add set admin function to `acs-cmd` commandline utility package
+-   #3024 Gateway will automatically proxy all GET requests received at `/api/v0/registry` to registry read-only nodes (excepts Hooks APIs)
 
 ## 0.0.58
 

--- a/deploy/helm/internal-charts/gateway/README.md
+++ b/deploy/helm/internal-charts/gateway/README.md
@@ -63,7 +63,11 @@ Kubernetes: `>= 1.14.0-0`
 
 A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
 - `to`: target url
-- `methods`: array of string. "all" means all methods
+- `methods`: array of string or objects with fields "method" & "target".
+  - When the array item is a string, the string stands for the HTTP method. "all" means all methods.
+  - When the array item us an object, the object can have the following fields:
+    - "method": the HTTP method of the requests to be proxied. "all" means all methods.
+    - "target": the alternative proxy target URL
 - `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
 - `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
 - `statusCheck`: check target's live status from the gateway
@@ -79,6 +83,21 @@ defaultRoutes:
     auth: true
   registry:
     to: http://registry-api/v0
+    methods:
+    - method: get
+      target: http://registry-api-read-only/v0
+    - method: head
+      target: http://registry-api-read-only/v0
+    - method: options
+      target: http://registry-api-read-only/v0
+    - method: post
+      target: http://registry-api/v0
+    - method: put
+      target: http://registry-api/v0
+    - method: patch
+      target: http://registry-api/v0
+    - method: delete
+      target: http://registry-api/v0
     auth: true
   registry-read-only:
     to: http://registry-api-read-only/v0

--- a/deploy/helm/internal-charts/gateway/README.md
+++ b/deploy/helm/internal-charts/gateway/README.md
@@ -81,6 +81,9 @@ defaultRoutes:
   search:
     to: http://search-api/v0
     auth: true
+  "registry/hooks":
+    to: http://registry-api/v0/hooks
+    auth: true
   registry:
     to: http://registry-api/v0
     methods:

--- a/deploy/helm/internal-charts/gateway/README.md.gotmpl
+++ b/deploy/helm/internal-charts/gateway/README.md.gotmpl
@@ -39,6 +39,9 @@ defaultRoutes:
   search:
     to: http://search-api/v0
     auth: true
+  "registry/hooks":
+    to: http://registry-api/v0/hooks
+    auth: true
   registry:
     to: http://registry-api/v0
     methods:

--- a/deploy/helm/internal-charts/gateway/README.md.gotmpl
+++ b/deploy/helm/internal-charts/gateway/README.md.gotmpl
@@ -21,7 +21,11 @@
 
 A proxy target definition that defines `defaultRoutes` or `webRoutes` above support the following fields:
 - `to`: target url
-- `methods`: array of string. "all" means all methods
+- `methods`: array of string or objects with fields "method" & "target". 
+  - When the array item is a string, the string stands for the HTTP method. "all" means all methods.
+  - When the array item us an object, the object can have the following fields:
+    - "method": the HTTP method of the requests to be proxied. "all" means all methods.
+    - "target": the alternative proxy target URL
 - `auth`: whether this target requires session. Otherwise, session / password related midddleware won't run
 - `redirectTrailingSlash`: make /xxx auto redirect to /xxxx/
 - `statusCheck`: check target's live status from the gateway
@@ -37,6 +41,21 @@ defaultRoutes:
     auth: true
   registry:
     to: http://registry-api/v0
+    methods:
+    - method: get
+      target: http://registry-api-read-only/v0
+    - method: head
+      target: http://registry-api-read-only/v0
+    - method: options
+      target: http://registry-api-read-only/v0
+    - method: post
+      target: http://registry-api/v0
+    - method: put
+      target: http://registry-api/v0
+    - method: patch
+      target: http://registry-api/v0
+    - method: delete
+      target: http://registry-api/v0
     auth: true
   registry-read-only:
     to: http://registry-api-read-only/v0

--- a/deploy/helm/internal-charts/gateway/values.yaml
+++ b/deploy/helm/internal-charts/gateway/values.yaml
@@ -78,6 +78,9 @@ defaultRoutes:
   search:
     to: http://search-api/v0
     auth: true
+  "registry/hooks":
+    to: http://registry-api/v0/hooks
+    auth: true
   registry:
     to: http://registry-api/v0
     methods:

--- a/deploy/helm/internal-charts/gateway/values.yaml
+++ b/deploy/helm/internal-charts/gateway/values.yaml
@@ -80,6 +80,21 @@ defaultRoutes:
     auth: true
   registry:
     to: http://registry-api/v0
+    methods:
+    - method: get
+      target: http://registry-api-read-only/v0
+    - method: head
+      target: http://registry-api-read-only/v0
+    - method: options
+      target: http://registry-api-read-only/v0
+    - method: post
+      target: http://registry-api/v0
+    - method: put
+      target: http://registry-api/v0
+    - method: patch
+      target: http://registry-api/v0
+    - method: delete
+      target: http://registry-api/v0
     auth: true
   registry-read-only:
     to: http://registry-api-read-only/v0

--- a/deploy/helm/internal-charts/indexer/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/indexer/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
             "-Dhttp.port=80",
             "-Dregistry.webhookUrl=http://indexer/v0/registry-hook",
             "-Dregistry.baseUrl=http://registry-api",
+            "-Dregistry.readOnlyBaseUrl=http://registry-api-read-only",
             "-Dindexer.readSnapshots={{ .Values.readSnapshots }}",
             "-Dindexer.makeSnapshots={{ .Values.makeSnapshots }}",
             "-Dakka.loglevel={{ .Values.global.logLevel }}",

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -77,6 +77,7 @@ export default function createBaseProxy(
 ): httpProxy {
     const proxy = httpProxy.createProxyServer({
         prependUrl: false,
+        ignorePath: true,
         changeOrigin: true
     } as httpProxy.ServerOptions);
 
@@ -102,6 +103,11 @@ export default function createBaseProxy(
     });
 
     proxy.on("proxyReq", function (proxyReq, req, res) {
+        // as we set `ignorePath`=true, we need append req.path to proxyReq.path
+        if (req.url !== "/") {
+            proxyReq.path = proxyReq.path + req.url;
+        }
+
         // Presume that we've already got whatever auth details we need out of the request and so remove it now.
         // If we keep it it causes scariness upstream - like anything that goes through the TerriaJS proxy will
         // be leaking auth details to wherever it proxies to.

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -104,8 +104,16 @@ export default function createBaseProxy(
 
     proxy.on("proxyReq", function (proxyReq, req, res) {
         // as we set `ignorePath`=true, we need append req.path to proxyReq.path
+        // we need to use req.url to include query string
         if (req.url !== "/") {
-            proxyReq.path = proxyReq.path + req.url;
+            if (
+                proxyReq.path[proxyReq.path.length - 1] === "/" &&
+                req.url[0] === "/"
+            ) {
+                proxyReq.path = proxyReq.path + req.url.substr(1);
+            } else {
+                proxyReq.path = proxyReq.path + req.url;
+            }
         }
 
         // Presume that we've already got whatever auth details we need out of the request and so remove it now.

--- a/magda-gateway/src/createGenericProxyRouter.ts
+++ b/magda-gateway/src/createGenericProxyRouter.ts
@@ -12,7 +12,7 @@ import { TenantMode } from "./setupTenantMode";
 export type ProxyTarget = DetailedProxyTarget | string;
 export type MethodWithProxyTaget = {
     method: string;
-    target: string;
+    target?: string;
 };
 export type ProxyMethodType = string | MethodWithProxyTaget;
 export interface DetailedProxyTarget {

--- a/magda-gateway/src/createGenericProxyRouter.ts
+++ b/magda-gateway/src/createGenericProxyRouter.ts
@@ -134,6 +134,7 @@ export default function createGenericProxyRouter(
 
     Object.keys(options.routes)
         .sort((a, b) => {
+            // make sure route path has more path segment items will be installed first (i.e. higher priority when takes up requests)
             const segmentLenA = urijs(a).segment().length;
             const segmentLenB = urijs(b).segment().length;
             if (segmentLenA < segmentLenB) {

--- a/magda-gateway/src/test/createGenericProxyRouter.spec.ts
+++ b/magda-gateway/src/test/createGenericProxyRouter.spec.ts
@@ -237,7 +237,7 @@ describe("createGenericProxyRouter", () => {
         await supertest(app).post("/test-route").expect(404);
     });
 
-    it("should forward incoming request path incorrectly", async () => {
+    it("should forward incoming request path correctly", async () => {
         const dummyAuthenticator = sinon.createStubInstance(Authenticator);
 
         const router = createGenericProxyRouter({
@@ -332,7 +332,7 @@ describe("createGenericProxyRouter", () => {
         expect(res.body.route).to.equal("POST:route3/12");
     });
 
-    it("should forward incoming request path incorrectly when route key contains segment (e.g. test-route/abcd)", async () => {
+    it("should forward incoming request path correctly when route key contains segment (e.g. test-route/abcd)", async () => {
         const dummyAuthenticator = sinon.createStubInstance(Authenticator);
 
         const router = createGenericProxyRouter({

--- a/magda-gateway/src/test/createGenericProxyRouter.spec.ts
+++ b/magda-gateway/src/test/createGenericProxyRouter.spec.ts
@@ -202,4 +202,232 @@ describe("createGenericProxyRouter", () => {
         res = await supertest(app).patch("/test-route").expect(200);
         expect(res.body.route).to.equal("default");
     });
+
+    it("should accept url string as target proxy definition item", async () => {
+        let isApplyToRouteCalled = false;
+
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        dummyAuthenticator.applyToRoute = () => {
+            isApplyToRouteCalled = true;
+        };
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route": "http://test-route.com"
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com").get("/").reply(200);
+
+        await supertest(app).get("/test-route").expect(200);
+        expect(scope.isDone()).to.be.true;
+
+        // by default no auth
+        expect(isApplyToRouteCalled).to.be.false;
+
+        // only `get` route is setup by default
+        scope.post("/", {}).reply(200);
+        await supertest(app).post("/test-route").expect(404);
+    });
+
+    it("should forward incoming request path incorrectly", async () => {
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route": {
+                    to: "http://test-route.com/routes",
+                    auth: true,
+                    methods: ["get", "post"]
+                }
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com");
+
+        let res;
+        // check GET routes
+        scope.get("/routes").reply(200, { route: "GET:root" });
+        res = await supertest(app).get("/test-route").expect(200);
+        expect(res.body.route).to.equal("GET:root");
+
+        scope
+            .get((uri) => {
+                // nock won't match request for tailing path with a query string somehow
+                // use function instead
+                return uri === "/routes/?sds=232";
+            })
+            .reply(200, { route: "GET:root", query: "?sds=232" });
+        res = await supertest(app).get("/test-route/?sds=232").expect(200);
+        expect(res.body.route).to.equal("GET:root");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route1").reply(200, { route: "GET:route1" });
+        res = await supertest(app).get("/test-route/route1").expect(200);
+        expect(res.body.route).to.equal("GET:route1");
+
+        scope
+            .get("/routes/route1?sds=232")
+            .reply(200, { route: "GET:route1", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/route1?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route1");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route2/").reply(200, { route: "GET:route2/" });
+        res = await supertest(app).get("/test-route/route2/").expect(200);
+        expect(res.body.route).to.equal("GET:route2/");
+
+        scope
+            .get((uri) => {
+                // nock won't match request for tailing path with a query string somehow
+                // use function instead
+                return uri === "/routes/route2/?sds=232";
+            })
+            .reply(200, { route: "GET:route2/", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/route2/?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route2/");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route3/12").reply(200, { route: "GET:route3/12" });
+        res = await supertest(app).get("/test-route/route3/12").expect(200);
+        expect(res.body.route).to.equal("GET:route3/12");
+
+        scope
+            .get("/routes/route3/12?sds=232")
+            .reply(200, { route: "GET:route3/12", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/route3/12?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route3/12");
+        expect(res.body.query).to.equal("?sds=232");
+
+        // check POST routes
+        scope.post("/routes/route1").reply(200, { route: "POST:route1" });
+        res = await supertest(app).post("/test-route/route1").expect(200);
+        expect(res.body.route).to.equal("POST:route1");
+
+        scope.post("/routes/route2/").reply(200, { route: "POST:route2/" });
+        res = await supertest(app).post("/test-route/route2/").expect(200);
+        expect(res.body.route).to.equal("POST:route2/");
+
+        scope.post("/routes/route3/12").reply(200, { route: "POST:route3/12" });
+        res = await supertest(app).post("/test-route/route3/12").expect(200);
+        expect(res.body.route).to.equal("POST:route3/12");
+    });
+
+    it("should forward incoming request path incorrectly when route key contains segment (e.g. test-route/abcd)", async () => {
+        const dummyAuthenticator = sinon.createStubInstance(Authenticator);
+
+        const router = createGenericProxyRouter({
+            authenticator: dummyAuthenticator,
+            jwtSecret: "xxx",
+            routes: {
+                "test-route/abcd": {
+                    to: "http://test-route.com/abcd/routes",
+                    auth: true,
+                    methods: ["get", "post"]
+                }
+            },
+            tenantMode: defaultTenantMode
+        });
+
+        const app = express();
+        app.use(router);
+
+        const scope = nock("http://test-route.com/abcd");
+
+        let res;
+        // check GET routes
+        scope.get("/routes").reply(200, { route: "GET:root" });
+        res = await supertest(app).get("/test-route/abcd").expect(200);
+        expect(res.body.route).to.equal("GET:root");
+
+        scope
+            .get((uri) => {
+                // nock won't match request for tailing path with a query string somehow
+                // use function instead
+                return uri === "/abcd/routes/?sds=232";
+            })
+            .reply(200, { route: "GET:root", query: "?sds=232" });
+        res = await supertest(app).get("/test-route/abcd/?sds=232").expect(200);
+        expect(res.body.route).to.equal("GET:root");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route1").reply(200, { route: "GET:route1" });
+        res = await supertest(app).get("/test-route/abcd/route1").expect(200);
+        expect(res.body.route).to.equal("GET:route1");
+
+        scope
+            .get("/routes/route1?sds=232")
+            .reply(200, { route: "GET:route1", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/abcd/route1?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route1");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route2/").reply(200, { route: "GET:route2/" });
+        res = await supertest(app).get("/test-route/abcd/route2/").expect(200);
+        expect(res.body.route).to.equal("GET:route2/");
+
+        scope
+            .get((uri) => {
+                // nock won't match request for tailing path with a query string somehow
+                // use function instead
+                return uri === "/abcd/routes/route2/?sds=232";
+            })
+            .reply(200, { route: "GET:route2/", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/abcd/route2/?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route2/");
+        expect(res.body.query).to.equal("?sds=232");
+
+        scope.get("/routes/route3/12").reply(200, { route: "GET:route3/12" });
+        res = await supertest(app)
+            .get("/test-route/abcd/route3/12")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route3/12");
+
+        scope
+            .get("/routes/route3/12?sds=232")
+            .reply(200, { route: "GET:route3/12", query: "?sds=232" });
+        res = await supertest(app)
+            .get("/test-route/abcd/route3/12?sds=232")
+            .expect(200);
+        expect(res.body.route).to.equal("GET:route3/12");
+        expect(res.body.query).to.equal("?sds=232");
+
+        // check POST routes
+        scope.post("/routes/route1").reply(200, { route: "POST:route1" });
+        res = await supertest(app).post("/test-route/abcd/route1").expect(200);
+        expect(res.body.route).to.equal("POST:route1");
+
+        scope.post("/routes/route2/").reply(200, { route: "POST:route2/" });
+        res = await supertest(app).post("/test-route/abcd/route2/").expect(200);
+        expect(res.body.route).to.equal("POST:route2/");
+
+        scope.post("/routes/route3/12").reply(200, { route: "POST:route3/12" });
+        res = await supertest(app)
+            .post("/test-route/abcd/route3/12")
+            .expect(200);
+        expect(res.body.route).to.equal("POST:route3/12");
+    });
 });

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -63,6 +63,7 @@ registry {
   webhookId = "indexer"
   webhookUrl = "http://localhost:6103/v0/registry-hook"
   baseUrl = "http://localhost:6101"
+  readOnlyBaseUrl = "http://localhost:6101"
 }
 
 regionLoading {

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -186,6 +186,7 @@ class RegistryExternalInterface(
   }
 
   def getWebhooks(): Future[List[WebHook]] = {
+    // cannot use readOnlyFetcher (even for read operation) as hook info can only be fetched from main registry node
     fetcher
       .get(path = s"$baseApiPath/hooks", headers = Seq(authHeader))
       .flatMap { response =>
@@ -198,6 +199,7 @@ class RegistryExternalInterface(
   }
 
   def getWebhook(id: String): Future[Option[WebHook]] = {
+    // cannot use readOnlyFetcher (even for read operation)  as hook info can only be fetched from main registry node
     fetcher
       .get(path = s"$baseApiPath/hooks/$id", headers = Seq(authHeader))
       .flatMap { response =>

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/RegistryExternalInterface.scala
@@ -92,7 +92,7 @@ class RegistryExternalInterface(
   implicit val defaultOffset =
     ZoneOffset.of(config.getString("time.defaultOffset"))
   implicit val fetcher = httpFetcher
-  implicit val readOnlyfetcher = readOnlyHttpFetcher
+  implicit val readOnlyFetcher = readOnlyHttpFetcher
   implicit val logger = Logging(system, getClass)
 
   val authJws = Authentication.signToken(
@@ -126,7 +126,7 @@ class RegistryExternalInterface(
       pageToken: String,
       number: Int
   ): scala.concurrent.Future[(Option[String], List[DataSet])] = {
-    readOnlyfetcher
+    readOnlyFetcher
       .get(
         path =
           s"$baseRecordsPath&dereference=true&pageToken=$pageToken&limit=$number",
@@ -158,7 +158,7 @@ class RegistryExternalInterface(
       start: Long,
       number: Int
   ): scala.concurrent.Future[(Option[String], List[DataSet])] = {
-    readOnlyfetcher
+    readOnlyFetcher
       .get(
         path = s"$baseRecordsPath&dereference=true&start=$start&limit=$number",
         headers = Seq(systemIdHeader, authHeader)
@@ -186,7 +186,7 @@ class RegistryExternalInterface(
   }
 
   def getWebhooks(): Future[List[WebHook]] = {
-    readOnlyfetcher
+    fetcher
       .get(path = s"$baseApiPath/hooks", headers = Seq(authHeader))
       .flatMap { response =>
         response.status match {
@@ -198,7 +198,7 @@ class RegistryExternalInterface(
   }
 
   def getWebhook(id: String): Future[Option[WebHook]] = {
-    readOnlyfetcher
+    fetcher
       .get(path = s"$baseApiPath/hooks/$id", headers = Seq(authHeader))
       .flatMap { response =>
         response.status match {


### PR DESCRIPTION
### What this PR does

Fixes #3024 

- Gateway should proxy all GET requests (at `/api/v0/registry`) to registry-read-only nodes
  - Registry Hooks APIs Still forward to main registry node as the hook info has to be retrieved from the main registry node
- handle proxy path handling manually so that trailing slash '/' won't be auto-added to target URL. 
  - (e.g. Before `/route` to `/target-route/` Now: `/route` to `/target-route`)
  - This for making proxying `registry/hooks` request possible (and not conflict with `registry/hooks/id` endpoint)
- Indexer will pull datasets from registry read-only nodes

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
