### PR TITLE
#3197 Minion SDK: Make minion proactive crawling records number configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0
 
+- #3197 Minion SDK: Make minion proactive crawling records number configurable
+
 ## 0.0.60
 
 - Updated dataset pages and Ask A Question options for datasets with no contact points

--- a/magda-minion-framework/src/Crawler.ts
+++ b/magda-minion-framework/src/Crawler.ts
@@ -5,6 +5,9 @@ import AsyncPage, { forEachAsync } from "magda-typescript-common/src/AsyncPage";
 import Registry from "magda-typescript-common/src/registry/AuthorizedRegistryClient";
 import MinionOptions from "./MinionOptions";
 
+// default no. of record crawler fetechs per requests
+const DEFAULT_CRAWLER_RECORD_FETCH_NUMBER = 100;
+
 class Crawler {
     private isCrawling: boolean = false;
     private crawlingPageToken: string = null;
@@ -57,6 +60,11 @@ class Crawler {
             this.isCrawling = true;
             console.info("Crawling existing records in registry");
 
+            const crawlerRecordFetchNumber = this.options
+                ?.crawlerRecordFetchNumber
+                ? this.options.crawlerRecordFetchNumber
+                : DEFAULT_CRAWLER_RECORD_FETCH_NUMBER;
+
             const registryPage = AsyncPage.create<RecordsPage<Record>>(
                 (previous) => {
                     if (previous && previous.hasMore === false) {
@@ -81,7 +89,7 @@ class Crawler {
                                 this.options.optionalAspects,
                                 previous && previous.nextPageToken,
                                 true,
-                                10
+                                crawlerRecordFetchNumber
                             )
                             .then(unionToThrowable)
                             .then((page) => {

--- a/magda-minion-framework/src/MinionOptions.ts
+++ b/magda-minion-framework/src/MinionOptions.ts
@@ -11,7 +11,7 @@ export type onRecordFoundType = (
     record: Record,
     registry: AuthorizedRegistryClient
 ) => Promise<void>;
-export default class MinionOptions {
+export default interface MinionOptions {
     argv: MinionArguments;
     id: string;
     aspects: string[];
@@ -22,4 +22,6 @@ export default class MinionOptions {
     express?: () => express.Express;
     maxRetries?: number;
     concurrency?: number;
+    // no.of records the crawller fetchs per request
+    crawlerRecordFetchNumber?: number;
 }

--- a/magda-minion-framework/src/commonYargs.ts
+++ b/magda-minion-framework/src/commonYargs.ts
@@ -93,6 +93,11 @@ export default function commonYargs<
             describe: "The number of times to retry calling the registry",
             type: "number",
             default: process.env.RETRIES || 10
+        })
+        .option("crawlerRecordFetchNumber", {
+            describe: "The number of times to retry calling the registry",
+            type: "number",
+            default: process.env.CRAWLER_RECORD_FETCH_NUMBER || 100
         });
 
     const returnValue = addJwtSecretFromEnvVar(additions(yarr).argv);


### PR DESCRIPTION
### What this PR does

Fixes #3197

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
