### PR TITLE
Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - #3367 Fixed Content API header item schema target field type
 - #3369 Content API Get by id API didn't response content in correct mime type
 - #3371 Content API Get by id API generate one more unnecessary DB query
+- Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22
 
 ## 1.3.0
 

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.2.2-alpha.0
 - name: openfaas
   repository: https://charts.magda.io
-  version: 5.5.5-magda.1
+  version: 5.5.5-magda.2
 - name: magda-function-history-report
   repository: https://charts.magda.io
   version: 1.1.0
@@ -29,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:d7f01debaeed9da8b778f3308434304713a377d448c59744688b8c3fb2b21bf5
-generated: "2022-04-04T11:41:25.198235+10:00"
+digest: sha256:bb5d105f8857a598349a9911d3213202ad2f7096c31d7d73f0f4157bd516149e
+generated: "2022-06-29T20:17:58.877107+10:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: file://../magda-core
 
   - name: openfaas
-    version: 5.5.5-magda.1
+    version: 5.5.5-magda.2
     repository: https://charts.magda.io
     # Users should turn on / off openfaas via this condition var `global.openfaas.enabled` rather than `tags`
     # Due to a limitation of helm, the value of tags is not available in chart template.

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -23,7 +23,7 @@ A complete solution for managing, publishing and discovering government data, pr
 | https://charts.magda.io | minion-format(magda-minion-format) | 1.1.0 |
 | https://charts.magda.io | minion-linked-data-rating(magda-minion-linked-data-rating) | 1.1.0 |
 | https://charts.magda.io | minion-visualization(magda-minion-visualization) | 1.0.0 |
-| https://charts.magda.io | openfaas | 5.5.5-magda.1 |
+| https://charts.magda.io | openfaas | 5.5.5-magda.2 |
 
 ## Values
 


### PR DESCRIPTION
### What this PR does

Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
