### PR TITLE
Upgrade es 6.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 - #3293 Upgrade elasticsearch to 6.8.22
 - Upgrade logback to 1.2.10
 - #3294 Indexer will auto-fixes non-topologically closed Polygons / MultiPolygons
-- Crawler will now wait for 30 seconds (used to be 1 second) before perform trim action to avoid timeout issue
+- Crawler will now wait for 3 seconds (used to be 1 second) before perform trim action to avoid timeout issue
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 1.2.0
 
 - #3291 Remove log4j from scala codebase dependency list
-- Upgrade elasticsearch to 6.8.22
+- #3293 Upgrade elasticsearch to 6.8.22
 - Upgrade logback to 1.2.10
 
 ## 1.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - #3291 Remove log4j from scala codebase dependency list
 - #3293 Upgrade elasticsearch to 6.8.22
 - Upgrade logback to 1.2.10
+- #3294 Indexer will auto-fixes non-topologically closed Polygons / MultiPolygons
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - #3294 Indexer will auto-fixes non-topologically closed Polygons / MultiPolygons
 - Crawler will now wait for 3 seconds (used to be 1 second) before perform trim action to avoid timeout issue
 - Refactor Indexer code to remove the redundant index queue
+- Allow overiding publisher / format indice version number for search API
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Upgrade logback to 1.2.10
 - #3294 Indexer will auto-fixes non-topologically closed Polygons / MultiPolygons
 - Crawler will now wait for 3 seconds (used to be 1 second) before perform trim action to avoid timeout issue
+- Refactor Indexer code to remove the redundant index queue
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## 1.2.0
 
 - #3291 Remove log4j from scala codebase dependency list
+- Upgrade elasticsearch to 6.8.22
+- Upgrade logback to 1.2.10
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - #3293 Upgrade elasticsearch to 6.8.22
 - Upgrade logback to 1.2.10
 - #3294 Indexer will auto-fixes non-topologically closed Polygons / MultiPolygons
+- Crawler will now wait for 30 seconds (used to be 1 second) before perform trim action to avoid timeout issue
 
 ## 1.1.0
 

--- a/deploy/helm/internal-charts/elasticsearch/README.md
+++ b/deploy/helm/internal-charts/elasticsearch/README.md
@@ -37,7 +37,7 @@ Kubernetes: `>= 1.14.0-0`
 | kibanaImage.pullPolicy | string | `"IfNotPresent"` |  |
 | kibanaImage.pullSecrets | bool | `false` |  |
 | kibanaImage.repository | string | `"docker.elastic.co/kibana"` |  |
-| kibanaImage.tag | string | `"6.5.4"` |  |
+| kibanaImage.tag | string | `"6.8.22"` |  |
 | master.pluginsInstall | string | `""` |  |
 | master.replicas | int | `3` |  |
 | master.resources.limits.cpu | string | `"100m"` |  |

--- a/deploy/helm/internal-charts/elasticsearch/values.yaml
+++ b/deploy/helm/internal-charts/elasticsearch/values.yaml
@@ -9,7 +9,7 @@ initContainerImage:
 kibanaImage:
   name: kibana-oss
   repository: docker.elastic.co/kibana
-  tag: "6.5.4"
+  tag: "6.8.22"
   pullPolicy: IfNotPresent
   pullSecrets: false
 

--- a/deploy/helm/internal-charts/search-api/README.md
+++ b/deploy/helm/internal-charts/search-api/README.md
@@ -20,7 +20,9 @@ Kubernetes: `>= 1.14.0-0`
 | defaultImage.pullPolicy | string | `"IfNotPresent"` |  |
 | defaultImage.pullSecrets | bool | `false` |  |
 | defaultImage.repository | string | `"docker.io/data61"` |  |
+| formatsIndexVersion | string | `nil` | Manually set format index version. If not specify, default version will be used. you want to manually set this setting when upgrade to a Magda version that involves region index version changes. As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built. |
 | image.name | string | `"magda-search-api"` |  |
+| publishersIndexVersion | string | `nil` | Manually set publisher index version. If not specify, default version will be used. you want to manually set this setting when upgrade to a Magda version that involves region index version changes. As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built. |
 | regionsIndexVersion | string | `nil` | Manually set region index version. If not specify, default version will be used. you want to manually set this setting when upgrade to a Magda version that involves region index version changes. As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built. |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.requests.cpu | string | `"50m"` |  |

--- a/deploy/helm/internal-charts/search-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/search-api/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
 {{- if .Values.regionsIndexVersion }}
           - "-DelasticSearch.indices.regions.version={{ .Values.regionsIndexVersion }}"
 {{- end }}
+{{- if .Values.publishersIndexVersion }}
+          - "-DelasticSearch.indices.publishers.version={{ .Values.publishersIndexVersion }}"
+{{- end }}
+{{- if .Values.formatsIndexVersion }}
+          - "-DelasticSearch.indices.formats.version={{ .Values.formatsIndexVersion }}"
+{{- end }}
 {{- if .Values.global.enableLivenessProbes }}
         livenessProbe:
           httpGet:

--- a/deploy/helm/internal-charts/search-api/values.yaml
+++ b/deploy/helm/internal-charts/search-api/values.yaml
@@ -33,3 +33,17 @@ datasetsIndexVersion:
 # you want to manually set this setting when upgrade to a Magda version that involves region index version changes.
 # As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built.
 regionsIndexVersion:
+
+
+# -- Manually set publisher index version.
+# If not specify, default version will be used.
+# you want to manually set this setting when upgrade to a Magda version that involves region index version changes.
+# As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built.
+publishersIndexVersion:
+
+# -- Manually set format index version.
+# If not specify, default version will be used.
+# you want to manually set this setting when upgrade to a Magda version that involves region index version changes.
+# As it takes time to rebuild the index, you could use this setting to make search API query existing old version index before the new version index is built.
+formatsIndexVersion:
+

--- a/docs/docs/migration/1.2.0.md
+++ b/docs/docs/migration/1.2.0.md
@@ -1,0 +1,17 @@
+# Migrate from Magda v1.0.0 / v1.1.0 to v1.2.0
+
+## Elasticsearch Upgrade
+
+In v1.2.0, we upgraded elasticsearch to 6.8.22 (from 6.5.4). Once you upgrade Magda to v1.2.0, indexer will auto-recreate all elasticsearch indexes for newer version elasticsearch engine. Depends on your database size, this might take some time.
+
+To avoid showing incomplete result till re-index is completed, you can manually set the index version that search API uses to the existing versions via [helm chart options](https://github.com/magda-io/magda/blob/944ae887842b98c51698d567435003be2e9dbefd/deploy/helm/internal-charts/search-api/values.yaml#L29).
+
+e.g. you can set the following in your helm deployment values file / config:
+
+```yaml
+search-api:
+  datasetsIndexVersion: 48
+  regionsIndexVersion: 25
+  publishersIndexVersion: 6
+  formatsIndexVersion: 2
+```

--- a/magda-elastic-search/Dockerfile
+++ b/magda-elastic-search/Dockerfile
@@ -1,14 +1,12 @@
-FROM --platform=linux/amd64 docker.elastic.co/elasticsearch/elasticsearch:6.5.4 as stage-amd64
+FROM --platform=linux/amd64 docker.elastic.co/elasticsearch/elasticsearch:6.8.22 as stage-amd64
 RUN yum -y install sudo zip
 # Delete all x-pack modules
 RUN find modules -type d -name "x-pack-*" -exec rm -r {} +
 COPY --chown=elasticsearch:elasticsearch component/elasticsearch.yml /usr/share/elasticsearch/config/
-RUN cd /usr/share/elasticsearch/lib && zip -q -d log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
-FROM --platform=linux/arm64 data61/elasticsearch:6.5.4 as stage-arm64
+FROM --platform=linux/arm64 data61/elasticsearch:6.8.22 as stage-arm64
 RUN apt-get update && apt-get install -y --no-install-recommends sudo zip && rm -rf /var/lib/apt/lists/*
 COPY --chown=elasticsearch:elasticsearch component/elasticsearch-arm64.yml /usr/share/elasticsearch/config/elasticsearch.yml
-RUN cd /usr/share/elasticsearch/lib && zip -q -d log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 ARG TARGETARCH
 

--- a/magda-elastic-search/docker-compose.yml
+++ b/magda-elastic-search/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   test-es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.22
     ports:
       - 9200:9200
       - 9300:9300

--- a/magda-indexer/build.sbt
+++ b/magda-indexer/build.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.bintrayRepo("monsanto", "maven")
 
 libraryDependencies ++= {
   val akkaV       = "2.5.23"
-  val akkaHttpV   = "10.1.8"
+  val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaV,

--- a/magda-indexer/build.sbt
+++ b/magda-indexer/build.sbt
@@ -7,7 +7,7 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 resolvers += Resolver.bintrayRepo("monsanto", "maven")
 
 libraryDependencies ++= {
-  val akkaV       = "2.5.23"
+  val akkaV       = "2.5.32"
   val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -52,8 +52,9 @@ class RegistryCrawler(
       .index(interfaceSource)
       .flatMap { result =>
         log.info(
-          "Indexed datasets result: {} successes, {} successes after retry and {} failures",
+          "Indexed datasets result: {} successes, {} successes with retry and {} failures",
           result.successes,
+          result.warns,
           result.failures
         )
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -66,7 +66,7 @@ class RegistryCrawler(
         // visible to search. Defaults to 1s. Can be set to -1 to disable refresh.
         // Ref: https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index-modules.html#dynamic-index-settings
         Future {
-          val delay = 1000
+          val delay = 30000
           Thread.sleep(delay)
         }.flatMap(_ => {
           val futureOpt: Option[Future[Unit]] =

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/crawler/RegistryCrawler.scala
@@ -66,7 +66,7 @@ class RegistryCrawler(
         // visible to search. Defaults to 1s. Can be set to -1 to disable refresh.
         // Ref: https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index-modules.html#dynamic-index-settings
         Future {
-          val delay = 30000
+          val delay = 3000
           Thread.sleep(delay)
         }.flatMap(_ => {
           val futureOpt: Option[Future[Unit]] =

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
@@ -32,10 +32,14 @@ trait SearchIndexer {
 
 object SearchIndexer {
   case class IndexResult(
-      successes: Long,
-      failures: Seq[String] = Seq(),
-      warns: Seq[String] = Seq(),
-      spatialFieldRetryCount: Long = 0
+      // no. of successfully indexed datasets
+      successes: Long = 0,
+      // no. of failures
+      failures: Long = 0,
+      // no .of datasets that are indexed with warns (e.g. after retry)
+      warns: Long = 0,
+      failureReasons: Seq[String] = Seq(),
+      warnReasons: Seq[String] = Seq()
   )
 
   def apply(clientProvider: ClientProvider, indices: Indices)(

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
@@ -2,7 +2,7 @@ package au.csiro.data61.magda.indexer.search
 
 import au.csiro.data61.magda.model.misc._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import akka.stream.Materializer
 import akka.actor.ActorSystem
 import au.csiro.data61.magda.search.elasticsearch.{ClientProvider, Indices}
@@ -19,9 +19,26 @@ import au.csiro.data61.magda.search.elasticsearch.IndexDefinition
 
 trait SearchIndexer {
 
+  /**
+    * Provide simple / alternative interface and call `performIndex`` to perform index action
+    * @param dataSetStream
+    * @return
+    */
   def index(
       dataSetStream: Source[DataSet, NotUsed]
   ): Future[SearchIndexer.IndexResult]
+
+  /**
+    * Teh actual method to perform index action
+    * @param dataSetStream
+    * @param retryFailedDatasets
+    * @return
+    */
+  def performIndex(
+      dataSetStream: Source[(DataSet, Promise[Unit]), NotUsed],
+      retryFailedDatasets: Boolean = true
+  ): Future[SearchIndexer.IndexResult]
+
   def delete(identifiers: Seq[String]): Future[Unit]
   def snapshot(): Future[Unit]
   def ready: Future[Unit]

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/SearchIndexer.scala
@@ -7,9 +7,11 @@ import akka.stream.Materializer
 import akka.actor.ActorSystem
 import au.csiro.data61.magda.search.elasticsearch.{ClientProvider, Indices}
 import com.typesafe.config.Config
+
 import java.time.Instant
 import akka.stream.scaladsl.Source
 import akka.NotUsed
+
 import java.time.OffsetDateTime
 import au.csiro.data61.magda.indexer.search.elasticsearch.ElasticSearchIndexer
 import au.csiro.data61.magda.indexer.crawler.RegistryCrawler
@@ -29,7 +31,12 @@ trait SearchIndexer {
 }
 
 object SearchIndexer {
-  case class IndexResult(successes: Long, failures: Seq[String])
+  case class IndexResult(
+      successes: Long,
+      failures: Seq[String] = Seq(),
+      warns: Seq[String] = Seq(),
+      spatialFieldRetryCount: Long = 0
+  )
 
   def apply(clientProvider: ClientProvider, indices: Indices)(
       implicit config: Config,

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
@@ -360,6 +360,7 @@ class ElasticSearchIndexer(
           .execute(
             ElasticDsl
               .getMapping(indices.getIndex(config, indexDef.indicesIndex))
+              .copy(includeTypeName = Some(true))
           )
           .flatMap {
             case results: RequestSuccess[Seq[IndexMappings]] =>

--- a/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
+++ b/magda-indexer/src/test/scala/au/csiro/data61/magda/indexer/helpers/StreamControllerTest.scala
@@ -105,7 +105,7 @@ class StreamControllerTest extends FlatSpec with Matchers {
         .map(dataSet => {
           (dataSet.identifier, index(dataSet))
         })
-        .runWith(Sink.fold(Future(SearchIndexer.IndexResult(0, Seq()))) {
+        .runWith(Sink.fold(Future(SearchIndexer.IndexResult())) {
           case (
               combinedResultFuture,
               (thisResultIdentifier, thisResultFuture)
@@ -118,7 +118,7 @@ class StreamControllerTest extends FlatSpec with Matchers {
                 .recover {
                   case _: Throwable =>
                     combinedResult.copy(
-                      failures = combinedResult.failures :+ thisResultIdentifier
+                      failureReasons = combinedResult.failureReasons :+ thisResultIdentifier
                     )
                 }
             }
@@ -197,7 +197,7 @@ class StreamControllerTest extends FlatSpec with Matchers {
     sc.start()
 
     indexResultF.map(
-      indexResult => indexResult shouldEqual IndexResult(dataSets.size, List())
+      indexResult => indexResult shouldEqual IndexResult(dataSets.size)
     )
   }
 

--- a/magda-int-test/build.sbt
+++ b/magda-int-test/build.sbt
@@ -16,11 +16,11 @@ libraryDependencies ++= {
   Seq(
     "org.scalatest"     %% "scalatest" % scalaTestV % "test",
 
-    "org.elasticsearch.plugin" % "reindex-client" % "6.3.0" % "test",
-    "org.elasticsearch.plugin" % "percolator-client" % "6.3.0" % "test",
-    "org.elasticsearch.plugin" % "lang-mustache-client" % "6.3.0" % "test",
-    "org.elasticsearch.plugin" % "transport-netty4-client" % "6.3.0" % "test",
-    "org.codelibs.elasticsearch.module" % "analysis-common" % "6.3.0" % "test",
+    "org.elasticsearch.plugin" % "reindex-client" % "6.8.22" % "test",
+    "org.elasticsearch.plugin" % "percolator-client" % "6.8.22" % "test",
+    "org.elasticsearch.plugin" % "lang-mustache-client" % "6.8.22" % "test",
+    "org.elasticsearch.plugin" % "transport-netty4-client" % "6.8.22" % "test",
+    "org.codelibs.elasticsearch.module" % "analysis-common" % "6.8.12" % "test",
 
     "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test",
     "com.fortysevendeg" %% "scalacheck-datetime" % "0.2.0" % "test",

--- a/magda-int-test/build.sbt
+++ b/magda-int-test/build.sbt
@@ -10,25 +10,25 @@ resolvers += "elasticsearch-releases" at "https://artifacts.elastic.co/maven"
 
 libraryDependencies ++= {
   val akkaV       = "2.5.20"
-  val akkaHttpV   = "10.1.7"
+  val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   val LuceneVersion = "7.3.1"
   Seq(
-    "org.scalatest"     %% "scalatest" % scalaTestV % "test",
+    "org.scalatest"     %% "scalatest" % scalaTestV % Test,
 
-    "org.elasticsearch.plugin" % "reindex-client" % "6.8.22" % "test",
-    "org.elasticsearch.plugin" % "percolator-client" % "6.8.22" % "test",
-    "org.elasticsearch.plugin" % "lang-mustache-client" % "6.8.22" % "test",
-    "org.elasticsearch.plugin" % "transport-netty4-client" % "6.8.22" % "test",
-    "org.codelibs.elasticsearch.module" % "analysis-common" % "6.8.12" % "test",
+    "org.elasticsearch.plugin" % "reindex-client" % "6.8.22" % Test,
+    "org.elasticsearch.plugin" % "percolator-client" % "6.8.22" % Test,
+    "org.elasticsearch.plugin" % "lang-mustache-client" % "6.8.22" % Test,
+    "org.elasticsearch.plugin" % "transport-netty4-client" % "6.8.22" % Test,
+    "org.codelibs.elasticsearch.module" % "analysis-common" % "6.8.12" % Test,
 
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test",
-    "com.fortysevendeg" %% "scalacheck-datetime" % "0.2.0" % "test",
-    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test",
-    "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "org.mock-server" % "mockserver-client-java" % "5.5.1" % "test",
-    "org.mock-server" % "mockserver-netty" % "5.5.1" % "test"
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test,
+    "com.fortysevendeg" %% "scalacheck-datetime" % "0.2.0" % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test,
+    "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
+    "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
+    "org.mock-server" % "mockserver-client-java" % "5.5.1" % Test,
+    "org.mock-server" % "mockserver-netty" % "5.5.1" % Test
   )
 }
 

--- a/magda-int-test/build.sbt
+++ b/magda-int-test/build.sbt
@@ -9,7 +9,7 @@ resolvers += Resolver.bintrayRepo("monsanto", "maven")
 resolvers += "elasticsearch-releases" at "https://artifacts.elastic.co/maven"
 
 libraryDependencies ++= {
-  val akkaV       = "2.5.20"
+  val akkaV       = "2.5.32"
   val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   val LuceneVersion = "7.3.1"

--- a/magda-int-test/src/test/resources/sampleDatasets/wa1-with-invalid-spatial-data.json
+++ b/magda-int-test/src/test/resources/sampleDatasets/wa1-with-invalid-spatial-data.json
@@ -1,0 +1,474 @@
+{
+    "aspects": {
+        "source": {
+            "id": "wa",
+            "name": "Western Australia Government",
+            "type": "ckan-dataset",
+            "url": "https://catalogue.data.wa.gov.au/api/3/action/package_show?id=d2a2f5b0-5819-48c8-acc5-410e54e84596"
+        },
+        "dcat-dataset-strings": {
+            "description": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018\r\n\r\nAustralian sea lions (ASL) are protected by the Environment Protection and Biodiversity Conservation Act 1999. The Australian sea lion Gillnet Exclusion Zones (Zones) are the latest changes in WA to address concerns about ASLs.\r\n\r\nWaters within the Zones will be closed to gillnet fishing by commercial demersal gillnet and demersal longline operators, however fishers will still be able to use gillnets outside these Zones.\r\n\r\nThe Zones have been established to reduce the risk of ASLs interacting with demersal gillnets when foraging around their breeding colonies and to maintain a viable commercial fishery.\r\n",
+            "issued": "2018-06-28T07:51:49Z",
+            "keywords": [
+                "boundaries",
+                "demersal",
+                "fisheries",
+                "gillnet",
+                "legislation",
+                "prohibition",
+                "prohibition on fishing",
+                "sea lion",
+                "seal"
+            ],
+            "landingPage": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596",
+            "languages": [],
+            "modified": "2021-09-29T21:17:47Z",
+            "publisher": "Department of Primary Industries and Regional Development",
+            "spatial": "{\n    \"type\": \"MultiPolygon\",\n    \"coordinates\": [\n      [\n        [\n          [\n            136.213733593,\n            35.786550021\n          ],\n          [\n            136.213891619,\n            35.786492823\n          ],\n          [\n            136.214369639,\n            35.786314141\n          ],\n          [\n            136.214423308,\n            35.786327978\n          ],\n          [\n            136.214762481,\n            35.787228399\n          ],\n          [\n            136.214867863,\n            35.78749709\n          ],\n          [\n            136.214150004,\n            35.787679904\n          ],\n          [\n            136.213733593,\n            35.786550021\n          ]\n        ],\n        [\n          [\n            136.213703006,\n            35.786561093\n          ],\n          [\n            136.212561159,\n            35.788209032\n          ],\n          [\n            136.214047375,\n            35.787822628\n          ],\n          [\n            136.215960152,\n            35.787316346\n          ],\n          [\n            136.215922928,\n            35.78721168\n          ],\n          [\n            136.215682347,\n            35.787289767\n          ],\n          [\n            136.214932678,\n            35.787475211\n          ],\n          [\n            136.214644095,\n            35.786154679\n          ],\n          [\n            136.2133956,\n            35.78660853\n          ],\n          [\n            136.213703006,\n            35.786561093\n          ]\n        ]\n      ]\n    ]\n  }",
+            "temporal": {},
+            "themes": ["DPIRD Fisheries Guide"],
+            "title": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018 (DPIRD-088)"
+        },
+        "dataset-publisher": {
+            "publisher": {
+                "aspects": {
+                    "organization-details": {
+                        "description": "The amalgamation of the former Departments of Agriculture and Food; Fisheries and Regional Development will enable us to provide a strong and unified service for Western Australia’s vital primary industries and regions.",
+                        "imageUrl": "https://catalogue.data.wa.gov.au/uploads/group/2020-10-07-084842.405113DPIRD-datawa.svg",
+                        "name": "department-of-primary-industries-and-regional-development",
+                        "title": "Department of Primary Industries and Regional Development"
+                    },
+                    "source": {
+                        "id": "wa",
+                        "name": "Western Australia Government",
+                        "type": "ckan-organization",
+                        "url": "https://catalogue.data.wa.gov.au/api/3/action/organization_show?id=f9047e3b-8381-463f-9ae3-50c70d85e822"
+                    }
+                },
+                "id": "org-wa-f9047e3b-8381-463f-9ae3-50c70d85e822",
+                "name": "Department of Primary Industries and Regional Development"
+            }
+        },
+        "dataset-distributions": {
+            "distributions": [
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2018-06-28T07:52:24.035804",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "GPX file of coordinates and boundaries",
+                            "format": "gpx",
+                            "hash": "",
+                            "id": "6789015f-fa4e-43c8-b57d-72b4de050acb",
+                            "last_modified": "2018-10-17T04:36:32.588108",
+                            "metadata_modified": "2021-09-15T19:38:18.848588",
+                            "name": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 0,
+                            "state": "active",
+                            "url": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/6789015f-fa4e-43c8-b57d-72b4de050acb/download/prohibitiononfishingwcdgdlmforder2018.gpx",
+                            "url_type": "upload"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 90,
+                            "format": "GPX+XML"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "GPX file of coordinates and boundaries",
+                            "downloadURL": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/6789015f-fa4e-43c8-b57d-72b4de050acb/download/prohibitiononfishingwcdgdlmforder2018.gpx",
+                            "format": "gpx",
+                            "issued": "2018-06-28T07:52:24Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2018-10-17T04:36:32Z",
+                            "title": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=6789015f-fa4e-43c8-b57d-72b4de050acb"
+                        },
+                        "source-link-status": {
+                            "httpStatusCode": 206,
+                            "status": "active"
+                        }
+                    },
+                    "id": "dist-wa-6789015f-fa4e-43c8-b57d-72b4de050acb",
+                    "name": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2018-06-28T07:52:57.112565",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "MapInfo file of coordinates and boundaries",
+                            "format": ".zip shapefile, file geodatabase, mapinfo mid/mif",
+                            "hash": "",
+                            "id": "75f0d5d9-68f9-49a7-ac28-33208b1334b9",
+                            "last_modified": "2018-10-17T04:36:49.195787",
+                            "metadata_modified": "2021-09-15T19:38:18.848715",
+                            "name": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 1,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/75f0d5d9-68f9-49a7-ac28-33208b1334b9/download/prohibitiononfishingwcdgdlmforder2018coordinates.zip",
+                            "url_type": "upload"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 90,
+                            "format": "ZIP"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "MapInfo file of coordinates and boundaries",
+                            "downloadURL": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/75f0d5d9-68f9-49a7-ac28-33208b1334b9/download/prohibitiononfishingwcdgdlmforder2018coordinates.zip",
+                            "format": ".zip shapefile, file geodatabase, mapinfo mid/mif",
+                            "issued": "2018-06-28T07:52:57Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2018-10-17T04:36:49Z",
+                            "title": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=75f0d5d9-68f9-49a7-ac28-33208b1334b9"
+                        },
+                        "source-link-status": {
+                            "httpStatusCode": 206,
+                            "status": "active"
+                        }
+                    },
+                    "id": "dist-wa-75f0d5d9-68f9-49a7-ac28-33208b1334b9",
+                    "name": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:13.281620",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "Web Feature Service (WFS) provides an interface that allows requests for geographical features across the web using platform independent calls.\n\nWFS allows a user to download and spatially analyse the features within a datset.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "format": "WFS",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "hash": "",
+                            "id": "13835293-a12b-4474-b875-f795a21cfeca",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:42.755139",
+                            "name": "Web Feature Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 2,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "wfs_layer": "SLIP_Public_Services_DPIRD_Fisheries_Guide_WFS:Prohibition_on_Fishing__WCDGDLIMF__Order_2018__DPIRD-088_"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "WFS"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "Web Feature Service (WFS) provides an interface that allows requests for geographical features across the web using platform independent calls.\n\nWFS allows a user to download and spatially analyse the features within a datset.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "format": "WFS",
+                            "issued": "2021-09-15T20:58:13Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "Web Feature Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=13835293-a12b-4474-b875-f795a21cfeca"
+                        }
+                    },
+                    "id": "dist-wa-13835293-a12b-4474-b875-f795a21cfeca",
+                    "name": "Web Feature Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:23.056497",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "An ArcGIS Server Map Service offers access to a geographic dataset - such as a map or imagery - by providing a set of tiled images for use in web-based maps.\n\nDepending on the capabilities enabled, this web service may also allow a client to dynamically draw, search, and query its features.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as ArcGIS and QGIS.",
+                            "format": "API ArcGIS Server Map Service",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "hash": "",
+                            "id": "c0a24b13-e087-45a2-97b2-7bf33241d992",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:52.711979",
+                            "name": "ArcGIS Server Map Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 3,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "wms_layer": "97"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 70,
+                            "format": "ESRI MAPSERVER"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "An ArcGIS Server Map Service offers access to a geographic dataset - such as a map or imagery - by providing a set of tiled images for use in web-based maps.\n\nDepending on the capabilities enabled, this web service may also allow a client to dynamically draw, search, and query its features.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as ArcGIS and QGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "format": "API ArcGIS Server Map Service",
+                            "issued": "2021-09-15T20:58:23Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "ArcGIS Server Map Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=c0a24b13-e087-45a2-97b2-7bf33241d992"
+                        }
+                    },
+                    "id": "dist-wa-c0a24b13-e087-45a2-97b2-7bf33241d992",
+                    "name": "ArcGIS Server Map Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:23.975869",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "Web Map Service (WMS) is a standard protocol for serving georeferenced map images over the internet that are generated by a map server using data from a GIS database.\n\nWMS allows a user to spatially visualise the dataset, and query individual features, but does not allow downloading the raw data.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "format": "WMS",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "hash": "",
+                            "id": "fbcdda68-57b4-45df-aa42-6f9719e99c46",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:53.403796",
+                            "name": "Web Mapping Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 4,
+                            "preview_data": "true",
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "wms_layer": "0"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "WMS"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "Web Map Service (WMS) is a standard protocol for serving georeferenced map images over the internet that are generated by a map server using data from a GIS database.\n\nWMS allows a user to spatially visualise the dataset, and query individual features, but does not allow downloading the raw data.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "format": "WMS",
+                            "issued": "2021-09-15T20:58:23Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "Web Mapping Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=fbcdda68-57b4-45df-aa42-6f9719e99c46"
+                        }
+                    },
+                    "id": "dist-wa-fbcdda68-57b4-45df-aa42-6f9719e99c46",
+                    "name": "Web Mapping Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:25",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a shapefile. Shapefiles can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free SLIP account.",
+                            "format": "SHP",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile",
+                            "hash": "",
+                            "id": "dc38b0a1-2ce7-4079-87e6-a00166f23c10",
+                            "last_modified": "2021-09-13T11:59:25",
+                            "metadata_modified": "2021-09-15T21:18:11.800576",
+                            "name": "Shapefile",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 5,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "SHP"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a shapefile. Shapefiles can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free SLIP account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile",
+                            "format": "SHP",
+                            "issued": "2021-09-13T11:59:25Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:25Z",
+                            "title": "Shapefile"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=dc38b0a1-2ce7-4079-87e6-a00166f23c10"
+                        }
+                    },
+                    "id": "dist-wa-dc38b0a1-2ce7-4079-87e6-a00166f23c10",
+                    "name": "Shapefile"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:28",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a GeoPackage. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "GeoPackage",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage",
+                            "hash": "",
+                            "id": "10d5c227-4051-414d-8ff8-1c4017ade405",
+                            "last_modified": "2021-09-13T11:59:23",
+                            "metadata_modified": "2021-09-29T21:17:47.662812",
+                            "name": "Geopackage",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 6,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "GEOPACKAGE"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a GeoPackage. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage",
+                            "format": "GeoPackage",
+                            "issued": "2021-09-13T11:59:28Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:23Z",
+                            "title": "Geopackage"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=10d5c227-4051-414d-8ff8-1c4017ade405"
+                        }
+                    },
+                    "id": "dist-wa-10d5c227-4051-414d-8ff8-1c4017ade405",
+                    "name": "Geopackage"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:36:26",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a File Geodatabase. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "FGDB",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase",
+                            "hash": "",
+                            "id": "53e5298a-06c2-40e5-b94f-2c9134198397",
+                            "last_modified": "2021-09-13T11:36:26",
+                            "metadata_modified": "2021-09-15T21:18:24.529528",
+                            "name": "File Geodatabase",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 7,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "FGDB"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a File Geodatabase. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase",
+                            "format": "FGDB",
+                            "issued": "2021-09-13T11:36:26Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:36:26Z",
+                            "title": "File Geodatabase"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=53e5298a-06c2-40e5-b94f-2c9134198397"
+                        }
+                    },
+                    "id": "dist-wa-53e5298a-06c2-40e5-b94f-2c9134198397",
+                    "name": "File Geodatabase"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:21",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as GeoJSON. GeoJSON can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "GeoJSON",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON",
+                            "hash": "",
+                            "id": "63553223-48a8-403e-98c6-9b8d73444a79",
+                            "last_modified": "2021-09-13T11:59:21",
+                            "metadata_modified": "2021-09-16T19:37:38.235548",
+                            "name": "GeoJSON",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 8,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "GEOJSON"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as GeoJSON. GeoJSON can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON",
+                            "format": "GeoJSON",
+                            "issued": "2021-09-13T11:59:21Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:21Z",
+                            "title": "GeoJSON"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=63553223-48a8-403e-98c6-9b8d73444a79"
+                        }
+                    },
+                    "id": "dist-wa-63553223-48a8-403e-98c6-9b8d73444a79",
+                    "name": "GeoJSON"
+                }
+            ]
+        },
+        "dataset-quality-rating": {
+            "dataset-linked-data-rating": {
+                "score": 0.6,
+                "weighting": 1
+            }
+        }
+    },
+    "id": "ds-wa-invalid-001",
+    "name": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018 (DPIRD-088)",
+    "sourceTag": "12853da9-8a0c-4dac-86b1-e7e834863e54",
+    "tenantId": 0
+}

--- a/magda-int-test/src/test/resources/sampleDatasets/wa1.json
+++ b/magda-int-test/src/test/resources/sampleDatasets/wa1.json
@@ -1,0 +1,474 @@
+{
+    "aspects": {
+        "source": {
+            "id": "wa",
+            "name": "Western Australia Government",
+            "type": "ckan-dataset",
+            "url": "https://catalogue.data.wa.gov.au/api/3/action/package_show?id=d2a2f5b0-5819-48c8-acc5-410e54e84596"
+        },
+        "dcat-dataset-strings": {
+            "description": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018\r\n\r\nAustralian sea lions (ASL) are protected by the Environment Protection and Biodiversity Conservation Act 1999. The Australian sea lion Gillnet Exclusion Zones (Zones) are the latest changes in WA to address concerns about ASLs.\r\n\r\nWaters within the Zones will be closed to gillnet fishing by commercial demersal gillnet and demersal longline operators, however fishers will still be able to use gillnets outside these Zones.\r\n\r\nThe Zones have been established to reduce the risk of ASLs interacting with demersal gillnets when foraging around their breeding colonies and to maintain a viable commercial fishery.\r\n",
+            "issued": "2018-06-28T07:51:49Z",
+            "keywords": [
+                "boundaries",
+                "demersal",
+                "fisheries",
+                "gillnet",
+                "legislation",
+                "prohibition",
+                "prohibition on fishing",
+                "sea lion",
+                "seal"
+            ],
+            "landingPage": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596",
+            "languages": [],
+            "modified": "2021-09-29T21:17:47Z",
+            "publisher": "Department of Primary Industries and Regional Development",
+            "spatial": "{\"type\": \"Polygon\", \"coordinates\": [[[113.58154999990352, -30.81596666648388], [115.19059913517697, -30.81596666648388], [115.19059913517697, -28.451649998896013], [113.58154999990352, -28.451649998896013]]]}",
+            "temporal": {},
+            "themes": ["DPIRD Fisheries Guide"],
+            "title": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018 (DPIRD-088)"
+        },
+        "dataset-publisher": {
+            "publisher": {
+                "aspects": {
+                    "organization-details": {
+                        "description": "The amalgamation of the former Departments of Agriculture and Food; Fisheries and Regional Development will enable us to provide a strong and unified service for Western Australia’s vital primary industries and regions.",
+                        "imageUrl": "https://catalogue.data.wa.gov.au/uploads/group/2020-10-07-084842.405113DPIRD-datawa.svg",
+                        "name": "department-of-primary-industries-and-regional-development",
+                        "title": "Department of Primary Industries and Regional Development"
+                    },
+                    "source": {
+                        "id": "wa",
+                        "name": "Western Australia Government",
+                        "type": "ckan-organization",
+                        "url": "https://catalogue.data.wa.gov.au/api/3/action/organization_show?id=f9047e3b-8381-463f-9ae3-50c70d85e822"
+                    }
+                },
+                "id": "org-wa-f9047e3b-8381-463f-9ae3-50c70d85e822",
+                "name": "Department of Primary Industries and Regional Development"
+            }
+        },
+        "dataset-distributions": {
+            "distributions": [
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2018-06-28T07:52:24.035804",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "GPX file of coordinates and boundaries",
+                            "format": "gpx",
+                            "hash": "",
+                            "id": "6789015f-fa4e-43c8-b57d-72b4de050acb",
+                            "last_modified": "2018-10-17T04:36:32.588108",
+                            "metadata_modified": "2021-09-15T19:38:18.848588",
+                            "name": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 0,
+                            "state": "active",
+                            "url": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/6789015f-fa4e-43c8-b57d-72b4de050acb/download/prohibitiononfishingwcdgdlmforder2018.gpx",
+                            "url_type": "upload"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 90,
+                            "format": "GPX+XML"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "GPX file of coordinates and boundaries",
+                            "downloadURL": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/6789015f-fa4e-43c8-b57d-72b4de050acb/download/prohibitiononfishingwcdgdlmforder2018.gpx",
+                            "format": "gpx",
+                            "issued": "2018-06-28T07:52:24Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2018-10-17T04:36:32Z",
+                            "title": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=6789015f-fa4e-43c8-b57d-72b4de050acb"
+                        },
+                        "source-link-status": {
+                            "httpStatusCode": 206,
+                            "status": "active"
+                        }
+                    },
+                    "id": "dist-wa-6789015f-fa4e-43c8-b57d-72b4de050acb",
+                    "name": "GPX Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2018-06-28T07:52:57.112565",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "MapInfo file of coordinates and boundaries",
+                            "format": ".zip shapefile, file geodatabase, mapinfo mid/mif",
+                            "hash": "",
+                            "id": "75f0d5d9-68f9-49a7-ac28-33208b1334b9",
+                            "last_modified": "2018-10-17T04:36:49.195787",
+                            "metadata_modified": "2021-09-15T19:38:18.848715",
+                            "name": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 1,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/75f0d5d9-68f9-49a7-ac28-33208b1334b9/download/prohibitiononfishingwcdgdlmforder2018coordinates.zip",
+                            "url_type": "upload"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 90,
+                            "format": "ZIP"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "MapInfo file of coordinates and boundaries",
+                            "downloadURL": "https://catalogue.data.wa.gov.au/dataset/d2a2f5b0-5819-48c8-acc5-410e54e84596/resource/75f0d5d9-68f9-49a7-ac28-33208b1334b9/download/prohibitiononfishingwcdgdlmforder2018coordinates.zip",
+                            "format": ".zip shapefile, file geodatabase, mapinfo mid/mif",
+                            "issued": "2018-06-28T07:52:57Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2018-10-17T04:36:49Z",
+                            "title": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=75f0d5d9-68f9-49a7-ac28-33208b1334b9"
+                        },
+                        "source-link-status": {
+                            "httpStatusCode": 206,
+                            "status": "active"
+                        }
+                    },
+                    "id": "dist-wa-75f0d5d9-68f9-49a7-ac28-33208b1334b9",
+                    "name": "MapInfo (CPlot) Prohibition on Fishing (WCDGDLIMF) Order 2018"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:13.281620",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "Web Feature Service (WFS) provides an interface that allows requests for geographical features across the web using platform independent calls.\n\nWFS allows a user to download and spatially analyse the features within a datset.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "format": "WFS",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "hash": "",
+                            "id": "13835293-a12b-4474-b875-f795a21cfeca",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:42.755139",
+                            "name": "Web Feature Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 2,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "wfs_layer": "SLIP_Public_Services_DPIRD_Fisheries_Guide_WFS:Prohibition_on_Fishing__WCDGDLIMF__Order_2018__DPIRD-088_"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "WFS"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "Web Feature Service (WFS) provides an interface that allows requests for geographical features across the web using platform independent calls.\n\nWFS allows a user to download and spatially analyse the features within a datset.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide_WFS/MapServer/WFSServer",
+                            "format": "WFS",
+                            "issued": "2021-09-15T20:58:13Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "Web Feature Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=13835293-a12b-4474-b875-f795a21cfeca"
+                        }
+                    },
+                    "id": "dist-wa-13835293-a12b-4474-b875-f795a21cfeca",
+                    "name": "Web Feature Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:23.056497",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "An ArcGIS Server Map Service offers access to a geographic dataset - such as a map or imagery - by providing a set of tiled images for use in web-based maps.\n\nDepending on the capabilities enabled, this web service may also allow a client to dynamically draw, search, and query its features.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as ArcGIS and QGIS.",
+                            "format": "API ArcGIS Server Map Service",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "hash": "",
+                            "id": "c0a24b13-e087-45a2-97b2-7bf33241d992",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:52.711979",
+                            "name": "ArcGIS Server Map Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 3,
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "wms_layer": "97"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 70,
+                            "format": "ESRI MAPSERVER"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "An ArcGIS Server Map Service offers access to a geographic dataset - such as a map or imagery - by providing a set of tiled images for use in web-based maps.\n\nDepending on the capabilities enabled, this web service may also allow a client to dynamically draw, search, and query its features.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as ArcGIS and QGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/rest/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/97",
+                            "format": "API ArcGIS Server Map Service",
+                            "issued": "2021-09-15T20:58:23Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "ArcGIS Server Map Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=c0a24b13-e087-45a2-97b2-7bf33241d992"
+                        }
+                    },
+                    "id": "dist-wa-c0a24b13-e087-45a2-97b2-7bf33241d992",
+                    "name": "ArcGIS Server Map Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open",
+                            "created": "2021-09-15T20:58:23.975869",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "Web Map Service (WMS) is a standard protocol for serving georeferenced map images over the internet that are generated by a map server using data from a GIS database.\n\nWMS allows a user to spatially visualise the dataset, and query individual features, but does not allow downloading the raw data.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "format": "WMS",
+                            "harvesting_source": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "hash": "",
+                            "id": "fbcdda68-57b4-45df-aa42-6f9719e99c46",
+                            "last_modified": "2021-09-13T00:00:00",
+                            "metadata_modified": "2021-09-16T21:01:53.403796",
+                            "name": "Web Mapping Service",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 4,
+                            "preview_data": "true",
+                            "section": "web_services_and_apis",
+                            "state": "active",
+                            "url": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "wms_layer": "0"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "WMS"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "Web Map Service (WMS) is a standard protocol for serving georeferenced map images over the internet that are generated by a map server using data from a GIS database.\n\nWMS allows a user to spatially visualise the dataset, and query individual features, but does not allow downloading the raw data.\n\nThis service is aimed at advanced geographical information users, and will require access to geographical information system (GIS) software such as QGIS and ArcGIS.",
+                            "downloadURL": "https://services.slip.wa.gov.au/public/services/SLIP_Public_Services/DPIRD_Fisheries_Guide/MapServer/WMSServer",
+                            "format": "WMS",
+                            "issued": "2021-09-15T20:58:23Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T00:00:00Z",
+                            "title": "Web Mapping Service"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=fbcdda68-57b4-45df-aa42-6f9719e99c46"
+                        }
+                    },
+                    "id": "dist-wa-fbcdda68-57b4-45df-aa42-6f9719e99c46",
+                    "name": "Web Mapping Service"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:25",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a shapefile. Shapefiles can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free SLIP account.",
+                            "format": "SHP",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile",
+                            "hash": "",
+                            "id": "dc38b0a1-2ce7-4079-87e6-a00166f23c10",
+                            "last_modified": "2021-09-13T11:59:25",
+                            "metadata_modified": "2021-09-15T21:18:11.800576",
+                            "name": "Shapefile",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 5,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "SHP"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a shapefile. Shapefiles can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free SLIP account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Shapefile",
+                            "format": "SHP",
+                            "issued": "2021-09-13T11:59:25Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:25Z",
+                            "title": "Shapefile"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=dc38b0a1-2ce7-4079-87e6-a00166f23c10"
+                        }
+                    },
+                    "id": "dist-wa-dc38b0a1-2ce7-4079-87e6-a00166f23c10",
+                    "name": "Shapefile"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:28",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a GeoPackage. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "GeoPackage",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage",
+                            "hash": "",
+                            "id": "10d5c227-4051-414d-8ff8-1c4017ade405",
+                            "last_modified": "2021-09-13T11:59:23",
+                            "metadata_modified": "2021-09-29T21:17:47.662812",
+                            "name": "Geopackage",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 6,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "GEOPACKAGE"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a GeoPackage. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/Geopackage",
+                            "format": "GeoPackage",
+                            "issued": "2021-09-13T11:59:28Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:23Z",
+                            "title": "Geopackage"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=10d5c227-4051-414d-8ff8-1c4017ade405"
+                        }
+                    },
+                    "id": "dist-wa-10d5c227-4051-414d-8ff8-1c4017ade405",
+                    "name": "Geopackage"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:36:26",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as a File Geodatabase. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "FGDB",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase",
+                            "hash": "",
+                            "id": "53e5298a-06c2-40e5-b94f-2c9134198397",
+                            "last_modified": "2021-09-13T11:36:26",
+                            "metadata_modified": "2021-09-15T21:18:24.529528",
+                            "name": "File Geodatabase",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 7,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "FGDB"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as a File Geodatabase. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/File Geodatabase",
+                            "format": "FGDB",
+                            "issued": "2021-09-13T11:36:26Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:36:26Z",
+                            "title": "File Geodatabase"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=53e5298a-06c2-40e5-b94f-2c9134198397"
+                        }
+                    },
+                    "id": "dist-wa-53e5298a-06c2-40e5-b94f-2c9134198397",
+                    "name": "File Geodatabase"
+                },
+                {
+                    "aspects": {
+                        "ckan-resource": {
+                            "access_level": "open_login",
+                            "created": "2021-09-13T11:59:21",
+                            "datastore_active": false,
+                            "datastore_contains_all_records_of_source_file": false,
+                            "description": "This resource provides the latest snapshot of the dataset as GeoJSON. GeoJSON can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "format": "GeoJSON",
+                            "harvesting_source": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON",
+                            "hash": "",
+                            "id": "63553223-48a8-403e-98c6-9b8d73444a79",
+                            "last_modified": "2021-09-13T11:59:21",
+                            "metadata_modified": "2021-09-16T19:37:38.235548",
+                            "name": "GeoJSON",
+                            "package_id": "d2a2f5b0-5819-48c8-acc5-410e54e84596",
+                            "position": 8,
+                            "section": "data_downloads",
+                            "state": "active",
+                            "url": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON"
+                        },
+                        "dataset-format": {
+                            "confidenceLevel": 33,
+                            "format": "GEOJSON"
+                        },
+                        "dcat-distribution-strings": {
+                            "description": "This resource provides the latest snapshot of the dataset as GeoJSON. GeoJSON can be opened in many spatial and non-spatial software packages. Note: When accessing this resource you will be prompted to signup for a free account.",
+                            "downloadURL": "https://data-downloads.slip.wa.gov.au/DPIRD-088/GeoJSON",
+                            "format": "GeoJSON",
+                            "issued": "2021-09-13T11:59:21Z",
+                            "license": "Creative Commons Attribution 4.0",
+                            "modified": "2021-09-13T11:59:21Z",
+                            "title": "GeoJSON"
+                        },
+                        "source": {
+                            "id": "wa",
+                            "name": "Western Australia Government",
+                            "type": "ckan-resource",
+                            "url": "https://catalogue.data.wa.gov.au/api/3/action/resource_show?id=63553223-48a8-403e-98c6-9b8d73444a79"
+                        }
+                    },
+                    "id": "dist-wa-63553223-48a8-403e-98c6-9b8d73444a79",
+                    "name": "GeoJSON"
+                }
+            ]
+        },
+        "dataset-quality-rating": {
+            "dataset-linked-data-rating": {
+                "score": 0.6,
+                "weighting": 1
+            }
+        }
+    },
+    "id": "ds-wa-d2a2f5b0-5819-48c8-acc5-410e54e84596",
+    "name": "Prohibition on Fishing (West Coast Demersal Gillnet and Demersal Longline Interim Managed Fishery) Order 2018 (DPIRD-088)",
+    "sourceTag": "12853da9-8a0c-4dac-86b1-e7e834863e54",
+    "tenantId": 0
+}

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/api/DataSetSearchSpec.scala
@@ -3,17 +3,15 @@ package au.csiro.data61.magda.api
 import java.time.OffsetDateTime
 import java.time.temporal.{ChronoField, TemporalField}
 import java.util.{Calendar, GregorianCalendar}
-
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.server.Route
 import au.csiro.data61.magda.api.model.SearchResult
-
 import au.csiro.data61.magda.model.misc._
 import au.csiro.data61.magda.model.Registry._
 import au.csiro.data61.magda.search.SearchStrategy.MatchAll
-import au.csiro.data61.magda.spatial.RegionSource
+import au.csiro.data61.magda.spatial.{GeometryUtils, RegionSource}
 import au.csiro.data61.magda.test.util.ApiGenerators.{queryGen, _}
 import au.csiro.data61.magda.test.util.Generators.{
   coordGen,
@@ -1220,7 +1218,18 @@ class DataSetSearchSpec extends BaseSearchApiSpec {
                 withClue(
                   s"responseBoundingBox $responseBoundingBox vs indexedBoundingBox $indexedBoundingBox with $geometry"
                 ) {
-                  responseBoundingBox should equal(indexedBoundingBox)
+                  responseBoundingBox.north should be(
+                    indexedBoundingBox.north +- GeometryUtils.minEnvelopeMargin
+                  )
+                  responseBoundingBox.south should be(
+                    indexedBoundingBox.south +- GeometryUtils.minEnvelopeMargin
+                  )
+                  responseBoundingBox.west should be(
+                    indexedBoundingBox.west +- GeometryUtils.minEnvelopeMargin
+                  )
+                  responseBoundingBox.east should be(
+                    indexedBoundingBox.east +- GeometryUtils.minEnvelopeMargin
+                  )
                 }
             }
           }

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/crawler/CrawlerApiSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/crawler/CrawlerApiSpec.scala
@@ -171,7 +171,7 @@ class CrawlerApiSpec
 
       val routes = crawlerApi.routes
 
-      crawler.crawl().await(30 seconds)
+      crawler.crawl().await(60 seconds) // we need to wait 60 seconds here as crawler will wait for 30 seconds before perform trim action
       indexer.ready.await(30 seconds)
 
       // Combine all the datasets but keep what interface they come from

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/crawler/CrawlerApiSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/crawler/CrawlerApiSpec.scala
@@ -171,7 +171,9 @@ class CrawlerApiSpec
 
       val routes = crawlerApi.routes
 
-      crawler.crawl().await(60 seconds) // we need to wait 60 seconds here as crawler will wait for 30 seconds before perform trim action
+      crawler
+        .crawl()
+        .await(30 seconds)
       indexer.ready.await(30 seconds)
 
       // Combine all the datasets but keep what interface they come from

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIndexDatasetSamplesSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIndexDatasetSamplesSpec.scala
@@ -88,7 +88,8 @@ class WebhookIndexDatasetSamplesSpec
               indexingResultValidationFunc.get(result)
             } else {
               result.successes shouldBe 1
-              result.failures.size shouldBe 0
+              result.failures shouldBe 0
+              result.warns shouldBe 0
             }
           }
         }
@@ -148,9 +149,8 @@ class WebhookIndexDatasetSamplesSpec
       }),
       Some(result => {
         result.successes shouldBe 1
-        result.failures.size shouldBe 0
-        result.warns.size shouldBe 0
-        result.spatialFieldRetryCount shouldBe 0
+        result.failures shouldBe 0
+        result.warns shouldBe 0
       })
     )
 
@@ -165,10 +165,9 @@ class WebhookIndexDatasetSamplesSpec
         esDataset.spatial.get.text.isDefined shouldBe true
       }),
       Some(result => {
-        result.successes shouldBe 1
-        result.failures.size shouldBe 0
-        result.warns.size shouldBe 0
-        result.spatialFieldRetryCount shouldBe 1
+        result.successes shouldBe 0
+        result.failures shouldBe 0
+        result.warns shouldBe 1
       })
     )
 

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIndexDatasetSamplesSpec.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/indexer/WebhookIndexDatasetSamplesSpec.scala
@@ -1,0 +1,93 @@
+package au.csiro.data61.magda.indexer
+
+import akka.event.LoggingAdapter
+import au.csiro.data61.magda.api.model.SearchResult
+import spray.json._
+import au.csiro.data61.magda.model.Registry._
+
+import scala.io.BufferedSource
+import scala.io.Source.fromFile
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes.OK
+import au.csiro.data61.magda.client.Conversions
+import org.scalamock.scalatest.MockFactory
+import akka.stream.scaladsl.Source
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+
+import java.time.ZoneOffset
+
+class WebhookIndexDatasetSamplesSpec
+    extends WebhookSpecBase
+    with MockFactory
+    with ScalaFutures {
+
+  describe("Test indexing sample datasets") {
+
+    implicit val defaultOffset: ZoneOffset =
+      ZoneOffset.of(config.getString("time.defaultOffset"))
+
+    val sampleFileDir = "magda-int-test/src/test/resources/sampleDatasets/"
+
+    def testSampleFile(fileName: String): Unit = {
+      it(s"should index sample dataset file: ${fileName} with no error") {
+        val jsonResSource: BufferedSource = fromFile(
+          sampleFileDir + fileName
+        )
+        val jsonRes: String =
+          try {
+            jsonResSource.mkString
+          } finally {
+            jsonResSource.close()
+          }
+
+        val record = JsonParser(jsonRes).convertTo[Record]
+
+        val mockLogger = mock[LoggingAdapter]
+        (mockLogger.error _: String => Unit)
+          .expects(*)
+          .onCall { msg: String =>
+            fail(msg)
+          }
+          .anyNumberOfTimes()
+
+        val dataset = Conversions
+          .convertRegistryDataSet(record, Some(mockLogger))
+
+        val builtIndex = buildIndex()
+
+        whenReady(
+          builtIndex.indexer
+            .index(Source(List(dataset))),
+          timeout(Span(3, Seconds))
+        ) { result =>
+          withClue("Elasticsearch failed to index the dataset: "){
+            result.successes shouldBe 1
+            result.failures.size shouldBe 0
+          }
+        }
+
+        builtIndex.indexNames.foreach { idxName =>
+          refresh(idxName)
+        }
+
+        blockUntilExactCount(1, builtIndex.indexId)
+
+        Get(s"/v0/datasets?query=*&limit=10") ~> addSingleTenantIdHeader ~> builtIndex.searchApi.routes ~> check {
+          status shouldBe OK
+          val response = responseAs[SearchResult]
+
+          response.hitCount shouldBe 1
+          response.dataSets.head.identifier shouldBe record.id
+        }
+
+        builtIndex.indexNames.foreach { idxName =>
+          deleteIndex(idxName)
+        }
+      }
+    }
+
+    testSampleFile("wa1.json")
+
+  }
+}

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/SharedElasticSugar.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/SharedElasticSugar.scala
@@ -70,7 +70,7 @@ trait HttpElasticSugar {
   def ensureIndexExists(index: String): Unit =
     try {
       http.execute {
-        createIndex(index)
+        createIndex(index).copy(includeTypeName = Some(true))
       }.await
     } catch {
       case _: ResourceAlreadyExistsException => // Ok, ignore.

--- a/magda-registry-api/build.sbt
+++ b/magda-registry-api/build.sbt
@@ -5,7 +5,7 @@ name := "magda-registry-api"
 
 libraryDependencies ++= {
   val akkaV       = "2.5.23"
-  val akkaHttpV   = "10.1.8"
+  val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaV,
@@ -14,19 +14,19 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
     "org.scalikejdbc" %% "scalikejdbc" % "3.0.0-RC3",
     "org.scalikejdbc" %% "scalikejdbc-config" % "3.0.0-RC3",
-    "org.scalikejdbc" %% "scalikejdbc-test" % "3.0.0-RC3" % "test",
+    "org.scalikejdbc" %% "scalikejdbc-test" % "3.0.0-RC3" % Test,
     "ch.qos.logback"  %  "logback-classic" % "1.2.0",
     "org.postgresql"  %  "postgresql" % "9.4.1212",
-    "org.scalatest" %% "scalatest" % scalaTestV % "test",
+    "org.scalatest" %% "scalatest" % scalaTestV % Test,
     "de.heikoseeberger" %% "akka-http-circe" % "1.16.1",
     "io.circe" %% "circe-generic" % "0.8.0",
     "io.circe" %% "circe-java8" % "0.8.0",
     "org.gnieh" %% "diffson-spray-json" % "2.1.2",
     "net.virtual-void" %%  "json-lenses" % "0.6.2",
-    "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
-    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test",
-    "org.flywaydb" % "flyway-core" % "4.2.0" % "test",
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test",
+    "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test,
+    "org.flywaydb" % "flyway-core" % "4.2.0" % Test,
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test,
     "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.0",
     "jakarta.xml.bind" % "jakarta.xml.bind-api" % "2.3.2",
     "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.2"

--- a/magda-registry-api/build.sbt
+++ b/magda-registry-api/build.sbt
@@ -4,7 +4,7 @@ import DockerSetup._
 name := "magda-registry-api"
 
 libraryDependencies ++= {
-  val akkaV       = "2.5.23"
+  val akkaV       = "2.5.32"
   val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(

--- a/magda-registry-api/build.sbt
+++ b/magda-registry-api/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= {
     "org.scalikejdbc" %% "scalikejdbc" % "3.0.0-RC3",
     "org.scalikejdbc" %% "scalikejdbc-config" % "3.0.0-RC3",
     "org.scalikejdbc" %% "scalikejdbc-test" % "3.0.0-RC3" % Test,
-    "ch.qos.logback"  %  "logback-classic" % "1.2.0",
+    "ch.qos.logback"  %  "logback-classic" % "1.2.10",
     "org.postgresql"  %  "postgresql" % "9.4.1212",
     "org.scalatest" %% "scalatest" % scalaTestV % Test,
     "de.heikoseeberger" %% "akka-http-circe" % "1.16.1",

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -2180,7 +2180,7 @@ class WebHookProcessingSpec
       (a, payload) => a ++ payload.events.get
     )
 
-    if(payloadsSize.isDefined) {
+    if (payloadsSize.isDefined) {
       payloads.length shouldBe payloadsSize
     }
 
@@ -2198,18 +2198,32 @@ class WebHookProcessingSpec
   private def assertRecordsInPayloads(
       expectedRecordIdAndTenantIds: Seq[ExpectedRecordIdAndTenantId]
   ) = {
-    payloads.size shouldBe expectedRecordIdAndTenantIds.size
     val records = payloads.foldLeft[List[Record]](Nil)(
       (a, payload) => a ++ payload.records.get
     )
     records
-      .zip(expectedRecordIdAndTenantIds)
-      .map(pair => {
-        val actual = pair._1
-        val expected = pair._2
-        actual.id shouldBe expected.recordId
-        actual.tenantId shouldBe Some(expected.tenantId)
-      })
+      .filter(
+        record =>
+          expectedRecordIdAndTenantIds
+            .find(
+              item =>
+                item.recordId == record.id && item.tenantId == record.tenantId.get
+            )
+            .isEmpty
+      )
+      .length shouldBe 0
+
+    expectedRecordIdAndTenantIds
+      .filter(
+        item =>
+          records
+            .find(
+              record =>
+                item.recordId == record.id && item.tenantId == record.tenantId.get
+            )
+            .isEmpty
+      )
+      .length shouldBe 0
   }
 
   describe("async web hooks") {

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -1067,8 +1067,7 @@ class WebHookProcessingSpec
           List(
             ExpectedEventIdAndTenantId(3, TENANT_1),
             ExpectedEventIdAndTenantId(4, TENANT_1)
-          ),
-          payloadsSize = 2
+          )
         )
 
         for (i <- 1 to 50) {
@@ -1344,8 +1343,7 @@ class WebHookProcessingSpec
           List(
             ExpectedEventIdAndTenantId(8, TENANT_1),
             ExpectedEventIdAndTenantId(9, TENANT_2)
-          ),
-          payloadsSize = 2
+          )
         )
         assertRecordsInPayloads(
           List(
@@ -2175,13 +2173,16 @@ class WebHookProcessingSpec
 
   private def assertEventsInPayloads(
       expectedEventIdAndTenantIds: Seq[ExpectedEventIdAndTenantId],
-      payloadsSize: Int = 1
+      payloadsSize: Option[Int] = None
   ) = {
     Util.waitUntilAllDone(1000)
-    payloads.length shouldBe payloadsSize
     val events = payloads.foldLeft[List[RegistryEvent]](Nil)(
       (a, payload) => a ++ payload.events.get
     )
+
+    if(payloadsSize.isDefined) {
+      payloads.length shouldBe payloadsSize
+    }
 
     events.size shouldBe expectedEventIdAndTenantIds.size
     events

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -7,7 +7,7 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= {
   val akkaV       = "2.5.23"
-  val akkaHttpV   = "10.1.8"
+  val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   val jjwtV = "0.10.7"
 
@@ -39,6 +39,9 @@ libraryDependencies ++= {
     "io.jsonwebtoken" % "jjwt-impl" % jjwtV,
     "io.jsonwebtoken" % "jjwt-jackson" % jjwtV,
 
-    "org.scalatest" %% "scalatest" % scalaTestV % Test
+    "org.scalatest" %% "scalatest" % scalaTestV % Test,
+
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaV % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test
   )
 }

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -25,13 +25,13 @@ libraryDependencies ++= {
 
     "org.locationtech.spatial4j" % "spatial4j" % "0.7",
     "org.locationtech.jts" % "jts-core" % "1.15.0",
-    "org.elasticsearch" % "elasticsearch" % "6.5.1" exclude("org.apache.logging.log4j", "log4j-api"),
+    "org.elasticsearch" % "elasticsearch" % "6.8.22" exclude("org.apache.logging.log4j", "log4j-api"),
 
-    "com.sksamuel.elastic4s" %% "elastic4s-core" % "6.5.1",
-    "com.sksamuel.elastic4s" %% "elastic4s-http" % "6.5.1",
+    "com.sksamuel.elastic4s" %% "elastic4s-core" % "6.7.8",
+    "com.sksamuel.elastic4s" %% "elastic4s-http" % "6.7.8",
 
     "com.beachape" %% "enumeratum" % "1.5.10",
-    "com.github.swagger-akka-http" %% "swagger-akka-http" % "1.1.0",
+    "com.github.swagger-akka-http" %% "swagger-akka-http" % "1.4.0",
     "net.virtual-void" %%  "json-lenses" % "0.6.2",
     "com.mapbox.mapboxsdk" % "mapbox-sdk-geojson" % "4.5.0",
 

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http" % akkaHttpV,
     "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,
-    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "ch.qos.logback" % "logback-classic" % "1.2.10",
     "com.monsanto.labs" %% "mwundo-core" % "0.5.0" exclude("xerces", "xercesImpl"),
     "com.monsanto.labs" %% "mwundo-spray" % "0.5.0",
     "org.scalaz" %% "scalaz-core" % "7.2.8",

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -6,7 +6,7 @@ resolvers += "elasticsearch-releases" at "https://artifacts.elastic.co/maven"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= {
-  val akkaV       = "2.5.23"
+  val akkaV       = "2.5.32"
   val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   val jjwtV = "0.10.7"

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -10,11 +10,11 @@ elasticSearch {
 
     indices {
         regions {
-            version = 24
+            version = 25
         }
 
         datasets {
-            version = 47
+            version = 48
         }
 
         publishers {

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -18,11 +18,11 @@ elasticSearch {
         }
 
         publishers {
-            version = 5
+            version = 6
         }
 
         formats {
-            version = 1
+            version = 2
         }
     }
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -163,7 +163,7 @@ package misc {
   )
 
   object Location {
-    val geoJsonPattern: Regex = "\\{\"type\":\\s*\".+\",.*\\}".r
+    val geoJsonPattern: Regex = "\\{\\s*\"type\":\\s*\".+\",.*\\}".r
     val emptyPolygonPattern: Regex = "POLYGON \\(\\(0 0, 0 0, 0 0, 0 0\\)\\)".r
 
     val polygonPattern: Regex =

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/TenantId.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/TenantId.scala
@@ -1,24 +1,33 @@
 package au.csiro.data61.magda.model
 
+import com.sksamuel.elastic4s.searches.queries.Query
+import com.sksamuel.elastic4s.searches.queries.matches.MatchAllQuery
+import com.sksamuel.elastic4s.searches.queries.term.TermQuery
+
 object TenantId {
   sealed trait TenantId {
     def specifiedOrThrow(): BigInt
     def isAllTenants(): Boolean
+    def getEsQuery(field: String = "tenantId"): Query
   }
   case object AllTenantsId extends TenantId {
-    override def specifiedOrThrow(): BigInt =
+
+    def specifiedOrThrow(): BigInt =
       throw new Exception("Used specifiedOrThrow on unspecified tenant id")
 
-    override def isAllTenants(): Boolean = true
+    def isAllTenants(): Boolean = true
+    def getEsQuery(field: String = "tenantId") = MatchAllQuery()
   }
   case class SpecifiedTenantId(tenantId: BigInt) extends TenantId {
-    override def specifiedOrThrow(): BigInt = tenantId;
+    def specifiedOrThrow(): BigInt = tenantId;
 
     override def toString: String = {
       tenantId.toString
     }
 
-    override def isAllTenants(): Boolean = false
+    def isAllTenants(): Boolean = false
+
+    def getEsQuery(field: String = "tenantId") = TermQuery(field, tenantId)
 
   }
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -407,7 +407,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val publishers: IndexDefinition =
     new IndexDefinition(
       name = "publishers",
-      version = 5,
+      version = 6,
       indicesIndex = Indices.PublishersIndex,
       definition = (indices, config) => {
         val createIdxReq =
@@ -455,7 +455,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val formats: IndexDefinition =
     new IndexDefinition(
       name = "formats",
-      version = 1,
+      version = 2,
       indicesIndex = Indices.FormatsIndex,
       definition = (indices, config) => {
         val createIdxReq =

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -7,6 +7,7 @@ import au.csiro.data61.magda.model.misc.BoundingBox
 import au.csiro.data61.magda.search.elasticsearch.ElasticSearchImplicits._
 import au.csiro.data61.magda.spatial.RegionSource.generateRegionId
 import au.csiro.data61.magda.spatial.{RegionLoader, RegionSources, RegionSource}
+import au.csiro.data61.magda.spatial.GeometryUtils.createEnvelope
 import au.csiro.data61.magda.util.MwundoJTSConversions._
 import com.monsanto.labs.mwundo.GeoJson
 import com.sksamuel.elastic4s.analyzers._
@@ -721,19 +722,5 @@ object IndexDefinition extends DefaultJsonProtocol {
       .map { count =>
         logger.info("Successfully indexed {} regions", count)
       }
-  }
-
-  val geoFactory = new GeometryFactory()
-
-  def createEnvelope(geometry: GeoJson.Geometry): BoundingBox = {
-    val indexedEnvelope =
-      GeometryConverter.toJTSGeo(geometry, geoFactory).getEnvelopeInternal
-
-    BoundingBox(
-      indexedEnvelope.getMaxY,
-      indexedEnvelope.getMaxX,
-      indexedEnvelope.getMinY,
-      indexedEnvelope.getMinX
-    )
   }
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUnit.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUnit.scala
@@ -1,0 +1,125 @@
+package au.csiro.data61.magda.spatial
+
+/**
+    The work of this module is ported from [Turfjs](https://github.com/Turfjs/turf/blob/cd719cde909db79340d390de39d2c6afe3173062/packages/turf-helpers/index.ts)
+
+    The MIT License (MIT)
+
+    Copyright (c) 2019 Morgan Herlocker
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
+
+object GeometryUnit extends Enumeration {
+  type GeometryUnit = Value
+
+  val CentiMeters, Degrees, Feet, Inches, Kilometers, Meters, Miles,
+      Millimeters, Nauticalmiles, Radians, Yards = Value
+
+  val earthRadius = 6371008.8
+
+  /**
+    * Unit of measurement factors using a spherical (non-ellipsoid) earth radius.
+    * From Turfjs: https://github.com/Turfjs/turf/blob/cd719cde909db79340d390de39d2c6afe3173062/packages/turf-helpers/index.ts#L73
+    *
+    * @param unit
+    * @return
+    */
+  def factors(unit: GeometryUnit): Double = unit match {
+    case CentiMeters   => earthRadius * 100
+    case Degrees       => 360 / (2 * math.Pi)
+    case Feet          => earthRadius * 3.28084
+    case Inches        => earthRadius * 39.37
+    case Kilometers    => earthRadius / 1000
+    case Meters        => earthRadius
+    case Miles         => earthRadius / 1609.344
+    case Millimeters   => earthRadius * 1000
+    case Nauticalmiles => earthRadius / 1852
+    case Radians       => 1
+    case Yards         => earthRadius * 1.0936
+    case _             => throw new Error("Unknown unit type")
+  }
+
+  /**
+    * Convert a distance measurement (assuming a spherical Earth) from radians to a more friendly unit.
+    * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
+    * From Turfjs: https://github.com/Turfjs/turf/blob/cd719cde909db79340d390de39d2c6afe3173062/packages/turf-helpers/index.ts#L603
+    *
+    * @param radians
+    * @param units
+    * @return
+    */
+  def radiansToLength(radians: Double, units: GeometryUnit = Kilometers) =
+    radians * factors(units)
+
+  /**
+    * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into radians
+    * @param distance
+    * @param units
+    * @return
+    */
+  def lengthToRadians(
+      distance: Double,
+      units: GeometryUnit = Kilometers
+  ) = distance / factors(units)
+
+  /**
+    * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into degrees
+    * @param distance
+    * @param units
+    * @return
+    */
+  def lengthToDegrees(distance: Double, units: GeometryUnit = Kilometers) =
+    radiansToDegrees(lengthToRadians(distance, units))
+
+  /**
+    * Converts an angle in radians to degrees
+    * @param radians
+    * @return
+    */
+  def radiansToDegrees(radians: Double): Double = {
+    val degrees = radians % (2 * math.Pi)
+    (degrees * 180) / math.Pi;
+  }
+
+  /**
+    * Converts an angle in degrees to radians
+    * From Turfjs: https://github.com/Turfjs/turf/blob/cd719cde909db79340d390de39d2c6afe3173062/packages/turf-helpers/index.ts#L684
+    *
+    * @param degrees
+    * @return
+    */
+  def degreesToRadians(degrees: Double) = {
+    val radians = degrees % 360
+    (radians * math.Pi) / 180
+  }
+
+  /**
+    * Converts a length to the requested unit.
+    * @param length
+    * @param originalUnit
+    * @param finalUnit
+    * @return
+    */
+  def convertLength(
+      length: Double,
+      originalUnit: GeometryUnit = Kilometers,
+      finalUnit: GeometryUnit = Kilometers
+  ): Double = radiansToLength(lengthToRadians(length, originalUnit), finalUnit)
+
+}

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUtils.scala
@@ -1,0 +1,65 @@
+package au.csiro.data61.magda.spatial
+
+import au.csiro.data61.magda.model.misc.BoundingBox
+import au.csiro.data61.magda.spatial.GeometryUnit._
+import au.csiro.data61.magda.util.MwundoJTSConversions.GeometryConverter
+import com.monsanto.labs.mwundo.GeoJson
+import org.locationtech.jts.geom._
+
+object GeometryUtils {
+
+  /**
+    * Add buffer to geometry. Here we assume the unit of the geometry is in Degrees
+    * @param geometry
+    * @param distance
+    * @param unit distance unit. e.g. Kilometers
+    * @return
+    */
+  def buffer(
+      geometry: Geometry,
+      distance: Double,
+      unit: GeometryUnit
+  ): Geometry = {
+    val distanceInDegrees = convertLength(distance, unit, Degrees)
+    geometry.buffer(distanceInDegrees)
+  }
+
+  val geoFactory = new GeometryFactory()
+  // min. bounding box size in meters
+  val MIN_BOUNDING_BOX_SIZE = 100
+
+  def toValidLat(lat: Double): Double = {
+    if (math.abs(lat) > 90) {
+      Math.signum(lat) * 90
+    } else {
+      lat
+    }
+  }
+
+  def toValidLon(lon: Double): Double = {
+    if (math.abs(lon) > 180) {
+      Math.signum(lon) * 180
+    } else {
+      lon
+    }
+  }
+
+  def createEnvelope(geometry: GeoJson.Geometry): BoundingBox = {
+    val jtsGeometry = GeometryConverter.toJTSGeo(geometry, geoFactory)
+    val envelope = jtsGeometry.getEnvelopeInternal
+
+    val indexedEnvelope =
+      if (envelope.getWidth == 0 && envelope.getHeight == 0) {
+        buffer(jtsGeometry, MIN_BOUNDING_BOX_SIZE, Meters).getEnvelopeInternal
+      } else {
+        envelope
+      }
+
+    BoundingBox(
+      toValidLat(indexedEnvelope.getMaxY),
+      toValidLon(indexedEnvelope.getMaxX),
+      toValidLat(indexedEnvelope.getMinY),
+      toValidLon(indexedEnvelope.getMinX)
+    )
+  }
+}

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/GeometryUtils.scala
@@ -25,8 +25,8 @@ object GeometryUtils {
   }
 
   val geoFactory = new GeometryFactory()
-  // min. bounding box size in meters
-  val MIN_BOUNDING_BOX_SIZE = 100
+
+  val minEnvelopeMargin = 0.00000001
 
   def toValidLat(lat: Double): Double = {
     if (math.abs(lat) > 90) {

--- a/magda-search-api/build.sbt
+++ b/magda-search-api/build.sbt
@@ -3,7 +3,7 @@ import DockerSetup._
 name := "magda-search-api"
 
 libraryDependencies ++= {
-  val akkaV       = "2.5.23"
+  val akkaV       = "2.5.32"
   val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(

--- a/magda-search-api/build.sbt
+++ b/magda-search-api/build.sbt
@@ -4,7 +4,7 @@ name := "magda-search-api"
 
 libraryDependencies ++= {
   val akkaV       = "2.5.23"
-  val akkaHttpV   = "10.1.8"
+  val akkaHttpV   = "10.2.7"
   val scalaTestV  = "3.0.8"
   Seq(
        "com.typesafe.akka" %% "akka-http-xml" % akkaHttpV,

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -209,7 +209,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
         publishingStatusQueryFuture.flatMap { publishingStatusQuery =>
           val filterQuery = boolQuery().must(
             Seq(
-              termQuery("tenantId", tenantId),
+              tenantId.getEsQuery(),
               publishingStatusQuery,
               matchQuery(s"${field}.autoComplete", inputString)
             )
@@ -532,7 +532,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
       strategy: SearchStrategy,
       facetSize: Int
   ) = {
-    val tenantIdTermQuery = termQuery("tenantId", tenantId)
+    val tenantIdTermQuery = tenantId.getEsQuery()
     filterAggregation("filter")
       .query(
         must(
@@ -584,7 +584,8 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
       */
     val allScorers = Seq(weightScore(1)) ++ qualityScorers ++ geomScorer.toSeq
 
-    val tenantTermQuery: TermQuery = termQuery("tenantId", tenantId)
+    val tenantTermQuery = tenantId.getEsQuery()
+
     val q: QueryDefinition = queryToQueryDef(query, strategy)
     functionScoreQuery()
       .query(
@@ -910,7 +911,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
 
     clientFuture.flatMap { client =>
       val queryStringContent = queryString.getOrElse("*").trim
-      val tenantTermQuery: TermQuery = termQuery("tenantId", tenantId)
+      val tenantTermQuery = tenantId.getEsQuery()
       val query = ElasticDsl
         .search(indices.getIndex(config, Indices.DataSetsIndex))
         .start(start)


### PR DESCRIPTION
### What this PR does

Fixes:
- #3293
- #3294  
- Upgrade logback to 1.2.10
- Crawler will now wait for 3 seconds (used to be 1 second) before perform trim action to avoid timeout issue
- Refactor Indexer code to remove the redundant index queue

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
