### PR TITLE
#3145 Upgrade `magda-preview-map` to v1.0.0 for proxy host list helm chart configuration support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 - #3140 Ability to supply external CSS files to magda-web-client via Config
 - #3138 Allow Edit Dataset Button to be replaced by External UI Plugins
 - #3136 Added auth plugin customised logout process support to Gateway
+- #3145 Upgrade `magda-preview-map` to v1.0.0 for proxy host list helm chart configuration support
 
 ## 0.0.59
 

--- a/deploy/helm/magda-core/Chart.lock
+++ b/deploy/helm/magda-core/Chart.lock
@@ -34,7 +34,7 @@ dependencies:
   version: 0.0.60-alpha.0
 - name: magda-preview-map
   repository: https://charts.magda.io
-  version: 0.0.58
+  version: 1.0.0
 - name: registry-api
   repository: file://../internal-charts/registry-api
   version: 0.0.60-alpha.0
@@ -77,5 +77,5 @@ dependencies:
 - name: rds-dev-proxy
   repository: file://../internal-charts/rds-dev-proxy
   version: 0.0.60-alpha.0
-digest: sha256:b226de678445b95c8a7f9fb81f128a441996e53fa016d646ff63b2719fe5d08b
-generated: "2021-04-26T17:48:41.351477+10:00"
+digest: sha256:470b2316ee103dca4940a168b6d2d76f35ba45b96b3eca8530ad2a4ed2ae332a
+generated: "2021-06-01T18:07:12.897682+10:00"

--- a/deploy/helm/magda-core/Chart.yaml
+++ b/deploy/helm/magda-core/Chart.yaml
@@ -75,7 +75,7 @@ dependencies:
       - all
       - indexer
   - name: magda-preview-map
-    version: 0.0.58
+    version: 1.0.0
     alias: preview-map
     repository: https://charts.magda.io
     tags:

--- a/deploy/helm/magda-core/README.md
+++ b/deploy/helm/magda-core/README.md
@@ -41,7 +41,7 @@ Kubernetes: `>= 1.14.0-0`
 | file://../internal-charts/tenant-api | tenant-api | 0.0.60-alpha.0 |
 | file://../internal-charts/tenant-db | tenant-db | 0.0.60-alpha.0 |
 | file://../internal-charts/web-server | web-server | 0.0.60-alpha.0 |
-| https://charts.magda.io | preview-map(magda-preview-map) | 0.0.58 |
+| https://charts.magda.io | preview-map(magda-preview-map) | 1.0.0 |
 
 ## Values
 


### PR DESCRIPTION
### What this PR does

Fixes #3145 

Upgrade `magda-preview-map` to v1.0.0 for proxy host list helm chart configuration support

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
