### PR TITLE
#3362 explicitly mark pods using emptyDir as safe to evict for cluster-autoscaler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - #3369 Content API Get by id API didn't response content in correct mime type
 - #3371 Content API Get by id API generate one more unnecessary DB query
 - Upgrade openfaas helm chart to 5.5.5-magda.2 to be compatible with k8s 1.22
+- #3362 explicitly mark pods using emptyDir as safe to evict for cluster-autoscaler
 
 ## 1.3.0
 

--- a/deploy/helm/internal-charts/cloud-sql-proxy/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/cloud-sql-proxy/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         service: cloud-sql-proxy
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
 {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") .Values.global.enablePriorityClass }}
       priorityClassName: magda-9

--- a/deploy/helm/internal-charts/elasticsearch/templates/client-deployment.yml
+++ b/deploy/helm/internal-charts/elasticsearch/templates/client-deployment.yml
@@ -20,6 +20,8 @@ spec:
       labels:
         component: elasticsearch
         role: client
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       {{- include "magda.elasticsearch.initContainer" . | indent 6 }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}

--- a/deploy/helm/internal-charts/elasticsearch/templates/master-deployment.yml
+++ b/deploy/helm/internal-charts/elasticsearch/templates/master-deployment.yml
@@ -20,6 +20,8 @@ spec:
       labels:
         component: elasticsearch
         role: master
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       {{- include "magda.elasticsearch.initContainer" . | indent 6 }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}

--- a/deploy/helm/internal-charts/opa/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/opa/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         service: opa
+      annotations:
+         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       {{- include "magda.imagePullSecrets" (dict "image" .Values.image) | indent 6 }}
 {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") .Values.global.enablePriorityClass }}


### PR DESCRIPTION
### What this PR does

Fixes #3362 explicitly mark pods using emptyDir as safe to evict for cluster-autoscaler

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
