### PR TITLE
fix yarn install error with higher version git

### DIFF
--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -78,7 +78,7 @@
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^3.4.2",
-    "nock": "git://github.com/magda-io/nock.git#master",
+    "nock": "https://github.com/magda-io/nock.git#master",
     "randomstring": "^1.1.5",
     "sinon": "^2.4.1",
     "supertest": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13818,9 +13818,9 @@ nock@^9.0.14, nock@^9.1.6, nock@^9.2.5:
     qs "^6.5.1"
     semver "^5.5.0"
 
-"nock@git://github.com/magda-io/nock.git#master":
+"nock@https://github.com/magda-io/nock.git#master":
   version "0.0.0-development"
-  resolved "git://github.com/magda-io/nock.git#b82b93a80b4893f39bbdd83a81dd4db610894f2a"
+  resolved "https://github.com/magda-io/nock.git#b82b93a80b4893f39bbdd83a81dd4db610894f2a"
   dependencies:
     chai "^4.1.2"
     debug "^4.1.0"


### PR DESCRIPTION
### What this PR does

replace node github dependency url with https protocol to avoid git error on higher version

### Checklist

-   [x] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
