### PR TITLE
Issue/3192 Use use apiextensions.k8s.io/v1 for CRDs (Make it compitible with k8s 1.22)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - #3273 Fixed: when fetch data failed for preview chart, there should be proper error message shown to users
 - Fix TerriaJS sharing for data preview maps (See: https://github.com/TerriaJS/nationalmap/issues/1099)
 - #3232: fixed base backup made by wal-g remotely might miss files
+- #3192: Use use apiextensions.k8s.io/v1 for CRDs; Update all faas function charts
 
 ## 1.0.1
 

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.2.3
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.0.0
@@ -34,7 +34,7 @@ dependencies:
   version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.0.0
@@ -73,16 +73,16 @@ dependencies:
   version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-csw-connector
   repository: https://charts.magda.io
   version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.0.0
@@ -94,10 +94,10 @@ dependencies:
   version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-dap-connector
   repository: https://charts.magda.io
   version: 1.0.0
@@ -110,5 +110,5 @@ dependencies:
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.0.0
-digest: sha256:510aa0c0744b835ca5d93d66355b701c589d5257fd0fc9937abb35f444988372
-generated: "2021-12-13T14:54:01.296956+11:00"
+digest: sha256:4d83a746b24ea9a307300ad658ba61ecd90802e9ed76eceff5c4b767220c9ebb
+generated: "2021-12-15T16:06:43.082685+11:00"

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
   ## Data.gov.au connector to provide some initial data. Remove this if you
   ## don't want any data.gov.au connector
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-dga
     repository: https://charts.magda.io
     tags:
@@ -83,7 +83,7 @@ dependencies:
       - connectors
       - connector-aurin
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-brisbane
     repository: https://charts.magda.io
     tags:
@@ -174,7 +174,7 @@ dependencies:
       - connectors
       - connector-neii
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-nsw
     repository: https://charts.magda.io
     tags:
@@ -188,14 +188,14 @@ dependencies:
       - connectors
       - connector-sdinsw
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-qld
     repository: https://charts.magda.io
     tags:
       - connectors
       - connector-qld
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-sa
     repository: https://charts.magda.io
     tags:
@@ -223,14 +223,14 @@ dependencies:
       - connectors
       - connector-tern
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-vic
     repository: https://charts.magda.io
     tags:
       - connectors
       - connector-vic
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: connector-wa
     repository: https://charts.magda.io
     tags:

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -28,6 +28,6 @@ dependencies:
   version: 1.2.0
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
-  version: 1.0.0
-digest: sha256:515278c6765a590fdc7f09953e7734dfac9edbd4a745e61ba0099415c049e37e
-generated: "2021-12-14T23:00:13.337068+11:00"
+  version: 1.1.0
+digest: sha256:5744efd4e7241083af60e8ce8f31d26a1e25ee2cf554703e255c141e00d3a50a
+generated: "2021-12-15T00:24:46.322628+11:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 5.5.5-magda.1
 - name: magda-function-history-report
   repository: https://charts.magda.io
-  version: 1.0.0
+  version: 1.1.0
 - name: magda-minion-broken-link
   repository: https://charts.magda.io
   version: 1.0.0
@@ -25,9 +25,9 @@ dependencies:
   version: 1.0.0
 - name: magda-ckan-connector
   repository: https://charts.magda.io
-  version: 1.2.0
+  version: 1.3.0
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:5744efd4e7241083af60e8ce8f31d26a1e25ee2cf554703e255c141e00d3a50a
-generated: "2021-12-15T00:24:46.322628+11:00"
+digest: sha256:f9d1a6566e7144f87ce21635115d81354ab96be2b53cd004a83a1afd41fc6665
+generated: "2021-12-15T14:50:34.971084+11:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.0-alpha.4
 - name: openfaas
   repository: https://charts.magda.io
-  version: 5.5.5-magda
+  version: 5.5.5-magda.1
 - name: magda-function-history-report
   repository: https://charts.magda.io
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.0.0
-digest: sha256:55ed7c35465358f8edee259fe5affd03da20a843cf068cbf8437afbadec5cab3
-generated: "2021-12-13T14:53:45.706745+11:00"
+digest: sha256:515278c6765a590fdc7f09953e7734dfac9edbd4a745e61ba0099415c049e37e
+generated: "2021-12-14T23:00:13.337068+11:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -79,7 +79,7 @@ dependencies:
       - ckan-connector-functions
 
   - name: magda-function-esri-url-processor
-    version: "1.0.0"
+    version: "1.1.0"
     repository: https://charts.magda.io
     tags:
       - all

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: file://../magda-core
 
   - name: openfaas
-    version: 5.5.5-magda
+    version: 5.5.5-magda.1
     repository: https://charts.magda.io
     # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
     # Due to a limitation of helm, the value of tags is not available in chart template.

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   # Thus, no tags or condition are required.
   # You should set its sub-chart to enabled or not.
   - name: magda-function-history-report
-    version: "1.0.0"
+    version: "1.1.0"
     repository: https://charts.magda.io
     tags:
       - all
@@ -70,7 +70,7 @@ dependencies:
       - minion-ckan-exporter
 
   - name: magda-ckan-connector
-    version: "1.2.0"
+    version: "1.3.0"
     alias: ckan-connector-functions
     repository: https://charts.magda.io
     tags:

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.14.0-0`
 | https://charts.magda.io | minion-format(magda-minion-format) | 1.1.0 |
 | https://charts.magda.io | minion-linked-data-rating(magda-minion-linked-data-rating) | 1.1.0 |
 | https://charts.magda.io | minion-visualization(magda-minion-visualization) | 1.0.0 |
-| https://charts.magda.io | openfaas | 5.5.5-magda |
+| https://charts.magda.io | openfaas | 5.5.5-magda.1 |
 
 ## Values
 

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -17,9 +17,9 @@ Kubernetes: `>= 1.14.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../magda-core | magda-core | 1.1.0-alpha.4 |
-| https://charts.magda.io | ckan-connector-functions(magda-ckan-connector) | 1.2.0 |
-| https://charts.magda.io | magda-function-esri-url-processor | 1.0.0 |
-| https://charts.magda.io | magda-function-history-report | 1.0.0 |
+| https://charts.magda.io | ckan-connector-functions(magda-ckan-connector) | 1.3.0 |
+| https://charts.magda.io | magda-function-esri-url-processor | 1.1.0 |
+| https://charts.magda.io | magda-function-history-report | 1.1.0 |
 | https://charts.magda.io | minion-broken-link(magda-minion-broken-link) | 1.0.0 |
 | https://charts.magda.io | magda-minion-ckan-exporter | 1.0.0 |
 | https://charts.magda.io | minion-format(magda-minion-format) | 1.1.0 |


### PR DESCRIPTION
### What this PR does

Fixes 
- #3192
- upgrade openfaas helm chart
- upgrade openfaas functions

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
