### PR TITLE
Set `CRYPTOGRAPHY_DONT_BUILD_RUST` in CI to fix the docker-compose installation issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button`
   CACHE_VERSION: ts-12-scala-5
+  CRYPTOGRAPHY_DONT_BUILD_RUST: 1
 
 stages:
   - builders

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.0.60
 
+-   Set `CRYPTOGRAPHY_DONT_BUILD_RUST` in CI to fix the docker-compose installation issue
+
 ## 0.0.59
 
 -   Allow Magda API endpoints to be served at non-root path


### PR DESCRIPTION
### What this PR does

Fixes #3074

Set `CRYPTOGRAPHY_DONT_BUILD_RUST` in CI to fix the docker-compose installation issue
### Checklist

-   [x] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
