### PR TITLE
Fix terriajs sharing for data preview map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Registry-api, search API & indexer are now listen at non 80 port as they now run as non-root user in docker containers. Corresponding k8s svcs are still exposing services at 80 port.
 - Upgrade sbt to 1.4.9 to fix compatibility issues with apple m1 users
 - Fix: correct db backup job default schedule to `0 15 * * 6`
+- Fix TerriaJS sharing for data preview maps
 
 ## 1.0.0
 

--- a/magda-web-client/src/Components/Common/DataPreviewMapOpenInNationalMapButton.tsx
+++ b/magda-web-client/src/Components/Common/DataPreviewMapOpenInNationalMapButton.tsx
@@ -72,6 +72,7 @@ class DataPreviewMapOpenInNationalMapButton extends Component<PropsType> {
                 version: "8.0.0",
                 initSources: [
                     {
+                        stratum: "user",
                         catalog: [
                             {
                                 name: distribution?.title,


### PR DESCRIPTION
### Fix terriajs sharing for data preview map

Fixes https://github.com/TerriaJS/nationalmap/issues/1099

### Test link

http://ci.terria.io/main/#start={%22initSources%22:[{%22catalog%22:[{%22name%22:%22Public%20Weighbridge%20List%20-%20Jul%202020%20%22,%22type%22:%22magda%22,%22recordId%22:%22dist-dga-9bba55fa-1d12-42f3-9eaa-2c5f32f7bfb6%22,%22url%22:%22https://data.gov.au/%22,%22id%22:%22data.gov.au-postMessage-dist-dga-9bba55fa-1d12-42f3-9eaa-2c5f32f7bfb6%22}],%22workbench%22:[%22data.gov.au-postMessage-dist-dga-9bba55fa-1d12-42f3-9eaa-2c5f32f7bfb6%22],%22baseMapName%22:%22Positron%20(Light)%22,%22stratum%22:%22user%22}]}

Then create a share link

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
