### PR TITLE
#3057 Fixed API `/auth/plugins` will skip the failed loading config item without throwing error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 -   Add set admin function to `acs-cmd` commandline utility package
 -   #3024 Gateway will automatically proxy all GET requests received at `/api/v0/registry` to registry read-only nodes (excepts Hooks APIs)
 -   Change openfaas docker image repository
+-   #3057 Fixed: API `/auth/plugins` will skip the failed loading config item and return other config items without breaking request processing
 
 ## 0.0.58
 

--- a/magda-gateway/src/createAuthRouter.ts
+++ b/magda-gateway/src/createAuthRouter.ts
@@ -132,18 +132,27 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
 
         const data = await Promise.all(
             options.plugins.map(async (plugin) => {
-                const res = await fetch(
-                    addTrailingSlash(plugin.baseUrl) + "config"
-                );
-                const data = (await res.json()) as AuthPluginConfig;
-                return {
-                    ...data,
-                    key: plugin.key
-                };
+                try {
+                    const res = await fetch(
+                        addTrailingSlash(plugin.baseUrl) + "config"
+                    );
+                    const data = (await res.json()) as AuthPluginConfig;
+                    return {
+                        ...data,
+                        key: plugin.key
+                    };
+                } catch (e) {
+                    // when failed to load, skip loading this config item by returning null
+                    console.error(
+                        `Failed to load authentication plugin config from ${plugin.baseUrl}: ` +
+                            e
+                    );
+                    return null;
+                }
             })
         );
 
-        res.json(data);
+        res.json(data.filter((item) => !!item));
     });
 
     // setup auth plugin routes


### PR DESCRIPTION
### What this PR does

Fixes #3057 

Fixed API `/auth/plugins` will skip the failed loading config item without throwing error

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
