### PR TITLE
use data61/elasticsearch:6.8.22 image in docker compose file

### DIFF
--- a/magda-elastic-search/docker-compose.yml
+++ b/magda-elastic-search/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   test-es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.22
+    image: data61/elasticsearch:6.8.22
     ports:
       - 9200:9200
       - 9300:9300


### PR DESCRIPTION
### What this PR does

Update the docker image that is used for running test case (and local tests) to a muti-arch version image.

### Checklist

-   [x] unit tests aren't applicable
