### PR TITLE
#3170 Remove unused old admin UI endpoint from Gateway

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@
 - Upgrade format & rating minion to 1.0.0, Preview Map to 1.0.1
 - #3179 Fixed Invalid HTML in description make Google Chrome Unresponsive
 - Further simplify the error message from map preview module
+- #3170 Remove unused old admin UI endpoint from Gateway
 
 ## 0.0.59
 

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -20,7 +20,6 @@
     "@magda/typescript-common": "^0.0.60-rc.4",
     "body-parser": "^1.13.2",
     "compression": "^1.7.2",
-    "connect-ensure-login": "^0.1.1",
     "connect-pg-simple": "^6.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.3",

--- a/magda-gateway/src/createAuthRouter.ts
+++ b/magda-gateway/src/createAuthRouter.ts
@@ -97,19 +97,6 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
         }
     ];
 
-    // Define routes.
-    authRouter.get("/", authenticatorMiddleware, function (req, res) {
-        res.render("home", { user: req.user });
-    });
-
-    authRouter.get("/login", authenticatorMiddleware, function (req, res) {
-        res.render("login");
-    });
-
-    authRouter.get("/admin", authenticatorMiddleware, function (req, res) {
-        res.render("admin");
-    });
-
     /**
      * @apiGroup Authentication API
      * @api {get} https://<host>/auth/plugins Get the list of available authentication plugins
@@ -195,23 +182,6 @@ export default function createAuthRouter(options: AuthRouterOptions): Router {
                 .map((provider) => provider.id)
         );
     });
-
-    authRouter.get(
-        "/profile",
-        authenticatorMiddleware,
-        require("connect-ensure-login").ensureLoggedIn(),
-        function (req, res) {
-            authApi
-                .getUser(req.user.id)
-                .then((user) =>
-                    res.render("profile", { user: user.valueOrThrow() })
-                )
-                .catch((error: Error) => {
-                    console.error(error);
-                    res.status(500).send("Error");
-                });
-        }
-    );
 
     /**
      * @apiGroup Authentication API

--- a/yarn.lock
+++ b/yarn.lock
@@ -6482,11 +6482,6 @@ confusing-browser-globals@^1.0.9:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
 
-connect-ensure-login@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/connect-ensure-login/-/connect-ensure-login-0.1.1.tgz#174dcc51243b9eac23f8d98215aeb6694e2e8a12"
-  integrity sha1-F03MUSQ7nqwj+NmCFa62aU4uihI=
-
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"


### PR DESCRIPTION
### What this PR does

Fixes #3170

Remove unused old admin UI endpoint from Gateway

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
