### PR TITLE
#3233 use networking.k8s.io/v1 for default Ingress chart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - #3320 Upgrade djv to 2.1.4
 - #3321 upgrade lodash to 4.17.21
 - #3126 Remove Hardcoded "postgres" username from Content DB migration script
+- #3233 use networking.k8s.io/v1 for default Ingress chart
 
 ## 1.2.0
 

--- a/deploy/helm/internal-charts/ingress/templates/ingress.yaml
+++ b/deploy/helm/internal-charts/ingress/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -23,10 +23,13 @@ spec:
   rules:
   - http:
       paths:
-      - backend:
-          serviceName: {{ .Values.targetService | default "gateway" }}
-          servicePort: 80
-        path: {{ if eq (.Values.ingressClass | default "") "gce" -}} /* {{- else -}} / {{- end }}
+      - pathType: {{ if eq (.Values.ingressClass | default "") "gce" -}} "ImplementationSpecific" {{- else -}} "Prefix" {{- end }}
+        path: {{ if eq (.Values.ingressClass | default "") "gce" -}} "/*" {{- else -}} "/" {{- end }}
+        backend:
+          service:
+            name: {{ .Values.targetService | default "gateway" }}
+            port: 
+              number: 80
     {{- if .Values.hostname  }}
     host: {{ .Values.hostname }}
     {{- end }}


### PR DESCRIPTION
### What this PR does

Fixes 
- #3233

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
