### PR TITLE
remove --wait from helm command

### DIFF
--- a/docs/docs/building-and-running-on-k3d.md
+++ b/docs/docs/building-and-running-on-k3d.md
@@ -31,6 +31,6 @@ into your hosts file, so that both your local docker and k3d will be able to res
 -   Don't install the docker registry or docker registry proxy (skip "Install a local kube registry")
 -   Don't ever run `eval $(minikube docker-env)`
 -   Instead of `docker-build-local`, run `export MAGDA_DOCKER_REPOSITORY=registry.local:5000 && export MAGDA_DOCKER_VERSION=latest && yarn lerna run docker-build-prod -- --concurrency=1 --stream`
--   Instead of `helm install <etc>`, run `helm upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/magda --set global.image.repository=registry.local:5000/data61`
+-   Instead of `helm install <etc>`, run `helm upgrade --install --timeout 9999s -f deploy/helm/minikube-dev.yml magda deploy/helm/magda --set global.image.repository=registry.local:5000/data61`
 
 This will start an instance of Magda in the default namespace that uses K3D's built-in docker registry instead of the Helm-based one that a minikube install would use.

--- a/docs/docs/building-and-running-on-microk8s.md
+++ b/docs/docs/building-and-running-on-microk8s.md
@@ -20,6 +20,6 @@ To build and run with MicroK8S, Follow the instructions in [building-and-running
 -   When running the create secrets script, select "microk8s"
 -   Don't ever run `eval $(minikube docker-env)`
 -   Instead of `docker-build-local`, run `export MAGDA_DOCKER_REPOSITORY=localhost:32000 && export MAGDA_DOCKER_VERSION=latest && yarn lerna run docker-build-prod -- --concurrency=1 --stream`
--   Instead of `helm install <etc>`, run `microk8s helm3 upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/magda --set global.image.repository=localhost:32000/data61`
+-   Instead of `helm install <etc>`, run `microk8s helm3 upgrade --install --timeout 9999s -f deploy/helm/minikube-dev.yml magda deploy/helm/magda --set global.image.repository=localhost:32000/data61`
 
 This will start an instance of Magda in the default namespace that uses MicroK8S' built-in docker registry instead of the Helm-based one that a minikube install would use.

--- a/docs/docs/building-and-running.md
+++ b/docs/docs/building-and-running.md
@@ -165,7 +165,7 @@ helm repo update
 # update magda chart dependencies
 yarn update-all-charts
 # deploy the magda chart from magda helm repo
-helm upgrade --install --timeout 9999s --wait -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
+helm upgrade --install --timeout 9999s -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
 ```
 
 > If you need HTTPS access to your local dev cluster, please check [this doc](./how-to-setup-https-to-local-cluster.md) for extra setup steps.
@@ -182,7 +182,7 @@ helm repo update
 # update magda chart dependencies
 yarn update-all-charts
 # deploy the magda chart from magda helm repo
-helm upgrade --install --timeout 9999s --wait -f deploy/helm/docker-desktop-windows.yml -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
+helm upgrade --install --timeout 9999s -f deploy/helm/docker-desktop-windows.yml -f deploy/helm/minikube-dev.yml magda deploy/helm/local-deployment
 ```
 
 If you want to deploy the packed & production ready helm chart in our helm repo, please check out this sample [config repo](https://github.com/magda-io/magda-config).

--- a/docs/docs/deploy-to-search-data-gov-au.md
+++ b/docs/docs/deploy-to-search-data-gov-au.md
@@ -72,13 +72,13 @@ kubectl config use-context <prod-cluster-name>
 If there were changes to the index versions, you'll need to set the search api to still point at the previous version of the index while the indexer builds the new one:
 
 ```bash
-helm upgrade magda --timeout 999999999 --wait -f deploy/helm/search-data-gov-au.yml deploy/helm/magda --set search-api.datasetsIndexVersion=<version>,search-api.regionsIndexVersion=<version>
+helm upgrade magda --timeout 9999s -f deploy/helm/search-data-gov-au.yml deploy/helm/magda --set search-api.datasetsIndexVersion=<version>,search-api.regionsIndexVersion=<version>
 ```
 
 Once the indexer has finished (watch `kubectl logs -f <indexer pod name>`) or if there's no changes to the indices:
 
 ```bash
-helm upgrade magda --timeout 999999999 --wait -f deploy/helm/search-data-gov-au.yml deploy/helm/magda
+helm upgrade magda --timeout 9999s -f deploy/helm/search-data-gov-au.yml deploy/helm/magda
 ```
 
 -   [ ] Look at the logs on magda-registry and the webhooks table of the database to make sure it's processing webhooks again

--- a/docs/docs/migration/0.0.56-to-0.0.57.md
+++ b/docs/docs/migration/0.0.56-to-0.0.57.md
@@ -134,7 +134,7 @@ to add the Magda helm chart repo.
 Run `helm upgrade` to upgrade your release. Here is the sample command to upgrade your release to `0.0.57-0`:
 
 ```bash
-helm --namespace [your magda deploy namespace] upgrade --install --timeout 9999s --wait -f [path to your config value file] magda magda --repo https://charts.magda.io --version 0.0.57-0
+helm --namespace [your magda deploy namespace] upgrade --install --timeout 9999s -f [path to your config value file] magda magda --repo https://charts.magda.io --version 0.0.57-0
 ```
 
 #### Step 8: Clean up Helm v2 data & Tiller


### PR DESCRIPTION
### What this PR does

- Remove `--wait` switch from helm command in all our docs.
- `--wait` seems work differently in helm3 which will wait till all deployment is ready (if you turned on the liveness probe) before start to run any hooks (see [here](https://helm.sh/docs/topics/charts_hooks/))
  - We actually need a behaviour that run migrator before all pods are ready.  

### Checklist

-   [x] unit tests aren't applicable
