### PR TITLE
#3126 Remove Hardcoded "postgres" username from Content DB migration script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - #3319 Upgrade kramdown to 2.3.1
 - #3320 Upgrade djv to 2.1.4
 - #3321 upgrade lodash to 4.17.21
+- #3126 Remove Hardcoded "postgres" username from Content DB migration script
 
 ## 1.2.0
 

--- a/magda-migrator-content-db/sql/V1__Initial.sql
+++ b/magda-migrator-content-db/sql/V1__Initial.sql
@@ -11,6 +11,3 @@ WITH (
     OIDS = FALSE
 )
 TABLESPACE pg_default;
-
-ALTER TABLE public.content
-    OWNER to postgres;


### PR DESCRIPTION
### What this PR does

Fixes:
- #3126

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
