### PR TITLE
upgrade JDK to bring CI pipeline backonline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 -   Fixed #1774 #2736 use non-default service account for admin-api & allow admin-api to be deployed at different namespace rather than "default"
 -   Fixed #3073 Frontend can't handle invalid `dataset-publisher` aspect data and trigger a blank screen
 -   Fixed #3080 remove `--acl public-read` in CI as cloudfront has been setup for public read only access
+-   Upgraded JDK in base scala docker image
 
 ## 0.0.59
 

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -20,8 +20,7 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u212
-ENV JAVA_ALPINE_VERSION 8.222.10-r0
+ENV JAVA_ALPINE_VERSION 8.275.01-r0
 
 RUN set -x \
 	&& apk update \


### PR DESCRIPTION
### What this PR does

upgrade JDK to bring CI pipeline back online

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
