### PR TITLE
Simpler preview map message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 - #3178 Better Error Handling for Preview Map via postMessage
 - Upgrade format & rating minion to 1.0.0, Preview Map to 1.0.1
 - #3179 Fixed Invalid HTML in description make Google Chrome Unresponsive
+- Further simplify the error message from map preview module
 
 ## 0.0.59
 

--- a/magda-web-client/src/Components/Common/DataPreviewMap.tsx
+++ b/magda-web-client/src/Components/Common/DataPreviewMap.tsx
@@ -25,8 +25,6 @@ import xml2json from "../../helpers/xml2json";
 import ReactSelect from "react-select";
 import CustomStyles from "../Common/react-select/ReactSelectStyles";
 
-console.log(xml2json("<a><b>2332</b></a>"));
-
 const DEFAULT_DATA_SOURCE_PREFERENCE: RawPreviewMapFormatPerferenceItem[] = [
     {
         format: "WMS",
@@ -515,7 +513,6 @@ class DataPreviewMapTerria extends Component<
             return (
                 <div className="error-message-box au-body au-page-alerts au-page-alerts--warning">
                     <h3>Map Preview Experienced an Error:</h3>
-                    <p>{this.state.errorMessage}</p>
                     {this.state.errorMessage
                         .toLowerCase()
                         .indexOf("status code") !== -1 ? (
@@ -523,7 +520,12 @@ class DataPreviewMapTerria extends Component<
                             The requested data source might not be available at
                             this moment.
                         </p>
-                    ) : null}
+                    ) : (
+                        <p>
+                            The requested data source is not in the valid format
+                            or might not be available at this moment.
+                        </p>
+                    )}
                 </div>
             );
         }


### PR DESCRIPTION
### What this PR does

For some cases, the error message from Magda Preview Module is still over complicated for user:

![image](https://user-images.githubusercontent.com/674387/124887208-4e27cc00-e018-11eb-8e47-2a3270976911.png)

This PR will simplify it to:

![image](https://user-images.githubusercontent.com/674387/124887351-6f88b800-e018-11eb-8049-98eae3c37f31.png)


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
