### PR TITLE
Fixes #3198 Indexer will by default auto reindex / trim obsolete publisher / format weekly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,7 @@
 - Improve CSV visualisation tool date columns recognition logic
 - #3161 Fixed: UTF-16 encoded CSV causes "unsupported Unicode escape sequence" error when saving a dataset draft
 - Upgraded format-minion to v1.0.1
+- #3198 Indexer will by default auto reindex / trim obsolete publisher / format weekly
 
 ## 0.0.59
 

--- a/deploy/helm/internal-charts/indexer/README.md
+++ b/deploy/helm/internal-charts/indexer/README.md
@@ -12,6 +12,8 @@ Kubernetes: `>= 1.14.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| autoReIndex.enable | bool | `true` | Whether turn on the cronjob to trigger reindex. `publisher` & `format` indices might contains obsolete records which require the triming / reindex process to be removed. |
+| autoReIndex.schedule | string | "0 15 * * 0": 15:00PM UTC timezone (1:00AM in AEST Sydney timezone) on every Sunday | auto reindex cronjob schedule string. specified using unix-cron format (in UTC timezone by default). |
 | elasticsearch.replicas | int | `0` |  |
 | elasticsearch.shards | int | `1` |  |
 | elasticsearch.useGcsSnapshots | bool | `false` |  |

--- a/deploy/helm/internal-charts/indexer/templates/cronjob-reindex.yaml
+++ b/deploy/helm/internal-charts/indexer/templates/cronjob-reindex.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoReIndex.enable -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: indexer-reindex
+spec:
+  concurrencyPolicy: Forbid
+  schedule: {{ .Values.autoReIndex.schedule | quote }}
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          name: indexer-reindex
+          labels:
+            cron: indexer-reindex
+        spec:
+          containers:
+          - image: "alpine"
+            imagePullPolicy: IfNotPresent
+            name: indexer-reindex
+            command:
+              - "/bin/sh"
+              - "-c"
+              - "apk add --no-cache ca-certificates curl && curl -i -X POST http://indexer/v0/reindex"
+          restartPolicy: OnFailure
+{{- end }}

--- a/deploy/helm/internal-charts/indexer/values.yaml
+++ b/deploy/helm/internal-charts/indexer/values.yaml
@@ -11,3 +11,10 @@ resources:
     cpu: 250m
 makeSnapshots: false
 readSnapshots: false
+autoReIndex:
+  # -- Whether turn on the cronjob to trigger reindex.
+  # `publisher` & `format` indices might contains obsolete records which require the triming / reindex process to be removed.
+  enable: true
+  # -- auto reindex cronjob schedule string. specified using unix-cron format (in UTC timezone by default).
+  # @default -- "0 15 * * 0": 15:00PM UTC timezone (1:00AM in AEST Sydney timezone) on every Sunday
+  schedule: "0 15 * * 0"


### PR DESCRIPTION
### What this PR does

Fixes #3198 Indexer will by default auto reindex / trim obsolete publisher / format weekly


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
