### PR TITLE
Get User API fixes, registry APIs improvements and more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,8 @@
 - #3366 New Registry API capability: new filter operator, merge mode, group operations and more
 - Add `target` & `rel` fields to footer link item schema
 - Make sure dataset creation tool always create `dcat-dataset-strings` aspect for draft datasets
-- Add `reversePageTokenOrder` parameter to registry APIs `GET /records` & `GET /records/summary`
+- Add `reversePageTokenOrder` parameter to registry APIs `GET /records`, `GET /records/summary` & `GET /records/:recordId/history`
+- #3163 Fixed Registry history API incorrectly reports more event available on the last page
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 - #3366 New Registry API capability: new filter operator, merge mode, group operations and more
 - Add `target` & `rel` fields to footer link item schema
 - Make sure dataset creation tool always create `dcat-dataset-strings` aspect for draft datasets
+- Add `reversePageTokenOrder` parameter to registry APIs `GET /records` & `GET /records/summary`
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 - Make sure dataset creation tool always create `dcat-dataset-strings` aspect for draft datasets
 - Add `reversePageTokenOrder` parameter to registry APIs `GET /records`, `GET /records/summary` & `GET /records/:recordId/history`
 - #3163 Fixed Registry history API incorrectly reports more event available on the last page
+- #3383 Registry get records API didn't group aspectOrQuery correctly
 
 ## 1.3.1
 

--- a/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createAccessGroupApiRouter.ts
@@ -1261,19 +1261,19 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                 }
 
                 if (req.query?.id) {
-                    conditions.push(sqls`"users.id" = ${req.query.id}`);
+                    conditions.push(sqls`users.id = ${req.query.id}`);
                 }
                 if (req.query?.source) {
-                    conditions.push(sqls`"users.source" = ${req.query.source}`);
+                    conditions.push(sqls`users.source = ${req.query.source}`);
                 }
                 if (req.query?.orgUnitId) {
                     conditions.push(
-                        sqls`"users.orgUnitId" = ${req.query.orgUnitId}`
+                        sqls`users."orgUnitId" = ${req.query.orgUnitId}`
                     );
                 }
                 if (req.query?.sourceId) {
                     conditions.push(
-                        sqls`"users.sourceId" = ${req.query.sourceId}`
+                        sqls`users."sourceId" = ${req.query.sourceId}`
                     );
                 }
 
@@ -1290,7 +1290,10 @@ export default function createAccessGroupApiRouter(options: ApiRouterOptions) {
                             : (req?.query?.offset as string),
                         limit: returnCount
                             ? undefined
-                            : (req?.query?.limit as string)
+                            : (req?.query?.limit as string),
+                        orderBy: returnCount
+                            ? undefined
+                            : sqls`users."displayName" ASC`
                     }
                 );
                 if (returnCount) {

--- a/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createRoleApiRouter.ts
@@ -82,19 +82,19 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                 }
 
                 if (req.query?.id) {
-                    conditions.push(sqls`"users.id" = ${req.query.id}`);
+                    conditions.push(sqls`users.id = ${req.query.id}`);
                 }
                 if (req.query?.source) {
-                    conditions.push(sqls`"users.source" = ${req.query.source}`);
+                    conditions.push(sqls`users.source = ${req.query.source}`);
                 }
                 if (req.query?.orgUnitId) {
                     conditions.push(
-                        sqls`"users.orgUnitId" = ${req.query.orgUnitId}`
+                        sqls`users."orgUnitId" = ${req.query.orgUnitId}`
                     );
                 }
                 if (req.query?.sourceId) {
                     conditions.push(
-                        sqls`"users.sourceId" = ${req.query.sourceId}`
+                        sqls`users."sourceId" = ${req.query.sourceId}`
                     );
                 }
 
@@ -111,7 +111,10 @@ export default function createRoleApiRouter(options: ApiRouterOptions) {
                             : (req?.query?.offset as string),
                         limit: returnCount
                             ? undefined
-                            : (req?.query?.limit as string)
+                            : (req?.query?.limit as string),
+                        orderBy: returnCount
+                            ? undefined
+                            : sqls`users."displayName" ASC`
                     }
                 );
                 if (returnCount) {

--- a/magda-authorization-api/src/apiRouters/createUserApiRouter.ts
+++ b/magda-authorization-api/src/apiRouters/createUserApiRouter.ts
@@ -732,7 +732,10 @@ export default function createUserApiRouter(options: ApiRouterOptions) {
                             : (req?.query?.offset as string),
                         limit: returnCount
                             ? undefined
-                            : (req?.query?.limit as string)
+                            : (req?.query?.limit as string),
+                        orderBy: returnCount
+                            ? undefined
+                            : sqls`"displayName" ASC`
                     }
                 );
                 if (returnCount) {

--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN npm install -g lerna
+RUN npm install -g lerna@3.22.1
 
 # Install haveged and run it so that we don't get lockups due to a lack of entropy
 RUN apk --no-cache add haveged

--- a/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
+++ b/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
@@ -428,3 +428,6 @@ VALUES
 ('api/indexer/reindex/in-progress', 'the API gets the progress info of the recent full proactive reindex', '', (SELECT id FROM resources WHERE uri = 'api/indexer')),
 ('api/indexer/reindex/snapshot','the API triggers snapshot creation', '', (SELECT id FROM resources WHERE uri = 'api/indexer'));
 -- end add new indexer api resource / operations --
+-- create index for user display name --
+CREATE INDEX users_display_name_gin_trgm_idx ON "public"."users" USING gin ("displayName" gin_trgm_ops);
+-- end create index for user display name --

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -360,9 +360,13 @@ class DefaultRecordPersistence(config: Config)
     val andConditions =
       AspectQueryGroup(aspectQueries, joinWithAnd = true)
         .toSql(config)
+        // SQLSyntax.toAndConditionOpt fails to check the statement with and / or & newlines
+        // thus we manually add roundBracket here
+        .map(SQLSyntax.roundBracket(_))
     val orConditions =
       AspectQueryGroup(aspectOrQueries, joinWithAnd = false)
         .toSql(config)
+        .map(SQLSyntax.roundBracket(_))
 
     SQLSyntax
       .toAndConditionOpt(andConditions, orConditions)

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -44,7 +44,8 @@ trait RecordPersistence {
       authDecision: AuthDecision,
       pageToken: Option[String],
       start: Option[Int],
-      limit: Option[Int]
+      limit: Option[Int],
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[RecordSummary]
 
   def getAllWithAspects(
@@ -58,7 +59,8 @@ trait RecordPersistence {
       dereference: Option[Boolean] = None,
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil,
-      orderBy: Option[OrderByDef] = None
+      orderBy: Option[OrderByDef] = None,
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[Record]
 
   def getCount(
@@ -332,9 +334,17 @@ class DefaultRecordPersistence(config: Config)
       authDecision: AuthDecision,
       pageToken: Option[String],
       start: Option[Int],
-      limit: Option[Int]
+      limit: Option[Int],
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[RecordSummary] = {
-    this.getSummaries(tenantId, authDecision, pageToken, start, limit)
+    this.getSummaries(
+      tenantId,
+      authDecision,
+      pageToken,
+      start,
+      limit,
+      reversePageTokenOrder = reversePageTokenOrder
+    )
   }
 
   private def getSqlFromAspectQueries(
@@ -370,7 +380,8 @@ class DefaultRecordPersistence(config: Config)
       dereference: Option[Boolean] = None,
       aspectQueries: Iterable[AspectQuery] = Nil,
       aspectOrQueries: Iterable[AspectQuery] = Nil,
-      orderBy: Option[OrderByDef] = None
+      orderBy: Option[OrderByDef] = None,
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[Record] = {
 
     // --- make sure if orderBy is used, the involved aspectId is, at least, included in optionalAspectIds
@@ -393,7 +404,9 @@ class DefaultRecordPersistence(config: Config)
       limit,
       dereference,
       selectors,
-      orderBy
+      orderBy,
+      None,
+      reversePageTokenOrder = reversePageTokenOrder
     )
   }
 
@@ -1694,7 +1707,8 @@ class DefaultRecordPersistence(config: Config)
       pageToken: Option[String],
       start: Option[Int],
       rawLimit: Option[Int],
-      recordId: Option[String] = None
+      recordId: Option[String] = None,
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[RecordSummary] = {
     val idWhereClause = recordId.map(id => sqls"Records.recordId=$id")
     val authDecisionCondition = authDecision.toSql()
@@ -1702,9 +1716,17 @@ class DefaultRecordPersistence(config: Config)
     val whereClauseParts = Seq(idWhereClause) :+ authDecisionCondition :+ SQLUtils
       .tenantIdToWhereClause(tenantId) :+ pageToken
       .map(
-        token => sqls"Records.sequence > ${token.toLong}"
+        token =>
+          if (reversePageTokenOrder.getOrElse(false))
+            sqls"Records.sequence < ${token.toLong}"
+          else sqls"Records.sequence > ${token.toLong}"
       )
     val limit = rawLimit.getOrElse(defaultResultCount)
+
+    val orderBy =
+      if (reversePageTokenOrder.getOrElse(false))
+        sqls"order by sequence DESC"
+      else sqls"order by sequence"
 
     val result =
       sql"""select Records.sequence as sequence,
@@ -1721,7 +1743,7 @@ class DefaultRecordPersistence(config: Config)
                    Records.tenantId as tenantId
             from Records
             ${SQLSyntax.where(SQLSyntax.toAndConditionOpt(whereClauseParts: _*))}
-            order by sequence
+            ${orderBy}
             offset ${start.getOrElse(0)}
             limit ${limit + 1}"""
         .map(rs => {
@@ -1753,7 +1775,8 @@ class DefaultRecordPersistence(config: Config)
       dereference: Option[Boolean] = None,
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable(),
       orderBy: Option[OrderByDef] = None,
-      maxLimit: Option[Int] = None
+      maxLimit: Option[Int] = None,
+      reversePageTokenOrder: Option[Boolean] = None
   )(implicit session: DBSession): RecordsPage[Record] = {
 
     if (orderBy.isDefined && pageToken.isDefined) {
@@ -1778,7 +1801,12 @@ class DefaultRecordPersistence(config: Config)
 
     val whereClauseParts: Seq[Option[SQLSyntax]] =
       theRecordSelector.toSeq :+ aspectWhereClauses :+ authQueryConditions :+ pageToken
-        .map(token => sqls"Records.sequence > $token")
+        .map(
+          token =>
+            if (reversePageTokenOrder.getOrElse(false))
+              sqls"Records.sequence < $token"
+            else sqls"Records.sequence > $token"
+        )
 
     val aspectSelectors = aspectIdsToSelectClauses(
       tenantId,
@@ -1798,7 +1826,10 @@ class DefaultRecordPersistence(config: Config)
 
     val orderBySql = orderBy match {
       case None =>
-        SQLSyntax.orderBy(sqls"${tempName}.sequence")
+        if (reversePageTokenOrder.getOrElse(false))
+          SQLSyntax.orderBy(sqls"${tempName}.sequence").desc
+        else
+          SQLSyntax.orderBy(sqls"${tempName}.sequence")
       case Some(orderBy) =>
         orderBy.getSql(
           List.concat(aspectIds, optionalAspectIds),

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1406,6 +1406,7 @@ export class RecordHistoryApi {
      * @param limit The maximum number of events to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
      * @param aspect The aspects for which to included in event history, specified as multiple occurrences of this query parameter.
      * @param dereference true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.
+     * @param reversePageTokenOrder When pagination via pageToken, by default, records with smaller pageToken (i.e. older records) will be returned first. When this parameter is set to &#x60;true&#x60;, higher pageToken records (newer records) will be returned.
      */
     public history(
         xMagdaTenantId: number,
@@ -1415,7 +1416,8 @@ export class RecordHistoryApi {
         start?: number,
         limit?: number,
         aspect?: Array<string>,
-        dereference?: boolean
+        dereference?: boolean,
+        reversePageTokenOrder?: boolean
     ): Promise<{ response: http.IncomingMessage; body: EventsPage }> {
         const localVarPath =
             this.basePath +
@@ -1466,6 +1468,10 @@ export class RecordHistoryApi {
 
         if (dereference !== undefined) {
             queryParameters["dereference"] = dereference;
+        }
+
+        if (reversePageTokenOrder !== undefined) {
+            queryParameters["reversePageTokenOrder"] = reversePageTokenOrder;
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1912,6 +1912,7 @@ export class RecordsApi {
      * @param orderBy Specify the field to sort the result. Aspect field can be supported in a format like aspectId.path.to.field
      * @param orderByDir Specify the order by direction. Either &#x60;asc&#x60; or &#x60;desc&#x60;
      * @param orderNullFirst Specify whether nulls appear before (&#x60;true&#x60;) or after (&#x60;false&#x60;) non-null values in the sort ordering.
+     * @param reversePageTokenOrder When pagination via pageToken, by default, records with smaller pageToken (i.e. older records) will be returned first. When this parameter is set to &#x60;true&#x60;, higher pageToken records (newer records) will be returned.
      * @param xMagdaSession Magda internal session id
      */
     public getAll(
@@ -1927,6 +1928,7 @@ export class RecordsApi {
         orderBy?: string,
         orderByDir?: string,
         orderNullFirst?: boolean,
+        reversePageTokenOrder?: boolean,
         xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Array<Record> }> {
         const localVarPath = this.basePath + "/records";
@@ -1985,6 +1987,10 @@ export class RecordsApi {
             queryParameters["orderNullFirst"] = orderNullFirst;
         }
 
+        if (reversePageTokenOrder !== undefined) {
+            queryParameters["reversePageTokenOrder"] = reversePageTokenOrder;
+        }
+
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;
 
         headerParams["X-Magda-Session"] = xMagdaSession;
@@ -2036,6 +2042,7 @@ export class RecordsApi {
      * @param pageToken A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results.
      * @param start The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
      * @param limit The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
+     * @param reversePageTokenOrder When pagination via pageToken, by default, records with smaller pageToken (i.e. older records) will be returned first. When this parameter is set to &#x60;true&#x60;, higher pageToken records (newer records) will be returned.
      * @param xMagdaSession Magda internal session id
      */
     public getAllSummary(
@@ -2043,6 +2050,7 @@ export class RecordsApi {
         pageToken?: string,
         start?: number,
         limit?: number,
+        reversePageTokenOrder?: boolean,
         xMagdaSession?: string
     ): Promise<{ response: http.IncomingMessage; body: Array<RecordSummary> }> {
         const localVarPath = this.basePath + "/records/summary";
@@ -2067,6 +2075,10 @@ export class RecordsApi {
 
         if (limit !== undefined) {
             queryParameters["limit"] = limit;
+        }
+
+        if (reversePageTokenOrder !== undefined) {
+            queryParameters["reversePageTokenOrder"] = reversePageTokenOrder;
         }
 
         headerParams["X-Magda-Tenant-Id"] = xMagdaTenantId;

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -227,7 +227,8 @@ export default class RegistryClient {
         aspectOrQuery?: string[],
         orderBy?: string,
         orderByDir?: string,
-        orderNullFirst?: boolean
+        orderNullFirst?: boolean,
+        reversePageTokenOrder?: boolean
     ): Promise<RecordsPage<I> | ServerError> {
         const operation = (pageToken: string) => () =>
             this.recordsApi.getAll(
@@ -243,6 +244,7 @@ export default class RegistryClient {
                 orderBy,
                 orderByDir,
                 orderNullFirst,
+                reversePageTokenOrder,
                 this.jwt
             );
         return <any>retry(

--- a/magda-web-client/src/Components/Home/MyDatasetSection.tsx
+++ b/magda-web-client/src/Components/Home/MyDatasetSection.tsx
@@ -5,7 +5,6 @@ import DatasetList from "./MyDatasetSectionComponents/DatasetList";
 import { User } from "reducers/userManagementReducer";
 
 type PropsType = {
-    userId: string;
     user: User;
 };
 
@@ -13,7 +12,7 @@ const MyDatasetSection: FunctionComponent<PropsType> = (props) => {
     return (
         <div className="my-dataset-section-container">
             <SideNavigation user={props.user} />
-            <DatasetList userId={props.userId} />
+            <DatasetList />
         </div>
     );
 };

--- a/magda-web-client/src/Components/Home/MyDatasetSectionComponents/DatasetGrid.scss
+++ b/magda-web-client/src/Components/Home/MyDatasetSectionComponents/DatasetGrid.scss
@@ -73,35 +73,8 @@
 
         .paging-area {
             padding-right: 55px;
-            .next-page-button,
-            .first-page-button {
-                cursor: pointer;
+            .rs-btn-group {
                 float: right;
-                height: 42px;
-                width: 130px;
-                border-radius: 2px;
-                background-color: #30384d;
-                color: #ffffff;
-                font-size: 16px;
-                letter-spacing: -0.2px;
-                line-height: 24px;
-                text-align: center;
-                border: none;
-                &:disabled {
-                    opacity: 0.3;
-                    cursor: default;
-                }
-            }
-            .first-page-button {
-                margin-right: 10px;
-            }
-            .page-idx-info-area {
-                float: right;
-                line-height: 42px;
-                margin-right: 10px;
-                color: #9b9b9b;
-                font-size: 17px;
-                letter-spacing: -0.5px;
             }
         }
     }

--- a/magda-web-client/src/Components/Home/MyDatasetSectionComponents/DatasetList.tsx
+++ b/magda-web-client/src/Components/Home/MyDatasetSectionComponents/DatasetList.tsx
@@ -7,9 +7,7 @@ import { ReactComponent as SearchIcon } from "assets/search-dark.svg";
 import "../../../rsuite.scss";
 import ConfirmDialog from "../../Settings/ConfirmDialog";
 
-type PropsType = {
-    userId: string;
-};
+type PropsType = {};
 
 type TabNames = DatasetTypes;
 
@@ -82,7 +80,6 @@ const DatasetList: FunctionComponent<PropsType> = (props) => {
                         key={`tab:${activeTab}|searchtext:${searchText}`}
                         searchText={searchText}
                         datasetType={activeTab}
-                        userId={props.userId}
                     />
                 </div>
             </div>

--- a/magda-web-client/src/Components/Home/MyDatasetSectionComponents/getDatasetAspectQueries.ts
+++ b/magda-web-client/src/Components/Home/MyDatasetSectionComponents/getDatasetAspectQueries.ts
@@ -4,9 +4,8 @@ import {
     DatasetTypes
 } from "api-clients/RegistryApis";
 
-export default function getMyDatasetAspectQueries(
+export default function getDatasetAspectQueries(
     datasetType: DatasetTypes,
-    userId: string,
     searchText: string
 ) {
     const aspectQueries: AspectQuery[] = [];
@@ -26,8 +25,8 @@ export default function getMyDatasetAspectQueries(
         aspectQueries.push(
             new AspectQuery(
                 "publishing.state",
-                AspectQueryOperators["="],
-                `published`,
+                AspectQueryOperators["!="],
+                `draft`,
                 true
             )
         );

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -355,6 +355,7 @@ export type FetchRecordsOptions = {
     orderBy?: string;
     orderByDirection?: "asc" | "desc";
     noCache?: boolean;
+    reversePageTokenOrder?: boolean;
 };
 
 export async function fetchRecords({
@@ -367,7 +368,8 @@ export async function fetchRecords({
     aspectQueries,
     orderBy,
     orderByDirection,
-    noCache
+    noCache,
+    reversePageTokenOrder
 }: FetchRecordsOptions): Promise<{
     records: RawDataset[];
     hasMore: boolean;
@@ -421,6 +423,10 @@ export async function fetchRecords({
                 `orderByDir=${encodeURIComponent(orderByDirection)}`
             );
         }
+    }
+
+    if (reversePageTokenOrder) {
+        parameters.push(`reversePageTokenOrder=true`);
     }
 
     const url =


### PR DESCRIPTION
### What this PR does

- Get User API fixes
- User records will by ordered by displayName asc
- add index to displayName
- Use pageToken for dataset datagrid pagination (for performance consideration)
- Add `reversePageTokenOrder` parameter to registry `GET /records`, `GET /records/summary` & `GET /records/:recordId/history` APIs 
- Fixed #3163
- Fixed #3383 

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
