### PR TITLE
Fix broken jars dependencies (mwundo) due to Bintray repo stop service (part 2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,12 @@ registry-typescript-api:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
     paths:
-      - "sbt-cache"
+      - "target"
+      - "project/target"
+      - "project/project/target"
+      - "*/target"
+      - "*/project/target"
+      - "*/project/project/target"
       - "magda-typescript-common/src/generated"
     expire_in: 7 days
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
     -Dsbt.ivy.home=$CI_PROJECT_DIR/sbt-cache/ivy
   # If you changed dependencies (especially for scala), you might want to prevent your branch from using old cache by increase the version blew
   # gitlab actually use the same technique when you click the `Clear Cache Button`
-  CACHE_VERSION: ts-12-scala-6
+  CACHE_VERSION: ts-12-scala-7
   CRYPTOGRAPHY_DONT_BUILD_RUST: 1
 
 stages:
@@ -92,6 +92,7 @@ registry-typescript-api:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
     paths:
+      - "sbt-cache"
       - "target"
       - "project/target"
       - "project/project/target"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,7 @@ registry-typescript-api:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
     paths:
+      - "sbt-cache"
       - "magda-typescript-common/src/generated"
     expire_in: 7 days
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,12 +91,12 @@ registry-typescript-api:
     - builders-and-yarn
     - sbt-prebuild
   dependencies:
+    - builders-and-yarn
     - sbt-prebuild
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
     paths:
-      - "sbt-cache"
       - "magda-typescript-common/src/generated"
     expire_in: 7 days
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,18 +87,16 @@ check-scala-formatting:
 registry-typescript-api:
   stage: prebuild
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
-  needs: ["builders-and-yarn"]
+  needs: 
+    - builders-and-yarn
+    - sbt-prebuild
+  dependencies:
+    - sbt-prebuild
   script:
     - lerna run generate --scope=@magda/typescript-common --stream
   artifacts:
     paths:
       - "sbt-cache"
-      - "target"
-      - "project/target"
-      - "project/project/target"
-      - "*/target"
-      - "*/project/target"
-      - "*/project/project/target"
       - "magda-typescript-common/src/generated"
     expire_in: 7 days
 


### PR DESCRIPTION
### What this PR does

See PR https://github.com/magda-io/magda/pull/3131

The previous PR didn't fix generate registry api step.
