### PR TITLE
destroyMagdaSession: will check session cookie before attempt deleting it

### DIFF
--- a/packages/authentication-plugin-sdk/src/index.ts
+++ b/packages/authentication-plugin-sdk/src/index.ts
@@ -116,7 +116,9 @@ export async function destroyMagdaSession(
     cookieOptions: SessionCookieOptions
 ): Promise<void> {
     await destroySession(req);
-    deleteCookie(DEFAULT_SESSION_COOKIE_NAME, cookieOptions, res);
+    if (req?.cookies?.[DEFAULT_SESSION_COOKIE_NAME]) {
+        deleteCookie(DEFAULT_SESSION_COOKIE_NAME, cookieOptions, res);
+    }
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Improvement on authentication Plugin SDK:

destroyMagdaSession: will check session cookie before attempt deleting it.

This is the missing bit for [the previous PR](https://github.com/magda-io/magda/pull/3143) for #3136

### Checklist

-   [x] unit tests aren't applicable
