### PR TITLE
Some generic homepage visual adjustment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Refactor Indexer code to remove the redundant index queue
 - Allow overiding publisher / format indice version number for search API
 - #3301 Overide "LIQ NUM" & "REG AUD NUM" to category column type in Chart Preview
+- General home tiles & background visual improvements.
 
 ## 1.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Crawler will now wait for 3 seconds (used to be 1 second) before perform trim action to avoid timeout issue
 - Refactor Indexer code to remove the redundant index queue
 - Allow overiding publisher / format indice version number for search API
+- #3301 Overide "LIQ NUM" & "REG AUD NUM" to category column type in Chart Preview
 
 ## 1.1.0
 

--- a/magda-web-client/src/Components/Home/HighlightsAdminPage.tsx
+++ b/magda-web-client/src/Components/Home/HighlightsAdminPage.tsx
@@ -26,7 +26,7 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
 
     refresh() {
         listContent("home/highlights/*", "home/highlight-images/*").then(
-            highlights => {
+            (highlights) => {
                 let items = {};
                 for (const item of highlights) {
                     if (item.id.indexOf("home/highlight-images/") === 0) {
@@ -40,7 +40,7 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
                         Object.assign(items[id], item.content);
                     }
                 }
-                items = Object.entries(items).map(params => {
+                items = Object.entries(items).map((params) => {
                     let [id, body] = params;
                     return Object.assign(body, { id });
                 });
@@ -88,8 +88,8 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
     }
 
     renderItem(item) {
-        const save = field => {
-            return async value => {
+        const save = (field) => {
+            return async (value) => {
                 const { text, url } = item;
                 const toSave = {
                     text: text || undefined,
@@ -210,9 +210,9 @@ export default class HighlightsAdminPage extends React.Component<any, any> {
                 [1440, 1440, 902],
                 [2160, 2160, 1353]
             ]) {
-                const [dim, width, height] = w;
+                const [dim, width] = w;
                 if (image.width >= width) {
-                    images[`${dim}w`] = resizeImage(image, width, height);
+                    images[`${dim}w`] = resizeImage(image, width, image.height);
                 }
             }
 

--- a/magda-web-client/src/Components/Home/HomePage.scss
+++ b/magda-web-client/src/Components/Home/HomePage.scss
@@ -1,10 +1,14 @@
 @import "variables";
 @import "./pancake/sass/core.scss";
 
-.homepage-app-container {
-    position: relative;
-    overflow-y: hidden;
+@media (min-width: 992px) {
+    .homepage-app-container {
+        position: relative;
+        overflow-y: hidden;
+    }
+}
 
+.homepage-app-container {
     .app-container {
         position: relative;
     }

--- a/magda-web-client/src/Components/Home/HomePage.scss
+++ b/magda-web-client/src/Components/Home/HomePage.scss
@@ -1,14 +1,10 @@
 @import "variables";
 @import "./pancake/sass/core.scss";
 
-@media (min-width: 992px) {
-    .homepage-app-container {
-        position: relative;
-        overflow-y: hidden;
-    }
-}
-
 .homepage-app-container {
+    position: relative;
+    overflow-y: hidden;
+
     .app-container {
         position: relative;
     }

--- a/magda-web-client/src/Components/Home/HomePage.scss
+++ b/magda-web-client/src/Components/Home/HomePage.scss
@@ -9,7 +9,7 @@
     .homepage-background-img {
         position: absolute;
         width: 100%;
-        height: 100vh;
+        height: auto;
         z-index: -1;
         min-width: $minimum;
     }

--- a/magda-web-client/src/Components/Home/HomePage.scss
+++ b/magda-web-client/src/Components/Home/HomePage.scss
@@ -2,6 +2,9 @@
 @import "./pancake/sass/core.scss";
 
 .homepage-app-container {
+    position: relative;
+    overflow-y: hidden;
+
     .app-container {
         position: relative;
     }
@@ -9,7 +12,7 @@
     .homepage-background-img {
         position: absolute;
         width: 100%;
-        height: fit-content;
+        height: auto;
         z-index: -1;
         min-width: $minimum;
     }

--- a/magda-web-client/src/Components/Home/HomePage.scss
+++ b/magda-web-client/src/Components/Home/HomePage.scss
@@ -9,7 +9,7 @@
     .homepage-background-img {
         position: absolute;
         width: 100%;
-        height: auto;
+        height: fit-content;
         z-index: -1;
         min-width: $minimum;
     }

--- a/magda-web-client/src/Components/Home/HomePage.tsx
+++ b/magda-web-client/src/Components/Home/HomePage.tsx
@@ -62,6 +62,7 @@ const getBgImg = (backgroundImageUrls) => {
                     }
                 >
                     <img
+                        alt="background"
                         src={imageMap[size]}
                         className="homepage-background-img"
                     />

--- a/magda-web-client/src/Components/Home/HomePage.tsx
+++ b/magda-web-client/src/Components/Home/HomePage.tsx
@@ -41,16 +41,16 @@ const getBgImg = (backgroundImageUrls) => {
 
     const screenSizes = Object.keys(imageMap);
 
-    function getBackgroundImage(imageUrl) {
-        return {
-            backgroundImage: "url(" + imageUrl + ")",
-            backgroundPosition: "center",
-            backgroundRepeat: "no-repeat",
-            backgroundSize: "cover"
-        };
-    }
+    // function getBackgroundImage(imageUrl) {
+    //     return {
+    //         backgroundImage: "url(" + imageUrl + ")",
+    //         backgroundPosition: "center",
+    //         backgroundRepeat: "no-repeat",
+    //         backgroundSize: "cover"
+    //     };
+    // }
     return (
-        <div>
+        <>
             {screenSizes.map((size, i) => (
                 <MediaQuery
                     key={size}
@@ -61,13 +61,13 @@ const getBgImg = (backgroundImageUrls) => {
                             : screenSizes[i + 1] + "px"
                     }
                 >
-                    <div
+                    <img
+                        src={imageMap[size]}
                         className="homepage-background-img"
-                        style={getBackgroundImage(imageMap[size])}
                     />
                 </MediaQuery>
             ))}
-        </div>
+        </>
     );
 };
 

--- a/magda-web-client/src/Components/Home/Stories.scss
+++ b/magda-web-client/src/Components/Home/Stories.scss
@@ -12,6 +12,7 @@
         display: flex;
         justify-content: space-between;
         align-items: stretch;
+        margin-bottom: 16px;
     }
     .col-3 {
         width: calc(100% / 3 - 20px);

--- a/magda-web-client/src/Components/Home/Stories.tsx
+++ b/magda-web-client/src/Components/Home/Stories.tsx
@@ -42,8 +42,8 @@ class Stories extends Component<PropsType, StateType> {
             return null;
         }
         const rows: StoryDataType[][] = [];
-        for (let x = 0; x < stories.length; x += 4) {
-            rows.push(stories.slice(x, x + 4));
+        for (let x = 0; x < stories.length; x += 2) {
+            rows.push(stories.slice(x, x + 2));
         }
         return (
             <div className="homepage-stories">
@@ -98,92 +98,27 @@ class Stories extends Component<PropsType, StateType> {
                         >
                             <div>
                                 {rows.map((row, r) => {
-                                    switch (row.length) {
-                                        case 1:
-                                            return (
+                                    return (
+                                        <div
+                                            className="stories-container"
+                                            key={r}
+                                        >
+                                            {row.map((story, i) => (
                                                 <div
-                                                    className="row"
-                                                    key="stories-boxes"
+                                                    className={`col-2`}
+                                                    key={i}
                                                 >
-                                                    <div className="col-md-4">
-                                                        <StoryBox
-                                                            idx={r * 4}
-                                                            story={row[0]}
-                                                            className={`stories medium-screen-layout story-box-${
-                                                                r * 4
-                                                            }`}
-                                                        />
-                                                    </div>
+                                                    <StoryBox
+                                                        idx={r * 2 + i}
+                                                        story={story}
+                                                        className={`stories medium-screen-layout story-box-${
+                                                            r * 4 + i
+                                                        }`}
+                                                    />
                                                 </div>
-                                            );
-                                        case 2:
-                                        case 3:
-                                            return (
-                                                <div
-                                                    className="stories-container"
-                                                    key={r}
-                                                >
-                                                    {row.map((story, i) => (
-                                                        <div
-                                                            className={`col-${row.length}`}
-                                                            key={i}
-                                                        >
-                                                            <StoryBox
-                                                                idx={r * 4 + i}
-                                                                story={story}
-                                                                className={`stories medium-screen-layout story-box-${
-                                                                    r * 4 + i
-                                                                }`}
-                                                            />
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            );
-                                        default:
-                                            return (
-                                                <div
-                                                    className="stories-container"
-                                                    key={r}
-                                                >
-                                                    <div className="col-3">
-                                                        <StoryBox
-                                                            idx={r * 4 + 0}
-                                                            story={row[0]}
-                                                            className={`stories medium-screen-layout story-box-${
-                                                                r * 4 + 0
-                                                            }`}
-                                                        />
-                                                    </div>
-                                                    <div className="col-3">
-                                                        <div className="row-2">
-                                                            <StoryBox
-                                                                idx={r * 4 + 1}
-                                                                story={row[1]}
-                                                                className={`stories medium-screen-layout story-box-${
-                                                                    r * 4 + 1
-                                                                }`}
-                                                            />
-                                                            <StoryBox
-                                                                idx={r * 4 + 2}
-                                                                story={row[2]}
-                                                                className={`stories medium-screen-layout story-box-${
-                                                                    r * 4 + 2
-                                                                }`}
-                                                            />
-                                                        </div>
-                                                    </div>
-                                                    <div className="col-3">
-                                                        <StoryBox
-                                                            idx={r * 4 + 3}
-                                                            story={row[3]}
-                                                            className={`stories medium-screen-layout story-box-${
-                                                                r * 4 + 3
-                                                            }`}
-                                                        />
-                                                    </div>
-                                                </div>
-                                            );
-                                    }
+                                            ))}
+                                        </div>
+                                    );
                                 })}
                             </div>
                         </CSSTransition>

--- a/magda-web-client/src/Components/Home/Stories.tsx
+++ b/magda-web-client/src/Components/Home/Stories.tsx
@@ -24,6 +24,8 @@ class Stories extends Component<PropsType, StateType> {
 
     componentDidMount() {
         window.addEventListener("scroll", this.showStories);
+        // we made all stories are shown on initial page load to avoid a long background image cut off issue.
+        this.showStories();
     }
 
     showStories() {

--- a/magda-web-client/src/Components/Home/StoryBox.scss
+++ b/magda-web-client/src/Components/Home/StoryBox.scss
@@ -65,11 +65,5 @@
             border-top-left-radius: 4px;
             border-top-right-radius: 4px;
         }
-
-        .story-box-2 {
-            .story-title {
-                margin-top: 0px;
-            }
-        }
     }
 }

--- a/magda-web-client/src/helpers/ChartDatasetEncoder.js
+++ b/magda-web-client/src/helpers/ChartDatasetEncoder.js
@@ -54,7 +54,9 @@ const OVERRIDE_TO_CATEGORY_COLUMNS = [
     "reason",
     "year",
     "country",
-    /^registration number$/i
+    /^registration number$/i,
+    /^LIQ NUM$/i,
+    /^REG AUD NUM$/i
 ];
 /** Columns with these terms in them will be overridden as time types */
 const OVERRIDE_TO_TIME_COLUMNS = [

--- a/magda-web-client/src/helpers/resizeImage.js
+++ b/magda-web-client/src/helpers/resizeImage.js
@@ -5,20 +5,8 @@ export default function resizeImage(img, width, height) {
     canvas.width = width;
     canvas.height = height;
     const ctx = canvas.getContext("2d");
-    const imageAspect = img.width / img.height;
-    const targetAspect = width / height;
-    let x = 0,
-        y = 0,
-        dx = width,
-        dy = height;
-    if (imageAspect < targetAspect) {
-        dy = img.height * (dx / img.width);
-        y = (height - dy) / 2;
-    } else if (imageAspect > targetAspect) {
-        dx = img.width * (height / img.height);
-        y = (width - dx) / 2;
-    }
-    ctx.drawImage(img, x, y, dx, dy); // destination rectangle
+    console.log(`resizing image to ${width}, ${height}`);
+    ctx.drawImage(img, 0, 0, width, height); // destination rectangle
     return dataURItoBlob(canvas.toDataURL("image/jpeg", 90));
 }
 


### PR DESCRIPTION
### What this PR does

Some generic homepage visual adjustment.
- Make home tiles 2 columns layout (instead 3 tiles with various sizes)
- Keep original image size when uploading background images from the admin panel
- CSS fixes to make sure the background images original height is kept but not beyond the content length.

Those changes are introduced based on DGA feedback but are generic in nature.

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
