### PR TITLE
#3285 Set default Google Cloud SQL proxy version to 1.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - #3192: Use use apiextensions.k8s.io/v1 for CRDs; Update all faas function charts
 - Upgraded both [CSW](https://github.com/magda-io/magda-csw-connector) & [project open data](https://github.com/magda-io/magda-project-open-data-connector) connector to v1.1.0
 - #3283 mitigate log4j DOS (denial of service) Vulnerability CVE-2021-45046
+- #3285 Set default Google Cloud SQL proxy version to 1.11 (Seems 1.11 is more stable on high load. If prefer higher version, user can manually set image version via Helm chart config)
 
 ## 1.0.1
 

--- a/deploy/helm/internal-charts/cloud-sql-proxy/README.md
+++ b/deploy/helm/internal-charts/cloud-sql-proxy/README.md
@@ -33,7 +33,7 @@ kubectl -n [Magda Deploy Namespace] create secret generic cloudsql-instance-cred
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.pullSecrets | bool | `false` |  |
 | image.repository | string | `"gcr.io/cloudsql-docker"` |  |
-| image.tag | string | `"1.26.0"` |  |
+| image.tag | string | `"1.11"` |  |
 | ipAddressTypes | string | PUBLIC,PRIVATE | A comma-delimited list of preferred IP types for connecting to an instance.  For example, setting this to PRIVATE will force the proxy to connect to instances using an instance's associated private IP. Available from docker image 1.23.0 |
 | logDebugStdout | bool | false | This is to log non-error output to standard out instead of standard error.  For example, if you don't want connection related messages to log as errors, set this flag to true. Available from docker image 1.23.0 |
 | maxConnections | int | 0 (no limit). | If provided, the maximum number of connections to establish before refusing new connections.  Available from docker image 1.23.0 |

--- a/deploy/helm/internal-charts/cloud-sql-proxy/values.yaml
+++ b/deploy/helm/internal-charts/cloud-sql-proxy/values.yaml
@@ -2,7 +2,7 @@ global: {}
 image:
   name: gce-proxy
   repository: gcr.io/cloudsql-docker
-  tag: "1.26.0"
+  tag: "1.11"
   pullPolicy: IfNotPresent
   pullSecrets: false
 


### PR DESCRIPTION
### What this PR does

Fixes 
- #3285

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
