### PR TITLE
#3115 Hide Home Page "My Datasets" Section when `cataloguing` = `false`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 -   #3094 Make openfaas a dependecy of magda chart instead of magda-core
 -   #3111 Make SVG icons load via inline React Components rather than `<img/>`
 -   #3113 Fixed "Suggest a Dataset Form" Styling Issue
+-   #3115 Hide Home Page "My Datasets" Section when `cataloguing` = `false`
 
 ## 0.0.59
 

--- a/magda-web-client/src/Components/Home/HomePage.tsx
+++ b/magda-web-client/src/Components/Home/HomePage.tsx
@@ -17,6 +17,7 @@ import MediaQuery from "react-responsive";
 import { User } from "reducers/userManagementReducer";
 import MyDatasetSection from "./MyDatasetSection";
 import { getPluginHeader, HeaderNavItem } from "externalPluginComponents";
+import { config } from "../../config";
 
 const HeaderPlugin = getPluginHeader();
 
@@ -113,20 +114,28 @@ class HomePage extends React.Component<PropsType> {
             return null;
         }
         if (this?.props?.user?.id) {
-            // --- my dataset section should only show for desktop due to the size of the design
-            // --- on mobile should still stories as before
-            return (
-                <Small>
-                    <Stories stories={this.props.stories} />
-                </Small>
-            );
+            if (config?.featureFlags?.cataloguing) {
+                // --- my dataset section should only show for desktop due to the size of the design
+                // --- on mobile should still stories as before
+                return (
+                    <Small>
+                        <Stories stories={this.props.stories} />
+                    </Small>
+                );
+            } else {
+                return <Stories stories={this.props.stories} />;
+            }
         } else {
             return <Stories stories={this.props.stories} />;
         }
     }
 
     getMyDatasetSection() {
-        if (this?.props?.isFetchingWhoAmI === true || !this?.props?.user?.id) {
+        if (
+            this?.props?.isFetchingWhoAmI === true ||
+            !this?.props?.user?.id ||
+            !config?.featureFlags?.cataloguing
+        ) {
             return null;
         } else {
             // --- my dataset section should only show for desktop due to the size of the design

--- a/magda-web-client/src/Components/Home/Stories.tsx
+++ b/magda-web-client/src/Components/Home/Stories.tsx
@@ -63,7 +63,7 @@ class Stories extends Component<PropsType, StateType> {
                                             <StoryBox
                                                 idx={index}
                                                 story={story}
-                                                className="story-box-{index}"
+                                                className={`story-box-${index} small-screen-layout`}
                                                 key={index}
                                             />
                                         ))}
@@ -109,7 +109,9 @@ class Stories extends Component<PropsType, StateType> {
                                                         <StoryBox
                                                             idx={r * 4}
                                                             story={row[0]}
-                                                            className="stories"
+                                                            className={`stories medium-screen-layout story-box-${
+                                                                r * 4
+                                                            }`}
                                                         />
                                                     </div>
                                                 </div>
@@ -129,7 +131,9 @@ class Stories extends Component<PropsType, StateType> {
                                                             <StoryBox
                                                                 idx={r * 4 + i}
                                                                 story={story}
-                                                                className="stories"
+                                                                className={`stories medium-screen-layout story-box-${
+                                                                    r * 4 + i
+                                                                }`}
                                                             />
                                                         </div>
                                                     ))}
@@ -145,7 +149,9 @@ class Stories extends Component<PropsType, StateType> {
                                                         <StoryBox
                                                             idx={r * 4 + 0}
                                                             story={row[0]}
-                                                            className="stories"
+                                                            className={`stories medium-screen-layout story-box-${
+                                                                r * 4 + 0
+                                                            }`}
                                                         />
                                                     </div>
                                                     <div className="col-3">
@@ -153,12 +159,16 @@ class Stories extends Component<PropsType, StateType> {
                                                             <StoryBox
                                                                 idx={r * 4 + 1}
                                                                 story={row[1]}
-                                                                className="row stories"
+                                                                className={`stories medium-screen-layout story-box-${
+                                                                    r * 4 + 1
+                                                                }`}
                                                             />
                                                             <StoryBox
                                                                 idx={r * 4 + 2}
                                                                 story={row[2]}
-                                                                className="row stories"
+                                                                className={`stories medium-screen-layout story-box-${
+                                                                    r * 4 + 2
+                                                                }`}
                                                             />
                                                         </div>
                                                     </div>
@@ -166,7 +176,9 @@ class Stories extends Component<PropsType, StateType> {
                                                         <StoryBox
                                                             idx={r * 4 + 3}
                                                             story={row[3]}
-                                                            className="stories"
+                                                            className={`stories medium-screen-layout story-box-${
+                                                                r * 4 + 3
+                                                            }`}
                                                         />
                                                     </div>
                                                 </div>

--- a/magda-web-client/src/Components/Home/StoryBox.scss
+++ b/magda-web-client/src/Components/Home/StoryBox.scss
@@ -40,6 +40,13 @@
         }
     }
 
+    .small-screen-layout {
+        .story-title {
+            padding-top: 15px;
+            padding-left: 15px;
+        }
+    }
+
     @media (max-width: $medium) {
         .story-box-text {
             padding: 16px;


### PR DESCRIPTION
### What this PR does

Fixes #3115 
- Hide Home Page "My Datasets" Section when `cataloguing` = `false`
- Also fixed some minor layout issue for home page stories on mobile screen

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
