### PR TITLE
#3161 UTF-16 encoded CSV causes "unsupported Unicode escape sequence" error when saving a dataset draft

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 - #3186 Fixed: avoid extra slash in inqury email dataset URLs
 - #3188 Publish openfaas chart & Move openfaas helm chart out of main repo
 - #3183 Make search input accept empty string as search query string
+- #3161 Fixed: UTF-16 encoded CSV causes "unsupported Unicode escape sequence" error when saving a dataset draft
 
 ## 0.0.59
 

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractContents.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractContents.ts
@@ -153,7 +153,8 @@ async function extractSpreadsheetFile(
                     .map((row) => Object.values(row).join(","))
                     .join("\n");
             })
-            .join("\n\n");
+            .join("\n\n")
+            .replace(/\u0000/g, "");
     }
 
     return {
@@ -214,7 +215,7 @@ function getKeywordsFromWorksheet(
                 return;
             }
 
-            let value = sheet[key].v.trim();
+            let value = sheet[key].v.trim().replace(/\u0000/g, "");
 
             if (value === "") {
                 return;

--- a/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
+++ b/magda-web-client/src/Components/Dataset/MetadataExtraction/extractKeywords.ts
@@ -50,10 +50,9 @@ export async function extractKeywords(
     if (depInput.text && depInput.largeTextBlockIdentified !== false) {
         // Only take up to a certain length - anything longer results in massive delays and the browser
         // prompting with a "Should I stop this script?" warning.
-        const trimmedText = depInput.text.slice(
-            0,
-            MAX_CHARACTERS_FOR_EXTRACTION
-        );
+        const trimmedText = depInput.text
+            .replace(/\u0000/g, "")
+            .slice(0, MAX_CHARACTERS_FOR_EXTRACTION);
 
         const candidateKeywords = keywords.concat(
             await getKeywordsFromText(trimmedText)


### PR DESCRIPTION
### What this PR does

Fixes #3161 UTF-16 encoded CSV causes "unsupported Unicode escape sequence" error when saving a dataset draft

We only addressed this issue at frontend.

We will look for a more generic fix in ticket #3193

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
