### PR TITLE
Disabled `faas-idler` by default as it's now only available via Openfaas Pro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 -   Release `acs-cmd` & `org-tree` as separate NPM packages
 -   Add set admin function to `acs-cmd` commandline utility package
 -   #3024 Gateway will automatically proxy all GET requests received at `/api/v0/registry` to registry read-only nodes (excepts Hooks APIs)
+-   #3053 Disabled `faas-idler` by default
 
 ## 0.0.58
 

--- a/deploy/helm/openfaas/values.yaml
+++ b/deploy/helm/openfaas/values.yaml
@@ -224,7 +224,7 @@ ingressOperator:
 faasIdler:
   image: openfaas/faas-idler:0.2.1
   replicas: 1
-  create: true
+  create: false
   inactivityDuration: 30m               # If a function is inactive for 15 minutes, it may be scaled to zero
   reconcileInterval: 2m                 # The interval between each attempt to scale functions to zero
   dryRun: true                          # Set to false to enable the idler to apply changes and scale to zero


### PR DESCRIPTION
### What this PR does

Fixes #3053

Disabled `faas-idler` by default as it's now only available via Openfaas Pro

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
