### PR TITLE
#3168 Fixed: double clicking the search icon button will clear search text input incorrectly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@
 - #3160 Add strip_html filter to "description" fields for elasticsearch indexing analyzer
 - Remove "data.gov.au" keyword from "correspondence-api" email "from" field
 - #3166 Update text description under the data source section on data detail page
+- #3168 Fixed: double clicking the search icon button will clear search text input incorrectly
 
 ## 0.0.59
 

--- a/magda-web-client/src/Components/Dataset/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Dataset/Search/SearchBox.js
@@ -102,9 +102,8 @@ class SearchBox extends Component {
     /**
      * If the search button is clicked, we do the search immediately
      */
-    doSearchNow(keepFilters) {
-        this.debounceUpdateSearchQuery.cancel();
-        this.updateSearchText(this.state.searchText, true);
+    doSearchNow() {
+        this.debounceUpdateSearchQuery.flush();
     }
 
     /**
@@ -210,9 +209,7 @@ class SearchBox extends Component {
                                         {this.getSearchBoxValue()}
                                     </span>
                                     <button
-                                        onClick={() =>
-                                            this.doSearchNow(!isSmall)
-                                        }
+                                        onClick={this.doSearchNow.bind(this)}
                                         className={`search-btn ${
                                             this.getSearchBoxValue().length > 0
                                                 ? "not-empty"


### PR DESCRIPTION
### What this PR does

Fixes #3168 Fixed: double clicking the search icon button will clear search text input incorrectly


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
