### PR TITLE
Issue/3269 Backend Support Access Group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@
 - #3360: Recategorize auth object related API docs & more auth object related APIs for convenient of future UI development.
 - #3363: Update postgres helm chart repo url
 
+## 1.3.1
+
+- #3367 Fixed Content API header item schema target field type
+
 ## 1.3.0
 
 - Upgrade nodemailer to 6.7.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
 - #3369 Content API Get by id API didn't response content in correct mime type
 - #3371 Content API Get by id API generate one more unnecessary DB query
 - #3363: Update postgres helm chart repo url
+- Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22
+- #3362 explicitly mark pods using emptyDir as safe to evict for cluster-autoscaler
 
 ## 1.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 - Fixed: helm chart version update script incorrectly skip updating dependencies version when `versionUpdateExclude` config in package.json is empty
 - Fixed: incorrect scss-compiler-config data might be generated if non-default docker image config is used.
 - #3360: Recategorize auth object related API docs & more auth object related APIs for convenient of future UI development.
+- Fixed: `set-scss-vars` script will use proper imagePullSecrets to generate the UI CSS update job
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@
 - #3360: Recategorize auth object related API docs & more auth object related APIs for convenient of future UI development.
 - Fixed: `set-scss-vars` script will use proper imagePullSecrets to generate the UI CSS update job
 - Allow the `no cache` behaviour of `whoami` & `getUserById` api to be turned off
+- #3269 Backend support for Access Group
+- #3366 New Registry API capability: new filter operator, merge mode, group operations and more
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 ## 1.3.1
 
 - #3367 Fixed Content API header item schema target field type
+- #3369 Content API Get by id API didn't response content in correct mime type
 
 ## 1.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,13 +36,13 @@
 - Fixed: helm chart version update script incorrectly skip updating dependencies version when `versionUpdateExclude` config in package.json is empty
 - Fixed: incorrect scss-compiler-config data might be generated if non-default docker image config is used.
 - #3360: Recategorize auth object related API docs & more auth object related APIs for convenient of future UI development.
-- #3363: Update postgres helm chart repo url
 
 ## 1.3.1
 
 - #3367 Fixed Content API header item schema target field type
 - #3369 Content API Get by id API didn't response content in correct mime type
 - #3371 Content API Get by id API generate one more unnecessary DB query
+- #3363: Update postgres helm chart repo url
 
 ## 1.3.0
 
@@ -51,6 +51,7 @@
 - #3020 Remove all legacy auth provider from gateway and convert them into auth plugins in separate repos
 - Add `authPluginAllowedExternalRedirectDomains` support to auth plugin spec & rewrite relevant packages
 - Redirect users to login page with proper error message, when they try to access the admin pages that they don't have permissions.
+- #3363: Update postgres helm chart repo url
 
 ## 1.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Fixed: incorrect scss-compiler-config data might be generated if non-default docker image config is used.
 - #3360: Recategorize auth object related API docs & more auth object related APIs for convenient of future UI development.
 - Fixed: `set-scss-vars` script will use proper imagePullSecrets to generate the UI CSS update job
+- Allow the `no cache` behaviour of `whoami` & `getUserById` api to be turned off
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 
 - #3367 Fixed Content API header item schema target field type
 - #3369 Content API Get by id API didn't response content in correct mime type
+- #3371 Content API Get by id API generate one more unnecessary DB query
 
 ## 1.3.0
 

--- a/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         service: authorization-api
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
 {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") .Values.global.enablePriorityClass }}
       priorityClassName: magda-8

--- a/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             secretKeyRef:
               name: auth-secrets
               key: jwt-secret
+        - name: USER_ID
+          value: {{ .Values.global.defaultAdminUserId }}
         {{- include "magda.db-client-credential-env" (dict "dbName" "authorization-db" "root" .) | indent 8 }}
       - name: opa
         {{- $imageEnv := omit . "Values" }}

--- a/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/authorization-api/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
             "--listenPort", "80",
             "--dbHost", "authorization-db",
             "--dbPort", "5432",
+            "--registryApiUrl", "http://registry-api/v0",
             "--opaUrl", "http://localhost:8181/",
 {{- if .Values.debug }}
             "--debug", "true",

--- a/deploy/helm/internal-charts/cloud-sql-proxy/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/cloud-sql-proxy/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         service: cloud-sql-proxy
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
 {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") .Values.global.enablePriorityClass }}
       priorityClassName: magda-9

--- a/deploy/helm/internal-charts/elasticsearch/templates/client-deployment.yml
+++ b/deploy/helm/internal-charts/elasticsearch/templates/client-deployment.yml
@@ -20,6 +20,8 @@ spec:
       labels:
         component: elasticsearch
         role: client
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       {{- include "magda.elasticsearch.initContainer" . | indent 6 }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}

--- a/deploy/helm/internal-charts/elasticsearch/templates/master-deployment.yml
+++ b/deploy/helm/internal-charts/elasticsearch/templates/master-deployment.yml
@@ -20,6 +20,8 @@ spec:
       labels:
         component: elasticsearch
         role: master
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       {{- include "magda.elasticsearch.initContainer" . | indent 6 }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}

--- a/deploy/helm/internal-charts/magda-postgres/Chart.lock
+++ b/deploy/helm/internal-charts/magda-postgres/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 10.9.1
 digest: sha256:f0f7c763c2f2d05b70c667ad3553604f9d34a0f01340c2fb67fa3f29d423e10a
-generated: "2022-06-14T23:20:51.699319+10:00"
+generated: "2022-06-28T18:33:29.340263+10:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -29,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:bb5d105f8857a598349a9911d3213202ad2f7096c31d7d73f0f4157bd516149e
-generated: "2022-06-29T20:17:58.877107+10:00"
+digest: sha256:7fb1e519ba6c37bb7917952dcc50916642c180a3d608da1097ae8ff17ca65259
+generated: "2022-07-07T19:51:16.629879+10:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 2.0.0-alpha.0
 - name: openfaas
   repository: https://charts.magda.io
-  version: 5.5.5-magda.1
+  version: 5.5.5-magda.2
 - name: magda-function-history-report
   repository: https://charts.magda.io
   version: 1.1.0
@@ -29,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:120b6b94ba0952eca8ed5ea5033008c492ba666c57ea9b87ef3e06435dfa69af
-generated: "2022-03-09T14:58:58.47184+11:00"
+digest: sha256:bb5d105f8857a598349a9911d3213202ad2f7096c31d7d73f0f4157bd516149e
+generated: "2022-06-29T20:17:58.877107+10:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: file://../magda-core
 
   - name: openfaas
-    version: 5.5.5-magda.1
+    version: 5.5.5-magda.2
     repository: https://charts.magda.io
     # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
     # Due to a limitation of helm, the value of tags is not available in chart template.

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -23,7 +23,7 @@ A complete solution for managing, publishing and discovering government data, pr
 | https://charts.magda.io | minion-format(magda-minion-format) | 1.1.0 |
 | https://charts.magda.io | minion-linked-data-rating(magda-minion-linked-data-rating) | 1.1.0 |
 | https://charts.magda.io | minion-visualization(magda-minion-visualization) | 1.0.0 |
-| https://charts.magda.io | openfaas | 5.5.5-magda.1 |
+| https://charts.magda.io | openfaas | 5.5.5-magda.2 |
 
 ## Values
 

--- a/magda-authorization-api/package.json
+++ b/magda-authorization-api/package.json
@@ -68,7 +68,8 @@
       "include": "node_modules dist Dockerfile"
     },
     "jwtSecret": "squirrel",
-    "SESSION_SECRET": "keyboard cat"
+    "SESSION_SECRET": "keyboard cat",
+    "userId": "00000000-0000-4000-8000-000000000000"
   },
   "magda": {
     "language": "typescript",

--- a/magda-authorization-api/src/Database.ts
+++ b/magda-authorization-api/src/Database.ts
@@ -5,7 +5,9 @@ import {
     Permission,
     APIKeyRecord,
     UserRecord,
-    CreateUserData
+    CreateUserData,
+    ResourceRecord,
+    OperationRecord
 } from "magda-typescript-common/src/authorization-api/model";
 import { Maybe } from "tsmonad";
 import arrayToMaybe from "magda-typescript-common/src/util/arrayToMaybe";
@@ -977,5 +979,37 @@ export default class Database {
         } finally {
             client.release();
         }
+    }
+
+    async getResourceByUri(
+        uri: string,
+        client: pg.Client | pg.PoolClient = null
+    ) {
+        if (!uri) {
+            throw new ServerError("uri cannot be empty!", 400);
+        }
+        const result = await (client ? client : this.pool).query(
+            ...sqls`SELECT * FROM resources WHERE uri = ${uri} LIMIT 1`.toQuery()
+        );
+        if (!result?.rows?.length) {
+            return null;
+        }
+        return result.rows[0] as ResourceRecord;
+    }
+
+    async getOperationByUri(
+        uri: string,
+        client: pg.Client | pg.PoolClient = null
+    ) {
+        if (!uri) {
+            throw new ServerError("uri cannot be empty!", 400);
+        }
+        const result = await (client ? client : this.pool).query(
+            ...sqls`SELECT * FROM operations WHERE uri = ${uri} LIMIT 1`.toQuery()
+        );
+        if (!result?.rows?.length) {
+            return null;
+        }
+        return result.rows[0] as OperationRecord;
     }
 }

--- a/magda-authorization-api/src/Database.ts
+++ b/magda-authorization-api/src/Database.ts
@@ -895,51 +895,62 @@ export default class Database {
         }
     }
 
-    async deletePermission(permissionId?: string): Promise<boolean> {
+    async deletePermission(
+        permissionId?: string,
+        client: pg.PoolClient = null
+    ): Promise<boolean> {
         if (!isUuid(permissionId)) {
             throw new ServerError("permission id should be a valid uuid.", 400);
         }
 
-        const pool = this.pool;
-        const permission = await getTableRecord(
-            pool,
-            "permissions",
-            permissionId
-        );
-        if (!permission) {
-            return false;
+        const shouldReleaseClient = client ? false : true;
+        if (!client) {
+            client = await this.pool.connect();
         }
-        const result = await pool.query(
-            ...sqls`SELECT 1 FROM role_permissions WHERE permission_id = ${permissionId}`.toQuery()
-        );
-        if (result?.rows?.length) {
-            throw new ServerError(
-                `Cannot delete permission: ${permissionId} before remove it from all assigned roles.`,
-                400
-            );
-        }
-        const client = await pool.connect();
+
         try {
-            await client.query("BEGIN");
-
-            await client.query(
-                ...sqls`DELETE FROM permission_operations WHERE permission_id = ${permissionId}`.toQuery()
+            const permission = await getTableRecord(
+                client,
+                "permissions",
+                permissionId
             );
-            await client.query(
-                ...sqls`DELETE FROM permissions WHERE id = ${permissionId}`.toQuery()
+            if (!permission) {
+                return false;
+            }
+            const result = await client.query(
+                ...sqls`SELECT 1 FROM role_permissions WHERE permission_id = ${permissionId}`.toQuery()
             );
+            if (result?.rows?.length) {
+                throw new ServerError(
+                    `Cannot delete permission: ${permissionId} before remove it from all assigned roles.`,
+                    400
+                );
+            }
 
-            await client.query("COMMIT");
-            return true;
-        } catch (e) {
-            await client.query("ROLLBACK");
-            throw e;
+            try {
+                await client.query("BEGIN");
+
+                await client.query(
+                    ...sqls`DELETE FROM permission_operations WHERE permission_id = ${permissionId}`.toQuery()
+                );
+                await client.query(
+                    ...sqls`DELETE FROM permissions WHERE id = ${permissionId}`.toQuery()
+                );
+
+                await client.query("COMMIT");
+                return true;
+            } catch (e) {
+                await client.query("ROLLBACK");
+                throw e;
+            }
         } finally {
-            client.release();
+            if (shouldReleaseClient) {
+                client.release();
+            }
         }
     }
 
-    async deleteRole(roleId?: string) {
+    async deleteRole(roleId?: string, client: pg.PoolClient = null) {
         roleId = roleId?.trim();
         if (!roleId) {
             throw new ServerError("Invalid empty role id supplied.", 400);
@@ -952,34 +963,38 @@ export default class Database {
             );
         }
 
-        const pool = this.pool;
-        const role = await getTableRecord(pool, "roles", roleId);
-        if (!role) {
-            throw new ServerError(
-                "Cannot locate role record by ID: " + roleId,
-                404
-            );
-        }
-        const userRolesResult = await pool.query(
-            ...sqls`SELECT 1 FROM user_roles WHERE role_id = ${roleId} LIMIT 1`.toQuery()
-        );
-        if (userRolesResult?.rows?.length) {
-            throw new ServerError(
-                "Please remove the role from all users and try again",
-                400
-            );
+        const shouldReleaseClient = client ? false : true;
+        if (!client) {
+            client = await this.pool.connect();
         }
 
-        const client = await pool.connect();
         try {
-            await client.query("BEGIN");
-
-            await client.query(
-                ...sqls`DELETE FROM user_roles WHERE role_id = ${roleId}`.toQuery()
+            const role = await getTableRecord(client, "roles", roleId);
+            if (!role) {
+                throw new ServerError(
+                    "Cannot locate role record by ID: " + roleId,
+                    404
+                );
+            }
+            const userRolesResult = await client.query(
+                ...sqls`SELECT 1 FROM user_roles WHERE role_id = ${roleId} LIMIT 1`.toQuery()
             );
-            // delete all permission / operation relationship that not belong to other roles
-            await client.query(
-                ...sqls`DELETE FROM permission_operations WHERE permission_id IN (
+            if (userRolesResult?.rows?.length) {
+                throw new ServerError(
+                    "Please remove the role from all users and try again",
+                    400
+                );
+            }
+
+            try {
+                await client.query("BEGIN");
+
+                await client.query(
+                    ...sqls`DELETE FROM user_roles WHERE role_id = ${roleId}`.toQuery()
+                );
+                // delete all permission / operation relationship that not belong to other roles
+                await client.query(
+                    ...sqls`DELETE FROM permission_operations WHERE permission_id IN (
                             SELECT rp1.permission_id FROM role_permissions rp1 
                             WHERE rp1.permission_id IN (
                                 SELECT rp2.permission_id FROM role_permissions rp2 WHERE rp2.role_id = ${roleId}
@@ -987,11 +1002,11 @@ export default class Database {
                                 SELECT 1 FROM role_permissions rp3 WHERE rp1.permission_id = rp3.permission_id AND rp3.role_id != ${roleId}
                             )
                         )`.toQuery()
-            );
+                );
 
-            // delete all permissions that not belong to other roles
-            await client.query(
-                ...sqls`DELETE FROM permissions WHERE id IN (
+                // delete all permissions that not belong to other roles
+                await client.query(
+                    ...sqls`DELETE FROM permissions WHERE id IN (
                             SELECT rp1.permission_id FROM role_permissions rp1 
                             WHERE rp1.permission_id IN (
                                 SELECT rp2.permission_id FROM role_permissions rp2 WHERE rp2.role_id = ${roleId}
@@ -999,18 +1014,21 @@ export default class Database {
                                 SELECT 1 FROM role_permissions rp3 WHERE rp1.permission_id = rp3.permission_id AND rp3.role_id != ${roleId}
                             )
                         )`.toQuery()
-            );
+                );
 
-            await client.query(
-                ...sqls`DELETE FROM roles WHERE id = ${roleId}`.toQuery()
-            );
+                await client.query(
+                    ...sqls`DELETE FROM roles WHERE id = ${roleId}`.toQuery()
+                );
 
-            await client.query("COMMIT");
-        } catch (e) {
-            await client.query("ROLLBACK");
-            throw e;
+                await client.query("COMMIT");
+            } catch (e) {
+                await client.query("ROLLBACK");
+                throw e;
+            }
         } finally {
-            client.release();
+            if (shouldReleaseClient) {
+                client.release();
+            }
         }
     }
 
@@ -1055,304 +1073,121 @@ export default class Database {
             client = await this.pool.connect();
         }
 
-        if (options?.resourceId && options?.resourceUri) {
-            throw new ServerError(
-                "`resourceId` & `resourceUri` parameter cannot be both supplied.",
-                400
-            );
-        }
-        if (!options?.resourceId && !options?.resourceUri) {
-            throw new ServerError(
-                "Either `resourceId` or `resourceUri` parameter has to be supplied.",
-                400
-            );
-        }
-        if (isArray(options?.operationIds) && isArray(options?.operationUris)) {
-            throw new ServerError(
-                "`operationIds` & `operationUris` parameter cannot be both supplied.",
-                400
-            );
-        }
-        if (
-            !isArray(options?.operationIds) &&
-            !isArray(options?.operationUris)
-        ) {
-            throw new ServerError(
-                "Either `operationIds` or `operationUris` has be valid array.",
-                400
-            );
-        }
-        let {
-            name,
-            description,
-            userOwnershipConstraint,
-            orgUnitOwnershipConstraint,
-            preAuthorisedConstraint,
-            resourceId,
-            operationIds,
-            ownerId,
-            createBy
-        } = options;
-
-        if (!name || typeof name !== "string") {
-            throw new ServerError(
-                "`name` field must be a non-empty string.",
-                400
-            );
-        }
-
-        if (ownerId && !isUuid(ownerId)) {
-            throw new ServerError("`ownerId` field must be a valid uuid.", 400);
-        }
-
-        if (createBy && !isUuid(createBy)) {
-            throw new ServerError(
-                "`createBy` field must be a valid uuid.",
-                400
-            );
-        }
-
-        description = description ? "" + description : "";
-        userOwnershipConstraint =
-            typeof userOwnershipConstraint == "boolean"
-                ? userOwnershipConstraint
-                : false;
-        orgUnitOwnershipConstraint =
-            typeof orgUnitOwnershipConstraint == "boolean"
-                ? orgUnitOwnershipConstraint
-                : false;
-        preAuthorisedConstraint =
-            typeof preAuthorisedConstraint == "boolean"
-                ? preAuthorisedConstraint
-                : false;
-        let resource: ResourceRecord;
-        if (options?.resourceUri) {
-            resource = await this.getResourceByUri(options.resourceUri, client);
-            if (!resource) {
-                throw new ServerError(
-                    `resource uri ${options.resourceUri} doesn't exist`,
-                    400
-                );
-            }
-            resourceId = resource.id;
-        } else {
-            resource = await getTableRecord(client, "resources", resourceId);
-            if (!resource) {
-                throw new ServerError(
-                    `cannot locate resource with id: ${options.resourceId}`,
-                    400
-                );
-            }
-        }
-
-        if (isArray(options?.operationUris)) {
-            // operationUris is supplied
-            // validate operationUris
-            let operationUris = options.operationUris;
-            operationUris = operationUris
-                .filter((item) => !!item)
-                .map((item) => `${item}`.trim().toLowerCase())
-                .filter((item) => !!item);
-            if (!operationUris.length) {
-                throw new ServerError(
-                    "Supplied `operationUris` doesn't contain any valid items",
-                    400
-                );
-            }
-            operationUris = uniq(operationUris);
-            const result = await client.query(
-                ...sqls`SELECT id
-                FROM operations 
-                WHERE uri IN (${SQLSyntax.csv(
-                    ...operationUris.map((item) => sqls`${item}`)
-                )}) AND resource_id = ${resourceId}`.toQuery()
-            );
-
-            if (result?.rows?.length !== operationUris.length) {
-                throw new ServerError(
-                    `Not all provided operation uris are valid and belong to the resource ${resource.uri}`,
-                    400
-                );
-            }
-            operationIds = result.rows;
-        } else {
-            // operationIds is supplied
-            // validate operationIds
-            const invalidOperationId = operationIds.find(
-                (item) => !isUuid(item)
-            );
-            if (typeof invalidOperationId !== "undefined") {
-                throw new ServerError(
-                    `One of the provided operation id is not valid UUID: ${invalidOperationId}`,
-                    400
-                );
-            }
-            if (!operationIds.length) {
-                throw new ServerError(
-                    "Supplied `operationIds` must not be empty array",
-                    400
-                );
-            }
-
-            const result = await client.query(
-                ...sqls`SELECT COUNT(*) as count
-            FROM operations 
-            WHERE id IN (${SQLSyntax.csv(
-                ...operationIds.map((item) => sqls`${item}`)
-            )}) AND resource_id = ${resource.id}`.toQuery()
-            );
-
-            if (result?.rows?.[0]?.["count"] !== operationIds.length) {
-                throw new Error(
-                    `Not all provided operation ids are valid and belong to the resource ${resource.uri}`
-                );
-            }
-            operationIds = uniq(operationIds);
-        }
-
-        const permissionData = {
-            name,
-            description,
-            resource_id: resourceId,
-            user_ownership_constraint: userOwnershipConstraint,
-            org_unit_ownership_constraint: orgUnitOwnershipConstraint,
-            pre_authorised_constraint: preAuthorisedConstraint
-        } as any;
-
-        if (ownerId) {
-            permissionData["owner_id"] = ownerId;
-        }
-
-        if (createBy) {
-            permissionData["create_by"] = createBy;
-            permissionData["edit_by"] = createBy;
-        }
-
         try {
-            await client.query("BEGIN");
-            const permission = await createTableRecord(
-                client,
-                "permissions",
-                permissionData,
-                [
-                    "name",
-                    "resource_id",
-                    "user_ownership_constraint",
-                    "org_unit_ownership_constraint",
-                    "pre_authorised_constraint",
-                    "description",
-                    "create_by",
-                    "owner_id",
-                    "edit_by"
-                ]
-            );
-
-            const values = (operationIds as string[]).map(
-                (id) => sqls`(${permission.id},${id})`
-            );
-
-            await client.query(
-                ...sqls`INSERT INTO permission_operations 
-            (permission_id, operation_id) VALUES 
-            ${SQLSyntax.csv(...values)}`.toQuery()
-            );
-            await client.query("COMMIT");
-            return permission;
-        } catch (e) {
-            await client.query("ROLLBACK");
-            throw e;
-        } finally {
-            if (shouldReleaseClient) {
-                client.release();
-            }
-        }
-    }
-
-    async updatePermission(
-        id: string,
-        options: UpdatePermissionOptions,
-        client: pg.PoolClient = null
-    ) {
-        if (isEmpty(options)) {
-            throw new ServerError("Empty update options are supplied.");
-        }
-        const shouldReleaseClient = client ? false : true;
-        if (!client) {
-            client = await this.pool.connect();
-        }
-
-        if (!isUuid(id)) {
-            throw new ServerError("id must be a valid UUID", 400);
-        }
-
-        const permission = await getTableRecord(client, "permissions", id);
-        if (!permission) {
-            throw new ServerError(
-                `cannot locate permission with id: ${id}`,
-                400
-            );
-        }
-
-        let {
-            name,
-            description,
-            userOwnershipConstraint,
-            orgUnitOwnershipConstraint,
-            preAuthorisedConstraint,
-            resourceId,
-            resourceUri,
-            operationIds,
-            operationUris,
-            ownerId,
-            editBy
-        } = options;
-
-        let resource: ResourceRecord;
-        if (resourceUri) {
-            resource = await this.getResourceByUri(resourceUri, client);
-            if (!resource) {
+            if (options?.resourceId && options?.resourceUri) {
                 throw new ServerError(
-                    `resource uri ${resourceUri} doesn't exist`,
+                    "`resourceId` & `resourceUri` parameter cannot be both supplied.",
                     400
                 );
             }
-            resourceId = resource.id;
-        } else if (resourceId) {
-            if (!isUuid(resourceId)) {
+            if (!options?.resourceId && !options?.resourceUri) {
                 throw new ServerError(
-                    `supplied resourceId ${resourceId} is not valid UUID`,
+                    "Either `resourceId` or `resourceUri` parameter has to be supplied.",
                     400
                 );
             }
-            resource = await getTableRecord(client, "resources", resourceId);
-            if (!resource) {
+            if (
+                isArray(options?.operationIds) &&
+                isArray(options?.operationUris)
+            ) {
                 throw new ServerError(
-                    `cannot locate resource with id: ${resourceId}`,
+                    "`operationIds` & `operationUris` parameter cannot be both supplied.",
                     400
                 );
             }
-        } else {
-            resourceId = permission.resource_id;
-            resource = await getTableRecord(client, "resources", resourceId);
-            if (!resource) {
+            if (
+                !isArray(options?.operationIds) &&
+                !isArray(options?.operationUris)
+            ) {
                 throw new ServerError(
-                    `cannot locate resource with id: ${resourceId}`,
-                    500
+                    "Either `operationIds` or `operationUris` has be valid array.",
+                    400
                 );
             }
-        }
+            let {
+                name,
+                description,
+                userOwnershipConstraint,
+                orgUnitOwnershipConstraint,
+                preAuthorisedConstraint,
+                resourceId,
+                operationIds,
+                ownerId,
+                createBy
+            } = options;
 
-        if (isArray(operationUris)) {
-            if (!operationUris.length) {
-                operationIds = [];
+            if (!name || typeof name !== "string") {
+                throw new ServerError(
+                    "`name` field must be a non-empty string.",
+                    400
+                );
+            }
+
+            if (ownerId && !isUuid(ownerId)) {
+                throw new ServerError(
+                    "`ownerId` field must be a valid uuid.",
+                    400
+                );
+            }
+
+            if (createBy && !isUuid(createBy)) {
+                throw new ServerError(
+                    "`createBy` field must be a valid uuid.",
+                    400
+                );
+            }
+
+            description = description ? "" + description : "";
+            userOwnershipConstraint =
+                typeof userOwnershipConstraint == "boolean"
+                    ? userOwnershipConstraint
+                    : false;
+            orgUnitOwnershipConstraint =
+                typeof orgUnitOwnershipConstraint == "boolean"
+                    ? orgUnitOwnershipConstraint
+                    : false;
+            preAuthorisedConstraint =
+                typeof preAuthorisedConstraint == "boolean"
+                    ? preAuthorisedConstraint
+                    : false;
+            let resource: ResourceRecord;
+            if (options?.resourceUri) {
+                resource = await this.getResourceByUri(
+                    options.resourceUri,
+                    client
+                );
+                if (!resource) {
+                    throw new ServerError(
+                        `resource uri ${options.resourceUri} doesn't exist`,
+                        400
+                    );
+                }
+                resourceId = resource.id;
             } else {
+                resource = await getTableRecord(
+                    client,
+                    "resources",
+                    resourceId
+                );
+                if (!resource) {
+                    throw new ServerError(
+                        `cannot locate resource with id: ${options.resourceId}`,
+                        400
+                    );
+                }
+            }
+
+            if (isArray(options?.operationUris)) {
+                // operationUris is supplied
+                // validate operationUris
+                let operationUris = options.operationUris;
                 operationUris = operationUris
                     .filter((item) => !!item)
                     .map((item) => `${item}`.trim().toLowerCase())
                     .filter((item) => !!item);
                 if (!operationUris.length) {
                     throw new ServerError(
-                        "Supplied `operationUris` contains invalid items",
+                        "Supplied `operationUris` doesn't contain any valid items",
                         400
                     );
                 }
@@ -1372,133 +1207,342 @@ export default class Database {
                     );
                 }
                 operationIds = result.rows;
-            }
-        } else if (isArray(operationIds) && operationIds.length) {
-            const invalidOperationId = operationIds.find(
-                (item) => !isUuid(item)
-            );
-            if (typeof invalidOperationId !== "undefined") {
-                throw new ServerError(
-                    `One of the provided operation id is not valid UUID: ${invalidOperationId}`,
-                    400
+            } else {
+                // operationIds is supplied
+                // validate operationIds
+                const invalidOperationId = operationIds.find(
+                    (item) => !isUuid(item)
                 );
-            }
+                if (typeof invalidOperationId !== "undefined") {
+                    throw new ServerError(
+                        `One of the provided operation id is not valid UUID: ${invalidOperationId}`,
+                        400
+                    );
+                }
+                if (!operationIds.length) {
+                    throw new ServerError(
+                        "Supplied `operationIds` must not be empty array",
+                        400
+                    );
+                }
 
-            const result = await client.query(
-                ...sqls`SELECT COUNT(*) as count
+                const result = await client.query(
+                    ...sqls`SELECT COUNT(*) as count
             FROM operations 
             WHERE id IN (${SQLSyntax.csv(
                 ...operationIds.map((item) => sqls`${item}`)
-            )}) AND resource_id = ${resourceId}`.toQuery()
-            );
-
-            if (result?.rows?.[0]?.["count"] !== operationIds.length) {
-                throw new Error(
-                    `Not all provided operation ids are valid and belong to the resource ${resource.uri}`
+            )}) AND resource_id = ${resource.id}`.toQuery()
                 );
+
+                if (result?.rows?.[0]?.["count"] !== operationIds.length) {
+                    throw new Error(
+                        `Not all provided operation ids are valid and belong to the resource ${resource.uri}`
+                    );
+                }
+                operationIds = uniq(operationIds);
             }
-            operationIds = uniq(operationIds);
-        }
 
-        const permissionData = {
-            resource_id: resourceId
-        } as any;
+            const permissionData = {
+                name,
+                description,
+                resource_id: resourceId,
+                user_ownership_constraint: userOwnershipConstraint,
+                org_unit_ownership_constraint: orgUnitOwnershipConstraint,
+                pre_authorised_constraint: preAuthorisedConstraint
+            } as any;
 
-        if (name) {
-            name = `${name}`.trim();
-            if (!name) {
-                throw new ServerError("`name` cannot be empty", 400);
+            if (ownerId) {
+                permissionData["owner_id"] = ownerId;
             }
-            permissionData["name"] = name;
-        }
 
-        if (description) {
-            description = `${description}`.trim();
-            permissionData["description"] = description;
-        }
+            if (createBy) {
+                permissionData["create_by"] = createBy;
+                permissionData["edit_by"] = createBy;
+            }
 
-        if (typeof userOwnershipConstraint === "boolean") {
-            permissionData[
-                "user_ownership_constraint"
-            ] = userOwnershipConstraint;
-        }
-
-        if (typeof orgUnitOwnershipConstraint === "boolean") {
-            permissionData[
-                "org_unit_ownership_constraint"
-            ] = orgUnitOwnershipConstraint;
-        }
-
-        if (typeof preAuthorisedConstraint === "boolean") {
-            permissionData[
-                "pre_authorised_constraint"
-            ] = preAuthorisedConstraint;
-        }
-
-        if (ownerId === null || isUuid(ownerId)) {
-            permissionData["owner_id"] = ownerId;
-        } else if (ownerId && !isUuid(ownerId)) {
-            throw new ServerError("`ownerId` must be valid UUID", 400);
-        }
-
-        if (editBy === null || isUuid(editBy)) {
-            permissionData["edit_by"] = editBy;
-        } else if (editBy && !isUuid(editBy)) {
-            throw new ServerError("`editBy` must be valid UUID", 400);
-        }
-
-        try {
-            await client.query("BEGIN");
-
-            const permissionUpdateData = {
-                ...permissionData,
-                edit_time: sqls` CURRENT_TIMESTAMP `
-            };
-
-            const permissionRecord = await updateTableRecord(
-                client,
-                "permissions",
-                id,
-                permissionUpdateData,
-                [
-                    "name",
-                    "resource_id",
-                    "user_ownership_constraint",
-                    "org_unit_ownership_constraint",
-                    "pre_authorised_constraint",
-                    "description",
-                    "owner_id",
-                    "edit_by",
-                    "edit_time"
-                ]
-            );
-
-            if (isArray(operationIds)) {
-                // operationIds property is provided
-                // i.e. user's intention is to update operations as well
-                // delete all current operation / permission relationship
-                await client.query(
-                    ...sqls`DELETE FROM permission_operations WHERE permission_id=${id}`.toQuery()
+            try {
+                await client.query("BEGIN");
+                const permission = await createTableRecord(
+                    client,
+                    "permissions",
+                    permissionData,
+                    [
+                        "name",
+                        "resource_id",
+                        "user_ownership_constraint",
+                        "org_unit_ownership_constraint",
+                        "pre_authorised_constraint",
+                        "description",
+                        "create_by",
+                        "owner_id",
+                        "edit_by"
+                    ]
                 );
-            }
 
-            if (operationIds.length) {
                 const values = (operationIds as string[]).map(
-                    (item) => sqls`(${id},${item})`
+                    (id) => sqls`(${permission.id},${id})`
                 );
 
                 await client.query(
                     ...sqls`INSERT INTO permission_operations 
-                    (permission_id, operation_id) VALUES 
-                    ${SQLSyntax.csv(...values)}`.toQuery()
+            (permission_id, operation_id) VALUES 
+            ${SQLSyntax.csv(...values)}`.toQuery()
+                );
+                await client.query("COMMIT");
+                return permission;
+            } catch (e) {
+                await client.query("ROLLBACK");
+                throw e;
+            }
+        } finally {
+            if (shouldReleaseClient) {
+                client.release();
+            }
+        }
+    }
+
+    async updatePermission(
+        id: string,
+        options: UpdatePermissionOptions,
+        client: pg.PoolClient = null
+    ) {
+        if (isEmpty(options)) {
+            throw new ServerError("Empty update options are supplied.");
+        }
+
+        if (!isUuid(id)) {
+            throw new ServerError("id must be a valid UUID", 400);
+        }
+
+        const shouldReleaseClient = client ? false : true;
+        if (!client) {
+            client = await this.pool.connect();
+        }
+
+        try {
+            const permission = await getTableRecord(client, "permissions", id);
+            if (!permission) {
+                throw new ServerError(
+                    `cannot locate permission with id: ${id}`,
+                    400
                 );
             }
 
-            await client.query("COMMIT");
-            return permissionRecord;
-        } catch (e) {
-            await client.query("ROLLBACK");
-            throw e;
+            let {
+                name,
+                description,
+                userOwnershipConstraint,
+                orgUnitOwnershipConstraint,
+                preAuthorisedConstraint,
+                resourceId,
+                resourceUri,
+                operationIds,
+                operationUris,
+                ownerId,
+                editBy
+            } = options;
+
+            let resource: ResourceRecord;
+            if (resourceUri) {
+                resource = await this.getResourceByUri(resourceUri, client);
+                if (!resource) {
+                    throw new ServerError(
+                        `resource uri ${resourceUri} doesn't exist`,
+                        400
+                    );
+                }
+                resourceId = resource.id;
+            } else if (resourceId) {
+                if (!isUuid(resourceId)) {
+                    throw new ServerError(
+                        `supplied resourceId ${resourceId} is not valid UUID`,
+                        400
+                    );
+                }
+                resource = await getTableRecord(
+                    client,
+                    "resources",
+                    resourceId
+                );
+                if (!resource) {
+                    throw new ServerError(
+                        `cannot locate resource with id: ${resourceId}`,
+                        400
+                    );
+                }
+            } else {
+                resourceId = permission.resource_id;
+                resource = await getTableRecord(
+                    client,
+                    "resources",
+                    resourceId
+                );
+                if (!resource) {
+                    throw new ServerError(
+                        `cannot locate resource with id: ${resourceId}`,
+                        500
+                    );
+                }
+            }
+
+            if (isArray(operationUris)) {
+                if (!operationUris.length) {
+                    operationIds = [];
+                } else {
+                    operationUris = operationUris
+                        .filter((item) => !!item)
+                        .map((item) => `${item}`.trim().toLowerCase())
+                        .filter((item) => !!item);
+                    if (!operationUris.length) {
+                        throw new ServerError(
+                            "Supplied `operationUris` contains invalid items",
+                            400
+                        );
+                    }
+                    operationUris = uniq(operationUris);
+                    const result = await client.query(
+                        ...sqls`SELECT id
+                FROM operations 
+                WHERE uri IN (${SQLSyntax.csv(
+                    ...operationUris.map((item) => sqls`${item}`)
+                )}) AND resource_id = ${resourceId}`.toQuery()
+                    );
+
+                    if (result?.rows?.length !== operationUris.length) {
+                        throw new ServerError(
+                            `Not all provided operation uris are valid and belong to the resource ${resource.uri}`,
+                            400
+                        );
+                    }
+                    operationIds = result.rows;
+                }
+            } else if (isArray(operationIds) && operationIds.length) {
+                const invalidOperationId = operationIds.find(
+                    (item) => !isUuid(item)
+                );
+                if (typeof invalidOperationId !== "undefined") {
+                    throw new ServerError(
+                        `One of the provided operation id is not valid UUID: ${invalidOperationId}`,
+                        400
+                    );
+                }
+
+                const result = await client.query(
+                    ...sqls`SELECT COUNT(*) as count
+            FROM operations 
+            WHERE id IN (${SQLSyntax.csv(
+                ...operationIds.map((item) => sqls`${item}`)
+            )}) AND resource_id = ${resourceId}`.toQuery()
+                );
+
+                if (result?.rows?.[0]?.["count"] !== operationIds.length) {
+                    throw new Error(
+                        `Not all provided operation ids are valid and belong to the resource ${resource.uri}`
+                    );
+                }
+                operationIds = uniq(operationIds);
+            }
+
+            const permissionData = {
+                resource_id: resourceId
+            } as any;
+
+            if (name) {
+                name = `${name}`.trim();
+                if (!name) {
+                    throw new ServerError("`name` cannot be empty", 400);
+                }
+                permissionData["name"] = name;
+            }
+
+            if (description) {
+                description = `${description}`.trim();
+                permissionData["description"] = description;
+            }
+
+            if (typeof userOwnershipConstraint === "boolean") {
+                permissionData[
+                    "user_ownership_constraint"
+                ] = userOwnershipConstraint;
+            }
+
+            if (typeof orgUnitOwnershipConstraint === "boolean") {
+                permissionData[
+                    "org_unit_ownership_constraint"
+                ] = orgUnitOwnershipConstraint;
+            }
+
+            if (typeof preAuthorisedConstraint === "boolean") {
+                permissionData[
+                    "pre_authorised_constraint"
+                ] = preAuthorisedConstraint;
+            }
+
+            if (ownerId === null || isUuid(ownerId)) {
+                permissionData["owner_id"] = ownerId;
+            } else if (ownerId && !isUuid(ownerId)) {
+                throw new ServerError("`ownerId` must be valid UUID", 400);
+            }
+
+            if (editBy === null || isUuid(editBy)) {
+                permissionData["edit_by"] = editBy;
+            } else if (editBy && !isUuid(editBy)) {
+                throw new ServerError("`editBy` must be valid UUID", 400);
+            }
+
+            try {
+                await client.query("BEGIN");
+
+                const permissionUpdateData = {
+                    ...permissionData,
+                    edit_time: sqls` CURRENT_TIMESTAMP `
+                };
+
+                const permissionRecord = await updateTableRecord(
+                    client,
+                    "permissions",
+                    id,
+                    permissionUpdateData,
+                    [
+                        "name",
+                        "resource_id",
+                        "user_ownership_constraint",
+                        "org_unit_ownership_constraint",
+                        "pre_authorised_constraint",
+                        "description",
+                        "owner_id",
+                        "edit_by",
+                        "edit_time"
+                    ]
+                );
+
+                if (isArray(operationIds)) {
+                    // operationIds property is provided
+                    // i.e. user's intention is to update operations as well
+                    // delete all current operation / permission relationship
+                    await client.query(
+                        ...sqls`DELETE FROM permission_operations WHERE permission_id=${id}`.toQuery()
+                    );
+                }
+
+                if (operationIds.length) {
+                    const values = (operationIds as string[]).map(
+                        (item) => sqls`(${id},${item})`
+                    );
+
+                    await client.query(
+                        ...sqls`INSERT INTO permission_operations 
+                    (permission_id, operation_id) VALUES 
+                    ${SQLSyntax.csv(...values)}`.toQuery()
+                    );
+                }
+
+                await client.query("COMMIT");
+                return permissionRecord;
+            } catch (e) {
+                await client.query("ROLLBACK");
+                throw e;
+            }
         } finally {
             if (shouldReleaseClient) {
                 client.release();

--- a/magda-authorization-api/src/Database.ts
+++ b/magda-authorization-api/src/Database.ts
@@ -1206,7 +1206,7 @@ export default class Database {
                         400
                     );
                 }
-                operationIds = result.rows;
+                operationIds = result.rows.map((item) => item.id);
             } else {
                 // operationIds is supplied
                 // validate operationIds
@@ -1414,7 +1414,7 @@ export default class Database {
                             400
                         );
                     }
-                    operationIds = result.rows;
+                    operationIds = result.rows.map((item) => item.id);
                 }
             } else if (isArray(operationIds) && operationIds.length) {
                 const invalidOperationId = operationIds.find(

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -815,39 +815,15 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                     );
                 }
 
-                let existingPreAuthorisedPermissionIds =
-                    res?.locals?.originalDataset?.aspects?.["access-control"]?.[
-                        "preAuthorisedPermissionIds"
-                    ];
-
-                if (!isArray(existingPreAuthorisedPermissionIds)) {
-                    existingPreAuthorisedPermissionIds = [permissionId];
-                } else {
-                    if (
-                        existingPreAuthorisedPermissionIds.indexOf(
-                            permissionId
-                        ) !== -1
-                    ) {
-                        // the dataset has the access group's permission id already
-                        // no need to re-do it
-                        res.json({ result: false });
-                        return;
-                    }
-                    existingPreAuthorisedPermissionIds.push(permissionId);
-                }
-
-                existingPreAuthorisedPermissionIds = uniq(
-                    existingPreAuthorisedPermissionIds
-                );
-
-                const result = await registryClient.patchRecords(recordIds, [
+                const result = await registryClient.putRecordsAspect(
+                    recordIds,
+                    "access-control",
                     {
-                        op: "replace",
-                        path:
-                            "/aspects/access-control/preAuthorisedPermissionIds",
-                        value: existingPreAuthorisedPermissionIds
-                    }
-                ]);
+                        preAuthorisedPermissionIds: [permissionId]
+                    },
+                    // merge data. will not produce duplicates array items
+                    true
+                );
 
                 if (result instanceof Error) {
                     throw result;

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -256,7 +256,7 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                 }
             }
         })),
-        getUserId,
+        getUserId(options.jwtSecret),
         async (req: Request, res: Response) => {
             try {
                 const agData = await validateAccessGroupCreationData(req, res);
@@ -481,7 +481,7 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
     router.put(
         "/:groupId",
         requireAccessGroupUnconditionalPermission("object/record/update"),
-        getUserId,
+        getUserId(options.jwtSecret),
         async function (req: Request, res: Response) {
             try {
                 const groupId = `${req.params.groupId}`.trim();

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -1,0 +1,477 @@
+import express, { Request, Response } from "express";
+import Database from "../Database";
+import respondWithError from "../respondWithError";
+import AuthDecisionQueryClient from "magda-typescript-common/src/opa/AuthDecisionQueryClient";
+import AuthorizedRegistryClient from "magda-typescript-common/src/registry/AuthorizedRegistryClient";
+import { MAGDA_ADMIN_PORTAL_ID } from "magda-typescript-common/src/registry/TenantConsts";
+import {
+    getUserId,
+    withAuthDecision,
+    requireUnconditionalAuthDecision
+} from "magda-typescript-common/src/authorization-api/authMiddleware";
+import {
+    requireObjectPermission,
+    requireObjectUpdatePermission
+} from "../recordAuthMiddlewares";
+import {
+    getTableRecord,
+    updateTableRecord,
+    deleteTableRecord,
+    createTableRecord
+} from "magda-typescript-common/src/SQLUtils";
+import ServerError from "magda-typescript-common/src/ServerError";
+import { sqls, SQLSyntax } from "sql-syntax";
+import {
+    CreateAccessGroupRequestBodyType,
+    PermissionRecord
+} from "magda-typescript-common/src/authorization-api/model";
+import uniq from "lodash/uniq";
+import isUuid from "magda-typescript-common/src/util/isUuid";
+import { v4 as uuidV4 } from "uuid";
+import { Record } from "@magda/typescript-common/dist/generated/registry/api";
+
+export interface ApiRouterOptions {
+    database: Database;
+    authDecisionClient: AuthDecisionQueryClient;
+    jwtSecret: string;
+    registryClient: AuthorizedRegistryClient;
+}
+
+export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
+    const database = options.database;
+    const authDecisionClient = options.authDecisionClient;
+    const registryClient = options.registryClient;
+
+    const router: express.Router = express.Router();
+
+    async function validateAccessGroupCreationData(
+        req: Request,
+        res: Response
+    ) {
+        let {
+            name,
+            description,
+            resourceUri,
+            keywords,
+            operationUris,
+            ownerId,
+            orgUnitId
+        } = req.body as CreateAccessGroupRequestBodyType;
+
+        if (!name) {
+            throw new ServerError("`name` field cannot be empty", 400);
+        }
+        if (!resourceUri) {
+            throw new ServerError("`resourceUri` field cannot be empty", 400);
+        }
+        if (resourceUri !== "object/record") {
+            throw new ServerError(
+                `Invalid value ${resourceUri} supplied for field \`${resourceUri}\``,
+                400
+            );
+        }
+
+        keywords = uniq(!keywords?.length ? [] : keywords).filter(
+            (item) => !!item
+        );
+        const invalidKeyword = keywords.find(
+            (item) => typeof item !== "string"
+        );
+        if (typeof invalidKeyword !== "undefined") {
+            throw new ServerError(
+                `One of keyword items is an invalid non-string value: ${invalidKeyword}`,
+                400
+            );
+        }
+
+        description = description ? "" + description : "";
+
+        operationUris = uniq(
+            !operationUris?.length ? [] : operationUris
+        ).filter((item) => !!item);
+        const invalidOperationUri = operationUris.find(
+            (item) =>
+                typeof item !== "string" || !item.startsWith("object/record/")
+        );
+        if (typeof invalidOperationUri !== "undefined") {
+            throw new ServerError(
+                `One of operationUris supplied is invalid: ${invalidOperationUri}`,
+                400
+            );
+        }
+
+        if (ownerId && !isUuid(ownerId)) {
+            throw new ServerError(
+                `Supplied ownerId is not valid UUID: ${ownerId}`,
+                400
+            );
+        }
+
+        if (orgUnitId && !isUuid(orgUnitId)) {
+            throw new ServerError(
+                `Supplied orgUnitId is not valid UUID: ${orgUnitId}`,
+                400
+            );
+        }
+
+        if (!ownerId && ownerId !== null && res.locals.userId) {
+            // needs to pre-fill ownerId with request user's id
+            ownerId = res.locals.userId;
+        }
+
+        if (!orgUnitId && orgUnitId !== null && res.locals.userId) {
+            // needs to pre-fill orgUnitId with request user's orgUnitId
+            const user = await database.getUser(res.locals.userId);
+            orgUnitId = user
+                .map((item) => (item.orgUnitId ? item.orgUnitId : null))
+                .valueOr<string | null>(null);
+        }
+
+        ownerId = ownerId ? ownerId : null;
+        orgUnitId = orgUnitId ? orgUnitId : null;
+
+        return {
+            name,
+            description,
+            resourceUri,
+            keywords,
+            operationUris,
+            ownerId,
+            orgUnitId
+        };
+    }
+
+    /**
+     * @apiGroup Auth Access Groups
+     * @api {post} /v0/auth/accessGroups Create a new access group
+     * @apiDescription Create a new access group.
+     * Returns the newly created access group.
+     * Required `object/accessGroup/create` permission to access this API.
+     *
+     * @apiParam (Request Body) {string} name A name given to the access group
+     * @apiParam (Request Body) {string} [description] The free text description for the access group
+     * @apiParam (Request Body) {string[]} [keywords] Tags (or keywords) help users discover the access-group
+     * @apiParam (Request Body) {string} resourceUri The Resource URI specifies the type of resources that the access group manages.
+     * At this moment, only one value `object/record` (registry records) is supported.
+     * @apiParam (Request Body) {string} operationUris A list of operations that the access group allows enrolled users to perform on included resources.
+     * @apiParam (Request Body) {string | null} [ownerId] The user ID of the access group owner. If not specified, the request user (if available) will be the owner.
+     * If a null value is supplied, the owner of the access group will be set to null.
+     * @apiParam (Request Body) {string | null} [orgUnitId] The ID of the orgUnit that the access group belongs to. If not specified, the request user's orgUnit (if available) will be used.
+     * If a null value is supplied, the orgUnit of the access group will be set to null.
+     *
+     * @apiParamExample (Body) {json}:
+     *     {
+     *       "name": "a test access group",
+     *       "description": "a test access group",
+     *       "resourceUri": "object/record",
+     *       "keywords": ["keyword 1", "keyword2"],
+     *       "operationUris": ["object/record/read", "object/record/update"],
+     *       "ownerId": "3535fdad-1804-4614-a9ce-ce196e880238",
+     *       "orgUnitId": "36ef9450-6579-421c-a178-d3b5b4f1a3df"
+     *     }
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *       "id": "e30135df-523f-46d8-99f6-2450fd8d6a37",
+     *       "name": "a test access group",
+     *       "description": "a test access group",
+     *       "resourceUri": "object/record",
+     *       "operationUris": ["object/record/read", "object/record/update"],
+     *       "keywords": ["keyword 1", "keyword2"],
+     *       "permissionId": "2b117a5f-dadb-4130-bf44-b72ee67d009b",
+     *       "roleId": "5b616fa0-a123-4e9c-b197-65b3db8522fa",
+     *       "ownerId": "3535fdad-1804-4614-a9ce-ce196e880238",
+     *       "orgUnitId": "36ef9450-6579-421c-a178-d3b5b4f1a3df",
+     *       "createBy": "3535fdad-1804-4614-a9ce-ce196e880238",
+     *       "editTime": "2022-03-28T10:18:10.479Z",
+     *       "editBy": "3535fdad-1804-4614-a9ce-ce196e880238",
+     *       "editTime": "2022-03-28T10:18:10.479Z"
+     *    }
+     *
+     * @apiErrorExample {json} 401/500
+     *    {
+     *      "isError": true,
+     *      "errorCode": 401, //--- or 500 depends on error type
+     *      "errorMessage": "Not authorized"
+     *    }
+     */
+    router.post(
+        "/",
+        requireUnconditionalAuthDecision(authDecisionClient, (req, res) => ({
+            operationUri: "object/accessGroup/create",
+            input: {
+                object: {
+                    accessGroup: req.body
+                }
+            }
+        })),
+        getUserId,
+        async (req: Request, res: Response) => {
+            try {
+                const agData = await validateAccessGroupCreationData(req, res);
+                const recordId = uuidV4();
+                const userId = res.locals.userId;
+                const timestamp = new Date().toISOString();
+                const pool = database.getPool();
+                const client = await pool.connect();
+                const agRecord = {
+                    id: recordId,
+                    name: agData.name,
+                    aspects: {
+                        "access-group-details": {
+                            name: agData.name,
+                            resourceUri: agData.resourceUri,
+                            description: agData.description,
+                            keywords: agData.keywords,
+                            operationUris: agData.operationUris,
+                            createTime: timestamp,
+                            createBy: userId,
+                            editTime: timestamp,
+                            editBy: userId,
+                            permissionId: "",
+                            roleId: ""
+                        },
+                        "access-control": {
+                            ownerId: agData.ownerId,
+                            orgUnitId: agData.orgUnitId
+                        }
+                    }
+                };
+
+                try {
+                    await client.query("BEGIN");
+
+                    const resource = await database.getResourceByUri(
+                        agData.resourceUri,
+                        client
+                    );
+
+                    if (!resource) {
+                        throw new ServerError(
+                            `resource uri ${agData.resourceUri} doesn't exist`,
+                            400
+                        );
+                    }
+
+                    const result = await pool.query(
+                        ...sqls`SELECT id
+                        FROM operations 
+                        WHERE uri IN (${SQLSyntax.csv(
+                            ...agData.operationUris.map((item) => sqls`${item}`)
+                        )}) AND resource_id = ${resource.id}`.toQuery()
+                    );
+
+                    if (result?.rows?.length !== agData.operationUris.length) {
+                        throw new ServerError(
+                            `Not all provided operation uris are valid and belong to the resource ${resource.uri}`,
+                            400
+                        );
+                    }
+
+                    const operationIds = result.rows;
+
+                    const permissionData = {
+                        name: "auto-created access group permission",
+                        description:
+                            "auto-created access group permission for access group " +
+                            recordId,
+                        resource_id: resource.id,
+                        user_ownership_constraint: false,
+                        org_unit_ownership_constraint: false,
+                        pre_authorised_constraint: true
+                    } as PermissionRecord;
+
+                    if (userId) {
+                        permissionData["create_by"] = userId;
+                        permissionData["owner_id"] = userId;
+                        permissionData["edit_by"] = userId;
+                    }
+
+                    const permissionRecord = await createTableRecord(
+                        client,
+                        "permissions",
+                        permissionData as any,
+                        [
+                            "name",
+                            "resource_id",
+                            "user_ownership_constraint",
+                            "org_unit_ownership_constraint",
+                            "pre_authorised_constraint",
+                            "description",
+                            "create_by",
+                            "owner_id",
+                            "edit_by"
+                        ]
+                    );
+
+                    const values = (operationIds as string[]).map(
+                        (id) => sqls`(${permissionRecord.id},${id})`
+                    );
+
+                    await client.query(
+                        ...sqls`INSERT INTO permission_operations 
+                    (permission_id, operation_id) VALUES 
+                    ${SQLSyntax.csv(...values)}`.toQuery()
+                    );
+
+                    const roleData = {
+                        name: "auto-created access group role",
+                        description:
+                            "auto-created access group role for access group " +
+                            recordId
+                    } as any;
+
+                    if (userId) {
+                        roleData["create_by"] = userId;
+                        roleData["owner_id"] = userId;
+                        roleData["edit_by"] = userId;
+                    }
+
+                    const role = await createTableRecord(
+                        client,
+                        "roles",
+                        roleData,
+                        [
+                            "name",
+                            "description",
+                            "create_by",
+                            "owner_id",
+                            "edit_by"
+                        ]
+                    );
+
+                    agRecord.aspects["access-group-details"].permissionId =
+                        permissionRecord.id;
+                    agRecord.aspects["access-group-details"].roleId = role.id;
+
+                    const recordCreationResult = await registryClient.creatRecord(
+                        agRecord as any
+                    );
+                    if (recordCreationResult instanceof Error) {
+                        throw recordCreationResult;
+                    }
+                    await client.query("COMMIT");
+                } catch (e) {
+                    await client.query("ROLLBACK");
+                    throw e;
+                } finally {
+                    client.release();
+                }
+                res.json({
+                    ...agRecord.aspects["access-group-details"],
+                    id: recordId
+                });
+            } catch (e) {
+                respondWithError("Create Access Group", res, e);
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Auth Access Groups
+     * @api {put} /v0/auth/accessGroups/:id Update an access group
+     * @apiDescription Update a access group
+     * Supply a JSON object that contains fields to be updated in body.
+     * You need have `authObject/operation/update` permission to access this API.
+     *
+     * @apiParam (URL Path) {string} id id of the operation record
+     * @apiParamExample (Body) {json}:
+     *    {
+     *       "uri": "object/aspect/delete",
+     *       "name": "Delete Aspect Definition",
+     *       "description": "test description"
+     *    }
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *       "id": "e30135df-523f-46d8-99f6-2450fd8d6a37",
+     *       "uri": "object/aspect/delete",
+     *       "name": "Delete Aspect Definition",
+     *       "description": "test description",
+     *       "resource_id": "2c0981d2-71bf-4806-a590-d1c779dcad8b"
+     *    }
+     *
+     * @apiErrorExample {json} 401/404/500
+     *    {
+     *      "isError": true,
+     *      "errorCode": 401, //--- or 404, 500 depends on error type
+     *      "errorMessage": "Not authorized"
+     *    }
+     */
+    router.put(
+        "/:id",
+        requireObjectUpdatePermission(
+            authDecisionClient,
+            database,
+            "authObject/operation/update",
+            (req, res) => req.params.id,
+            "operation"
+        ),
+        async function (req, res) {
+            try {
+                const record = await updateTableRecord(
+                    database.getPool(),
+                    "operations",
+                    req.params.id,
+                    req.body,
+                    ["uri", "name", "description"]
+                );
+                res.json(record);
+            } catch (e) {
+                respondWithError("modify `operation`", res, e);
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Auth Access Groups
+     * @api {delete} /v0/auth/accessGroups/:id Delete an access group
+     * @apiDescription Delete an access group
+     * When the operation is deleted, access will be removed from all existing permissions that are relevant to the operation.
+     *
+     * You need `authObject/operation/delete` permission in order to access this API.
+     *
+     * @apiParam (URL Path) {string} id id of the operation
+     *
+     * @apiSuccess [Response Body] {boolean} result Indicates whether the deletion action is actually performed or the record doesn't exist.
+     * @apiSuccessExample {json} 200
+     *    {
+     *        result: true
+     *    }
+     *
+     * @apiErrorExample {json} 401/500
+     *    {
+     *      "isError": true,
+     *      "errorCode": 401, //--- or 500 depends on error type
+     *      "errorMessage": "Not authorized"
+     *    }
+     */
+    router.delete(
+        "/:id",
+        requireObjectPermission(
+            authDecisionClient,
+            database,
+            "authObject/operation/delete",
+            (req, res) => req.params.id,
+            "operation"
+        ),
+        async function (req, res) {
+            try {
+                await deleteTableRecord(
+                    database.getPool(),
+                    "operations",
+                    req.params.id
+                );
+                res.json({ result: true });
+            } catch (e) {
+                respondWithError(
+                    `delete \`operation\` ${req.params.id}`,
+                    res,
+                    e
+                );
+            }
+        }
+    );
+
+    return router;
+}

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -829,7 +829,7 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                             ((recordData as any)[idx] = item)
                     );
                 }
-                res.locals.originalAccessGroup = fetchRecordResult;
+                res.locals.originalDataset = fetchRecordResult;
                 return {
                     operationUri: "object/record/update",
                     input: {

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -294,10 +294,9 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
 
                     const permissionRecord = await database.createPermission(
                         {
-                            name: "auto-created access group permission",
+                            name: "auto-created for access group",
                             description:
-                                "auto-created access group permission for access group " +
-                                recordId,
+                                "auto-created for access group " + recordId,
                             resourceUri: agData.resourceUri,
                             operationUris: agData.operationUris,
                             userOwnershipConstraint: false,
@@ -310,10 +309,8 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                     );
 
                     const roleData = {
-                        name: "auto-created access group role",
-                        description:
-                            "auto-created access group role for access group " +
-                            recordId
+                        name: "auto-created for access group",
+                        description: "auto-created for access group " + recordId
                     } as any;
 
                     if (userId) {
@@ -333,6 +330,17 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                             "owner_id",
                             "edit_by"
                         ]
+                    );
+
+                    // add permission to the role
+                    await createTableRecord(
+                        client,
+                        "role_permissions",
+                        {
+                            role_id: role.id,
+                            permission_id: permissionRecord.id
+                        },
+                        ["role_id", "permission_id"]
                     );
 
                     agRecord.aspects["access-group-details"].permissionId =

--- a/magda-authorization-api/src/apiRouters/createPermissionApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createPermissionApiRouter.ts
@@ -8,15 +8,9 @@ import {
     requirePermission,
     getUserId
 } from "magda-typescript-common/src/authorization-api/authMiddleware";
-import {
-    searchTableRecord,
-    createTableRecord,
-    getTableRecord,
-    updateTableRecord
-} from "magda-typescript-common/src/SQLUtils";
+import { searchTableRecord } from "magda-typescript-common/src/SQLUtils";
 import ServerError from "magda-typescript-common/src/ServerError";
-import SQLSyntax, { sqls } from "sql-syntax";
-import uniq from "lodash/uniq";
+import { sqls } from "sql-syntax";
 
 export interface ApiRouterOptions {
     database: Database;

--- a/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
@@ -363,86 +363,37 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
             try {
                 const pool = database.getPool();
                 const roleId = req.params.roleId;
-                let { operationIds, ...permissionData } = req.body;
 
-                if (!operationIds?.length) {
+                const role = await getTableRecord(pool, "roles", roleId);
+                if (!role) {
                     throw new ServerError(
-                        "Failed to create permission: operationIds is required and should be a list of operation ids.",
+                        "cannot locate role by supplied id:" + roleId,
                         400
                     );
                 }
 
-                operationIds = uniq(operationIds);
-
-                if (!permissionData.resource_id) {
-                    throw new ServerError(
-                        "Failed to create permission: resource_id is required.",
-                        400
-                    );
-                }
-
-                const resource = await getTableRecord(
-                    pool,
-                    "resources",
-                    permissionData.resource_id
-                );
-                if (!resource) {
-                    throw new ServerError(
-                        "Failed to create permission: cannot locate resource by supplied resource_id.",
-                        400
-                    );
-                }
-
-                const result = await pool.query(
-                    ...sqls`SELECT COUNT(*) as count
-                FROM operations 
-                WHERE id IN (${SQLSyntax.csv(
-                    ...operationIds
-                )}) AND resource_id = ${resource.id}`.toQuery()
-                );
-
-                if (result?.rows?.[0]?.["count"] !== operationIds.length) {
-                    throw new ServerError(
-                        `Failed to create permission: all provided operation id must be valid and belong to the resource ${resource.id}`,
-                        400
-                    );
-                }
+                const {
+                    resource_id,
+                    user_ownership_constraint,
+                    org_unit_ownership_constraint,
+                    pre_authorised_constraint
+                } = req.body;
 
                 const client = await pool.connect();
-                let permissionRecord: any;
                 try {
                     await client.query("BEGIN");
-                    const permissionSubmitData = { ...permissionData };
-                    if (res?.locals?.userId) {
-                        permissionSubmitData.create_by = res.locals.userId;
-                        permissionSubmitData.owner_id = res.locals.userId;
-                        permissionSubmitData.edit_by = res.locals.userId;
-                    }
-                    permissionRecord = await createTableRecord(
-                        client,
-                        "permissions",
-                        permissionSubmitData,
-                        [
-                            "name",
-                            "resource_id",
-                            "user_ownership_constraint",
-                            "org_unit_ownership_constraint",
-                            "pre_authorised_constraint",
-                            "description",
-                            "create_by",
-                            "owner_id",
-                            "edit_by"
-                        ]
-                    );
 
-                    const values = (operationIds as string[]).map(
-                        (id) => sqls`(${permissionRecord.id},${id})`
-                    );
-
-                    await client.query(
-                        ...sqls`INSERT INTO permission_operations 
-                    (permission_id, operation_id) VALUES 
-                    ${SQLSyntax.csv(...values)}`.toQuery()
+                    const permissionRecord = await database.createPermission(
+                        {
+                            ...(req.body ? req.body : {}),
+                            createBy: res?.locals?.userId,
+                            ownerId: res?.locals?.userId,
+                            userOwnershipConstraint: user_ownership_constraint,
+                            orgUnitOwnershipConstraint: org_unit_ownership_constraint,
+                            preAuthorisedConstraint: pre_authorised_constraint,
+                            resourceId: resource_id
+                        },
+                        client
                     );
 
                     await client.query(
@@ -450,13 +401,13 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                     );
 
                     await client.query("COMMIT");
+                    res.json(permissionRecord);
                 } catch (e) {
                     await client.query("ROLLBACK");
                     throw e;
                 } finally {
                     client.release();
                 }
-                res.json(permissionRecord);
             } catch (e) {
                 respondWithError(
                     "Create a permission and add to the role " +
@@ -528,7 +479,6 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                 const pool = database.getPool();
                 const roleId = req.params.roleId;
                 const permissionId = req.params.permissionId;
-                const { operationIds, ...permissionData } = req.body;
 
                 if (!roleId) {
                     throw new Error(
@@ -539,6 +489,14 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                 if (!permissionId) {
                     throw new Error(
                         "Failed to update permission: invalid empty permissionId."
+                    );
+                }
+
+                const role = await getTableRecord(pool, "roles", roleId);
+                if (!role) {
+                    throw new ServerError(
+                        "cannot locate role by supplied id:" + roleId,
+                        400
                     );
                 }
 
@@ -560,110 +518,38 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                     );
                 }
 
-                const permission = await getTableRecord(
-                    pool,
-                    "permissions",
-                    permissionId
-                );
-                if (!permission) {
-                    throw new Error(
-                        "Failed to update permission: cannot locate the permission record specified by permissionId: " +
-                            permissionId
-                    );
-                }
-
-                const opIds = operationIds ? uniq(operationIds) : [];
-
-                const resourceId = permissionData?.resource_id
-                    ? permissionData.resource_id
-                    : permission?.resource_id;
-
-                const resource = await getTableRecord(
-                    pool,
-                    "resources",
-                    resourceId
-                );
-                if (!resource) {
-                    throw new Error(
-                        "Failed to update permission: cannot locate resource by supplied resource_id."
-                    );
-                }
-
-                if (opIds.length) {
-                    const result = await pool.query(
-                        ...sqls`SELECT COUNT(*) as count
-                    FROM operations 
-                    WHERE id IN (${SQLSyntax.csv(
-                        ...operationIds
-                    )}) AND resource_id = ${resource.id}`.toQuery()
-                    );
-
-                    if (result?.rows?.[0]?.["count"] !== operationIds.length) {
-                        throw new Error(
-                            `Failed to update permission: all provided operation id must be valid and belong to the resource ${resource.id}`
-                        );
-                    }
-                }
-
                 const client = await pool.connect();
-                let permissionRecord: any;
                 try {
                     await client.query("BEGIN");
-                    const permissionUpdateData = {
-                        ...permissionData,
-                        edit_time: sqls` CURRENT_TIMESTAMP `
-                    };
-                    if (res?.locals?.userId) {
-                        permissionUpdateData.edit_by = res.locals.userId;
-                    } else {
-                        permissionUpdateData.edit_by = sqls` NULL `;
-                    }
-                    permissionRecord = await updateTableRecord(
-                        client,
-                        "permissions",
+
+                    const {
+                        resource_id,
+                        user_ownership_constraint,
+                        org_unit_ownership_constraint,
+                        pre_authorised_constraint
+                    } = req.body;
+
+                    const permissionRecord = await database.updatePermission(
                         permissionId,
-                        permissionUpdateData,
-                        [
-                            "name",
-                            "resource_id",
-                            "user_ownership_constraint",
-                            "org_unit_ownership_constraint",
-                            "pre_authorised_constraint",
-                            "description",
-                            "edit_by",
-                            "edit_time"
-                        ]
+                        {
+                            ...(req.body ? req.body : {}),
+                            editBy: res?.locals?.userId,
+                            ownerId: res?.locals?.userId,
+                            userOwnershipConstraint: user_ownership_constraint,
+                            orgUnitOwnershipConstraint: org_unit_ownership_constraint,
+                            preAuthorisedConstraint: pre_authorised_constraint,
+                            resourceId: resource_id
+                        },
+                        client
                     );
-
-                    if (typeof operationIds?.length !== "undefined") {
-                        // operationIds property is provided
-                        // i.e. user's intention is to update operations as well
-                        // delete all current operation / permission relationship
-                        await client.query(
-                            ...sqls`DELETE FROM permission_operations WHERE permission_id=${permissionId}`.toQuery()
-                        );
-                    }
-
-                    if (opIds.length) {
-                        const values = (opIds as string[]).map(
-                            (id) => sqls`(${permissionId},${id})`
-                        );
-
-                        await client.query(
-                            ...sqls`INSERT INTO permission_operations 
-                            (permission_id, operation_id) VALUES 
-                            ${SQLSyntax.csv(...values)}`.toQuery()
-                        );
-                    }
-
                     await client.query("COMMIT");
+                    res.json(permissionRecord);
                 } catch (e) {
                     await client.query("ROLLBACK");
                     throw e;
                 } finally {
                     client.release();
                 }
-                res.json(permissionRecord);
             } catch (e) {
                 respondWithError(
                     "Update permission for role " + req?.params?.roleId,

--- a/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
@@ -172,7 +172,7 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
     );
 
     /**
-     * @apiGroup Auth Access Groups
+     * @apiGroup Auth Users
      * @api {get} /v0/auth/roles/:roleId/users/count Get the count of all matched users with a role
      * @apiDescription return the count number of all matched users who have a certain role
      * Required `authObject/user/read` permission to access this API.

--- a/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
@@ -15,7 +15,6 @@ import {
     getTableRecord,
     updateTableRecord
 } from "magda-typescript-common/src/SQLUtils";
-import uniq from "lodash/uniq";
 import ServerError from "magda-typescript-common/src/ServerError";
 
 export interface ApiRouterOptions {

--- a/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
@@ -41,15 +41,12 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
     ) {
         return async function fetchRoleUsers(req: Request, res: Response) {
             try {
-                const roleId =
-                    res?.locals?.originalAccessGroup?.aspects?.[
-                        "access-group-details"
-                    ]?.["roleId"];
+                const roleId = req.params.roleId;
 
                 if (!isUuid(roleId)) {
                     throw new ServerError(
-                        `The access group "${req.params?.groupId}" has an invalid roleId.`,
-                        500
+                        `Invalid role ID "${roleId}" has been supplied.`,
+                        400
                     );
                 }
 
@@ -164,7 +161,7 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
      *    }
      */
     router.get(
-        "/:groupId/users",
+        "/:roleId/users",
         withAuthDecision(authDecisionClient, {
             operationUri: "authObject/user/read"
         }),
@@ -198,7 +195,7 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
      *    }
      */
     router.get(
-        "/:groupId/users/count",
+        "/:roleId/users/count",
         withAuthDecision(authDecisionClient, {
             operationUri: "authObject/user/read"
         }),

--- a/magda-authorization-api/src/apiRouters/createUserApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createUserApiRouter.ts
@@ -498,6 +498,9 @@ export default function createUserApiRouter(options: ApiRouterOptions) {
      * @apiDescription Returns the user info of the current user. If the user has not logged in yet,
      * the user will be considered as an anonymous user.
      *
+     * @apiParam (Query String) {string} [allowCache] By default, this API will respond with certain headers to disable any client side cache behaviour.
+     * You can opt to supply a string value `true` for this parameter to stop sending those headers.
+     *
      * @apiSuccessExample {json} 200
      *    {
      *        "id":"...",
@@ -823,7 +826,9 @@ export default function createUserApiRouter(options: ApiRouterOptions) {
      * @apiDescription Returns user by id.
      * Unlike `whoami` API endpoint, this API requires `authObject/user/read` permission.
      *
-     * @apiParam {string} userId id of user
+     * @apiParam (URL Path) {string} userId id of user
+     * @apiParam (Query String) {string} [allowCache] By default, this API will respond with certain headers to disable any client side cache behaviour.
+     * You can opt to supply a string value `true` for this parameter to stop sending those headers.
      *
      * @apiSuccessExample {json} 200
      *    {

--- a/magda-authorization-api/src/createApiRouter.ts
+++ b/magda-authorization-api/src/createApiRouter.ts
@@ -16,7 +16,9 @@ import createRoleApiRouter from "./apiRouters/createRoleApiRouter";
 import createResourceApiRouter from "./apiRouters/createResourceApiRouter";
 import createOperationApiRouter from "./apiRouters/createOperationApiRouter";
 import createPermissionApiRouter from "./apiRouters/createPermissionApiRouter";
+import createAccessGroupApiRouter from "./apiRouters/createAccessGroupApiRouter";
 import { ADMIN_USERS_ROLE_ID } from "@magda/typescript-common/dist/authorization-api/constants";
+import AuthorizedRegistryClient from "magda-typescript-common/src/registry/AuthorizedRegistryClient";
 
 export interface ApiRouterOptions {
     database: Database;
@@ -25,6 +27,7 @@ export interface ApiRouterOptions {
     jwtSecret: string;
     tenantId: number;
     failedApiKeyAuthBackOffSeconds: number;
+    registryClient: AuthorizedRegistryClient;
 }
 
 /**
@@ -390,6 +393,16 @@ export default function createApiRouter(options: ApiRouterOptions) {
             database,
             jwtSecret: options.jwtSecret,
             authDecisionClient: options.authDecisionClient
+        })
+    );
+
+    router.use(
+        "/public/accessGroups",
+        createAccessGroupApiRouter({
+            database,
+            jwtSecret: options.jwtSecret,
+            authDecisionClient: options.authDecisionClient,
+            registryClient: options.registryClient
         })
     );
 

--- a/magda-authorization-api/src/test/buildCreateApiRouter.spec.ts
+++ b/magda-authorization-api/src/test/buildCreateApiRouter.spec.ts
@@ -20,6 +20,8 @@ import {
 import { Request } from "supertest";
 import mockApiKeyStore from "./mockApiKeyStore";
 import AuthDecisionQueryClient from "magda-typescript-common/src/opa/AuthDecisionQueryClient";
+import AuthorizedRegistryClient from "magda-typescript-common/src/registry/AuthorizedRegistryClient";
+import { DEFAULT_ADMIN_USER_ID } from "magda-typescript-common/src/authorization-api/constants";
 
 describe("Auth api router", function (this: Mocha.ISuiteCallbackContext) {
     this.timeout(10000);
@@ -43,7 +45,8 @@ describe("Auth api router", function (this: Mocha.ISuiteCallbackContext) {
                 listenPort: 6014,
                 dbHost: "localhost",
                 dbPort: 5432,
-                jwtSecret: "squirrel"
+                jwtSecret: "squirrel",
+                userId: DEFAULT_ADMIN_USER_ID
             })
         );
         return argv;
@@ -61,6 +64,13 @@ describe("Auth api router", function (this: Mocha.ISuiteCallbackContext) {
                 "http://localhost",
                 true
             ),
+            registryClient: new AuthorizedRegistryClient({
+                baseUrl: "http://localhost:6101/v0",
+                jwtSecret: argv.jwtSecret as string,
+                userId: argv.userId,
+                tenantId: MAGDA_ADMIN_PORTAL_ID,
+                maxRetries: 0
+            }),
             failedApiKeyAuthBackOffSeconds: 5
         });
 

--- a/magda-authorization-api/src/utilityMiddlewares.ts
+++ b/magda-authorization-api/src/utilityMiddlewares.ts
@@ -1,4 +1,8 @@
 export const NO_CACHE = function (req: any, res: any, next: any) {
+    if (req?.query?.allowCache === "true") {
+        next();
+        return;
+    }
     res.set({
         "Cache-Control": "no-cache, no-store, must-revalidate",
         Pragma: "no-cache",

--- a/magda-content-api/package.json
+++ b/magda-content-api/package.json
@@ -27,6 +27,7 @@
     "request-promise-native": "^1.0.7",
     "tsmonad": "^0.7.2",
     "wildcard": "^1.1.2",
+    "mime-types": "^2.1.20",
     "yargs": "^12.0.5"
   },
   "devDependencies": {

--- a/magda-content-api/src/test/buildCreateApiRouter.spec.ts
+++ b/magda-content-api/src/test/buildCreateApiRouter.spec.ts
@@ -84,18 +84,48 @@ describe("Content api router", function (this: Mocha.ISuiteCallbackContext) {
                 .end(done);
         });
 
+        it("should return data for existing - json (without ext) - as json", (done) => {
+            agent
+                .get("/json-2")
+                .expect(200, { acdc: "test" })
+                .expect("Content-Type", /^application\/json/)
+                .end(done);
+        });
+
         IMAGE_FORMATS_SUPPORTED.forEach((format) => {
-            it(`should return data for existing - ${format} - as ${format}`, (done) => {
-                agent.get(`/${format}-id.bin`).expect(200).end(done);
+            it(`should return data for existing - ${format} - ext:bin- as ${format}`, (done) => {
+                const imgData = mockContentData.find(
+                    (item) => item.id === `${format}-id`
+                );
+                agent
+                    .get(`/${format}-id.bin`)
+                    .expect(200, Buffer.from(imgData.content, "base64"))
+                    .end(done);
+            });
+
+            it(`should return data for existing - ${format} - no ext - as ${format}`, (done) => {
+                const imgData = mockContentData.find(
+                    (item) => item.id === `${format}-id`
+                );
+                agent
+                    .get(`/${format}-id`)
+                    .expect(200, Buffer.from(imgData.content, "base64"))
+                    .end(done);
+            });
+
+            it(`should return data for existing - ${format} - ext:text - as ${format}`, (done) => {
+                const imgData = mockContentData.find(
+                    (item) => item.id === `${format}-id`
+                );
+                agent
+                    .get(`/${format}-id.text`)
+                    .expect(200, imgData.content)
+                    .end(done);
             });
         });
 
         it("should return 404 for non-existant", (done) => {
             agent.get("/json-3.json").expect(404).end(done);
-        });
-
-        it("should return 500 for other errors", (done) => {
-            agent.get("/svg-id.json").expect(500).end(done);
         });
 
         describe("list", () => {
@@ -256,7 +286,7 @@ describe("Content api router", function (this: Mocha.ISuiteCallbackContext) {
                 mime: "image/svg+xml",
                 content: gifImage,
                 getRoute: "/emailTemplates/assets/x-y-z.jpg",
-                expectedContent: gifImage.toString("utf8")
+                expectedContent: gifImage
             },
             {
                 route: "/lang/en/publishersPage/blahface",
@@ -270,7 +300,7 @@ describe("Content api router", function (this: Mocha.ISuiteCallbackContext) {
                 mime: "image/x-icon",
                 content: gifImage,
                 getRoute: "/favicon.ico",
-                expectedContent: gifImage.toString("utf8")
+                expectedContent: gifImage
             }
         ];
 

--- a/magda-content-api/src/test/mockDatabase.ts
+++ b/magda-content-api/src/test/mockDatabase.ts
@@ -15,6 +15,7 @@ export default class MockDatabase implements Database {
                         (item) =>
                             ({
                                 id: item.id,
+                                type: item.type,
                                 content: item.content
                             } as Content)
                     )

--- a/magda-content-schemas/header-navigation.schema.json
+++ b/magda-content-schemas/header-navigation.schema.json
@@ -24,7 +24,7 @@
                         },
                         "target": {
                             "type": "string",
-                            "enum": ["", "blank"]
+                            "minLength": 1
                         },
                         "href": {
                             "type": "string",

--- a/magda-int-test-ts/src/ServiceRunner.ts
+++ b/magda-int-test-ts/src/ServiceRunner.ts
@@ -552,6 +552,8 @@ export default class ServiceRunner {
             [
                 "--jwtSecret",
                 this.jwtSecret,
+                "--userId",
+                DEFAULT_ADMIN_USER_ID,
                 "--debug",
                 `${this.authApiDebugMode}`,
                 "--skipAuth",

--- a/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
+++ b/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
@@ -155,6 +155,16 @@ VALUES
 ('object/event/update', 'Update Event Record', '', (SELECT id FROM resources WHERE uri = 'object/event')),
 ('object/event/delete', 'Delete Event Record', '', (SELECT id FROM resources WHERE uri = 'object/event'));
 
+-- Add resource, operation for access `accessGroups` 
+INSERT INTO "public"."resources" 
+    ("uri", "name", "description")
+VALUES 
+('object/accessGroup', 'Access Group', 'Access Group Records');
+
+INSERT INTO "public"."operations" ("uri", "name", "description", "resource_id") 
+VALUES 
+('object/accessGroup/create','Create Access Group', '', (SELECT id FROM resources WHERE uri = 'object/accessGroup'));
+
 -- Add resource, operation for access `storage bucket` 
 INSERT INTO "public"."resources" 
     ("uri", "name", "description")

--- a/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
+++ b/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
@@ -163,7 +163,8 @@ VALUES
 
 INSERT INTO "public"."operations" ("uri", "name", "description", "resource_id") 
 VALUES 
-('object/accessGroup/create','Create Access Group', '', (SELECT id FROM resources WHERE uri = 'object/accessGroup'));
+('object/accessGroup/create','Create Access Group', 'Allow a user to create an access group via `POST /api/v0/auth/accessGroup` API. Once an access group is created, any other operations require relevant record level permission to the `access group` registry record to perform.', (SELECT id FROM resources WHERE uri = 'object/accessGroup')),
+('object/accessGroup/read','View Access Group', 'The actual read access is secured via resource operation `object/record/read` over access group registry records. This operation can be used by frontend to determine whether a user has access to `access group` related UI.', (SELECT id FROM resources WHERE uri = 'object/accessGroup'));
 
 -- Add resource, operation for access `storage bucket` 
 INSERT INTO "public"."resources" 

--- a/magda-opa/policies/entrypoint/allow.rego
+++ b/magda-opa/policies/entrypoint/allow.rego
@@ -61,6 +61,12 @@ allow {
 }
 
 allow {
+    ## delegate access group related decision to access group rules
+    startswith(input.operationUri, "object/accessGroup/")
+    data.object.accessGroup.allow
+}
+
+allow {
     ## delegate storage bucket related decision to storage bucket rules
     startswith(input.operationUri, "storage/bucket/")
     data.storage.bucket.allow

--- a/magda-opa/policies/object/accessGroup/allow.rego
+++ b/magda-opa/policies/object/accessGroup/allow.rego
@@ -1,0 +1,13 @@
+package object.accessGroup
+
+import data.common.hasNoConstraintPermission
+
+default allow = false
+
+# `object/accessGroup` resource currently only support one operation: `object/accessGroup/create`
+# the creation should done via API POST /auth/accessGroup
+# once it's created, any other operations will be assessed via access to other resources related to the access group.
+# Only users has a unlimited permission to perfom the operation `object/accessGroup/create` will be allowed
+allow {
+    hasNoConstraintPermission(input.operationUri)
+}

--- a/magda-opa/policies/object/accessGroup/allow.rego
+++ b/magda-opa/policies/object/accessGroup/allow.rego
@@ -4,11 +4,14 @@ import data.common.hasNoConstraintPermission
 
 default allow = false
 
-# `object/accessGroup` resource currently only support one operation: `object/accessGroup/create`
-# the creation should done via API POST /auth/accessGroup
+# `object/accessGroup` resource currently only support two operations: `object/accessGroup/create` & `object/accessGroup/read`
+# the creation should done via API `POST /auth/accessGroup`
 # we require `no constraint` `object/accessGroup/create` permission to access this API.
 # once an access group is created, any other operations requires relevant record level permission to the `access group record` to perform.
 # e.g. `object/record/update` or `object/record/delete`
+# `object/accessGroup/read` is only created for frontend to determine whether the access group related UI is available to a user.
+# The actual read access is secured via resource operation `object/record/read` over access group records
 allow {
     hasNoConstraintPermission(input.operationUri)
 }
+

--- a/magda-opa/policies/object/accessGroup/allow.rego
+++ b/magda-opa/policies/object/accessGroup/allow.rego
@@ -6,8 +6,9 @@ default allow = false
 
 # `object/accessGroup` resource currently only support one operation: `object/accessGroup/create`
 # the creation should done via API POST /auth/accessGroup
-# once it's created, any other operations will be assessed via access to other resources related to the access group.
-# Only users has a unlimited permission to perfom the operation `object/accessGroup/create` will be allowed
+# we require `no constraint` `object/accessGroup/create` permission to access this API.
+# once an access group is created, any other operations requires relevant record level permission to the `access group record` to perform.
+# e.g. `object/record/update` or `object/record/delete`
 allow {
     hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/dataset/hasAnyDraftReadPermission.rego
+++ b/magda-opa/policies/object/dataset/hasAnyDraftReadPermission.rego
@@ -5,3 +5,8 @@ default hasAnyDraftReadPermission = false
 hasAnyDraftReadPermission {
     input.user.permissions[_].operations[_].uri = "object/dataset/draft/read"
 }
+
+hasAnyDraftReadPermission {
+    # users with admin roles will have access to everything
+    input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
+}

--- a/magda-opa/policies/object/dataset/hasAnyPublishedReadPermission.rego
+++ b/magda-opa/policies/object/dataset/hasAnyPublishedReadPermission.rego
@@ -5,3 +5,8 @@ default hasAnyPublishedReadPermission = false
 hasAnyPublishedReadPermission {
     input.user.permissions[_].operations[_].uri = "object/dataset/published/read"
 }
+
+hasAnyPublishedReadPermission {
+    # users with admin roles will have access to everything
+    input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
+}

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.Config
 import gnieh.diffson.sprayJson._
 import au.csiro.data61.magda.model.TenantId._
 import au.csiro.data61.magda.model.Auth.UnconditionalTrueDecision
-import au.csiro.data61.magda.util.JsonPathUtils.processRecordPatchOperationsOnAspects
+import au.csiro.data61.magda.util.JsonPatchUtils.processRecordPatchOperationsOnAspects
 
 class AspectValidator(config: Config, recordPersistence: RecordPersistence) {
   def DEFAULT_META_SCHEMA_URI = "https://json-schema.org/draft-07/schema#"

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectValidator.scala
@@ -20,7 +20,7 @@ class AspectValidator(config: Config, recordPersistence: RecordPersistence) {
     else config.getBoolean("validateJsonSchema")
   }
 
-  def validate(aspectId: String, aspectData: JsObject, tenantId: TenantId)(
+  def validate(aspectId: String, aspectData: JsValue, tenantId: TenantId)(
       implicit session: DBSession
   ) {
     if (shouldValidate()) {
@@ -43,7 +43,7 @@ class AspectValidator(config: Config, recordPersistence: RecordPersistence) {
 
   def validateWithDefinition(
       aspectDef: AspectDefinition,
-      aspectData: JsObject
+      aspectData: JsValue
   ): Unit = {
     if (!aspectDef.jsonSchema.isDefined) {
       // --- json schema not set means skipping validation

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
@@ -26,7 +26,7 @@ import au.csiro.data61.magda.directives.AuthDirectives.{
 import au.csiro.data61.magda.directives.TenantDirectives.requiresTenantId
 import au.csiro.data61.magda.model.Auth
 import au.csiro.data61.magda.model.Registry.{AspectDefinition, Record, WebHook}
-import au.csiro.data61.magda.util.JsonPathUtils.applyJsonPathToRecordContextData
+import au.csiro.data61.magda.util.JsonPatchUtils.applyJsonPathToRecordContextData
 import au.csiro.data61.magda.model.Auth.{
   UnconditionalTrueDecision,
   recordToContextData

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -1,7 +1,6 @@
 package au.csiro.data61.magda.registry
 
-import au.csiro.data61.magda.model.Registry.{Record, RecordSummary, RecordType}
-import au.csiro.data61.magda.model.Registry._
+import au.csiro.data61.magda.model.Registry.{Record, RecordSummary, RecordType, jsonFormat2, _}
 import gnieh.diffson.sprayJson._
 
 final case class ReadyStatus(ready: Boolean = false)
@@ -41,4 +40,7 @@ trait Protocols extends DiffsonProtocol {
   implicit val webHookResponseFormat = jsonFormat1(WebHookResponse.apply)
   implicit val countResponseFormat = jsonFormat1(CountResponse.apply)
   implicit val readyState = jsonFormat1(ReadyStatus.apply)
+  implicit val patchRecordsRequestFormat = jsonFormat2(
+    PatchRecordsRequest.apply
+  )
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -1,6 +1,12 @@
 package au.csiro.data61.magda.registry
 
-import au.csiro.data61.magda.model.Registry.{Record, RecordSummary, RecordType, jsonFormat2, _}
+import au.csiro.data61.magda.model.Registry.{
+  Record,
+  RecordSummary,
+  RecordType,
+  jsonFormat2,
+  _
+}
 import gnieh.diffson.sprayJson._
 
 final case class ReadyStatus(ready: Boolean = false)

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -49,4 +49,7 @@ trait Protocols extends DiffsonProtocol {
   implicit val patchRecordsRequestFormat = jsonFormat2(
     PatchRecordsRequest.apply
   )
+  implicit val putRecordsAspectRequestFormat = jsonFormat2(
+    PutRecordsAspectRequest.apply
+  )
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -52,4 +52,7 @@ trait Protocols extends DiffsonProtocol {
   implicit val putRecordsAspectRequestFormat = jsonFormat2(
     PutRecordsAspectRequest.apply
   )
+  implicit val deleteRecordsAspectArrayItemsRequestFormat = jsonFormat3(
+    DeleteRecordsAspectArrayItemsRequest.apply
+  )
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -1042,7 +1042,8 @@ class DefaultRecordPersistence(config: Config)
         )
         .foldLeft(Try(Seq[Long]())) {
           case (Success(result), Success(newItem)) => Success(result :+ newItem)
-          case (Success(_), Failure(ex))           => Failure(ex)
+          case (_, Failure(ex))                    => Failure(ex)
+          case (Failure(ex), _)                    => Failure(ex)
         }
     }
 
@@ -1173,7 +1174,8 @@ class DefaultRecordPersistence(config: Config)
         )
         .foldLeft(Try(Seq[Long]())) {
           case (Success(result), Success(newItem)) => Success(result :+ newItem)
-          case (Success(_), Failure(ex))           => Failure(ex)
+          case (_, Failure(ex))                    => Failure(ex)
+          case (Failure(ex), _)                    => Failure(ex)
         }
     }
 
@@ -1466,7 +1468,8 @@ class DefaultRecordPersistence(config: Config)
         )
         .foldLeft(Try(Seq[Long]())) {
           case (Success(result), Success(newItem)) => Success(result :+ newItem)
-          case (Success(_), Failure(ex))           => Failure(ex)
+          case (_, Failure(ex))                    => Failure(ex)
+          case (Failure(ex), _)                    => Failure(ex)
         }
     }
   }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -28,7 +28,7 @@ import au.csiro.data61.magda.model.{
 import scala.util.{Failure, Success, Try}
 import com.typesafe.config.Config
 import scalikejdbc.interpolation.SQLSyntax
-import au.csiro.data61.magda.util.SQLUtils
+import au.csiro.data61.magda.util.{JsonUtils, SQLUtils}
 import au.csiro.data61.magda.util.JsonPathUtils.processRecordPatchOperationsOnAspects
 
 trait RecordPersistence {
@@ -181,7 +181,8 @@ trait RecordPersistence {
       aspectId: String,
       newAspect: JsObject,
       userId: String,
-      forceSkipAspectValidation: Boolean = false
+      forceSkipAspectValidation: Boolean = false,
+      merge: Boolean = false
   )(implicit session: DBSession): Try[(JsObject, Long)]
 
   def createRecord(
@@ -1090,63 +1091,70 @@ class DefaultRecordPersistence(config: Config)
       aspectId: String,
       newAspect: JsObject,
       userId: String,
-      forceSkipAspectValidation: Boolean = false
+      forceSkipAspectValidation: Boolean = false,
+      merge: Boolean = false
   )(implicit session: DBSession): Try[(JsObject, Long)] = {
-    for {
-      // --- validate Aspect data against JSON schema
-      _ <- Try {
-        if (!forceSkipAspectValidation)
-          aspectValidator.validate(aspectId, newAspect, tenantId)(
-            session
-          )
-      }
-      (oldAspect, eventId) <- this.getRecordAspectById(
-        tenantId,
-        UnconditionalTrueDecision,
-        recordId,
-        aspectId
-      ) match {
-        case Some(aspect) => Success((aspect, None))
-        // Possibility of a race condition here. The aspect doesn't exist, so we try to create it.
-        // But someone else could have created it in the meantime. So if our create fails, try one
-        // more time to get an existing one. We use a nested transaction so that, if the create fails,
-        // we don't end up with an extraneous record creation event in the database.
-        case None =>
-          DB.localTx { nested =>
-            // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
-            // --- as the aspect data has been validated (unless not required) in the beginning of current method
-            createRecordAspect(
-              tenantId,
-              recordId,
-              aspectId,
-              newAspect,
-              userId,
-              true
-            )(nested)
-          } match {
-            case Success((aspect, eventId)) => Success((aspect, Some(eventId)))
-            case Failure(e) =>
-              this.getRecordAspectById(
-                tenantId,
-                UnconditionalTrueDecision,
-                recordId,
-                aspectId
-              ) match {
-                case Some(aspect) => Success((aspect, None))
-                case None         => Failure(e)
-              }
-          }
-      }
-      recordAspectPatch <- Try {
-        // Diff the old record aspect and the new one
-        val oldAspectJson = oldAspect.toJson
-        val newAspectJson = newAspect.toJson
 
-        JsonDiff.diff(oldAspectJson, newAspectJson, remember = false)
+    (getRecordAspectById(
+      tenantId,
+      UnconditionalTrueDecision,
+      recordId,
+      aspectId
+    ) match {
+      case Some(aspect) => Success((aspect, None))
+      // Possibility of a race condition here. The aspect doesn't exist, so we try to create it.
+      // But someone else could have created it in the meantime. So if our create fails, try one
+      // more time to get an existing one. We use a nested transaction so that, if the create fails,
+      // we don't end up with an extraneous record creation event in the database.
+      case None =>
+        DB.localTx { nested =>
+          createRecordAspect(
+            tenantId,
+            recordId,
+            aspectId,
+            newAspect,
+            userId,
+            forceSkipAspectValidation
+          )(nested)
+        } match {
+          case Success((aspect, eventId)) => Success((aspect, Some(eventId)))
+          case Failure(e) =>
+            getRecordAspectById(
+              tenantId,
+              UnconditionalTrueDecision,
+              recordId,
+              aspectId
+            ) match {
+              case Some(aspect) => Success((aspect, None))
+              case None         => Failure(e)
+            }
+        }
+    }).flatMap { result =>
+      val oldAspect = result._1
+      val eventId = result._2
+      val finalAspectData = if (merge) {
+        JsonUtils.merge(oldAspect, newAspect)
+      } else {
+        newAspect
       }
+
+      if (!forceSkipAspectValidation) {
+        // --- validate Aspect data against JSON schema
+        aspectValidator.validate(aspectId, finalAspectData, tenantId)(
+          session
+        )
+      }
+
+      // Diff the old record aspect and the new one
+      val oldAspectJson = oldAspect.toJson
+      val finalAspectDataJson = finalAspectData.toJson
+
+      val recordAspectPatch =
+        JsonDiff.diff(oldAspectJson, finalAspectDataJson, remember = false)
+
       // --- we never need to validate here (thus, set `forceSkipAspectValidation` = true)
-      // --- as the aspect data has been validated (unless not required) in the beginning of current method
-      result <- patchRecordAspectById(
+      // --- as the aspect data has been validated (unless not required)
+      patchRecordAspectById(
         tenantId,
         recordId,
         aspectId,
@@ -1162,7 +1170,7 @@ class DefaultRecordPersistence(config: Config)
             Success(aspectData, patchEventId)
           }
       }
-    } yield result
+    }
   }
 
   def createRecord(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -29,7 +29,7 @@ import scala.util.{Failure, Success, Try}
 import com.typesafe.config.Config
 import scalikejdbc.interpolation.SQLSyntax
 import au.csiro.data61.magda.util.{JsonUtils, SQLUtils}
-import au.csiro.data61.magda.util.JsonPathUtils.processRecordPatchOperationsOnAspects
+import au.csiro.data61.magda.util.JsonPatchUtils.processRecordPatchOperationsOnAspects
 
 trait RecordPersistence {
 
@@ -206,6 +206,15 @@ trait RecordPersistence {
   def deleteRecord(
       tenantId: SpecifiedTenantId,
       recordId: String,
+      userId: String
+  )(implicit session: DBSession): Try[(Boolean, Long)]
+
+  def deleteRecordAspectArrayItems(
+      tenantId: SpecifiedTenantId,
+      recordId: String,
+      aspectId: String,
+      jsonPath: JsonPatch,
+      jsonItems: Seq[JsValue],
       userId: String
   )(implicit session: DBSession): Try[(Boolean, Long)]
 
@@ -1353,6 +1362,24 @@ class DefaultRecordPersistence(config: Config)
 
       }
     } yield (rowsDeleted > 0, eventId)
+  }
+
+  def deleteRecordAspectArrayItems(
+      tenantId: SpecifiedTenantId,
+      recordId: String,
+      aspectId: String,
+      jsonPath: JsonPatch,
+      jsonItems: Seq[JsValue],
+      userId: String
+  )(implicit session: DBSession): Try[(Boolean, Long)] = {
+    getRecordAspectById(
+      tenantId,
+      UnconditionalTrueDecision,
+      recordId,
+      aspectId
+    ).map{ aspectData =>
+
+    }
   }
 
   def trimRecordsBySource(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -841,7 +841,6 @@ class RecordsService(
     * @apiParamExample {json} Request-Example
     * {
     *   "recordIds": ["dsd-sds-xsds-22", "sds-sdds-2334-dds-34", "sdds-3439-34334343"],
-    *   "aspectId": "access-control",
     *   "jsonPath": "$.preAuthorisedPermissionIds",
     *   "items": ["b133d777-6208-4aa1-8d0b-80bb49b7e5fc", "5d33cc4d-d914-468e-9f02-ae74484af716"]
     * }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -723,7 +723,7 @@ class RecordsService(
     *      [122, 123, 124]
     * @apiUse GenericError
     */
-  @Path("/aspects/:aspectId")
+  @Path("/aspects/{aspectId}")
   @ApiOperation(
     value = "Modify a list of records's aspect with same new data",
     nickname = "putRecordsAspect",
@@ -854,7 +854,7 @@ class RecordsService(
     *      [122, 123, 124]
     * @apiUse GenericError
     */
-  @Path("/aspectArrayItems/:aspectId")
+  @Path("/aspectArrayItems/{aspectId}")
   @ApiOperation(
     value = "Remove items from records' aspect data",
     nickname = "deleteRecordsAspectArrayItems",

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -855,7 +855,7 @@ class RecordsService(
     *      [122, 123, 124]
     * @apiUse GenericError
     */
-  @Path("/aspects/:aspectId")
+  @Path("/aspectArrayItems/:aspectId")
   @ApiOperation(
     value = "Remove items from records' aspect data",
     nickname = "deleteRecordsAspectArrayItems",
@@ -896,8 +896,8 @@ class RecordsService(
       )
     )
   )
-  def deleteRecordsAspectArrayItems: Route = put {
-    path("aspects" / Segment) { (aspectId: String) =>
+  def deleteRecordsAspectArrayItems: Route = delete {
+    path("aspectArrayItems" / Segment) { (aspectId: String) =>
       requireUserId { userId =>
         requiresSpecifiedTenantId { tenantId =>
           entity(as[DeleteRecordsAspectArrayItemsRequest]) { requestData =>

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -77,6 +77,29 @@ class RecordsServiceRO(
     *
     *   `/v0/records?limit=100&optionalAspect=source&aspect=dcat-dataset-strings&aspectQuery=dcat-dataset-strings.title:?%2525rating%2525`
     *
+    *   Please note: when both `aspectQuery` and `aspectOrQuery` present, query conditions generated from `aspectQuery` and `aspectOrQuery` will be joined with `AND`
+    *
+    *   e.g. For the following `aspectQuery` & `aspectOrQuery` queries are specified:
+    *   - `aspectQuery`:
+    *     - q1
+    *     - q2
+    *   - `aspectOrQuery`:
+    *     - q3
+    *     - q4
+    *
+    *   The generated query conditions will be `((q1 AND q2) AND (q3 OR q4))`
+    *   <br/><br/>
+    *
+    *   e.g. For the following `aspectQuery` & `aspectOrQuery` queries are specified:
+    *   - `aspectQuery`:
+    *     - q1
+    *     - q2
+    *   - `aspectOrQuery`:
+    *     - q3
+    *
+    *   The generated query conditions will be `((q1 AND q2) AND q3 )`. This is equivalent to set `aspectQuery` only as `q1`, `q2` and `q3`.
+    *   <br/><br/><br/>
+    *
     *   NOTE: This is an early stage API and may change greatly in the future.
     *
     * @apiParam (query) {string[]} aspectOrQuery Filter the records returned by a value within the aspect JSON.

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -54,7 +54,7 @@ class RecordsServiceRO(
     *   - `value`
     *
     *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format before encoded as query string parameter value.
-    *   
+    *
     *   A sample query string encoding implementation is available [here](https://gist.github.com/t83714/db1725a347c07413c16803a77da13003).
     *
     *   If more than one queries is passed through the `aspectQuery` parameters, they will be grouped with `AND` logic.
@@ -464,7 +464,7 @@ class RecordsServiceRO(
     *   - `operator`
     *   - `value`
     *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format before encoded as query string parameter value.
-    *   
+    *
     *   A sample query string encoding implementation is available [here](https://gist.github.com/t83714/db1725a347c07413c16803a77da13003).
     *
     *   If more than one queries is passed through the `aspectQuery` parameters, they will be grouped with `AND` logic.

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -53,7 +53,9 @@ class RecordsServiceRO(
     *   - `operator`
     *   - `value`
     *
-    *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format.
+    *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format before encoded as query string parameter value.
+    *   
+    *   A sample query string encoding implementation is available [here](https://gist.github.com/t83714/db1725a347c07413c16803a77da13003).
     *
     *   If more than one queries is passed through the `aspectQuery` parameters, they will be grouped with `AND` logic.
     *
@@ -461,7 +463,9 @@ class RecordsServiceRO(
     *   - `aspectId.path.to.field`
     *   - `operator`
     *   - `value`
-    *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format.
+    *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format before encoded as query string parameter value.
+    *   
+    *   A sample query string encoding implementation is available [here](https://gist.github.com/t83714/db1725a347c07413c16803a77da13003).
     *
     *   If more than one queries is passed through the `aspectQuery` parameters, they will be grouped with `AND` logic.
     *

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -52,6 +52,7 @@ class RecordsServiceRO(
     *   - `aspectId.path.to.field`
     *   - `operator`
     *   - `value`
+    *
     *   Except `operator`, all parts must be encoded as `application/x-www-form-urlencoded` MIME format.
     *
     *   If more than one queries is passed through the `aspectQuery` parameters, they will be grouped with `AND` logic.
@@ -69,6 +70,8 @@ class RecordsServiceRO(
     *   - `:>=` greater than or equal to
     *   - `:<`  less than
     *   - `:<=` less than or equal to
+    *   - `:<|` the field is an array value and contains the value
+    *   - `:!<|` the field is not an array value or not contains the value
     *
     *   Example URL with aspectQuery `dcat-dataset-strings.title:?%rating%` (Search keyword `rating` in `dcat-dataset-strings` aspect `title` field)
     *
@@ -452,6 +455,8 @@ class RecordsServiceRO(
     *   - `:>=` greater than or equal to
     *   - `:<`  less than
     *   - `:<=` less than or equal to
+    *   - `:<|` the field is an array value and contains the value
+    *   - `:!<|` the field is not an array value or not contains the value
     *
     *   Example URL with aspectQuery `dcat-dataset-strings.title:?%rating%` (Search keyword `rating` in `dcat-dataset-strings` aspect `title` field)
     *

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
@@ -68,7 +68,7 @@ class RecordAspectServiceSpec extends ApiSpec {
                 "test-aspect" ->
                   """
                     | {
-                    |    "a" : [1,2],
+                    |    "a" : ["1","2"],
                     |    "b" : "yes",
                     |    "d" : {
                     |      "d1":1
@@ -87,7 +87,7 @@ class RecordAspectServiceSpec extends ApiSpec {
                 "test-aspect" ->
                   """
                     | {
-                    |    "a" : [3,4]
+                    |    "a" : ["3","4"]
                     | }
                     |""".stripMargin.parseJson.asJsObject
               ),
@@ -115,7 +115,7 @@ class RecordAspectServiceSpec extends ApiSpec {
               )
             ),
             "data" -> JsObject(
-              "a" -> JsArray(Vector(JsNumber(2), JsNumber(5))),
+              "a" -> JsArray(Vector(JsString("2"), JsString("5"))),
               "b" -> JsString("no"),
               "c" -> JsString("c-value"),
               "d" -> JsObject("d2" -> JsNumber(2))
@@ -137,7 +137,7 @@ class RecordAspectServiceSpec extends ApiSpec {
           "test-aspect",
           """
             |{
-            |  "a" : [1,2,5],
+            |  "a" : ["1","2","5"],
             |  "b" : "no",
             |  "c" : "c-value",
             |  "d" : {
@@ -155,7 +155,7 @@ class RecordAspectServiceSpec extends ApiSpec {
           "test-aspect",
           """
             |{
-            |  "a" : [3,4,2,5],
+            |  "a" : ["3","4","2","5"],
             |  "b" : "no",
             |  "c" : "c-value",
             |  "d" : {
@@ -171,7 +171,7 @@ class RecordAspectServiceSpec extends ApiSpec {
           "test-aspect",
           """
             |{
-            |  "a" : [2,5],
+            |  "a" : ["2","5"],
             |  "b" : "no",
             |  "c" : "c-value",
             |  "d" : {

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
@@ -35,7 +35,278 @@ class RecordAspectServiceSpec extends ApiSpec {
     param.authFetcher.resetMock()
   }
 
-  describe("Record Aspect Service Auth Logic") {
+  def verifyAspectData(
+      param: FixtureParam,
+      recordId: String,
+      aspectId: String,
+      jsonString: String
+  ) = {
+    Get(s"/v0/records/${recordId}/aspects/${aspectId}") ~> addUserId() ~> addTenantIdHeader(
+      TENANT_1
+    ) ~> param.api(Full).routes ~> check {
+      withClue(responseAs[String]) {
+        status shouldEqual StatusCodes.OK
+      }
+      val aspectData = responseAs[JsObject]
+      aspectData.toString() shouldBe
+        jsonString.parseJson.toString()
+    }
+  }
+
+  describe("Record Aspect Service Logic") {
+    describe(
+      "Modify endpoint {put} /v0/registry/records/aspects/{aspectId}"
+    ) {
+      it("should merge aspect correctly when merge = true") { param =>
+        settingUpTestData(
+          param,
+          List(
+            Record(
+              id = "record-1",
+              name = "test record 2",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [1,2],
+                    |    "b" : "yes",
+                    |    "d" : {
+                    |      "d1":1
+                    |    },
+                    |    "e": 2
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            ),
+            Record(
+              id = "record-2",
+              name = "test record 2",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [3,4]
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            ),
+            Record(
+              id = "record-3",
+              name = "test record 3",
+              aspects = Map(),
+              None,
+              None
+            )
+          )
+        )
+
+        Put(
+          s"/v0/records/aspects/test-aspect?merge=true",
+          JsObject(
+            "recordIds" -> JsArray(
+              Vector(
+                JsString("record-1"),
+                JsString("record-2"),
+                JsString("record-3")
+              )
+            ),
+            "data" -> JsObject(
+              "a" -> JsArray(Vector(JsNumber(2), JsNumber(5))),
+              "b" -> JsString("no"),
+              "c" -> JsString("c-value"),
+              "d" -> JsObject("d2" -> JsNumber(2))
+            )
+          )
+        ) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val eventList = responseAs[List[Long]]
+          eventList.length shouldBe 3
+        }
+
+        verifyAspectData(
+          param,
+          "record-1",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [1,2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d1":1,
+            |      "d2":2
+            |   },
+            |   "e": 2
+            |}
+            |""".stripMargin
+        )
+
+        verifyAspectData(
+          param,
+          "record-2",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [3,4,2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d2":2
+            |   }
+            |}
+            |""".stripMargin
+        )
+
+        verifyAspectData(
+          param,
+          "record-3",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d2":2
+            |   }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      it("should replace aspect data when merge = false") { param =>
+        settingUpTestData(
+          param,
+          List(
+            Record(
+              id = "record-1",
+              name = "test record 2",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [1,2],
+                    |    "b" : "yes",
+                    |    "d" : {
+                    |      "d1":1
+                    |    },
+                    |    "e": 2
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            ),
+            Record(
+              id = "record-2",
+              name = "test record 2",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [3,4]
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            ),
+            Record(
+              id = "record-3",
+              name = "test record 3",
+              aspects = Map(),
+              None,
+              None
+            )
+          )
+        )
+
+        Put(
+          s"/v0/records/aspects/test-aspect",
+          JsObject(
+            "recordIds" -> JsArray(
+              Vector(
+                JsString("record-1"),
+                JsString("record-2"),
+                JsString("record-3")
+              )
+            ),
+            "data" -> JsObject(
+              "a" -> JsArray(Vector(JsNumber(2), JsNumber(5))),
+              "b" -> JsString("no"),
+              "c" -> JsString("c-value"),
+              "d" -> JsObject("d2" -> JsNumber(2))
+            )
+          )
+        ) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val eventList = responseAs[List[Long]]
+          eventList.length shouldBe 3
+        }
+
+        verifyAspectData(
+          param,
+          "record-1",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d2":2
+            |   }
+            |}
+            |""".stripMargin
+        )
+
+        verifyAspectData(
+          param,
+          "record-2",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d2":2
+            |   }
+            |}
+            |""".stripMargin
+        )
+
+        verifyAspectData(
+          param,
+          "record-3",
+          "test-aspect",
+          """
+            |{
+            |  "a" : [2,5],
+            |  "b" : "no",
+            |  "c" : "c-value",
+            |  "d" : {
+            |      "d2":2
+            |   }
+            |}
+            |""".stripMargin
+        )
+      }
+
+    }
+
     describe(
       "Modify endpoint {put} /v0/registry/records/{recordId}/aspects/{aspectId}"
     ) {

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordAspectServiceSpec.scala
@@ -1,0 +1,200 @@
+package au.csiro.data61.magda.registry
+
+import akka.http.scaladsl.model.StatusCodes
+import au.csiro.data61.magda.model.Registry._
+import spray.json._
+
+/**
+  * This is functional test case suit. the auth is turned off in config in ApiSpec (i.e. all requested will be authorised)
+  * to minimise the code. Auth related logic will be moved to a separate test case suit (with auth turned on).
+  */
+class RecordAspectServiceSpec extends ApiSpec {
+
+  def settingUpTestData(param: FixtureParam, records: List[Record]) = {
+
+    val testDataAspects = records
+      .flatMap(_.aspects.map(_._1))
+      .toSet
+      .map(aspectId => AspectDefinition(aspectId, s"${aspectId} aspect", None))
+
+    testDataAspects.foreach { aspect =>
+      Post("/v0/aspects", aspect) ~> addUserId() ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    records.foreach { record =>
+      Post("/v0/records", record) ~> addUserId() ~> addTenantIdHeader(
+        TENANT_1
+      ) ~> param.api(Full).routes ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+    param.authFetcher.resetMock()
+  }
+
+  describe("Record Aspect Service Auth Logic") {
+    describe(
+      "Modify endpoint {put} /v0/registry/records/{recordId}/aspects/{aspectId}"
+    ) {
+
+      it("should merge aspect correctly when merge = true") { param =>
+        settingUpTestData(
+          param,
+          List(
+            Record(
+              id = "xxxxx",
+              name = "test record",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [1,2],
+                    |    "b" : "yes",
+                    |    "d" : {
+                    |      "d1":1
+                    |    },
+                    |    "e": 2
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            )
+          )
+        )
+
+        Put(
+          s"/v0/records/xxxxx/aspects/test-aspect?merge=true",
+          JsObject(
+            "a" -> JsArray(Vector(JsNumber(2), JsNumber(5))),
+            "b" -> JsString("no"),
+            "c" -> JsString("c-value"),
+            "d" -> JsObject("d2" -> JsNumber(2))
+          )
+        ) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val aspectData = responseAs[JsObject]
+          aspectData.toString() shouldBe
+            """
+              |{
+              |  "a" : [1,2,5],
+              |  "b" : "no",
+              |  "c" : "c-value",
+              |  "d" : {
+              |      "d1":1,
+              |      "d2":2
+              |   },
+              |   "e": 2
+              |}
+              |""".stripMargin.parseJson.toString()
+        }
+
+        Get("/v0/records/xxxxx/aspects/test-aspect") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val aspectData = responseAs[JsObject]
+          aspectData.toString() shouldBe
+            """
+              |{
+              |  "a" : [1,2,5],
+              |  "b" : "no",
+              |  "c" : "c-value",
+              |  "d" : {
+              |      "d1":1,
+              |      "d2":2
+              |   },
+              |   "e": 2
+              |}
+              |""".stripMargin.parseJson.toString()
+        }
+
+      }
+
+      it("should replace aspect instead when merge is not set") { param =>
+        settingUpTestData(
+          param,
+          List(
+            Record(
+              id = "xxxxx",
+              name = "test record",
+              aspects = Map(
+                "test-aspect" ->
+                  """
+                    | {
+                    |    "a" : [1,2],
+                    |    "b" : "yes",
+                    |    "d" : {
+                    |      "d1":1
+                    |    },
+                    |    "e": 2
+                    | }
+                    |""".stripMargin.parseJson.asJsObject
+              ),
+              None,
+              None
+            )
+          )
+        )
+
+        Put(
+          s"/v0/records/xxxxx/aspects/test-aspect",
+          JsObject(
+            "a" -> JsArray(Vector(JsNumber(2), JsNumber(5))),
+            "b" -> JsString("no"),
+            "c" -> JsString("c-value"),
+            "d" -> JsObject("d2" -> JsNumber(2))
+          )
+        ) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val aspectData = responseAs[JsObject]
+          aspectData.toString() shouldBe
+            """
+              |{
+              |  "a" : [2,5],
+              |  "b" : "no",
+              |  "c" : "c-value",
+              |  "d" : {
+              |      "d2":2
+              |   }
+              |}
+              |""".stripMargin.parseJson.toString()
+        }
+
+        Get("/v0/records/xxxxx/aspects/test-aspect") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(Full).routes ~> check {
+          withClue(responseAs[String]) {
+            status shouldEqual StatusCodes.OK
+          }
+          val aspectData = responseAs[JsObject]
+          aspectData.toString() shouldBe
+            """
+              |{
+              |  "a" : [2,5],
+              |  "b" : "no",
+              |  "c" : "c-value",
+              |  "d" : {
+              |      "d2":2
+              |   }
+              |}
+              |""".stripMargin.parseJson.toString()
+        }
+      }
+
+    }
+  }
+}

--- a/magda-registry-aspects/access-group-details.schema.json
+++ b/magda-registry-aspects/access-group-details.schema.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Access Group Details Aspect",
+    "description": "The aspect contains detail information of an access-group record. A access group can be used to grant users access to resources across orgUnit structure.",
+    "type": "object",
+    "properties": {
+        "name": {
+            "title": "Name",
+            "description": "A name given to the access group",
+            "type": "string"
+        },
+        "resourceUri": {
+            "title": "Resource URI",
+            "description": "One access group can only grant access to the same type of resources. The Resource URI specifies the type of resources that the access group manages. At this moment, only registry records `object/record` is supported.",
+            "type": "string",
+            "enum": ["object/record"]
+        },
+        "description": {
+            "title": "Description",
+            "description": "The free text description for the access group",
+            "type": "string"
+        },
+        "keywords": {
+            "title": "Keywords",
+            "description": "Tags (or keywords) help users discover the access-group",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "operationUris": {
+            "title": "Operation URIs",
+            "description": "A list of operations that the access group allows enrolled users to perform on included resources.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "permissionId": {
+            "title": "Access Group Permission ID",
+            "description": "The ID of the permission record that defines the access to be granted to all users to be added to this access group. The permission record must be a `pre-authorised` type permission record.",
+            "type": "string",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "roleId": {
+            "title": "Access Group Role ID",
+            "description": "The ID of the role record that is auto-created with the access-group creation. This role will be used to grant the access group permission (specified by `permissionId`) to all users who are added to this access group.",
+            "type": "string",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "createTime": {
+            "title": "Creation time",
+            "description": "the date and time when the record was created",
+            "type": "string",
+            "format": "date-time"
+        },
+        "createBy": {
+            "title": "Create By",
+            "description": "The ID of the user who created the access-group",
+            "type": "string",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "editTime": {
+            "title": "Edit time",
+            "description": "the date and time when the record was last updated",
+            "type": "string",
+            "format": "date-time"
+        },
+        "editBy": {
+            "title": "Edit By",
+            "description": "The ID of the last user who updated the access-group",
+            "type": "string",
+            "minLength": 36,
+            "maxLength": 36
+        }
+    },
+    "required": ["name", "resourceUri", "permissionId", "roleId"],
+    "additionalProperties": false
+}

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -41,6 +41,7 @@ libraryDependencies ++= {
     "io.lemonlabs"                 %% "scala-uri"            % "3.6.0",
     "org.scalamock"                %% "scalamock"            % "5.1.0" % Test,
     "org.scalikejdbc"              %% "scalikejdbc"          % "3.0.0-RC3",
-    "org.json4s"                   %  "json4s-native_2.12"   % "4.0.5"
+    "org.json4s"                   %  "json4s-native_2.12"   % "4.0.5",
+    "com.jayway.jsonpath"          %  "json-path"            % "2.7.0"
   )
 }

--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -40,6 +40,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"            %% "akka-http-testkit"    % akkaHttpV % Test,
     "io.lemonlabs"                 %% "scala-uri"            % "3.6.0",
     "org.scalamock"                %% "scalamock"            % "5.1.0" % Test,
-    "org.scalikejdbc"              %% "scalikejdbc"          % "3.0.0-RC3"
+    "org.scalikejdbc"              %% "scalikejdbc"          % "3.0.0-RC3",
+    "org.json4s"                   %  "json4s-native_2.12"   % "4.0.5"
   )
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -311,7 +311,6 @@ object Registry
     Registry.RegistryCountResponse.apply
   )
 
-
   implicit object RecordTypeFormat extends RootJsonFormat[Registry.RecordType] {
 
     def write(obj: Registry.RecordType) = obj match {

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -1,7 +1,6 @@
 package au.csiro.data61.magda.model
 
 import java.time.{OffsetDateTime, ZoneOffset}
-
 import akka.event.LoggingAdapter
 import au.csiro.data61.magda.model.Temporal.{ApiDate, PeriodOfTime, Periodicity}
 import au.csiro.data61.magda.model.misc.{Protocols => ModelProtocols, _}
@@ -10,6 +9,7 @@ import enumeratum.values.{IntEnum, IntEnumEntry}
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import spray.json.lenses.JsonLenses._
 import spray.json._
+import gnieh.diffson.sprayJson._
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success, Try}
@@ -260,6 +260,8 @@ object Registry
       ) lastEventIdReceived: Long
   )
 
+  case class PatchRecordsRequest(recordIds: List[String], jsonPath: JsonPatch)
+
   object RegistryConstants {
     val aspects = List("dcat-dataset-strings")
 
@@ -308,6 +310,7 @@ object Registry
   implicit val recordPageFormat = jsonFormat1(
     Registry.RegistryCountResponse.apply
   )
+
 
   implicit object RecordTypeFormat extends RootJsonFormat[Registry.RecordType] {
 

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -261,6 +261,7 @@ object Registry
   )
 
   case class PatchRecordsRequest(recordIds: List[String], jsonPath: JsonPatch)
+  case class PutRecordsAspectRequest(recordIds: List[String], data: JsObject)
 
   object RegistryConstants {
     val aspects = List("dcat-dataset-strings")

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -262,6 +262,11 @@ object Registry
 
   case class PatchRecordsRequest(recordIds: List[String], jsonPath: JsonPatch)
   case class PutRecordsAspectRequest(recordIds: List[String], data: JsObject)
+  case class DeleteRecordsAspectArrayItemsRequest(
+      recordIds: List[String],
+      jsonPath: String,
+      items: List[JsValue]
+  )
 
   object RegistryConstants {
     val aspects = List("dcat-dataset-strings")

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonPatchUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonPatchUtils.scala
@@ -6,7 +6,7 @@ import gnieh.diffson.sprayJson._
 import spray.json.JsObject
 import gnieh.diffson.PatchException
 
-object JsonPathUtils {
+object JsonPatchUtils {
 
   def processRecordPatchOperationsOnAspects[T](
       recordPatch: JsonPatch,
@@ -156,7 +156,7 @@ object JsonPathUtils {
   /**
     * Apply Json path to policy engine record context json data
     * @param recordContextData
-    * @param jsonPath
+    * @param recordPatch
     * @return
     */
   def applyJsonPathToRecordContextData(

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
@@ -1,0 +1,13 @@
+package au.csiro.data61.magda.util
+
+import spray.json._
+import spray.json.{JsValue}
+import org.json4s.native.JsonMethods._
+
+object JsonUtils {
+
+  def merge(a: JsValue, b: JsValue): JsValue = {
+    compact(render(parse(a.toString) merge parse(b.toString))).parseJson
+  }
+
+}

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
@@ -4,6 +4,10 @@ import au.csiro.data61.magda.ServerError
 import spray.json._
 import spray.json.JsValue
 import org.json4s.native.JsonMethods._
+import com.jayway.jsonpath.{JsonPath, PathNotFoundException}
+import net.minidev.json.{JSONArray, JSONValue}
+
+import scala.util.{Failure, Success, Try}
 
 object JsonUtils {
 
@@ -39,6 +43,35 @@ object JsonUtils {
       )
     }
     compact(render(parse(a.toString) merge parse(b.toString))).parseJson
+  }
+
+  def deleteJsonArrayItemsByJsonPath(
+      jsonData: JsValue,
+      jsonPath: String,
+      itemsToDelete: Seq[JsValue]
+  ): JsValue = {
+    val doc = JsonPath.parse(jsonData.toString())
+    (Try {
+      val readResult: JSONArray = doc.read(jsonPath)
+      Option(readResult) // when a null json value is read, this will become a None
+    } match {
+      case Success(Some(v)) =>
+        Some(v.toString().parseJson.asInstanceOf[JsArray])
+      case Success(None)                     => None
+      case Failure(e: PathNotFoundException) => None
+      case Failure(e)                        => throw e
+    }).map { v =>
+        val newArray =
+          JsArray(v.elements.filter(item => !itemsToDelete.contains(item)))
+        val jsonSmartVal =
+          JSONValue.parseWithException(newArray.toString()) match {
+            case v: JSONArray => v
+            case _ =>
+              throw ServerError("Failed to convert json to JSONArray", 500)
+          }
+        doc.set(jsonPath, jsonSmartVal).jsonString().parseJson
+      }
+      .getOrElse(jsonData) // None indicate no data found at JsonPath
   }
 
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/util/JsonUtils.scala
@@ -1,12 +1,43 @@
 package au.csiro.data61.magda.util
 
+import au.csiro.data61.magda.ServerError
 import spray.json._
-import spray.json.{JsValue}
+import spray.json.JsValue
 import org.json4s.native.JsonMethods._
 
 object JsonUtils {
 
+  def isArray(v: JsValue): Boolean = v match {
+    case JsArray(_) => true
+    case _          => false
+  }
+
+  def isObject(v: JsValue): Boolean = v match {
+    case JsObject(_) => true
+    case _           => false
+  }
+
   def merge(a: JsValue, b: JsValue): JsValue = {
+    if (!isArray(a) && !isObject(a)) {
+      throw ServerError(
+        s"Failed to merge Json: `${a.toString()}` must be an array or object",
+        400
+      )
+    }
+
+    if (!isArray(b) && !isObject(b)) {
+      throw ServerError(
+        s"Failed to merge Json: `${b.toString()}` must be an array or object",
+        400
+      )
+    }
+
+    if (isArray(a) != isArray(b)) {
+      throw ServerError(
+        s"Failed to merge Json: both json values should be in the same type",
+        400
+      )
+    }
     compact(render(parse(a.toString) merge parse(b.toString))).parseJson
   }
 

--- a/magda-scala-common/src/test/scala/au/csiro/data61/magda/model/AspectQuerySpec.scala
+++ b/magda-scala-common/src/test/scala/au/csiro/data61/magda/model/AspectQuerySpec.scala
@@ -1043,6 +1043,57 @@ class AspectQuerySpec extends FunSpec with Matchers {
         }
     )
 
+    testAspectQueryString(
+      "aspectQuery=testAspect4.field4.field-5:<|a-2",
+      aq =>
+        aq match {
+          case AspectQueryValueInArray(
+              aspectId,
+              path,
+              value,
+              negated
+              ) =>
+            aspectId shouldBe "testAspect4"
+            path.mkString(".") shouldBe "field4.field-5"
+            value shouldBe AspectQueryStringValue("a-2")
+            negated shouldBe false
+        }
+    )
+
+    testAspectQueryString(
+      "aspectQuery=testAspect4.field4.field-5%3A%3C%7C-a-2",
+      aq =>
+        aq match {
+          case AspectQueryValueInArray(
+              aspectId,
+              path,
+              value,
+              negated
+              ) =>
+            aspectId shouldBe "testAspect4"
+            path.mkString(".") shouldBe "field4.field-5"
+            value shouldBe AspectQueryStringValue("-a-2")
+            negated shouldBe false
+        }
+    )
+
+    testAspectQueryString(
+      "aspectQuery=testAspect4.field4.field-5%3A!%3C%7C-a-2",
+      aq =>
+        aq match {
+          case AspectQueryValueInArray(
+              aspectId,
+              path,
+              value,
+              negated
+              ) =>
+            aspectId shouldBe "testAspect4"
+            path.mkString(".") shouldBe "field4.field-5"
+            value shouldBe AspectQueryStringValue("-a-2")
+            negated shouldBe true
+        }
+    )
+
     def testComparisonOperators(operators: Seq[String]): Unit = {
       operators.map { opt =>
         testAspectQueryString(

--- a/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
+++ b/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
@@ -1,0 +1,58 @@
+package au.csiro.data61.magda.util
+
+import spray.json._
+import org.scalatest.{FunSpec, Matchers}
+
+class JsonUtilsSpec extends FunSpec with Matchers {
+
+  describe("test Json merge") {
+    it("should merge object & array type correctly") {
+      val objJson1 =
+        """
+          |    {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin
+
+      val objJson2 =
+        """
+          |    {
+          |      "lotto":{
+          |        "winners":[{
+          |          "winner-id":54,
+          |          "numbers":[52,3,12,11,18,22]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin
+
+      val expectedObjJson = """
+                              |    {
+                              |      "lotto":{
+                              |        "lotto-id":5,
+                              |        "winning-numbers":[2,45,34,23,7,5,3],
+                              |        "winners":[{
+                              |          "winner-id":23,
+                              |          "numbers":[2,45,34,23,3,5]
+                              |        },{
+                              |          "winner-id":54,
+                              |          "numbers":[52,3,12,11,18,22]
+                              |        }]
+                              |      }
+                              |    }
+                              |""".stripMargin
+
+      val result =
+        JsonUtils.merge(objJson1.parseJson, objJson2.parseJson).toString()
+
+      result shouldBe expectedObjJson.parseJson.toString()
+    }
+  }
+}

--- a/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
+++ b/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
@@ -4,10 +4,190 @@ import au.csiro.data61.magda.ServerError
 import spray.json._
 import org.scalatest.{FunSpec, Matchers}
 import akka.http.scaladsl.model.StatusCodes
-
 import scala.util.{Failure, Try}
 
 class JsonUtilsSpec extends FunSpec with Matchers {
+
+  describe("test Json path array items deletion") {
+    it("should delete number items from array correctly") {
+      val objJson1 =
+        """
+          |    {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":[52,3,12,11,18,22]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin
+
+      JsonUtils
+        .deleteJsonArrayItemsByJsonPath(
+          objJson1.parseJson,
+          "$.lotto.winners[1].numbers",
+          List(JsNumber(3), JsNumber(18))
+        )
+        .toString() shouldBe
+        """
+          |  {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":[52,12,11,22]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin.parseJson.toString()
+    }
+
+    it("should delete string items from array correctly") {
+      val objJson1 =
+        """
+          |    {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":["52","3","12","11","18","22"]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin
+
+      JsonUtils
+        .deleteJsonArrayItemsByJsonPath(
+          objJson1.parseJson,
+          "$.lotto.winners[1].numbers",
+          List(JsString("18"), JsString("11"))
+        )
+        .toString() shouldBe
+        """
+          |  {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":["52","3","12","22"]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin.parseJson.toString()
+    }
+
+    it("should delete mixed items from array correctly") {
+      val objJson1 =
+        """
+          |    {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":[52,"3",12,"11","18",22]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin
+
+      JsonUtils
+        .deleteJsonArrayItemsByJsonPath(
+          objJson1.parseJson,
+          "$.lotto.winners[1].numbers",
+          List(JsString("3"), JsNumber("22"))
+        )
+        .toString() shouldBe
+        """
+          |  {
+          |      "lotto":{
+          |        "lotto-id":5,
+          |        "winning-numbers":[2,45,34,23,7,5,3],
+          |        "winners":[{
+          |          "winner-id":23,
+          |          "numbers":[2,45,34,23,3,5]
+          |        },{
+          |          "winner-id":54,
+          |          "numbers":[52,12,"11","18"]
+          |        }]
+          |      }
+          |    }
+          |""".stripMargin.parseJson.toString()
+    }
+
+    it("should return original data with no error when jsonPath doesn't exist") {
+      val objJson1 =
+        """
+          |    {
+          |      "a":1,
+          |      "b":2
+          |    }
+          |""".stripMargin
+
+      JsonUtils
+        .deleteJsonArrayItemsByJsonPath(
+          objJson1.parseJson,
+          "$.a.b.c",
+          List(JsString("3"), JsNumber("22"))
+        )
+        .toString() shouldBe
+        """
+          |  {
+          |      "a":1,
+          |      "b":2
+          |    }
+          |""".stripMargin.parseJson.toString()
+    }
+
+    it(
+      "should return original data with no error when the value at the jsonPath is null value"
+    ) {
+      val objJson1 =
+        """
+          |    {
+          |      "a":1,
+          |      "b":2,
+          |      "c":null
+          |    }
+          |""".stripMargin
+
+      JsonUtils
+        .deleteJsonArrayItemsByJsonPath(
+          objJson1.parseJson,
+          "$.c",
+          List(JsString("3"), JsNumber("22"))
+        )
+        .toString() shouldBe
+        """
+          |  {
+          |      "a":1,
+          |      "b":2,
+          |      "c":null
+          |    }
+          |""".stripMargin.parseJson.toString()
+    }
+
+  }
 
   describe("test Json merge") {
     it("should merge object & array type correctly") {

--- a/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
+++ b/magda-scala-common/src/test/scala/au/csiro/data61/magda/util/JsonUtilsSpec.scala
@@ -1,7 +1,11 @@
 package au.csiro.data61.magda.util
 
+import au.csiro.data61.magda.ServerError
 import spray.json._
 import org.scalatest.{FunSpec, Matchers}
+import akka.http.scaladsl.model.StatusCodes
+
+import scala.util.{Failure, Try}
 
 class JsonUtilsSpec extends FunSpec with Matchers {
 
@@ -53,6 +57,35 @@ class JsonUtilsSpec extends FunSpec with Matchers {
         JsonUtils.merge(objJson1.parseJson, objJson2.parseJson).toString()
 
       result shouldBe expectedObjJson.parseJson.toString()
+    }
+
+    it("should merge empty object correctly type correctly") {
+      val objJson1 =
+        """
+          |    {
+          |      "a": 1
+          |    }
+          |""".stripMargin
+
+      val result =
+        JsonUtils.merge(objJson1.parseJson, JsObject()).toString()
+
+      result shouldBe objJson1.parseJson.toString()
+    }
+
+    it("should throw an error") {
+      val objJson1 =
+        """
+          |    [123]
+          |""".stripMargin
+
+      val result =
+        Try(JsonUtils.merge(objJson1.parseJson, JsObject()).toString()) match {
+          case Failure(ServerError(_, code)) => Some(code)
+          case _                             => None
+        }
+
+      result shouldBe Some(StatusCodes.BadRequest)
     }
   }
 }

--- a/magda-typescript-common/src/SQLUtils.ts
+++ b/magda-typescript-common/src/SQLUtils.ts
@@ -73,7 +73,7 @@ export function getTableColumnName(
  * @return {*}
  */
 export async function createTableRecord(
-    poolOrClient: pg.PoolClient | pg.Pool,
+    poolOrClient: pg.PoolClient | pg.Pool | pg.Client,
     table: string,
     data: { [key: string]: RawValue },
     allowFieldList?: string[],
@@ -168,7 +168,7 @@ export async function updateTableRecord(
 }
 
 export async function deleteTableRecord(
-    poolOrClient: pg.Client | pg.Pool,
+    poolOrClient: pg.Client | pg.Pool | pg.PoolClient,
     table: string,
     id: string
 ) {
@@ -202,7 +202,7 @@ export function parseIntParam(p: number | string | undefined) {
 export const MAX_PAGE_RECORD_NUMBER = 500;
 
 export async function searchTableRecord<T = any>(
-    poolOrClient: pg.Client | pg.Pool,
+    poolOrClient: pg.Client | pg.Pool | pg.PoolClient,
     table: string,
     contiditions: SQLSyntax[] = [],
     queryConfig?: {
@@ -291,7 +291,7 @@ export async function searchTableRecord<T = any>(
 }
 
 export async function getTableRecord<T = any>(
-    poolOrClient: pg.Client | pg.Pool,
+    poolOrClient: pg.Client | pg.Pool | pg.PoolClient,
     table: string,
     id: string,
     authDecision: AuthDecision = UnconditionalTrueDecision,
@@ -316,7 +316,7 @@ export async function getTableRecord<T = any>(
 }
 
 export async function countTableRecord(
-    poolOrClient: pg.Client | pg.Pool,
+    poolOrClient: pg.Client | pg.Pool | pg.PoolClient,
     table: string,
     contiditions: SQLSyntax[] = [],
     authDecision?: AuthDecision,

--- a/magda-typescript-common/src/authorization-api/model.ts
+++ b/magda-typescript-common/src/authorization-api/model.ts
@@ -170,3 +170,30 @@ export interface AccessControlMetaData {
         preAuthorisedPermissionIds?: string[];
     };
 }
+
+export interface CreateAccessGroupRequestBodyType {
+    name: string;
+    resourceUri: string;
+    description?: string;
+    keywords?: string[];
+    operationUris: string[];
+    ownerId?: string;
+    orgUnitId?: string;
+}
+
+export interface AccessGroup {
+    id: string;
+    name: string;
+    resourceUri: string;
+    operationUris: string[];
+    description?: string;
+    keywords?: string[];
+    permissionId: string;
+    roleId: string;
+    ownerId?: string;
+    orgUnit?: string;
+    createTime?: Date;
+    createBy?: string;
+    editTime?: Date;
+    editBy?: string;
+}

--- a/magda-typescript-common/src/authorization-api/model.ts
+++ b/magda-typescript-common/src/authorization-api/model.ts
@@ -181,6 +181,15 @@ export interface CreateAccessGroupRequestBodyType {
     orgUnitId?: string;
 }
 
+export interface UpdateAccessGroupRequestBodyType {
+    name?: string;
+    description?: string;
+    keywords?: string[];
+    operationUris?: string[];
+    ownerId?: string;
+    orgUnitId?: string;
+}
+
 export interface AccessGroup {
     id: string;
     name: string;

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1816,7 +1816,7 @@ export class RecordsApi {
     ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
         const localVarPath =
             this.basePath +
-            "/records/aspects/:aspectId".replace(
+            "/records/aspectArrayItems/:aspectId".replace(
                 "{" + "aspectId" + "}",
                 String(aspectId)
             );

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1816,7 +1816,7 @@ export class RecordsApi {
     ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
         const localVarPath =
             this.basePath +
-            "/records/aspectArrayItems/:aspectId".replace(
+            "/records/aspectArrayItems/{aspectId}".replace(
                 "{" + "aspectId" + "}",
                 String(aspectId)
             );
@@ -2809,7 +2809,7 @@ export class RecordsApi {
     ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
         const localVarPath =
             this.basePath +
-            "/records/aspects/:aspectId".replace(
+            "/records/aspects/{aspectId}".replace(
                 "{" + "aspectId" + "}",
                 String(aspectId)
             );

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -89,11 +89,20 @@ export class JsObject {
 
 export class JsValue {}
 
+export class JsonPatch {
+    "ops": Array<Operation>;
+}
+
 export class MultipleDeleteResult {
     "count": number;
 }
 
 export class Operation {}
+
+export class PatchRecordsRequest {
+    "recordIds": Array<string>;
+    "jsonPath": JsonPatch;
+}
 
 /**
  * A record in the registry, usually including data for one or more aspects, unique for a tenant.
@@ -2403,7 +2412,7 @@ export class RecordsApi {
      * Modify a record by applying a JSON Patch
      * The patch should follow IETF RFC 6902 (https://tools.ietf.org/html/rfc6902).
      * @param xMagdaTenantId 0
-     * @param id ID of the aspect to be saved.
+     * @param id ID of the record to be pacthed.
      * @param recordPatch The RFC 6902 patch to apply to the aspect.
      * @param xMagdaSession Magda internal session id
      */
@@ -2491,6 +2500,89 @@ export class RecordsApi {
                 });
             }
         );
+    }
+    /**
+     * Modify a list of records by applying the same JSON Patch
+     * The patch should follow IETF RFC 6902 (https://tools.ietf.org/html/rfc6902).
+     * @param xMagdaTenantId 0
+     * @param requestData An json object has key &#39;recordIds&#39; &amp; &#39;jsonPath&#39;
+     * @param xMagdaSession Magda internal session id
+     */
+    public patchRecords(
+        xMagdaTenantId: number,
+        requestData: PatchRecordsRequest,
+        xMagdaSession: string
+    ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
+        const localVarPath = this.basePath + "/records";
+        let queryParameters: any = {};
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let formParams: any = {};
+
+        // verify required parameter 'xMagdaTenantId' is not null or undefined
+        if (xMagdaTenantId === null || xMagdaTenantId === undefined) {
+            throw new Error(
+                "Required parameter xMagdaTenantId was null or undefined when calling patchRecords."
+            );
+        }
+
+        // verify required parameter 'requestData' is not null or undefined
+        if (requestData === null || requestData === undefined) {
+            throw new Error(
+                "Required parameter requestData was null or undefined when calling patchRecords."
+            );
+        }
+
+        // verify required parameter 'xMagdaSession' is not null or undefined
+        if (xMagdaSession === null || xMagdaSession === undefined) {
+            throw new Error(
+                "Required parameter xMagdaSession was null or undefined when calling patchRecords."
+            );
+        }
+
+        headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
+
+        let useFormData = false;
+
+        let requestOptions: request.Options = {
+            method: "PATCH",
+            qs: queryParameters,
+            headers: headerParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: requestData
+        };
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+        return new Promise<{
+            response: http.IncomingMessage;
+            body: Array<any>;
+        }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    if (
+                        response.statusCode >= 200 &&
+                        response.statusCode <= 299
+                    ) {
+                        resolve({ response: response, body: body });
+                    } else {
+                        reject({ response: response, body: body });
+                    }
+                }
+            });
+        });
     }
     /**
      * Modify a record by ID

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -104,6 +104,11 @@ export class PatchRecordsRequest {
     "jsonPath": JsonPatch;
 }
 
+export class PutRecordsAspectRequest {
+    "recordIds": Array<string>;
+    "data": JsObject;
+}
+
 /**
  * A record in the registry, usually including data for one or more aspects, unique for a tenant.
  */
@@ -1246,13 +1251,15 @@ export class RecordAspectsApi {
      * @param aspect The record aspect to save.
      * @param xMagdaSession Magda internal session id
      * @param xMagdaTenantId 0
+     * @param merge Whether merge the supplied aspect data to existing aspect data or replace it
      */
     public putById(
         recordId: string,
         aspectId: string,
         aspect: any,
         xMagdaSession: string,
-        xMagdaTenantId: number
+        xMagdaTenantId: number,
+        merge?: boolean
     ): Promise<{ response: http.IncomingMessage; body: any }> {
         const localVarPath =
             this.basePath +
@@ -1296,6 +1303,10 @@ export class RecordAspectsApi {
             throw new Error(
                 "Required parameter xMagdaTenantId was null or undefined when calling putById."
             );
+        }
+
+        if (merge !== undefined) {
+            queryParameters["merge"] = merge;
         }
 
         headerParams["X-Magda-Session"] = xMagdaSession;
@@ -2676,6 +2687,109 @@ export class RecordsApi {
                 });
             }
         );
+    }
+    /**
+     * Modify a list of records&#39;s aspect with same new data
+     * Modify a list of records&#39;s aspect with same new data
+     * @param xMagdaTenantId 0
+     * @param aspectId ID of the aspect to update.
+     * @param requestData An json object has key &#39;recordIds&#39; &amp; &#39;data&#39;
+     * @param xMagdaSession Magda internal session id
+     * @param merge Whether merge the supplied aspect data to existing aspect data or replace it
+     */
+    public putRecordsAspect(
+        xMagdaTenantId: number,
+        aspectId: string,
+        requestData: PutRecordsAspectRequest,
+        xMagdaSession: string,
+        merge?: boolean
+    ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
+        const localVarPath =
+            this.basePath +
+            "/records/aspects/:aspectId".replace(
+                "{" + "aspectId" + "}",
+                String(aspectId)
+            );
+        let queryParameters: any = {};
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let formParams: any = {};
+
+        // verify required parameter 'xMagdaTenantId' is not null or undefined
+        if (xMagdaTenantId === null || xMagdaTenantId === undefined) {
+            throw new Error(
+                "Required parameter xMagdaTenantId was null or undefined when calling putRecordsAspect."
+            );
+        }
+
+        // verify required parameter 'aspectId' is not null or undefined
+        if (aspectId === null || aspectId === undefined) {
+            throw new Error(
+                "Required parameter aspectId was null or undefined when calling putRecordsAspect."
+            );
+        }
+
+        // verify required parameter 'requestData' is not null or undefined
+        if (requestData === null || requestData === undefined) {
+            throw new Error(
+                "Required parameter requestData was null or undefined when calling putRecordsAspect."
+            );
+        }
+
+        // verify required parameter 'xMagdaSession' is not null or undefined
+        if (xMagdaSession === null || xMagdaSession === undefined) {
+            throw new Error(
+                "Required parameter xMagdaSession was null or undefined when calling putRecordsAspect."
+            );
+        }
+
+        if (merge !== undefined) {
+            queryParameters["merge"] = merge;
+        }
+
+        headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
+
+        let useFormData = false;
+
+        let requestOptions: request.Options = {
+            method: "PUT",
+            qs: queryParameters,
+            headers: headerParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: requestData
+        };
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+        return new Promise<{
+            response: http.IncomingMessage;
+            body: Array<any>;
+        }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    if (
+                        response.statusCode >= 200 &&
+                        response.statusCode <= 299
+                    ) {
+                        resolve({ response: response, body: body });
+                    } else {
+                        reject({ response: response, body: body });
+                    }
+                }
+            });
+        });
     }
     /**
      * Trim by source tag

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -47,6 +47,12 @@ export class CountResponse {
     "count": number;
 }
 
+export class DeleteRecordsAspectArrayItemsRequest {
+    "recordIds": Array<string>;
+    "jsonPath": string;
+    "items": Array<JsValue>;
+}
+
 export class DeleteResult {
     "deleted": boolean;
 }
@@ -1777,6 +1783,103 @@ export class RecordsApi {
         return new Promise<{
             response: http.IncomingMessage;
             body: DeleteResult;
+        }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    if (
+                        response.statusCode >= 200 &&
+                        response.statusCode <= 299
+                    ) {
+                        resolve({ response: response, body: body });
+                    } else {
+                        reject({ response: response, body: body });
+                    }
+                }
+            });
+        });
+    }
+    /**
+     * Remove items from records&#39; aspect data
+     * Remove items from records&#39; aspect data
+     * @param xMagdaTenantId 0
+     * @param aspectId ID of the aspect to update.
+     * @param requestData An json object has key &#39;recordIds&#39;, &#39;jsonPath&#39;, &#39;items&#39;
+     * @param xMagdaSession Magda internal session id
+     */
+    public deleteRecordsAspectArrayItems(
+        xMagdaTenantId: number,
+        aspectId: string,
+        requestData: DeleteRecordsAspectArrayItemsRequest,
+        xMagdaSession: string
+    ): Promise<{ response: http.IncomingMessage; body: Array<any> }> {
+        const localVarPath =
+            this.basePath +
+            "/records/aspects/:aspectId".replace(
+                "{" + "aspectId" + "}",
+                String(aspectId)
+            );
+        let queryParameters: any = {};
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let formParams: any = {};
+
+        // verify required parameter 'xMagdaTenantId' is not null or undefined
+        if (xMagdaTenantId === null || xMagdaTenantId === undefined) {
+            throw new Error(
+                "Required parameter xMagdaTenantId was null or undefined when calling deleteRecordsAspectArrayItems."
+            );
+        }
+
+        // verify required parameter 'aspectId' is not null or undefined
+        if (aspectId === null || aspectId === undefined) {
+            throw new Error(
+                "Required parameter aspectId was null or undefined when calling deleteRecordsAspectArrayItems."
+            );
+        }
+
+        // verify required parameter 'requestData' is not null or undefined
+        if (requestData === null || requestData === undefined) {
+            throw new Error(
+                "Required parameter requestData was null or undefined when calling deleteRecordsAspectArrayItems."
+            );
+        }
+
+        // verify required parameter 'xMagdaSession' is not null or undefined
+        if (xMagdaSession === null || xMagdaSession === undefined) {
+            throw new Error(
+                "Required parameter xMagdaSession was null or undefined when calling deleteRecordsAspectArrayItems."
+            );
+        }
+
+        headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
+
+        headerParams["X-Magda-Session"] = xMagdaSession;
+
+        let useFormData = false;
+
+        let requestOptions: request.Options = {
+            method: "DELETE",
+            qs: queryParameters,
+            headers: headerParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: requestData
+        };
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+        return new Promise<{
+            response: http.IncomingMessage;
+            body: Array<any>;
         }>((resolve, reject) => {
             request(requestOptions, (error, response, body) => {
                 if (error) {

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -322,7 +322,7 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         aspect: any,
         merge: boolean = false,
         tenantId: number = this.tenantId
-    ): Promise<Record | ServerError> {
+    ): Promise<any | ServerError> {
         const operation = () =>
             this.recordAspectsApi.putById(
                 encodeURIComponent(recordId),

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -277,7 +277,7 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             (e, retriesLeft) =>
                 console.log(
                     formatServiceError(
-                        `Failed to PUT data registry record with ID "${recordId}".`,
+                        `Failed to PATCH data registry record with ID "${recordId}".`,
                         e,
                         retriesLeft
                     )
@@ -285,6 +285,36 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         )
             .then((result) => result.body)
             .catch(toServerError("patchRecord"));
+    }
+
+    patchRecords(
+        recordIds: string[],
+        recordPatch: Operation[],
+        tenantId: number = this.tenantId
+    ): Promise<string[] | Error> {
+        const operation = () =>
+            this.recordsApi.patchRecords(
+                tenantId,
+                { recordIds, jsonPath: recordPatch as any },
+                this.jwt
+            );
+        return retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        `Failed to PATCH registry records with ID "${recordIds.join(
+                            ", "
+                        )}".`,
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then((result) => result.body)
+            .catch(toServerError("patchRecords"));
     }
 
     putRecordAspect(

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -207,6 +207,29 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             .catch(toServerError("resumeHook"));
     }
 
+    creatRecord(
+        record: Record,
+        tenantId: number = this.tenantId
+    ): Promise<Record | Error> {
+        const operation = () =>
+            this.recordsApi.create(tenantId, record, this.jwt);
+        return retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        `Failed to create registry record with ID "${record.id}".`,
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then((result) => result.body)
+            .catch(toServerError("createRecord"));
+    }
+
     putRecord(
         record: Record,
         tenantId: number = this.tenantId

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -349,6 +349,40 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             .catch(toServerError("putRecordAspect"));
     }
 
+    putRecordsAspect(
+        recordIds: string[],
+        aspectId: string,
+        aspectData: any,
+        merge: boolean = false,
+        tenantId: number = this.tenantId
+    ): Promise<string[] | ServerError> {
+        const operation = () =>
+            this.recordsApi.putRecordsAspect(
+                tenantId,
+                aspectId,
+                { recordIds, data: aspectData },
+                this.jwt,
+                merge
+            );
+        return retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        `Failed to PUT aspect ${aspectId} for records with ID: "${recordIds.join(
+                            ","
+                        )}".`,
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then((result) => result.body)
+            .catch(toServerError("putRecordsAspect"));
+    }
+
     deleteRecordAspect(
         recordId: string,
         aspectId: string,

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -383,6 +383,39 @@ export default class AuthorizedRegistryClient extends RegistryClient {
             .catch(toServerError("putRecordsAspect"));
     }
 
+    deleteRecordsAspectArrayItems(
+        recordIds: string[],
+        aspectId: string,
+        jsonPath: string,
+        items: (string | number)[],
+        tenantId: number = this.tenantId
+    ): Promise<string[] | ServerError> {
+        const operation = () =>
+            this.recordsApi.deleteRecordsAspectArrayItems(
+                tenantId,
+                aspectId,
+                { recordIds, jsonPath, items },
+                this.jwt
+            );
+        return retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        `Failed to deleteRecordsAspectArrayItems at jsonPath "${jsonPath}" aspect ${aspectId} for records with ID: "${recordIds.join(
+                            ","
+                        )}".`,
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then((result) => result.body)
+            .catch(toServerError("deleteRecordsAspectArrayItems"));
+    }
+
     deleteRecordAspect(
         recordId: string,
         aspectId: string,

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -320,6 +320,7 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         recordId: string,
         aspectId: string,
         aspect: any,
+        merge: boolean = false,
         tenantId: number = this.tenantId
     ): Promise<Record | ServerError> {
         const operation = () =>
@@ -328,7 +329,8 @@ export default class AuthorizedRegistryClient extends RegistryClient {
                 aspectId,
                 aspect,
                 this.jwt,
-                tenantId
+                tenantId,
+                merge
             );
         return retry(
             operation,

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -414,6 +414,26 @@ export default class AuthorizedRegistryClient extends RegistryClient {
         ).catch(toServerError("deleteBySource"));
     }
 
+    deleteRecord(id: string, tenantId: number = this.tenantId) {
+        const operation = () =>
+            this.recordsApi.deleteById(tenantId, id, this.jwt);
+        return retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        `Failed to DELETE registry record with ID "${id}".`,
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then((result) => result.body)
+            .catch(toServerError("deletetRecord"));
+    }
+
     getRecordHistory(
         id: string,
         pageToken?: string,

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -170,6 +170,34 @@ export default class RegistryClient {
             .catch(toServerError("getRecord"));
     }
 
+    getRecordAspect(id: string, aspectId: string): Promise<any | ServerError> {
+        const operation = (id: string) => () =>
+            this.recordAspectsApi.getById(
+                this.tenantId,
+                encodeURIComponent(id),
+                encodeURIComponent(aspectId),
+                this.jwt
+            );
+        return <any>retry(
+            operation(id),
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        "Failed to GET record Aspect.",
+                        e,
+                        retriesLeft
+                    )
+                ),
+            (e) => {
+                return e?.response?.statusCode !== 404;
+            }
+        )
+            .then((result) => result.body)
+            .catch(toServerError("getRecordAspect"));
+    }
+
     async getRecordInFull(id: string): Promise<Record> {
         try {
             const res = await this.recordsApi.getByIdInFull(

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -97,7 +97,7 @@ export default class RegistryClient {
         return this.baseUri.clone().segment("records").segment(id).toString();
     }
 
-    getAspectDefinitions(): Promise<AspectDefinition[] | Error> {
+    getAspectDefinitions(): Promise<AspectDefinition[] | ServerError> {
         const operation = () => () =>
             this.aspectDefinitionsApi.getAll(this.tenantId);
         return <any>retry(
@@ -128,7 +128,10 @@ export default class RegistryClient {
                 jwtToken
             );
             if (typeof res.body === "string") {
-                throw new Error("Invalid non-json response: " + res.body);
+                throw new ServerError(
+                    "Invalid non-json response: ",
+                    res?.response?.statusCode
+                );
             }
             return res.body;
         } catch (e) {
@@ -141,7 +144,7 @@ export default class RegistryClient {
         aspect?: Array<string>,
         optionalAspect?: Array<string>,
         dereference?: boolean
-    ): Promise<Record | Error> {
+    ): Promise<Record | ServerError> {
         const operation = (id: string) => () =>
             this.recordsApi.getById(
                 encodeURIComponent(id),
@@ -175,7 +178,10 @@ export default class RegistryClient {
                 this.jwt
             );
             if (typeof res.body === "string") {
-                throw new Error("Invalid non-json response: " + res.body);
+                throw new ServerError(
+                    "Invalid non-json response: " + res.body,
+                    res?.response?.statusCode
+                );
             }
             return res.body;
         } catch (e) {
@@ -194,7 +200,7 @@ export default class RegistryClient {
         orderBy?: string,
         orderByDir?: string,
         orderNullFirst?: boolean
-    ): Promise<RecordsPage<I> | Error> {
+    ): Promise<RecordsPage<I> | ServerError> {
         const operation = (pageToken: string) => () =>
             this.recordsApi.getAll(
                 this.tenantId,
@@ -227,7 +233,7 @@ export default class RegistryClient {
     getRecordsPageTokens(
         aspect?: Array<string>,
         limit?: number
-    ): Promise<string[] | Error> {
+    ): Promise<string[] | ServerError> {
         const operation = () =>
             this.recordsApi.getPageTokens(
                 this.tenantId,

--- a/magda-typescript-common/src/registry/model.ts
+++ b/magda-typescript-common/src/registry/model.ts
@@ -3,3 +3,9 @@ export interface AccessControlAspect {
     orgUnitId?: string;
     preAuthorisedPermissionIds?: string[];
 }
+
+export interface JsonPatch {
+    op: "replace" | "add" | "remove";
+    path: string;
+    value?: any;
+}

--- a/magda-typescript-common/src/util/unionToThrowable.ts
+++ b/magda-typescript-common/src/util/unionToThrowable.ts
@@ -1,5 +1,9 @@
-export default function unionToThrowable<T>(input: T | Error): T {
-    if (input instanceof Error) {
+import ServerError from "../ServerError";
+
+export default function unionToThrowable<T>(input: T | Error | ServerError): T {
+    if (input instanceof ServerError) {
+        throw <ServerError>input;
+    } else if (input instanceof Error) {
         throw <Error>input;
     } else {
         return <T>input;

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import Registry from "magda-typescript-common/src/registry/RegistryClient";
 import URI from "urijs";
+import ServerError from "magda-typescript-common/src/ServerError";
 const sm = require("sitemap");
 
 const DATASET_REQUIRED_ASPECTS = ["dcat-dataset-strings"];
@@ -115,8 +116,10 @@ export default function buildSitemapRouter({
     /**
      * Handles `| Error` union type failures from the registry client.
      */
-    function handleError<T>(result: T | Error) {
-        if (result instanceof Error) {
+    function handleError<T>(result: T | Error | ServerError) {
+        if (result instanceof ServerError) {
+            throw result;
+        } else if (result instanceof Error) {
             throw result;
         } else {
             return result;


### PR DESCRIPTION
### What this PR does

> This PR is mainly for adding backend API support for the access group proposal [here](https://github.com/magda-io/magda/issues/3269). Without those extra APIs, the implementation of the access group is still possible (after all, the access group feature is built on top of the existing role, permission & registry record facility). Having said that, the extra access group related APIs will help to reduce the implementation complexity at the frontend.

Changes Summary:
- #3269
  - also add GET `/auth/roles/:roleId/users` & GET `/auth/roles/:roleId/users/count` APIs
- #3366
- Fixed: `set-scss-vars` script will use proper imagePullSecrets to generate the UI CSS update job
- Allow the `no cache` behaviour of `whoami` & `getUserById` api to be turned off
- refactor code related to create / update permission

Merged Changes from v1:
- #3362
- #3367
- #3369
- #3371
- #3363
- Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22

### Other Info

This PR doesn't include frontend UI --- although we have a closed source version access group UI built & leverage the new backend capability created by this PR.

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
