### PR TITLE
Issue/3348 secure openfaas gateway with new auth model & update API docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@
 - Upgrade to Node 14
 - Upgrade bcrypt to 5.0.1
 - Fixed auth policy: make sure datasets without `publishing` aspect will be considered published
-- #3348 secure openfaas gateway with new auth model
+- #3348 secure openfaas gateway with new auth model & update API docs
 
 ## 1.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 - Upgrade to Node 14
 - Upgrade bcrypt to 5.0.1
 - Fixed auth policy: make sure datasets without `publishing` aspect will be considered published
+- #3348 secure openfaas gateway with new auth model
 
 ## 1.3.1
 

--- a/deploy/helm/internal-charts/gateway/README.md
+++ b/deploy/helm/internal-charts/gateway/README.md
@@ -57,6 +57,7 @@ Kubernetes: `>= 1.14.0-0`
 | service.externalPort | int | `80` |  |
 | service.internalPort | int | `80` |  |
 | service.type | string | `"NodePort"` |  |
+| skipAuth | bool | `false` | when set to true, API will not query policy engine for auth decision but assume it's always permitted.  It's for debugging only. |
 | web | string | `"http://web"` | Default web route.  This is the last route of the proxy. Main UI should be served from here. |
 | webRoutes | object | `{"preview-map":"http://preview-map:6110"}` | extra web routes. See [Proxy Target Definition](#proxy-target-definition) section below for route format. |
 

--- a/deploy/helm/internal-charts/gateway/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/gateway/templates/deployment.yaml
@@ -69,11 +69,13 @@ spec:
             "--web", {{ .Values.web | default "http://web" | quote }},
             "--defaultWebRouteConfig", "/etc/config/defaultWebRouteConfig.json",
             "--authorizationApi", "http://authorization-api/v0",
+{{- if .Values.skipAuth }}
+            "--skipAuth", "true",
+{{- end }}
             "--tenantUrl", "http://tenant-api/v0",
 {{- if .Values.global.openfaas }}
 {{- if .Values.global.openfaas.mainNamespace }}
             "--openfaasGatewayUrl", {{ include "magda.openfaasGatewayUrl" . | quote }},
-            "--openfaasAllowAdminOnly", {{ .Values.global.openfaas.allowAdminOnly | quote }},
 {{- end }}
 {{- end }}
 {{- if .Values.global.enableMultiTenants }}

--- a/deploy/helm/internal-charts/gateway/values.yaml
+++ b/deploy/helm/internal-charts/gateway/values.yaml
@@ -203,3 +203,7 @@ defaultCacheControl: "public, max-age=60"
 # If not set, the request will time out after 120 seconds.
 # @default -- nil (120 seconds default value will be used by upstream lib internally)
 proxyTimeout: 
+
+# -- when set to true, API will not query policy engine for auth decision but assume it's always permitted. 
+# It's for debugging only.
+skipAuth: false

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -35,10 +35,9 @@ A complete solution for managing, publishing and discovering government data, pr
 | ckan-connector-functions.includeInitialJobs | bool | `false` |  |
 | global.connectors.includeCronJobs | bool | `true` |  |
 | global.connectors.includeInitialJobs | bool | `false` |  |
-| global.openfaas.allowAdminOnly | bool | `true` |  |
-| global.openfaas.enabled | bool | `true` |  |
-| global.openfaas.functionNamespace | string | `"openfaas-fn"` |  |
-| global.openfaas.mainNamespace | string | `"openfaas"` |  |
+| global.openfaas.enabled | bool | `true` | turn on / off openfaas All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ). They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions) |
+| global.openfaas.functionNamespace | string | `"openfaas-fn"` | Default namespace for functions |
+| global.openfaas.mainNamespace | string | `"openfaas"` | Default namespace for gateway and other core modules |
 | global.openfaas.namespacePrefix | string | `""` |  |
 | global.openfaas.secrets.authSecrets | bool | `true` |  |
 | openfaas.basic_auth | bool | `false` |  |

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -12,14 +12,15 @@ global:
     includeInitialJobs: false
     includeCronJobs: true
   openfaas:
-    # turn on / off openfaas
+    # -- turn on / off openfaas
     # All openfaas dependents should check this field to decide deployment logic (`tags` unfortunately not available to ).
     # They choose to simply not deploy or prompt an error message via [helm required function](https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions)
     enabled: true 
     namespacePrefix: ""
-    functionNamespace: openfaas-fn  # Default namespace for functions
-    mainNamespace: openfaas # Default namespace for gateway and other core modules
-    allowAdminOnly: true # Only allow logged-in Admin to access openfaas gateway
+    # -- Default namespace for functions
+    functionNamespace: openfaas-fn  
+    # -- Default namespace for gateway and other core modules
+    mainNamespace: openfaas 
     secrets:
       authSecrets: true
 

--- a/magda-gateway/src/createOpenfaasGatewayProxy.ts
+++ b/magda-gateway/src/createOpenfaasGatewayProxy.ts
@@ -35,6 +35,37 @@ export default function createOpenfaasGatewayProxy(
         }
     });
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {get} /v0/openfaas/system/functions Get the info of all deployed functions
+     * @apiDescription Returns a list of deployed FaaS functions
+     * You need `object/faas/function/read` permission in order to access this API.
+     *
+     * @apiSuccessExample {json} 200
+     *    [
+     *       {
+     *           "name": "nodeinfo",
+     *           "image": "functions/nodeinfo:latest",
+     *           "invocationCount": 1337,
+     *           "replicas": 2,
+     *           "availableReplicas": 2,
+     *           "envProcess": "node main.js",
+     *           "labels": {
+     *             "foo": "bar"
+     *           },
+     *           "annotations": {
+     *             "topics": "awesome-kafka-topic",
+     *             "foo": "bar"
+     *           }
+     *       }
+     *    ]
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/read` on required resources
+     */
     router.get(
         "/system/functions",
         requireUnconditionalAuthDecision(
@@ -49,6 +80,63 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {post} /v0/openfaas/system/functions Create/Deploy a function
+     * @apiDescription Create/Deploy a function
+     * You need `object/faas/function/create` permission in order to access this API.
+     * You can also deploy FaaS function as the part of Magda deployment as a Helm Chart.
+     * Please see [magda-function-template](https://github.com/magda-io/magda-function-template)
+     *
+     * @apiParamExample {json} Request-Example:
+     *
+     *  {
+     *       "service": "nodeinfo",
+     *       "network": "func_functions",
+     *       "image": "functions/nodeinfo:latest",
+     *       "envProcess": "node main.js",
+     *       "envVars": {
+     *           "additionalProp1": "string",
+     *           "additionalProp2": "string",
+     *           "additionalProp3": "string"
+     *       },
+     *       "constraints": [
+     *           "node.platform.os == linux"
+     *       ],
+     *       "labels": {
+     *           "foo": "bar"
+     *       },
+     *       "annotations": {
+     *           "topics": "awesome-kafka-topic",
+     *           "foo": "bar"
+     *       },
+     *       "secrets": [
+     *           "secret-name-1"
+     *       ],
+     *       "registryAuth": "dXNlcjpwYXNzd29yZA==",
+     *       "limits": {
+     *           "memory": "128M",
+     *           "cpu": "0.01"
+     *       },
+     *       "requests": {
+     *           "memory": "128M",
+     *           "cpu": "0.01"
+     *       },
+     *       "readOnlyRootFilesystem": true
+     *   }
+     *
+     * @apiSuccessExample {string} 202
+     *    HTTP/1.1 202 Accepted
+     *
+     * @apiErrorExample {string} 400
+     *    HTTP/1.1 400 Bad Request
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/create` on required resources
+     */
     router.post(
         "/system/functions",
         requireUnconditionalAuthDecision(
@@ -63,6 +151,64 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {put} /v0/openfaas/system/functions Update a function
+     * @apiDescription Update a deployed function
+     * You need `object/faas/function/update` permission in order to access this API.
+     *
+     * @apiParamExample {json} Request-Example:
+     *
+     *  {
+     *       "service": "nodeinfo",
+     *       "network": "func_functions",
+     *       "image": "functions/nodeinfo:latest",
+     *       "envProcess": "node main.js",
+     *       "envVars": {
+     *           "additionalProp1": "string",
+     *           "additionalProp2": "string",
+     *           "additionalProp3": "string"
+     *       },
+     *       "constraints": [
+     *           "node.platform.os == linux"
+     *       ],
+     *       "labels": {
+     *           "foo": "bar"
+     *       },
+     *       "annotations": {
+     *           "topics": "awesome-kafka-topic",
+     *           "foo": "bar"
+     *       },
+     *       "secrets": [
+     *           "secret-name-1"
+     *       ],
+     *       "registryAuth": "dXNlcjpwYXNzd29yZA==",
+     *       "limits": {
+     *           "memory": "128M",
+     *           "cpu": "0.01"
+     *       },
+     *       "requests": {
+     *           "memory": "128M",
+     *           "cpu": "0.01"
+     *       },
+     *       "readOnlyRootFilesystem": true
+     *   }
+     *
+     * @apiSuccessExample {string} 200
+     *    HTTP/1.1 200 Accepted
+     *
+     * @apiErrorExample {string} 400
+     *    HTTP/1.1 400 Bad Request
+     *
+     * @apiErrorExample {string} 404
+     *    HTTP/1.1 404 Not Found
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/update` on required resources
+     */
     router.put(
         "/system/functions",
         requireUnconditionalAuthDecision(
@@ -77,6 +223,33 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {delete} /v0/openfaas/system/functions Delete a function
+     * @apiDescription Delete a deployed function
+     * You need `object/faas/function/delete` permission in order to access this API.
+     *
+     * @apiParamExample {json} Request-Example:
+     *
+     *  {
+     *     "functionName": "nodeinfo"
+     *  }
+     *
+     * @apiSuccessExample {string} 200
+     *    HTTP/1.1 200 Accepted
+     *
+     * @apiErrorExample {string} 400
+     *    HTTP/1.1 400 Bad Request
+     *
+     * @apiErrorExample {string} 404
+     *    HTTP/1.1 404 Not Found
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/delete` on required resources
+     */
     router.delete(
         "/system/functions",
         requireUnconditionalAuthDecision(
@@ -91,6 +264,36 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {post} /v0/openfaas/function/:functionName Invoke a function
+     * @apiDescription Invoke a function
+     * You need `object/faas/function/invoke` permission in order to access this API.
+     *
+     * @apiParam (path) {Number} functionName the name of the function
+     * @apiParam (body) {any} [input] when invoke the function, you can optionally supply function input in HTTP request body.
+     * The whole request body will be passed to the function as input. However, how body data is parsed depends on the mime type.
+     *
+     * @apiParamExample {json} Request-Example:
+     *  // Content-Type: application/json
+     *  {"hello": "world"}
+     *
+     * @apiSuccessExample {string} 200
+     *    HTTP/1.1 200 Ok
+     *    // HTTP response body contains value returned from function
+     *
+     * @apiErrorExample {string} 400
+     *    HTTP/1.1 400 Bad Request
+     *
+     * @apiErrorExample {string} 404
+     *    HTTP/1.1 404 Not Found
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/invoke` on required resources
+     */
     router.post(
         "/function/:functionName",
         requireUnconditionalAuthDecision(
@@ -105,6 +308,37 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {post} /v0/openfaas/async-function/:functionName Invoke a function asynchronously
+     * @apiDescription Invoke a function asynchronously
+     * You need `object/faas/function/invoke` permission in order to access this API.
+     *
+     * @apiParam (path) {Number} functionName the name of the function
+     * @apiParam (header) {String} X-Callback-Url the call back url that the function return data will be posted to.
+     * @apiParam (body) {any} [input] when invoke the function, you can optionally supply function input in HTTP request body.
+     * The whole request body will be passed to the function as input. However, how body data is parsed depends on the mime type.
+     *
+     * @apiParamExample {json} Request-Example:
+     *  // Content-Type: application/json
+     *  {"hello": "world"}
+     *
+     * @apiSuccess (header) {String} X-Call-Id the call id that identify this invocation.
+     * The same header will also be included by the notification request that is sent to the call back http url.
+     *
+     * @apiSuccessExample {string} 202
+     *    HTTP/1.1 202 Accepted
+     *    Request accepted and queued
+     *
+     * @apiErrorExample {string} 404
+     *    HTTP/1.1 404 Not Found
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/invoke` on required resources
+     */
     router.post(
         "/async-function/:functionName",
         requireUnconditionalAuthDecision(
@@ -119,6 +353,40 @@ export default function createOpenfaasGatewayProxy(
         }
     );
 
+    /**
+     * @apiGroup FaaS Function
+     * @api {get} /v0/openfaas/system/function/:functionName Get the info of a deployed function
+     * @apiDescription Returns the info of a deployed function
+     * You need `object/faas/function/read` permission in order to access this API.
+     *
+     * @apiParam (path) {Number} functionName the name of the function
+     *
+     * @apiSuccessExample {json} 200
+     *       {
+     *           "name": "nodeinfo",
+     *           "image": "functions/nodeinfo:latest",
+     *           "invocationCount": 1337,
+     *           "replicas": 2,
+     *           "availableReplicas": 2,
+     *           "envProcess": "node main.js",
+     *           "labels": {
+     *             "foo": "bar"
+     *           },
+     *           "annotations": {
+     *             "topics": "awesome-kafka-topic",
+     *             "foo": "bar"
+     *           }
+     *       }
+     *
+     * @apiErrorExample {string} 500
+     *    HTTP/1.1 500 Internal Server Error
+     *
+     * @apiErrorExample {string} 404
+     *    HTTP/1.1 404 Not Found
+     *
+     * @apiErrorExample {string} 403
+     *    you are not permitted to perform `object/faas/function/read` on required resources
+     */
     router.get(
         "/system/function/:functionName",
         requireUnconditionalAuthDecision(

--- a/magda-gateway/src/index.ts
+++ b/magda-gateway/src/index.ts
@@ -87,6 +87,12 @@ const argv = addJwtSecretFromEnvVar(
             type: "string",
             default: "http://localhost:6104/v0"
         })
+        .option("skipAuth", {
+            describe:
+                "When set to true, API will not query policy engine for auth decision but assume it's always permitted. It's for debugging only.",
+            type: "boolean",
+            default: process.env.SKIP_AUTH == "true" ? true : false
+        })
         .option("web", {
             describe: "The base URL of the web site.",
             type: "string",
@@ -189,12 +195,6 @@ const argv = addJwtSecretFromEnvVar(
         .option("openfaasGatewayUrl", {
             describe: "Internal openfaas gateway url",
             type: "string"
-        })
-        .option("openfaasAllowAdminOnly", {
-            describe:
-                "Whether only allow admin users to access openfaas gateway.",
-            type: "boolean",
-            default: false
         })
         .option("defaultCacheControl", {
             describe:

--- a/magda-gateway/src/test/createOpenfaasGatewayProxy.spec.ts
+++ b/magda-gateway/src/test/createOpenfaasGatewayProxy.spec.ts
@@ -3,67 +3,22 @@ import express from "express";
 import { expect } from "chai";
 import nock, { Scope } from "nock";
 import supertest from "supertest";
-import randomstring from "randomstring";
-import {
-    AUTHENTICATED_USERS_ROLE_ID,
-    ADMIN_USERS_ROLE_ID
-} from "magda-typescript-common/src/authorization-api/constants";
 import createOpenfaasGatewayProxy from "../createOpenfaasGatewayProxy";
 import setupTenantMode from "../setupTenantMode";
-
-const adminUserData = {
-    id: "00000000-0000-4000-8000-000000000000",
-    displayName: "Test Admin User",
-    email: "xxxx@xxx.com",
-    photoURL: "//www.gravatar.com/avatar/sdfsdfdsfdsfdsfdsfsdfd",
-    source: "ckan",
-    isAdmin: true,
-    orgUnitId: null as string | null,
-    roles: [
-        {
-            id: AUTHENTICATED_USERS_ROLE_ID,
-            name: "Authenticated Users",
-            permissionIds: [] as string[]
-        },
-        {
-            id: ADMIN_USERS_ROLE_ID,
-            name: "Admin Users",
-            permissionIds: []
-        }
-    ],
-    managingOrgUnitIds: [] as string[],
-    orgUnit: null as any
-};
-
-const nonAdminUserData = {
-    id: "00000000-0000-4000-8000-100000000000",
-    displayName: "Test Non-Admin User",
-    email: "xxxx@xxx.com",
-    photoURL: "//www.gravatar.com/avatar/sdfdsfdssf",
-    source: "ckan",
-    isAdmin: false,
-    orgUnitId: null as string | null,
-    roles: [
-        {
-            id: AUTHENTICATED_USERS_ROLE_ID,
-            name: "Authenticated Users",
-            permissionIds: [] as string[]
-        }
-    ],
-    managingOrgUnitIds: [] as string[],
-    orgUnit: null as any
-};
+import createMockAuthDecisionQueryClient, {
+    MockAuthDecisionClientConfig
+} from "magda-typescript-common/src/test/createMockAuthDecisionQueryClient";
+import {
+    UnconditionalTrueDecision,
+    UnconditionalFalseDecision
+} from "magda-typescript-common/src/opa/AuthDecision";
+import { getUserId } from "magda-typescript-common/src/session/GetUserId";
 
 describe("Test createOpenfaasGatewayProxy", () => {
     const openfaasGatewayUrl = "http://gateway.openfaas.com";
     const jwtSecret = "test-jwt";
     let openfaasGatewayScope: Scope;
-
-    const authApiBaseUrl = "http://authApi";
-    let authApiScope: Scope;
-
-    const adminUserId = ADMIN_USERS_ROLE_ID;
-    const nonAdminUserId = "00000000-0000-4000-8000-100000000000";
+    const testUserId = "6987c543-da7c-4695-99ef-d6bc2e900078";
 
     after(() => {
         nock.cleanAll();
@@ -75,32 +30,37 @@ describe("Test createOpenfaasGatewayProxy", () => {
         // Allow localhost connections so we can test local routes and mock servers.
         nock.enableNetConnect("127.0.0.1");
 
-        openfaasGatewayScope = nock(openfaasGatewayUrl).persist();
-        openfaasGatewayScope.get(/.*/).reply(200, (uri: string) => ({ uri }));
-        openfaasGatewayScope
-            .post(/.*/)
-            .reply(200, (uri: string, requestBody: any) => ({
+        function responseGenerator(this: any, uri: string, requestBody: any) {
+            const userId = getUserId(
+                {
+                    header: () => this.req.headers["x-magda-session"]
+                } as any,
+                jwtSecret
+            ).valueOrThrow();
+            return {
                 uri,
-                requestBody
-            }));
+                requestBody,
+                userId
+            };
+        }
 
-        authApiScope = nock(authApiBaseUrl).persist();
-        authApiScope
-            .get(new RegExp(`/public/users/${adminUserId}`, "i"))
-            .reply(200, { ...adminUserData });
-        authApiScope
-            .get(new RegExp(`/public/users/${nonAdminUserId}`, "i"))
-            .reply(200, { ...nonAdminUserData });
+        openfaasGatewayScope = nock(openfaasGatewayUrl).persist();
+        openfaasGatewayScope.get(/.*/).reply(200, responseGenerator);
+        openfaasGatewayScope.post(/.*/).reply(200, responseGenerator);
+        openfaasGatewayScope.put(/.*/).reply(200, responseGenerator);
+        openfaasGatewayScope.delete(/.*/).reply(200, responseGenerator);
     });
 
     /**
      * Create the test request
      *
-     * @param {boolean} allowAdminOnly
      * @param {string} [userId] optional parameter. Specified the authenticated userId. If undefined, indicates user not logged in yet.
      * @returns
      */
-    function createTestRequest(allowAdminOnly: boolean, userId?: string) {
+    function createTestRequest(
+        authDecisionOrHandler: MockAuthDecisionClientConfig,
+        userId: string = testUserId
+    ) {
         const tenantMode = setupTenantMode({
             enableMultiTenants: false
         });
@@ -119,15 +79,17 @@ describe("Test createOpenfaasGatewayProxy", () => {
             }
         };
 
+        const authDecisionClient = createMockAuthDecisionQueryClient(
+            authDecisionOrHandler
+        );
+
         const app: express.Application = express();
         app.use(
             createOpenfaasGatewayProxy({
                 gatewayUrl: openfaasGatewayUrl,
-                allowAdminOnly: allowAdminOnly,
-                baseAuthUrl: authApiBaseUrl,
-                jwtSecret,
+                authClient: authDecisionClient,
                 apiRouterOptions: {
-                    jwtSecret: "test",
+                    jwtSecret,
                     tenantMode,
                     authenticator: mockAuthenticator,
                     routes: {}
@@ -138,71 +100,60 @@ describe("Test createOpenfaasGatewayProxy", () => {
         return supertest(app);
     }
 
-    it("should allow admin users to access openfaas gateway if `allowAdminOnly` = true", async () => {
-        const testReq = createTestRequest(true, adminUserId);
-        const randomPath = "/" + randomstring.generate();
+    function test(
+        endpoint: string,
+        requiredOperation: string,
+        requestCreator: (
+            app: supertest.SuperTest<supertest.Test>
+        ) => supertest.Test
+    ) {
+        describe(`Test endpoint ${endpoint}`, () => {
+            it(`should require permission of operation ${requiredOperation}`, async () => {
+                const testReq = createTestRequest((config, jwtToken) => {
+                    expect(config.operationUri).to.equal(requiredOperation);
+                    return Promise.resolve(UnconditionalTrueDecision);
+                });
+                const response = await requestCreator(testReq).expect(200);
+                expect(response.body.userId).to.equal(testUserId);
+            });
 
-        let res = await testReq.get(randomPath).expect(200);
-        expect(res.body.uri).to.equal(randomPath);
+            it(`should response 403 when not sufficient permission`, async () => {
+                const testReq = createTestRequest((config, jwtToken) => {
+                    expect(config.operationUri).to.equal(requiredOperation);
+                    return Promise.resolve(UnconditionalFalseDecision);
+                });
+                await requestCreator(testReq).expect(403);
+            });
+        });
+    }
 
-        const randomData = randomstring.generate();
-        res = await testReq
-            .post(randomPath)
-            .send({ data: randomData })
-            .expect(200);
-        expect(res.body.uri).to.equal(randomPath);
-        expect(res.body.requestBody).to.deep.equal({ data: randomData });
-    });
+    test("/system/functions", "object/faas/function/read", (app) =>
+        app.get("/system/functions")
+    );
 
-    it("should return 403 when a non-admin user to access openfaas gateway and `allowAdminOnly` = true", async () => {
-        const testReq = createTestRequest(true, nonAdminUserId);
-        const randomPath = "/" + randomstring.generate();
+    test("/system/functions", "object/faas/function/create", (app) =>
+        app.post("/system/functions")
+    );
 
-        await testReq.get(randomPath).expect(403);
+    test("/system/functions", "object/faas/function/update", (app) =>
+        app.put("/system/functions")
+    );
 
-        const randomData = randomstring.generate();
-        await testReq.post(randomPath).send({ data: randomData }).expect(403);
-    });
+    test("/system/functions", "object/faas/function/delete", (app) =>
+        app.delete("/system/functions")
+    );
 
-    it("should return 401 when unauthenticated user to access openfaas gateway and `allowAdminOnly` = true", async () => {
-        const testReq = createTestRequest(true, undefined);
-        const randomPath = "/" + randomstring.generate();
+    test("/system/function/:functionName", "object/faas/function/read", (app) =>
+        app.get("/system/function/test-function")
+    );
 
-        await testReq.get(randomPath).expect(401);
+    test("/function/:functionName", "object/faas/function/invoke", (app) =>
+        app.post("/function/test-function")
+    );
 
-        const randomData = randomstring.generate();
-        await testReq.post(randomPath).send({ data: randomData }).expect(401);
-    });
-
-    it("should allow Non-admin users to access openfaas gateway if `allowAdminOnly` = false", async () => {
-        const testReq = createTestRequest(false, nonAdminUserId);
-        const randomPath = "/" + randomstring.generate();
-
-        let res = await testReq.get(randomPath).expect(200);
-        expect(res.body.uri).to.equal(randomPath);
-
-        const randomData = randomstring.generate();
-        res = await testReq
-            .post(randomPath)
-            .send({ data: randomData })
-            .expect(200);
-        expect(res.body.uri).to.equal(randomPath);
-        expect(res.body.requestBody).to.deep.equal({ data: randomData });
-    });
-
-    it("should allow unauthenticated users to access openfaas gateway if `allowAdminOnly` = false", async () => {
-        const testReq = createTestRequest(false, undefined);
-        const randomPath = "/" + randomstring.generate();
-
-        let res = await testReq.get(randomPath).expect(200);
-        expect(res.body.uri).to.equal(randomPath);
-
-        const randomData = randomstring.generate();
-        res = await testReq
-            .post(randomPath)
-            .send({ data: randomData })
-            .expect(200);
-        expect(res.body.uri).to.equal(randomPath);
-        expect(res.body.requestBody).to.deep.equal({ data: randomData });
-    });
+    test(
+        "/async-function/:functionName",
+        "object/faas/function/invoke",
+        (app) => app.post("/async-function/test-function")
+    );
 });

--- a/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
+++ b/magda-migrator-authorization-db/sql/V2_0__generic_auth_model.sql
@@ -296,6 +296,21 @@ VALUES
 ('authObject/orgUnit/update', 'Update Organization Unit', '', (SELECT id FROM resources WHERE uri = 'authObject/orgUnit')),
 ('authObject/orgUnit/delete', 'Delete Organization Unit', '', (SELECT id FROM resources WHERE uri = 'authObject/orgUnit'));
 
+-- Add resource, operation for access `faas function` 
+INSERT INTO "public"."resources" 
+    ("uri", "name", "description")
+VALUES 
+('object/faas/function', 'FaaS functions', 'Resource represents FaaS functions');
+
+INSERT INTO "public"."operations" ("uri", "name", "description", "resource_id") 
+VALUES 
+('object/faas/function/create','Deploy / Create a FaaS function', 'Allow a user to create / deploy a FaaS function.', (SELECT id FROM resources WHERE uri = 'object/faas/function')),
+('object/faas/function/read','Read any information of a FaaS function', 'Allow a user to read information of a FaaS function.', (SELECT id FROM resources WHERE uri = 'object/faas/function')),
+('object/faas/function/update','Update a FaaS function', 'Allow a user to update a FaaS function.', (SELECT id FROM resources WHERE uri = 'object/faas/function')),
+('object/faas/function/invoke','Invoke a FaaS function', 'Allow a user to invoke a FaaS function.', (SELECT id FROM resources WHERE uri = 'object/faas/function')),
+('object/faas/function/delete','Delete a FaaS function', 'Allow a user to delete a FaaS function.', (SELECT id FROM resources WHERE uri = 'object/faas/function'));
+-- End adding resource, operation for access `faas function` 
+
 -- create Data Stewards role
 INSERT INTO "public"."roles" ("id", "name", "description") 
 VALUES 
@@ -313,7 +328,8 @@ VALUES
 ('45247ef8-68b9-4dab-a5d5-a23143503887', 'View Published Datasets within Org Units', (SELECT id FROM resources WHERE uri = 'object/dataset/published') , 'f', 't', 'f', 'This permission allows Data Stewards to view published datasets within org units.'),
 ('5f89bd45-899a-4c37-9f71-3da878ad247b', 'View Distribution within Org Units', (SELECT id FROM resources WHERE uri = 'object/distribution') , 'f', 't', 'f', 'This permission allows Data Stewards to view distributions within org units.'),
 ('6a54f495-bcd0-4474-be12-60e1454aec7e', 'View Orgnisation (Publisher) within Org Units', (SELECT id FROM resources WHERE uri = 'object/organization') , 'f', 't', 'f', 'This permission allows Data Stewards to view orgnisation (publisher) within org units.'),
-('60ea27d1-5772-4e11-823d-92f88f927745', 'Read Org Units with own org units', (SELECT id FROM resources WHERE uri = 'authObject/orgUnit') , 'f', 't', 'f', 'This permission allows Data Stewards to read org unit info within his org unit sub tree.');
+('60ea27d1-5772-4e11-823d-92f88f927745', 'Read Org Units with own org units', (SELECT id FROM resources WHERE uri = 'authObject/orgUnit') , 'f', 't', 'f', 'This permission allows Data Stewards to read org unit info within his org unit sub tree.'),
+('2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1', 'Read / invoke FaaS functions', (SELECT id FROM resources WHERE uri = 'object/faas/function') , 'f', 'f', 'f', 'This permission allows Data Stewards to read / invoke all FaaS functions.');
 -- Add proper operations to permissions above
 INSERT INTO "public"."permission_operations" ("permission_id", "operation_id") 
 VALUES 
@@ -352,6 +368,10 @@ VALUES
 INSERT INTO "public"."permission_operations" ("permission_id", "operation_id") 
 VALUES 
 ('60ea27d1-5772-4e11-823d-92f88f927745', (SELECT id FROM operations WHERE uri = 'authObject/orgUnit/read'));
+INSERT INTO "public"."permission_operations" ("permission_id", "operation_id") 
+VALUES 
+('2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1', (SELECT id FROM operations WHERE uri = 'object/faas/function/read')),
+('2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1', (SELECT id FROM operations WHERE uri = 'object/faas/function/invoke'));
 -- Add permissions to Data Stewards role
 INSERT INTO "public"."role_permissions" ("role_id", "permission_id") 
 VALUES 
@@ -363,7 +383,8 @@ VALUES
 ('4154bf84-d36e-4551-9734-4666f5b1e1c0', '45247ef8-68b9-4dab-a5d5-a23143503887'),
 ('4154bf84-d36e-4551-9734-4666f5b1e1c0', '5f89bd45-899a-4c37-9f71-3da878ad247b'),
 ('4154bf84-d36e-4551-9734-4666f5b1e1c0', '6a54f495-bcd0-4474-be12-60e1454aec7e'),
-('4154bf84-d36e-4551-9734-4666f5b1e1c0', '60ea27d1-5772-4e11-823d-92f88f927745');
+('4154bf84-d36e-4551-9734-4666f5b1e1c0', '60ea27d1-5772-4e11-823d-92f88f927745'),
+('4154bf84-d36e-4551-9734-4666f5b1e1c0', '2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1');
 -- end create Data Stewards role
 
 -- START add more permissions to authenticated & anonymous users role

--- a/magda-opa/policies/common/verifyRecordPermission.rego
+++ b/magda-opa/policies/common/verifyRecordPermission.rego
@@ -1,6 +1,5 @@
 package common
 
-import data.common.breakdownOperationUri
 import data.common.hasNoConstraintPermission
 import data.common.hasOwnerConstraintPermission
 import data.common.hasOrgUnitConstaintPermission

--- a/magda-opa/policies/entrypoint/allow.rego
+++ b/magda-opa/policies/entrypoint/allow.rego
@@ -67,6 +67,12 @@ allow {
 }
 
 allow {
+    ## delegate FaaS function related decision to FaaS function rules
+    startswith(input.operationUri, "object/faas/function/")
+    data.object.faas.function.allow
+}
+
+allow {
     ## delegate storage bucket related decision to storage bucket rules
     startswith(input.operationUri, "storage/bucket/")
     data.storage.bucket.allow

--- a/magda-opa/policies/object/faas/function/allow.rego
+++ b/magda-opa/policies/object/faas/function/allow.rego
@@ -1,0 +1,9 @@
+package object.faas.function
+
+import data.common.hasNoConstraintPermission
+
+default allow = false
+
+allow {
+    hasNoConstraintPermission(input.operationUri)
+}

--- a/magda-typescript-common/src/authorization-api/authMiddleware.ts
+++ b/magda-typescript-common/src/authorization-api/authMiddleware.ts
@@ -134,7 +134,9 @@ export function withAuthDecision(
             if (!config) {
                 return;
             }
-            const jwtToken = req.get("X-Magda-Session");
+            const jwtToken = config?.jwtToken
+                ? config.jwtToken
+                : req.get("X-Magda-Session");
             const authDecision = await authDecisionClient.getAuthDecision(
                 config,
                 jwtToken

--- a/magda-typescript-common/src/opa/AuthDecisionQueryClient.ts
+++ b/magda-typescript-common/src/opa/AuthDecisionQueryClient.ts
@@ -11,6 +11,7 @@ export type AuthDecisionReqConfig = {
     pretty?: boolean;
     humanReadable?: boolean;
     concise?: boolean;
+    jwtToken?: string;
     input?: {
         [key: string]: any;
     };

--- a/magda-typescript-common/src/test/createMockAuthDecisionQueryClient.ts
+++ b/magda-typescript-common/src/test/createMockAuthDecisionQueryClient.ts
@@ -1,0 +1,28 @@
+import AuthDecisionQueryClient, {
+    AuthDecisionReqConfig
+} from "../opa/AuthDecisionQueryClient";
+import AuthDecision from "../opa/AuthDecision";
+import sinon from "sinon";
+
+type AuthDecisionRequestHandler = (
+    config: AuthDecisionReqConfig,
+    jwtToken?: string
+) => Promise<AuthDecision>;
+
+export type MockAuthDecisionClientConfig =
+    | AuthDecision
+    | AuthDecisionRequestHandler;
+
+function createMockAuthDecisionQueryClient(
+    authDecisionOrHandler: MockAuthDecisionClientConfig
+): AuthDecisionQueryClient {
+    const authClient = sinon.createStubInstance(AuthDecisionQueryClient);
+    if (typeof authDecisionOrHandler === "function") {
+        authClient.getAuthDecision.callsFake(authDecisionOrHandler);
+    } else {
+        authClient.getAuthDecision.returns(authDecisionOrHandler);
+    }
+    return authClient;
+}
+
+export default createMockAuthDecisionQueryClient;


### PR DESCRIPTION
### What this PR does

Fixes: 
- #3348 
also:
- remove faas `allowAdminOnly`
- add `skipAuth` config to gateway


### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
