### PR TITLE
#3129 Auth plugin SDK getAbsoluteUrl function should check the type of the baseUrl parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 -   #3117 Auto passing web-client config obj to external plugin components
 -   #3119 Make key redux actions & react-router available to external plugin components
 -   #3128 Create API key utils should report an error when no switch is provided rather then assumes `-c` switch
+-   #3129 Auth plugin SDK getAbsoluteUrl function should check the type of the baseUrl parameter
 
 ## 0.0.59
 

--- a/packages/authentication-plugin-sdk/src/index.ts
+++ b/packages/authentication-plugin-sdk/src/index.ts
@@ -178,6 +178,9 @@ export function getAbsoluteUrl(
         // --- absolute url, return directly
         return url;
     } else {
+        if (typeof baseUrl !== "string") {
+            baseUrl = "";
+        }
         const baseUri = urijs(baseUrl);
         const query = uri.search(true);
         const mergedUri = baseUri.segmentCoded(


### PR DESCRIPTION
### What this PR does

Fixes #3129 
- Auth plugin SDK getAbsoluteUrl function should check the type of the baseUrl parameter

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
