### PR TITLE
#3094 Make openfaas a dependecy of magda chart instead of magda-core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 -   Make `scssVars` option for content-api helm chart accept dictionary rather than JSON string
 -   Set default value of `enableMultiTenants` to `false` for `magda-core` chart
 -   Set gateway chart `enableAuthEndpoint` option default value to `true`
+-   #3094 Make openfaas a dependecy of magda chart instead of magda-core
 
 ## 0.0.59
 

--- a/deploy/helm/internal-charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/gateway/templates/deployment.yaml
@@ -81,9 +81,11 @@ spec:
             "--defaultWebRouteConfig", "/etc/config/defaultWebRouteConfig.json",
             "--authorizationApi", "http://authorization-api/v0",
             "--tenantUrl", "http://tenant-api/v0",
+{{- if .Values.global.openfaas }}
 {{- if .Values.global.openfaas.mainNamespace }}
             "--openfaasGatewayUrl", {{ include "magda.openfaasGatewayUrl" . | quote }},
             "--openfaasAllowAdminOnly", {{ .Values.global.openfaas.allowAdminOnly | quote }},
+{{- end }}
 {{- end }}
 {{- if .Values.global.enableMultiTenants }}
             "--enableMultiTenants", "true",

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -68,14 +68,11 @@ dependencies:
 - name: tenant-db
   repository: file://../internal-charts/tenant-db
   version: 0.0.60-alpha.0
-- name: openfaas
-  repository: file://../openfaas
-  version: 5.5.5-magda
 - name: priorities
   repository: file://../internal-charts/priorities
   version: 0.0.60-alpha.0
 - name: ingress
   repository: file://../internal-charts/ingress
   version: 0.0.60-alpha.0
-digest: sha256:207fc0d55ca01716b16fab485448bbaf6eea326970080ff1cfbb8fd02a121182
-generated: "2021-01-21T22:35:58.200793+11:00"
+digest: sha256:d418bd96f5c6c234e646ed69a2900e247a2de061134753bf2b21fe638918111f
+generated: "2021-04-08T12:57:35.123774+10:00"

--- a/deploy/helm/magda-core/Chart.yaml
+++ b/deploy/helm/magda-core/Chart.yaml
@@ -148,15 +148,6 @@ dependencies:
     tags:
       - all
       - tenant-db
-  - name: openfaas
-    version: 5.5.5-magda
-    repository: file://../openfaas
-    # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
-    # Due to a limitation of helm, the value of tags is not available in chart template.
-    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
-    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
-    condition: global.openfaas.enabled
-
   # K8s misc
   - name: priorities
     version: 0.0.60-alpha.0

--- a/deploy/helm/magda-core/README.md
+++ b/deploy/helm/magda-core/README.md
@@ -40,7 +40,6 @@ Kubernetes: `>= 1.14.0-0`
 | file://../internal-charts/tenant-api | tenant-api | 0.0.60-alpha.0 |
 | file://../internal-charts/tenant-db | tenant-db | 0.0.60-alpha.0 |
 | file://../internal-charts/web-server | web-server | 0.0.60-alpha.0 |
-| file://../openfaas | openfaas | 5.5.5-magda |
 | https://charts.magda.io | magda-preview-map | 0.0.58 |
 
 ## Values
@@ -59,26 +58,9 @@ Kubernetes: `>= 1.14.0-0`
 | global.logLevel | string | `"INFO"` |  |
 | global.namespace | string | `"default"` |  |
 | global.noDbAuth | bool | `false` |  |
-| global.openfaas.allowAdminOnly | bool | `true` |  |
-| global.openfaas.enabled | bool | `true` |  |
-| global.openfaas.functionNamespace | string | `"openfaas-fn"` |  |
-| global.openfaas.mainNamespace | string | `"openfaas"` |  |
-| global.openfaas.namespacePrefix | string | `""` |  |
 | global.rollingUpdate.maxUnavailable | int | `0` |  |
 | global.useCloudSql | bool | `false` |  |
 | global.useCombinedDb | bool | `true` |  |
-| openfaas.basic_auth | bool | `false` |  |
-| openfaas.faasIdler.dryRun | bool | `false` |  |
-| openfaas.faasnetes.imagePullPolicy | string | `"IfNotPresent"` |  |
-| openfaas.faasnetes.readTimeout | string | `"120s"` |  |
-| openfaas.faasnetes.writeTimeout | string | `"120s"` |  |
-| openfaas.gateway.readTimeout | string | `"125s"` |  |
-| openfaas.gateway.scaleFromZero | bool | `true` |  |
-| openfaas.gateway.upstreamTimeout | string | `"120s"` |  |
-| openfaas.gateway.writeTimeout | string | `"125s"` |  |
-| openfaas.ingress.enabled | bool | `false` |  |
-| openfaas.operator.create | bool | `true` |  |
-| openfaas.serviceType | string | `"ClusterIP"` |  |
 | tags | object | see default value of each individual tag below. | (object) Control on/ off of each modules.  To turn on/off openfaas, please set value to `global.openfaas.enabled` |
 | tags.admin-api | bool | `false` | turn on / off [admin-api](../internal-charts/admin-api/README.md) |
 | tags.all | bool | `true` | turn on / off all modules |

--- a/deploy/helm/magda-core/values.yaml
+++ b/deploy/helm/magda-core/values.yaml
@@ -29,34 +29,7 @@ global:
   # If this parameter not presents, user will be redirected further (at frontend) to account page /account.
   # Otherwise, user will redirected to the url sepcified by `redirectTo` query parameter.
   authPluginRedirectUrl: "/sign-in-redirect"
-  openfaas:
-    # turn on / off openfaas
-    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
-    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
-    enabled: true 
-    namespacePrefix: ""
-    functionNamespace: openfaas-fn  # Default namespace for functions
-    mainNamespace: openfaas # Default namespace for gateway and other core modules
-    allowAdminOnly: true # Only allow logged-in Admin to access openfaas gateway
-
-openfaas:
-  operator: 
-    create: true
-  serviceType: ClusterIP
-  basic_auth: false
-  ingress:
-    enabled: false
-  faasnetes:
-    readTimeout: 120s
-    writeTimeout: 120s
-    imagePullPolicy: IfNotPresent
-  gateway:
-    scaleFromZero: true
-    readTimeout: 125s
-    writeTimeout: 125s
-    upstreamTimeout: 120s
-  faasIdler:
-    dryRun: false
+  
 
 # -- (object) Control on/ off of each modules. 
 # To turn on/off openfaas, please set value to `global.openfaas.enabled`

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -40,6 +40,9 @@ tags:
   minion-format: true
 
 magda:
+  openfaas:
+    operator: 
+      createCRD: false
   magda-function-history-report:
     image:
       repository: docker.io/data61
@@ -168,10 +171,6 @@ magda:
         tag: 0.0.57-0
         pullPolicy: IfNotPresent
         imagePullSecret: false
-
-    openfaas:
-      operator: 
-        createCRD: false
 
 # auth plugin for google
 magda-auth-google:

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: magda-core
   repository: file://../magda-core
   version: 0.0.60-alpha.0
+- name: openfaas
+  repository: file://../openfaas
+  version: 5.5.5-magda
 - name: magda-function-history-report
   repository: https://charts.magda.io
   version: 0.0.57-0
@@ -26,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 0.0.57-0
-digest: sha256:02a2ddbcd162809572e96c18e698f896f6a5744d8dd8ce4b2d4acc0150a2c076
-generated: "2021-01-21T22:36:00.238924+11:00"
+digest: sha256:bd3e970c80869bc52f2ca00cf351db95c61b3fa678b2eff1c9e9b9855ce9d44f
+generated: "2021-04-08T12:57:40.200017+10:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -11,6 +11,16 @@ dependencies:
   - name: magda-core
     version: 0.0.60-alpha.0
     repository: file://../magda-core
+
+  - name: openfaas
+    version: 5.5.5-magda
+    repository: file://../openfaas
+    # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
+    # Due to a limitation of helm, the value of tags is not available in chart template.
+    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
+    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
+    condition: global.openfaas.enabled
+
   # magda-core chart is always enabled.
   # Thus, no tags or condition are required.
   # You should set its sub-chart to enabled or not.

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -17,6 +17,7 @@ Kubernetes: `>= 1.14.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../magda-core | magda-core | 0.0.60-alpha.0 |
+| file://../openfaas | openfaas | 5.5.5-magda |
 | https://charts.magda.io | magda-ckan-connector | 0.0.57-0 |
 | https://charts.magda.io | magda-function-esri-url-processor | 0.0.57-0 |
 | https://charts.magda.io | magda-function-history-report | 0.0.57-0 |
@@ -42,6 +43,18 @@ Kubernetes: `>= 1.14.0-0`
 | global.openfaas.mainNamespace | string | `"openfaas"` |  |
 | global.openfaas.namespacePrefix | string | `""` |  |
 | global.openfaas.secrets.authSecrets | bool | `true` |  |
+| openfaas.basic_auth | bool | `false` |  |
+| openfaas.faasIdler.dryRun | bool | `false` |  |
+| openfaas.faasnetes.imagePullPolicy | string | `"IfNotPresent"` |  |
+| openfaas.faasnetes.readTimeout | string | `"120s"` |  |
+| openfaas.faasnetes.writeTimeout | string | `"120s"` |  |
+| openfaas.gateway.readTimeout | string | `"125s"` |  |
+| openfaas.gateway.scaleFromZero | bool | `true` |  |
+| openfaas.gateway.upstreamTimeout | string | `"120s"` |  |
+| openfaas.gateway.writeTimeout | string | `"125s"` |  |
+| openfaas.ingress.enabled | bool | `false` |  |
+| openfaas.operator.create | bool | `true` |  |
+| openfaas.serviceType | string | `"ClusterIP"` |  |
 | tags.all | bool | `true` |  |
 | tags.connectors | bool | `false` |  |
 | tags.minion-broken-link | bool | `false` |  |

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -12,13 +12,35 @@ global:
     includeInitialJobs: false
     includeCronJobs: true
   openfaas:
-    enabled: true
+    # turn on / off openfaas
+    # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
+    # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
+    enabled: true 
     namespacePrefix: ""
     functionNamespace: openfaas-fn  # Default namespace for functions
     mainNamespace: openfaas # Default namespace for gateway and other core modules
     allowAdminOnly: true # Only allow logged-in Admin to access openfaas gateway
     secrets:
       authSecrets: true
+
+openfaas:
+  operator: 
+    create: true
+  serviceType: ClusterIP
+  basic_auth: false
+  ingress:
+    enabled: false
+  faasnetes:
+    readTimeout: 120s
+    writeTimeout: 120s
+    imagePullPolicy: IfNotPresent
+  gateway:
+    scaleFromZero: true
+    readTimeout: 125s
+    writeTimeout: 125s
+    upstreamTimeout: 120s
+  faasIdler:
+    dryRun: false
 
 ckan-connector-functions:
   includeInitialJobs: false

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -51,6 +51,9 @@ global:
       imagePullSecret: false
 
 magda:
+  openfaas:
+    faasnetes:
+      imagePullPolicy: Always
   magda-function-history-report:
     image:
       repository: docker.io/data61
@@ -117,10 +120,6 @@ magda:
         tag: 0.0.57-0
         pullPolicy: IfNotPresent
         imagePullSecret: false
-
-    openfaas:
-      faasnetes:
-        imagePullPolicy: Always
 
     elasticsearch:
       data:

--- a/deploy/helm/preview-multi-tenant.yml
+++ b/deploy/helm/preview-multi-tenant.yml
@@ -34,6 +34,9 @@ tags:
   connectors: false
 
 magda:
+  openfaas:
+    operator: 
+      createCRD: false
   magda-function-history-report:
     image:
       repository: docker.io/data61
@@ -141,10 +144,6 @@ magda:
         tag: 0.0.57-0
         pullPolicy: IfNotPresent
         imagePullSecret: false
-
-    openfaas:
-      operator: 
-        createCRD: false
 
 # auth plugin for google
 magda-auth-google:

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -34,6 +34,9 @@ tags:
   connectors: false
 
 magda:
+  openfaas:
+    operator: 
+      createCRD: false
   magda-function-history-report:
     image:
       repository: docker.io/data61
@@ -142,10 +145,6 @@ magda:
         tag: 0.0.57-0
         pullPolicy: IfNotPresent
         imagePullSecret: false
-
-    openfaas:
-      operator: 
-        createCRD: false
 
 # auth plugin for google
 magda-auth-google:


### PR DESCRIPTION
### What this PR does

Fixes #3094

Make openfaas a dependecy of magda chart instead of magda-core

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
