### PR TITLE
Removed exclamation from successHeader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 -   Fixed #3073 Frontend can't handle invalid `dataset-publisher` aspect data and trigger a blank screen
 -   Fixed #3080 remove `--acl public-read` in CI as cloudfront has been setup for public read only access
 -   Upgraded JDK in base scala docker image
+-   Removed exclamation point in successHeader message for Ask A Question
 
 ## 0.0.59
 

--- a/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
+++ b/magda-web-client/src/Components/Dataset/View/DatasetPageSuggestForm.js
@@ -103,7 +103,7 @@ export default class DatasetPageSuggestForm extends React.Component {
             textAreaLabel: "What would you like to ask about this dataset?",
             successHeader:
                 "Your request has been sent" +
-                (contactPointMatch ? " to " + contactPointMatch + "!" : ".")
+                (contactPointMatch ? " to " + contactPointMatch : ".")
         };
 
         return (


### PR DESCRIPTION
Exclamation could be confused as part of the email address.