### PR TITLE
Issue/3406 Registry Performance Issue and more

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -532,7 +532,7 @@ buildtest:opa-policies:
 
 buildtest:helm-charts:
   stage: buildtest
-  image: dtzar/helm-kubectl:3.5.2
+  image: dtzar/helm-kubectl:3.9.0
   needs:
     - yarn-install
   cache:
@@ -727,7 +727,7 @@ dockerize:dockerExtensions:
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl:3.5.2
+    name: dtzar/helm-kubectl:3.9.0
   retry: 1
   environment:
     name: preview/$CI_COMMIT_REF_NAME
@@ -803,7 +803,7 @@ Stop Preview: &stopPreview
   cache:
     paths: []
   image:
-    name: dtzar/helm-kubectl:3.5.2
+    name: dtzar/helm-kubectl:3.9.0
   retry: 1
   before_script: []
   environment:
@@ -830,7 +830,7 @@ Deploy Master To Dev:
     - dockerize:dockerExtensions
     - buildtest:integration-tests
   image:
-    name: dtzar/helm-kubectl:3.5.2
+    name: dtzar/helm-kubectl:3.9.0
   retry: 1
   before_script: []
   environment:
@@ -1021,7 +1021,7 @@ Publish Helm Chart S3:
     - dockerize:dockerExtensions
     - buildtest:integration-tests
   image:
-    name: dtzar/helm-kubectl:3.5.2
+    name: dtzar/helm-kubectl:3.9.0
   cache:
     key: $CI_JOB_NAME-$CACHE_VERSION
     paths:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 - Upgrade magda-ckan-connector to 2.0.0
 - Related to #3355, upgrade API version of all CronJob in `magda-core` to batch/v1 (for k8s 1.25 support)
 - Metadata Editor: avoid dataset editor UI refresh when refresh the user state data
+- Metadata Editor: make all orgUnitDropDown controls clearable configurable
+- Metadata Editor: make sure orgUnitDropDown controls are only clearable when they are not compulsory fields
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 - `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when not specified.
 - `/registry/hooks/{id}/ack` endpoint will reset webhook retryCount when `active` field is `true`.
 - #3410 Allow additional webhook options to be configured via minion options
+- Fix `PUT` `/v0/registry/hooks/{id}`: didn't update webhook registered eventTypes properly
+- Update create / update webhook API document re: required eventType data type
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Metadata Editor: make sure orgUnitDropDown controls are only clearable when they are not compulsory fields
 - Fixed: Registry Record Aspect Panel UI pagination issue
 - Metadata Editor: when publishing dataset for the first time, the `hasEverPublished` field should be set to `true`
+- Metadata Editor: UI adjustments on dataset published message page
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 - Update create / update webhook API document re: required eventType data type
 - The resume webhook action on minion's starting up should set the webhook to `active` (and consequently, reset the retryCount)
 - Upgrade magda-minion-visualization to 2.0.0
+- Upgrade magda-ckan-connector to 2.0.0
+- Related to #3355, upgrade API version of all CronJob in `magda-core` to batch/v1 (for k8s 1.25 support)
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Metadata Editor: avoid dataset editor UI refresh when refresh the user state data
 - Metadata Editor: make all orgUnitDropDown controls clearable configurable
 - Metadata Editor: make sure orgUnitDropDown controls are only clearable when they are not compulsory fields
+- Fixed: Registry Record Aspect Panel UI pagination issue
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Increase indexer default http request / idle timeout to 90s / 120s and make them configurable via the indexer helm chart
 - `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when not specified.
 - `/registry/hooks/{id}/ack` endpoint will reset webhook retryCount when `active` field is `true`.
+- #3410 Allow additional webhook options to be configured via minion options
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - Fixed: Registry Record Aspect Panel UI pagination issue
 - Metadata Editor: when publishing dataset for the first time, the `hasEverPublished` field should be set to `true`
 - Metadata Editor: UI adjustments on dataset published message page
+- #3394 Make sure scala pods can be gracefully terminated within 15 seconds
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 - Periodically refresh login status (Interval configurable via web-server helm chart)
 - Allow setting landingPage uri for anonymousUser and authenticatedUser
 - Logout action will redirect user to LandingPage
+- #3406 Improve registry webHook processing SQL performance
+- Increase indexer default http request / idle timeout to 90s / 120s and make them configurable via the indexer helm chart
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v2.0.2
+## v2.1.0
 
 - Use global state instead in ValidateUser
 - Periodically refresh login status (Interval configurable via web-server helm chart)
@@ -8,6 +8,8 @@
 - Logout action will redirect user to LandingPage
 - #3406 Improve registry webHook processing SQL performance
 - Increase indexer default http request / idle timeout to 90s / 120s and make them configurable via the indexer helm chart
+- `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when not specified.
+- `/registry/hooks/{id}/ack` endpoint will reset webhook retryCount when `active` field is `true`.
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - #3410 Allow additional webhook options to be configured via minion options
 - Fix `PUT` `/v0/registry/hooks/{id}`: didn't update webhook registered eventTypes properly
 - Update create / update webhook API document re: required eventType data type
+- The resume webhook action on minion's starting up should set the webhook to `active` (and consequently, reset the retryCount)
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fix `PUT` `/v0/registry/hooks/{id}`: didn't update webhook registered eventTypes properly
 - Update create / update webhook API document re: required eventType data type
 - The resume webhook action on minion's starting up should set the webhook to `active` (and consequently, reset the retryCount)
+- Upgrade magda-minion-visualization to 2.0.0
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - Metadata Editor: when publishing dataset for the first time, the `hasEverPublished` field should be set to `true`
 - Metadata Editor: UI adjustments on dataset published message page
 - #3394 Make sure scala pods can be gracefully terminated within 15 seconds
+- #3402 Allow access group users to have read permission to the access group itself
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Upgrade magda-minion-visualization to 2.0.0
 - Upgrade magda-ckan-connector to 2.0.0
 - Related to #3355, upgrade API version of all CronJob in `magda-core` to batch/v1 (for k8s 1.25 support)
+- Metadata Editor: avoid dataset editor UI refresh when refresh the user state data
 
 ## v2.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - Logout action will redirect user to LandingPage
 - #3406 Improve registry webHook processing SQL performance
 - Increase indexer default http request / idle timeout to 90s / 120s and make them configurable via the indexer helm chart
-- `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when not specified.
+- `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when `active` is not specified and `succeeded` = `true`.
 - `/registry/hooks/{id}/ack` endpoint will reset webhook retryCount when `active` field is `true`.
 - #3410 Allow additional webhook options to be configured via minion options
 - Fix `PUT` `/v0/registry/hooks/{id}`: didn't update webhook registered eventTypes properly

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Metadata Editor: make all orgUnitDropDown controls clearable configurable
 - Metadata Editor: make sure orgUnitDropDown controls are only clearable when they are not compulsory fields
 - Fixed: Registry Record Aspect Panel UI pagination issue
+- Metadata Editor: when publishing dataset for the first time, the `hasEverPublished` field should be set to `true`
 
 ## v2.0.1
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ helm repo add magda-io https://charts.magda.io
 kubectl create namespace magda
 
 # install Magda version v2.0.1 to namespace "magda", turn off openfass function and expose the service via loadBalancer
-helm upgrade --namespace magda --install --version 2.0.1 --timeout 9999s --set global.openfaas.enabled=false,magda-core.gateway.service.type=LoadBalancer magda magda-io/magda
+helm upgrade --namespace magda --install --version 2.0.1 --timeout 9999s --set magda-core.gateway.service.type=LoadBalancer magda magda-io/magda
 ```
 
 You can find out the load balancer IP and access it:

--- a/deploy/helm/internal-charts/indexer/Chart.yaml
+++ b/deploy/helm/internal-charts/indexer/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: indexer
 version: 2.0.1
-kubeVersion: ">= 1.14.0-0"
+kubeVersion: ">= 1.21.0"
 annotations:
   magdaModuleType: "core"

--- a/deploy/helm/internal-charts/indexer/README.md
+++ b/deploy/helm/internal-charts/indexer/README.md
@@ -12,6 +12,8 @@ Kubernetes: `>= 1.14.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| akka.http.server.idleTimeout | string | `"120s"` | The time after which an idle connection will be automatically closed. Set to `infinite` to completely disable idle connection timeouts. |
+| akka.http.server.requestTimeout | string | `"90s"` | Defines the default time period within which the application has to produce an HttpResponse for any given HttpRequest it received. The timeout begins to run when the *end* of the request has been received, so even potentially long uploads can have a short timeout. Set to `infinite` to completely disable request timeout checking. Make sure this timeout is smaller than the idle-timeout, otherwise, the idle-timeout will kick in first and reset the TCP connection without a response. If this setting is not `infinite` the HTTP server layer attaches a `Timeout-Access` header to the request, which enables programmatic customization of the timeout period and timeout response for each request individually. |
 | autoReIndex.enable | bool | `true` | Whether turn on the cronjob to trigger reindex. `publisher` & `format` indices might contains obsolete records which require the triming / reindex process to be removed. |
 | autoReIndex.schedule | string | "0 15 * * 0": 15:00PM UTC timezone (1:00AM in AEST Sydney timezone) on every Sunday | auto reindex cronjob schedule string. specified using unix-cron format (in UTC timezone by default). |
 | defaultImage.pullPolicy | string | `"IfNotPresent"` |  |

--- a/deploy/helm/internal-charts/indexer/README.md
+++ b/deploy/helm/internal-charts/indexer/README.md
@@ -6,7 +6,7 @@ A Helm chart for Kubernetes
 
 ## Requirements
 
-Kubernetes: `>= 1.14.0-0`
+Kubernetes: `>= 1.21.0`
 
 ## Values
 

--- a/deploy/helm/internal-charts/indexer/templates/cronjob-reindex.yaml
+++ b/deploy/helm/internal-charts/indexer/templates/cronjob-reindex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoReIndex.enable -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: indexer-reindex

--- a/deploy/helm/internal-charts/indexer/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/indexer/templates/deployment.yaml
@@ -62,6 +62,12 @@ spec:
 {{- end }}
             "-DelasticSearch.shardCount={{ .Values.elasticsearch.shards }}",
             "-DelasticSearch.replicaCount={{ .Values.elasticsearch.replicas }}",
+{{- if .Values.akka.http.server.requestTimeout }}
+            "-Dakka.http.server.request-timeout={{ .Values.akka.http.server.requestTimeout }}",
+{{- end }}
+{{- if .Values.akka.http.server.idleTimeout }}
+            "-Dakka.http.server.idle-timeout={{ .Values.akka.http.server.idleTimeout }}",
+{{- end }}
             "-Dauth.userId={{ .Values.global.defaultAdminUserId }}"
         ]
         volumeMounts:

--- a/deploy/helm/internal-charts/indexer/values.yaml
+++ b/deploy/helm/internal-charts/indexer/values.yaml
@@ -36,3 +36,25 @@ autoReIndex:
   # -- auto reindex cronjob schedule string. specified using unix-cron format (in UTC timezone by default).
   # @default -- "0 15 * * 0": 15:00PM UTC timezone (1:00AM in AEST Sydney timezone) on every Sunday
   schedule: "0 15 * * 0"
+
+akka:
+  http:
+    server:
+      # -- Defines the default time period within which the application has to
+      # produce an HttpResponse for any given HttpRequest it received.
+      # The timeout begins to run when the *end* of the request has been
+      # received, so even potentially long uploads can have a short timeout.
+      # Set to `infinite` to completely disable request timeout checking.
+      #
+      # Make sure this timeout is smaller than the idle-timeout, otherwise,
+      # the idle-timeout will kick in first and reset the TCP connection
+      # without a response.
+      #
+      # If this setting is not `infinite` the HTTP server layer attaches a
+      # `Timeout-Access` header to the request, which enables programmatic
+      # customization of the timeout period and timeout response for each
+      # request individually.
+      requestTimeout: 90s
+      # -- The time after which an idle connection will be automatically closed.
+      # Set to `infinite` to completely disable idle connection timeouts.
+      idleTimeout: 120s

--- a/deploy/helm/internal-charts/magda-postgres/Chart.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: magda-postgres
 description: "A helm wrapper chart that provides in-kubernetes postgreSQL for Magda."
 type: application
-kubeVersion: ">= 1.14.0-0"
+kubeVersion: ">= 1.21.0"
 version: "2.0.1"
 annotations:
   magdaModuleType: "core"

--- a/deploy/helm/internal-charts/magda-postgres/README.md
+++ b/deploy/helm/internal-charts/magda-postgres/README.md
@@ -12,7 +12,7 @@ The docker image used by the chart is built from [bitnami postgreSQL Docker Imag
 
 ## Requirements
 
-Kubernetes: `>= 1.14.0-0`
+Kubernetes: `>= 1.21.0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.backupRestore.backup.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ .Values.postgresql.fullnameOverride }}-backup-jobs"

--- a/deploy/helm/internal-charts/registry-db/Chart.yaml
+++ b/deploy/helm/internal-charts/registry-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: registry-db
 version: 2.0.1
-kubeVersion: ">= 1.14.0-0"
+kubeVersion: ">= 1.21.0"
 annotations:
   magdaModuleType: "core"
 dependencies:

--- a/deploy/helm/internal-charts/registry-db/README.md
+++ b/deploy/helm/internal-charts/registry-db/README.md
@@ -6,7 +6,7 @@ A Helm chart for Kubernetes
 
 ## Requirements
 
-Kubernetes: `>= 1.14.0-0`
+Kubernetes: `>= 1.21.0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/deploy/helm/internal-charts/registry-db/templates/registry-db-auto-vacuum-cron-job.yaml
+++ b/deploy/helm/internal-charts/registry-db/templates/registry-db-auto-vacuum-cron-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoVacuum.enable -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: registry-db-auto-vacuum-job

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -15,8 +15,8 @@ dependencies:
   repository: https://charts.magda.io
   version: 1.0.0
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.1.0
@@ -33,11 +33,11 @@ dependencies:
   repository: https://charts.magda.io
   version: 1.1.1
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.1.0
@@ -68,21 +68,21 @@ dependencies:
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.1.0
-- name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
-- name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
 - name: magda-csw-connector
   repository: https://charts.magda.io
   version: 1.1.1
 - name: magda-ckan-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
   repository: https://charts.magda.io
-  version: 1.3.0
+  version: 1.1.1
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-ckan-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.1.0
@@ -93,11 +93,11 @@ dependencies:
   repository: https://charts.magda.io
   version: 1.1.1
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-ckan-connector
-  repository: https://charts.magda.io
-  version: 1.3.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-dap-connector
   repository: https://charts.magda.io
   version: 1.0.0
@@ -110,5 +110,5 @@ dependencies:
 - name: magda-project-open-data-connector
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:e2950eaa202f5a36c1362e315817d0fff050c653a3fb7a6462d3996043980c95
-generated: "2022-08-30T10:38:26.550705+10:00"
+digest: sha256:fdc849b5c6c6c83a94206322b049a88f861d210da8a79937e08731aa1966a16d
+generated: "2022-09-28T15:34:43.93558+10:00"

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -39,9 +39,9 @@ dependencies:
   ## Data.gov.au connector to provide some initial data. Remove this if you
   ## don't want any data.gov.au connector
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-dga
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-dga
@@ -83,16 +83,16 @@ dependencies:
       - connectors
       - connector-bom
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-aurin
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-aurin
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-brisbane
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-brisbane
@@ -174,9 +174,9 @@ dependencies:
       - connectors
       - connector-neii
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-nsw
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-nsw
@@ -188,16 +188,16 @@ dependencies:
       - connectors
       - connector-sdinsw
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-qld
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-qld
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-sa
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-sa
@@ -223,16 +223,16 @@ dependencies:
       - connectors
       - connector-tern
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-vic
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-vic
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: connector-wa
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-wa

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -18,8 +18,8 @@ dependencies:
   repository: https://charts.magda.io
   version: 1.1.0
 - name: magda-minion-visualization
-  repository: https://charts.magda.io
-  version: 1.0.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-minion-ckan-exporter
   repository: https://charts.magda.io
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:78296436913a7f3abc53aaa597c9eec809e7ad19439c2c4c9aef2d976973555e
-generated: "2022-08-30T10:38:15.645395+10:00"
+digest: sha256:4a767e87e0e065d3b32344d8cc9ec5066687ded95f96c83c90d9e9e6ef190c60
+generated: "2022-09-27T22:54:53.153301+10:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -69,9 +69,9 @@ dependencies:
       - minion-ckan-exporter
 
   - name: magda-ckan-connector
-    version: "1.3.0"
+    version: "2.0.0"
     alias: ckan-connector-functions
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - all
       - url-processors

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -56,8 +56,8 @@ dependencies:
 
   - name: magda-minion-visualization
     alias: minion-visualization
-    version: "1.0.0"
-    repository: https://charts.magda.io
+    version: "2.0.0"
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
       - minion-visualization

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -15,15 +15,15 @@ A complete solution for managing, publishing and discovering government data, pr
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../magda-core | magda-core | 2.0.1 |
-| https://charts.magda.io | ckan-connector-functions(magda-ckan-connector) | 1.3.0 |
 | https://charts.magda.io | magda-function-esri-url-processor | 1.1.0 |
 | https://charts.magda.io | magda-function-history-report | 1.1.0 |
 | https://charts.magda.io | minion-broken-link(magda-minion-broken-link) | 1.0.0 |
 | https://charts.magda.io | magda-minion-ckan-exporter | 1.0.0 |
 | https://charts.magda.io | minion-format(magda-minion-format) | 1.1.2 |
 | https://charts.magda.io | minion-linked-data-rating(magda-minion-linked-data-rating) | 1.1.0 |
-| https://charts.magda.io | minion-visualization(magda-minion-visualization) | 1.0.0 |
 | https://charts.magda.io | openfaas | 5.5.5-magda.2 |
+| oci://ghcr.io/magda-io/charts | ckan-connector-functions(magda-ckan-connector) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | minion-visualization(magda-minion-visualization) | 2.0.0 |
 
 ## Values
 

--- a/magda-authorization-api/src/Database.ts
+++ b/magda-authorization-api/src/Database.ts
@@ -1195,7 +1195,7 @@ export default class Database {
                 let operationUris = options.operationUris;
                 operationUris = operationUris
                     .filter((item) => !!item)
-                    .map((item) => `${item}`.trim().toLowerCase())
+                    .map((item) => `${item}`.trim())
                     .filter((item) => !!item);
                 if (!operationUris.length) {
                     throw new ServerError(
@@ -1403,7 +1403,7 @@ export default class Database {
                 } else {
                     operationUris = operationUris
                         .filter((item) => !!item)
-                        .map((item) => `${item}`.trim().toLowerCase())
+                        .map((item) => `${item}`.trim())
                         .filter((item) => !!item);
                     if (!operationUris.length) {
                         throw new ServerError(

--- a/magda-indexer/src/main/resources/application.conf
+++ b/magda-indexer/src/main/resources/application.conf
@@ -26,6 +26,15 @@ akka {
     log-dead-letters = off
     # We don't want to see dead letters during system shutdown
     log-dead-letters-during-shutdown = off
+
+    http {
+        server {
+            request-timeout = 90s
+            idle-timeout = 120s
+        }
+
+
+    }
 }
 
 

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/IndexerApp.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/IndexerApp.scala
@@ -74,6 +74,20 @@ object IndexerApp extends App {
       .toMillis milliseconds
   )
 
+  logger.info(
+    "akka.http.server.request-timeout: {}",
+    config
+      .getDuration("akka.http.server.request-timeout")
+      .toMillis milliseconds
+  )
+
+  logger.info(
+    "akka.http.server.idle-timeout: {}",
+    config
+      .getDuration("akka.http.server.idle-timeout")
+      .toMillis milliseconds
+  )
+
   val shutdown = CoordinatedShutdown(system)
   shutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, "http-unbind") {
     () =>

--- a/magda-minion-framework/src/MinionOptions.ts
+++ b/magda-minion-framework/src/MinionOptions.ts
@@ -24,4 +24,8 @@ export default interface MinionOptions {
     concurrency?: number;
     // no.of records the crawller fetchs per request
     crawlerRecordFetchNumber?: number;
+    includeEvents?: boolean;
+    includeRecords?: boolean;
+    includeAspectDefinitions?: boolean;
+    dereference?: boolean;
 }

--- a/magda-minion-framework/src/buildWebhookConfig.ts
+++ b/magda-minion-framework/src/buildWebhookConfig.ts
@@ -7,9 +7,21 @@ export default function buildWebhookConfig(
     return {
         aspects: options.aspects,
         optionalAspects: options.optionalAspects,
-        includeEvents: false,
-        includeRecords: true,
-        includeAspectDefinitions: false,
-        dereference: true
+        includeEvents:
+            typeof options.includeEvents === "boolean"
+                ? options.includeEvents
+                : false,
+        includeRecords:
+            typeof options.includeRecords === "boolean"
+                ? options.includeRecords
+                : true,
+        includeAspectDefinitions:
+            typeof options.includeAspectDefinitions === "boolean"
+                ? options.includeAspectDefinitions
+                : false,
+        dereference:
+            typeof options.dereference === "boolean"
+                ? options.dereference
+                : true
     };
 }

--- a/magda-minion-framework/src/resumeWebhook.ts
+++ b/magda-minion-framework/src/resumeWebhook.ts
@@ -10,7 +10,12 @@ export default async function resumeWebhook(
 ) {
     console.info(`Attempting to resume webhook ${options.id}`);
 
-    const resumeResult = await registry.resumeHook(options.id);
+    const resumeResult = await registry.resumeHook(
+        options.id,
+        false,
+        null,
+        true
+    );
 
     if (resumeResult instanceof Error) {
         throw resumeResult;

--- a/magda-minion-framework/src/test/registry.spec.ts
+++ b/magda-minion-framework/src/test/registry.spec.ts
@@ -122,7 +122,8 @@ baseSpec(
                         `/hooks/${encodeURIComponentWithApost(hook.id)}/ack`,
                         {
                             succeeded: false,
-                            lastEventIdReceived: null
+                            lastEventIdReceived: null,
+                            active: true
                         },
                         {
                             reqheaders: reqHeaders(jwtSecret, userId)

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -298,7 +298,10 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       } else {
         orderBy.asc
       }
-
+    val offsetClause = start match {
+      case None    => SQLSyntax.empty
+      case Some(v) => sqls"offset ${v}"
+    }
     val results =
       sql"""select
             eventId,
@@ -310,7 +313,7 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
           from Events
           $whereClause
           ${orderByClause}
-          offset ${start.getOrElse(0)}
+          ${offsetClause}
           limit ${limitValue + 1}"""
         .map(rs => {
           (

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -7,7 +7,11 @@ import spray.json._
 import gnieh.diffson.sprayJson._
 import scalikejdbc._
 import akka.NotUsed
-import au.csiro.data61.magda.model.Auth.AuthDecision
+import au.csiro.data61.magda.model.AspectQueryToSqlConfig
+import au.csiro.data61.magda.model.Auth.{
+  AuthDecision,
+  UnconditionalTrueDecision
+}
 import au.csiro.data61.magda.util.SQLUtils
 
 trait EventPersistence {
@@ -29,6 +33,8 @@ trait EventPersistence {
   def getLatestEventId(implicit session: DBSession): Option[Long]
 
   def getEvents(
+      tenantId: TenantId,
+      authDecision: AuthDecision,
       pageToken: Option[Long] = None,
       start: Option[Int] = None,
       limit: Option[Int] = None,
@@ -36,8 +42,8 @@ trait EventPersistence {
       recordId: Option[String] = None,
       aspectIds: Set[String] = Set(),
       eventTypes: Set[EventType] = Set(),
-      tenantId: TenantId,
-      reversePageTokenOrder: Option[Boolean] = None
+      reversePageTokenOrder: Option[Boolean] = None,
+      dereference: Option[Boolean] = None
   )(implicit session: DBSession): EventsPage
 
   def getRecordReferencedIds(
@@ -52,11 +58,11 @@ trait EventPersistence {
       // thus, recordId is compulsory here
       tenantId: TenantId,
       authDecision: AuthDecision,
-      recordId: String,
       pageToken: Option[Long] = None,
       start: Option[Int] = None,
       limit: Option[Int] = None,
       lastEventId: Option[Long] = None,
+      recordId: String,
       aspectIds: Set[String] = Set(),
       eventTypes: Set[EventType] = Set(),
       reversePageTokenOrder: Option[Boolean] = None
@@ -81,12 +87,13 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       .unfold(sinceEventId)(offset => {
         val events = DB readOnly { implicit session =>
           getEvents(
+            tenantId = tenantId,
+            authDecision = UnconditionalTrueDecision,
             pageToken = Some(offset),
             start = None,
             limit = Some(eventStreamPageSize),
             recordId = recordId,
-            aspectIds = aspectIds,
-            tenantId = tenantId
+            aspectIds = aspectIds
           )
         }
         events.events.lastOption.map(last => (last.id.get, events))
@@ -105,13 +112,14 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       .unfold(0L)(offset => {
         val events = DB readOnly { implicit session =>
           getEvents(
+            tenantId = tenantId,
+            authDecision = UnconditionalTrueDecision,
             pageToken = Some(offset),
             start = None,
             limit = Some(eventStreamPageSize),
             lastEventId = Some(lastEventId),
             recordId = recordId,
-            aspectIds = aspectIds,
-            tenantId = tenantId
+            aspectIds = aspectIds
           )
         }
         events.events.lastOption.map(last => (last.id.get, events))
@@ -135,6 +143,9 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
     * event service for all web hooks, such as indexer and minions.
     *
     * @param session an implicit DB session
+    * @param tenantId The returned events will be filtered by this tenant ID.
+    *                 If it is a system ID, events belonging to all tenants are included (no tenant filtering).
+    * @param authDecision auth decision
     * @param pageToken The ID of event must be greater than the specified value. Optional and default to None.
     * @param start Specify the number of initial events to be dropped. Optional and default to None.
     * @param limit Specify the max number of events to be returned. Optional and default to None.
@@ -142,11 +153,13 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
     * @param recordId The data recordId field of event must equal to this value. Optional and default to None.
     * @param aspectIds The data aspectId field of event must equal to one of the specified values. Optional and default to empty Set.
     * @param eventTypes The type of event must equal to one of the specified values. Optional and default to empty Set.
-    * @param tenantId The returned events will be filtered by this tenant ID.
-    *                 If it is a system ID, events belonging to all tenants are included (no tenant filtering).
+    * @param reversePageTokenOrder When set to Some(true), the function will list events from newest ones to oldest ones
+    * @param dereference whether include events of all referenced records including the records that might not directly related to selected records
     * @return EventsPage containing events that meet the specified requirements
     */
   def getEvents(
+      tenantId: TenantId,
+      authDecision: AuthDecision,
       pageToken: Option[Long] = None,
       start: Option[Int] = None,
       limit: Option[Int] = None,
@@ -154,10 +167,12 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       recordId: Option[String] = None,
       aspectIds: Set[String] = Set(),
       eventTypes: Set[EventType] = Set(),
-      tenantId: TenantId,
-      reversePageTokenOrder: Option[Boolean] = None
+      reversePageTokenOrder: Option[Boolean] = None,
+      dereference: Option[Boolean] = None
   )(implicit session: DBSession): EventsPage = {
     getEventsWithRecordSelector(
+      tenantId = tenantId,
+      authDecision = authDecision,
       pageToken = pageToken,
       start = start,
       limit = limit,
@@ -165,12 +180,14 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       recordId = recordId,
       aspectIds = aspectIds,
       eventTypes = eventTypes,
-      tenantId = tenantId,
-      reversePageTokenOrder = reversePageTokenOrder
+      reversePageTokenOrder = reversePageTokenOrder,
+      dereference = dereference
     )
   }
 
   private def getEventsWithRecordSelector(
+      tenantId: TenantId,
+      authDecision: AuthDecision,
       pageToken: Option[Long] = None,
       start: Option[Int] = None,
       limit: Option[Int] = None,
@@ -178,10 +195,10 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       recordId: Option[String] = None,
       aspectIds: Set[String] = Set(),
       eventTypes: Set[EventType] = Set(),
-      tenantId: TenantId,
       recordSelector: Iterable[Option[SQLSyntax]] = Iterable(),
       maxLimit: Option[Int] = None,
-      reversePageTokenOrder: Option[Boolean] = None
+      reversePageTokenOrder: Option[Boolean] = None,
+      dereference: Option[Boolean] = None
   )(implicit session: DBSession): EventsPage = {
 
     val filters: Seq[Option[SQLSyntax]] = Seq(
@@ -195,7 +212,14 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
     ) ++ recordSelector
 
     val tenantFilter = SQLUtils.tenantIdToWhereClause(tenantId, "tenantid")
-    val theFilters = (filters ++ List(tenantFilter)).filter(_.isDefined)
+    val authDecisionCondition = authDecision.toSql(
+      AspectQueryToSqlConfig(
+        prefixes = Set("input.object.event"),
+        genericQuery = true
+      )
+    )
+    val theFilters =
+      (filters ++ List(tenantFilter, authDecisionCondition)).filter(_.isDefined)
 
     val eventTypesFilter =
       if (eventTypes.isEmpty) sqls"true"
@@ -211,19 +235,23 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
       Logic below (`dereferenceSelectors`) is to include all events of ANY records that are referenced by any records in one of their aspects.
       e.g. a distribution record might be referenced by a dataset record in 'dataset-distributions' aspect
      */
-    val linkAspects = recordPersistence.buildReferenceMap(aspectIds)
     val dereferenceSelectors: Set[SQLSyntax] =
-      linkAspects.toSet[(String, PropertyWithLink)].map {
-        case (aspectId, propertyWithLink) =>
-          if (propertyWithLink.isArray) {
-            sqls"""EXISTS (select 1 from RecordAspects
+      if (dereference.getOrElse(false)) {
+        val linkAspects = recordPersistence.buildReferenceMap(aspectIds)
+        linkAspects.toSet[(String, PropertyWithLink)].map {
+          case (aspectId, propertyWithLink) =>
+            if (propertyWithLink.isArray) {
+              sqls"""EXISTS (select 1 from RecordAspects
                          where aspectId = $aspectId AND
                          (RecordAspects.data->${propertyWithLink.propertyName})::jsonb @> (Events.data->'recordId')::jsonb)"""
-          } else {
-            sqls"""EXISTS (select 1 from RecordAspects
+            } else {
+              sqls"""EXISTS (select 1 from RecordAspects
                          where aspectId = $aspectId AND
                          RecordAspects.data->>${propertyWithLink.propertyName} = Events.data->>'recordId')"""
-          }
+            }
+        }
+      } else {
+        Set()
       }
 
     val aspectsSql =
@@ -432,11 +460,11 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
   def getEventsWithDereference(
       tenantId: TenantId,
       authDecision: AuthDecision,
-      recordId: String,
       pageToken: Option[Long] = None,
       start: Option[Int] = None,
       limit: Option[Int] = None,
       lastEventId: Option[Long] = None,
+      recordId: String,
       aspectIds: Set[String] = Set(),
       eventTypes: Set[EventType] = Set(),
       reversePageTokenOrder: Option[Boolean] = None
@@ -470,12 +498,13 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
     }
 
     getEventsWithRecordSelector(
+      tenantId = tenantId,
+      authDecision = authDecision,
       aspectIds = Set(),
       recordId = None,
       pageToken = pageToken,
       start = start,
       limit = limit,
-      tenantId = tenantId,
       recordSelector = Seq(
         Some(
           SQLSyntax.in(

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventPersistence.scala
@@ -234,6 +234,7 @@ class DefaultEventPersistence(recordPersistence: RecordPersistence)
     /*
       Logic below (`dereferenceSelectors`) is to include all events of ANY records that are referenced by any records in one of their aspects.
       e.g. a distribution record might be referenced by a dataset record in 'dataset-distributions' aspect
+      we should avoid using deference feature for any webhook implementation (e.g. minions) in future and eventually remove this feature completely for simpler (and more robust) design / protocol.
      */
     val dereferenceSelectors: Set[SQLSyntax] =
       if (dereference.getOrElse(false)) {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
@@ -268,14 +268,10 @@ object HookPersistence extends Protocols with DiffsonProtocol {
       acknowledgement: WebHookAcknowledgement
   )(implicit session: DBSession): Try[WebHookAcknowledgementResponse] = {
     Try {
-      val setActive = acknowledgement.active match {
-        case Some(active) =>
-          if (active) {
-            sqls", active=${active}, lastretrytime=null, retrycount=0"
-          } else {
-            sqls", active=${active}"
-          }
-        case None => sqls""
+      val setActive = acknowledgement.active.getOrElse(true) match {
+        case true =>
+          sqls", active=true, lastretrytime=null, retrycount=0"
+        case false => sqls", active=false"
       }
 
       if (acknowledgement.succeeded) {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
@@ -280,11 +280,17 @@ object HookPersistence extends Protocols with DiffsonProtocol {
       acknowledgement: WebHookAcknowledgement
   )(implicit session: DBSession): Try[WebHookAcknowledgementResponse] = {
     Try {
-      val setActive = acknowledgement.active.getOrElse(true) match {
-        case true =>
-          sqls", active=true, lastretrytime=null, retrycount=0"
-        case false => sqls", active=false"
-      }
+      val setActive =
+        (if (acknowledgement.active.isEmpty && acknowledgement.succeeded) {
+           Some(true)
+         } else {
+           acknowledgement.active
+         }) match {
+          case Some(true) =>
+            sqls", active=true, lastretrytime=null, retrycount=0"
+          case Some(false) => sqls", active=false"
+          case None        => sqls""
+        }
 
       if (acknowledgement.succeeded) {
         acknowledgement.lastEventIdReceived match {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HookPersistence.scala
@@ -269,8 +269,13 @@ object HookPersistence extends Protocols with DiffsonProtocol {
   )(implicit session: DBSession): Try[WebHookAcknowledgementResponse] = {
     Try {
       val setActive = acknowledgement.active match {
-        case Some(active) => sqls", active=${active}"
-        case None         => sqls""
+        case Some(active) =>
+          if (active) {
+            sqls", active=${active}, lastretrytime=null, retrycount=0"
+          } else {
+            sqls", active=${active}"
+          }
+        case None => sqls""
       }
 
       if (acknowledgement.succeeded) {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -762,7 +762,7 @@ class HooksService(
     *   `Webhook Notification Recipient` normally only want to set this field when the previous processing was failed and want registry pause the notification delivery for a while.
     *   Please note: an inactive web hook will be waken up after certain amount of time (By default: 1 hour). This can be configured by registry `webhooks.retryInterval` option.
     *   When the parameter is `true`, the registry will: 1> set webhook to active (if not active already) 2> clear all running statics (e.g. `retrycount`)
-    *   However, registry will not attempt to enable the webhook if it's disabled in database previously.
+    *   However, registry will not attempt to enable the webhook if it's disabled (`enable`=false) in database previously.
     *   The default value of this field is `true`.
     *
     * @apiParamExample {json} Successful Acknowledgement Request Body Example

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -763,7 +763,7 @@ class HooksService(
     *   Please note: an inactive web hook will be waken up after certain amount of time (By default: 1 hour). This can be configured by registry `webhooks.retryInterval` option.
     *   When the parameter is `true`, the registry will: 1> set webhook to active (if not active already) 2> clear all running statics (e.g. `retrycount`)
     *   However, registry will not attempt to enable the webhook if it's disabled (`enable`=false) in database previously.
-    *   The default value of this field is `true`.
+    *   When `succeeded`=`true`, we will assume the value of `active` is true` when it's not specified.
     *
     * @apiParamExample {json} Successful Acknowledgement Request Body Example
     *  {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -761,6 +761,9 @@ class HooksService(
     * @apiParam (Request Body JSON) {Boolean} [active] Should the status of webhook be changed to `active` or `inactive`.
     *   `Webhook Notification Recipient` normally only want to set this field when the previous processing was failed and want registry pause the notification delivery for a while.
     *   Please note: an inactive web hook will be waken up after certain amount of time (By default: 1 hour). This can be configured by registry `webhooks.retryInterval` option.
+    *   When the parameter is `true`, the registry will: 1> set webhook to active (if not active already) 2> clear all running statics (e.g. `retrycount`)
+    *   However, registry will not attempt to enable the webhook if it's disabled in database previously.
+    *   The default value of this field is `true`.
     *
     * @apiParamExample {json} Successful Acknowledgement Request Body Example
     *  {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -257,17 +257,17 @@ class HooksService(
     *   according to the aspects list provided here in the webhook notification payload.
     * @apiParam (Request Body JSON) {String[]} [config.optionalAspects] When `includeRecords` = `true`, registry will also include additional (optional) aspect data in the relevant record data
     *   in the webhook notification payload.
-    * @apiParam (Request Body JSON) {Number[]} eventTypes specify a list of event types that the webhook's interested in. Possible values are:
+    * @apiParam (Request Body JSON) {String[]} eventTypes specify a list of event types that the webhook's interested in. Possible values are:
     *   <ul>
-    *     <li>`0`: "CreateRecord"</li>
-    *     <li>`1`: "CreateAspectDefinition"</li>
-    *     <li>`2`: "CreateRecordAspect"</li>
-    *     <li>`3`: "PatchRecord"</li>
-    *     <li>`4`: "PatchAspectDefinition"</li>
-    *     <li>`5`: "PatchRecordAspect"</li>
-    *     <li>`6`: "DeleteRecord"</li>
-    *     <li>`7`: "DeleteAspectDefinition"</li>
-    *     <li>`8`: "DeleteRecordAspect"</li>
+    *     <li>"CreateRecord"</li>
+    *     <li>"CreateAspectDefinition"</li>
+    *     <li>"CreateRecordAspect"</li>
+    *     <li>"PatchRecord"</li>
+    *     <li>"PatchAspectDefinition"</li>
+    *     <li>"PatchRecordAspect"</li>
+    *     <li>"DeleteRecord"</li>
+    *     <li>"DeleteAspectDefinition"</li>
+    *     <li>"DeleteRecordAspect"</li>
     *   </ul>
     *   If you are not interested in the raw events in the webhook notification payload (e.g. you set `webhook.config.includeEvents`=`false` to turn it off), you can supply empty array [] here.
     *
@@ -278,7 +278,7 @@ class HooksService(
     *    "active": true,
     *    "url": "string",
     *    "eventTypes": [
-    *      0
+    *      "PatchRecordAspect"
     *    ],
     *    "config": {
     *      "aspects": [
@@ -518,17 +518,17 @@ class HooksService(
     *   according to the aspects list provided here in the webhook notification payload.
     * @apiParam (Request Body JSON) {String[]} [config.optionalAspects] When `includeRecords` = `true`, registry will also include additional (optional) aspect data in the relevant record data
     *   in the webhook notification payload.
-    * @apiParam (Request Body JSON) {Number[]} eventTypes specify a list of event types that the webhook's interested in. Possible values are:
+    * @apiParam (Request Body JSON) {String[]} eventTypes specify a list of event types that the webhook's interested in. Possible values are:
     *   <ul>
-    *     <li>`0`: "CreateRecord"</li>
-    *     <li>`1`: "CreateAspectDefinition"</li>
-    *     <li>`2`: "CreateRecordAspect"</li>
-    *     <li>`3`: "PatchRecord"</li>
-    *     <li>`4`: "PatchAspectDefinition"</li>
-    *     <li>`5`: "PatchRecordAspect"</li>
-    *     <li>`6`: "DeleteRecord"</li>
-    *     <li>`7`: "DeleteAspectDefinition"</li>
-    *     <li>`8`: "DeleteRecordAspect"</li>
+    *     <li>"CreateRecord"</li>
+    *     <li>"CreateAspectDefinition"</li>
+    *     <li>"CreateRecordAspect"</li>
+    *     <li>"PatchRecord"</li>
+    *     <li>"PatchAspectDefinition"</li>
+    *     <li>"PatchRecordAspect"</li>
+    *     <li>"DeleteRecord"</li>
+    *     <li>"DeleteAspectDefinition"</li>
+    *     <li>"DeleteRecordAspect"</li>
     *   </ul>
     *   If you are not interested in the raw events in the webhook notification payload (e.g. you set `webhook.config.includeEvents`=`false` to turn it off), you can supply empty array [] here.
     *
@@ -539,7 +539,7 @@ class HooksService(
     *    "active": true,
     *    "url": "string",
     *    "eventTypes": [
-    *      0
+    *      "PatchRecordAspect"
     *    ],
     *    "config": {
     *      "aspects": [

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -189,21 +189,22 @@ class RecordHistoryService(
                       tenantId = tenantId,
                       // we have checked the permission so passing `UnconditionalTrueDecision` here
                       authDecision = UnconditionalTrueDecision,
-                      recordId = id,
                       pageToken = pageToken,
                       start = start,
                       limit = limit,
+                      recordId = id,
                       aspectIds = aspectIdSet,
                       reversePageTokenOrder = reversePageTokenOrder
                     )
                   } else {
                     eventPersistence.getEvents(
-                      aspectIds = aspectIdSet,
-                      recordId = Some(id),
+                      tenantId = tenantId,
+                      authDecision = UnconditionalTrueDecision,
                       pageToken = pageToken,
                       start = start,
                       limit = limit,
-                      tenantId = tenantId,
+                      recordId = Some(id),
+                      aspectIds = aspectIdSet,
                       reversePageTokenOrder = reversePageTokenOrder
                     )
                   }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -518,6 +518,21 @@ class DefaultRecordPersistence(config: Config)
       )
   }
 
+  /**
+    * Given a list of record ids (`ids`) return any records that have an aspect (e.g. `dataset-distributions`) references any of the record ids (`ids`).
+    * The aspect that we found a matched record id must be one of aspect supplied in either `aspectIds` or `optionalAspectIds`.
+    * Before return the records as the result, we should also filter out any records whose id matches one of id in `idsToExclude` parameter (if supplied)
+    *
+    * @param tenantId
+    * @param authDecision
+    * @param ids
+    * @param idsToExclude
+    * @param aspectIds
+    * @param optionalAspectIds
+    * @param dereference
+    * @param session
+    * @return
+    */
   def getRecordsLinkingToRecordIds(
       tenantId: TenantId,
       authDecision: AuthDecision,
@@ -548,7 +563,7 @@ class DefaultRecordPersistence(config: Config)
                         "recordaspects.tenantid"
                       ),
                     Some(
-                      sqls"((data->${propertyWithLink.propertyName})::jsonb ?| ARRAY[$ids])"
+                      sqls"((data->${propertyWithLink.propertyName})::jsonb ${sqls"??|"} ARRAY[$ids])"
                     )
                   )
                 )
@@ -566,7 +581,7 @@ class DefaultRecordPersistence(config: Config)
                         "recordaspects.tenantid"
                       ),
                     Some(
-                      sqls"(data->>${propertyWithLink.propertyName} = $ids)"
+                      sqls"(data->>${propertyWithLink.propertyName} IN ($ids))"
                     )
                   )
                 )

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
@@ -499,7 +499,7 @@ object WebHookActor {
                   aspectIds =
                     (webHook.config.aspects ++ webHook.config.optionalAspects).flatten.toSet,
                   eventTypes = webHook.eventTypes,
-                  dereference = Some(true)
+                  dereference = webHook.config.dereference
                 )
               }
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
@@ -492,14 +492,14 @@ object WebHookActor {
             } else {
               val eventPage = DB readOnly { implicit session =>
                 eventPersistence.getEvents(
-                  webHook.lastEvent,
-                  None,
-                  Some(config.getInt("webhooks.eventPageSize")),
-                  None,
-                  None,
-                  (webHook.config.aspects ++ webHook.config.optionalAspects).flatten.toSet,
-                  webHook.eventTypes,
-                  AllTenantsId
+                  tenantId = AllTenantsId,
+                  authDecision = UnconditionalTrueDecision,
+                  pageToken = webHook.lastEvent,
+                  limit = Some(config.getInt("webhooks.eventPageSize")),
+                  aspectIds =
+                    (webHook.config.aspects ++ webHook.config.optionalAspects).flatten.toSet,
+                  eventTypes = webHook.eventTypes,
+                  dereference = Some(true)
                 )
               }
 

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -2438,6 +2438,29 @@ class WebHookProcessingSpec
             val hook = responseAs[WebHook]
             hook.active shouldEqual false
           }
+
+          // will re-process event with ID of 2 as the hook will be set to active
+          // We will assume active = true when succeeded=true & active not specified
+          Post(
+            "/v0/hooks/test/ack",
+            WebHookAcknowledgement(
+              succeeded = true,
+              lastEventIdReceived = Some(1)
+            )
+          ) ~> addUserId() ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          Util.waitUntilAllDone()
+          payloads.length shouldEqual 1
+
+          Get("/v0/hooks/test") ~> param
+            .api(Full)
+            .routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val hook = responseAs[WebHook]
+            hook.active shouldEqual true
+          }
         }
       }
 

--- a/magda-registry-aspects/access-group-details.schema.json
+++ b/magda-registry-aspects/access-group-details.schema.json
@@ -45,6 +45,16 @@
             "minLength": 36,
             "maxLength": 36
         },
+        "extraControlPermissionIds": {
+            "title": "Extra Access Group Record Control Permission ID",
+            "description": "A list of permissions that grant extra permissions to the group users. e.g. read only access to the access group record itself.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 36,
+                "maxLength": 36
+            }
+        },
         "roleId": {
             "title": "Access Group Role ID",
             "description": "The ID of the role record that is auto-created with the access-group creation. This role will be used to grant the access group permission (specified by `permissionId`) to all users who are added to this access group.",

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -2,18 +2,20 @@ akka {
     coordinated-shutdown {
         phases {
             service-unbind {
-                timeout = 30 s
+                timeout = 5 s
             }
             service-requests-done {
-                timeout = 30 s
+                timeout = 10 s
             }
         }
     }
 }
 
 http {
-    waitBeforeTermination = 5s
-    hardTerminationDeadline = 15s
+    # the two steps (`waitBeforeTermination` & `hardTerminationDeadline`) both happen with `service-requests-done` phrase
+    # Thus, total time of the two steps can't be longer than timeout of `service-requests-done` phase
+    waitBeforeTermination = 2s
+    hardTerminationDeadline = 8s
 }
 
 elasticSearch {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -352,8 +352,10 @@ function getInternalDatasetSourceAspectData() {
 
 function getAccessControlAspectData(state: State) {
     const { dataset, datasetPublishing } = state;
-    let orgUnitId: string | undefined;
-    if (
+    let orgUnitId: string | null | undefined = null;
+    if (datasetPublishing?.level === "organization") {
+        orgUnitId = null;
+    } else if (
         datasetPublishing?.level === "custodian" &&
         datasetPublishing?.custodianOrgUnitId
     ) {
@@ -376,8 +378,8 @@ function getAccessControlAspectData(state: State) {
             ? dataset.ownerId
             : dataset.editingUserId
             ? dataset.editingUserId
-            : undefined,
-        orgUnitId: orgUnitId ? orgUnitId : undefined
+            : null,
+        orgUnitId: orgUnitId ? orgUnitId : null
     };
 }
 

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddCommon.ts
@@ -184,6 +184,7 @@ export type Provenance = {
 
 export type DatasetPublishing = {
     state?: string;
+    hasEverPublished?: boolean;
     level?: string;
     custodianOrgUnitId?: string;
     managingOrgUnitId?: string;
@@ -342,7 +343,7 @@ type Access = {
 function getInternalDatasetSourceAspectData() {
     return {
         id: "magda",
-        name: "This Magda metadata creation tool",
+        name: "Magda metadata creation tool",
         type: "internal",
         url: config.baseExternalUrl
     };
@@ -736,6 +737,7 @@ export function createBlankState(user: User): State {
         datasetPublishing: {
             state: "draft",
             level: "custodian",
+            hasEverPublished: false,
             contactPointDisplay: "organization"
         },
         spatialCoverage: {

--- a/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/DatasetAddMetadataPage.tsx
@@ -382,7 +382,8 @@ class NewDataset extends React.Component<Props, State> {
                 isPublishing: true,
                 datasetPublishing: {
                     ...state.datasetPublishing,
-                    state: "published"
+                    state: "published",
+                    hasEverPublished: true
                 }
             }));
 
@@ -392,7 +393,8 @@ class NewDataset extends React.Component<Props, State> {
                     ...this.state,
                     datasetPublishing: {
                         ...this.state.datasetPublishing,
-                        state: "published"
+                        state: "published",
+                        hasEverPublished: true
                     }
                 },
                 this.setState.bind(this)

--- a/magda-web-client/src/Components/Dataset/Add/OrgUnitDropDown.scss
+++ b/magda-web-client/src/Components/Dataset/Add/OrgUnitDropDown.scss
@@ -18,6 +18,19 @@
         box-shadow: 0 0 0 1px #2684ff;
     }
 }
+.org-unit-drop-down-container {
+    .clear-button-container {
+        position: relative;
+        .clear-button {
+            position: absolute;
+            z-index: 99;
+            right: 40px;
+            top: 13px;
+            cursor: pointer;
+            color: #8e8e93;
+        }
+    }
+}
 .org-unit-drop-down.has-validation-error {
     .rs-picker-toggle {
         border-color: #d60000;

--- a/magda-web-client/src/Components/Dataset/Add/OrgUnitDropDown.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/OrgUnitDropDown.tsx
@@ -14,6 +14,7 @@ import { ItemDataType } from "rsuite/esm/@types/common";
 import { User } from "reducers/userManagementReducer";
 import ServerError from "@magda/typescript-common/dist/ServerError";
 import { useValidation, onInputFocusOut } from "./ValidationManager";
+import { MdOutlineClear } from "react-icons/md";
 import "./OrgUnitDropDown.scss";
 
 interface ItemType extends ItemDataType {
@@ -32,6 +33,7 @@ interface PropsType {
     onChange: (orgUnitId?: string) => void;
     validationFieldPath?: string;
     validationFieldLabel?: string;
+    cleanable?: boolean;
 }
 
 const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
@@ -41,6 +43,8 @@ const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
         validationFieldPath,
         validationFieldLabel
     } = props;
+    const cleanable =
+        typeof props.cleanable === "boolean" ? props.cleanable : true;
     const [
         isValidationError,
         validationErrorMessage,
@@ -52,6 +56,7 @@ const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
     const userData = useSelector<any, User>(
         (state) => state?.userManagement?.user
     );
+    const [hasSelected, setHasSelected] = useState<boolean>(false);
     const [data, setData] = useState<ItemType[]>([]);
     const { result, loading, error, execute } = useAsync(async () => {
         try {
@@ -112,7 +117,10 @@ const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
         );
     } else {
         return (
-            <div ref={validationCtlRef}>
+            <div
+                className="org-unit-drop-down-container"
+                ref={validationCtlRef}
+            >
                 {isValidationError ? (
                     <div>
                         <span className="au-error-text">
@@ -120,6 +128,17 @@ const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
                         </span>
                     </div>
                 ) : null}
+                {hasSelected || !orgUnitId || !cleanable ? null : (
+                    <div className="clear-button-container">
+                        <MdOutlineClear
+                            className="clear-button"
+                            onClick={() => {
+                                onChangeCallback(undefined);
+                                onInputFocusOut(validationFieldPath);
+                            }}
+                        />
+                    </div>
+                )}
                 <TreePicker
                     className={`org-unit-drop-down ${
                         isValidationError ? "has-validation-error" : ""
@@ -137,10 +156,11 @@ const OrgUnitDropDown: FunctionComponent<PropsType> = (props) => {
                             : "Please Select"
                     }
                     onSelect={(activeNode, value, event) => {
+                        setHasSelected(true);
                         onChangeCallback(value as string);
                         onInputFocusOut(validationFieldPath);
                     }}
-                    cleanable={true}
+                    cleanable={cleanable}
                     onClean={() => {
                         onChangeCallback(undefined);
                         onInputFocusOut(validationFieldPath);

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/DatasetAccessSettings.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/DatasetAccessSettings.tsx
@@ -100,7 +100,9 @@ const DatasetAccessSettings: FunctionComponent<PropsType> = (props) => {
         return (
             <div className="question-who-can-see-dataset">
                 <h4 className="with-icon">
-                    <span>Who can see the dataset once it is published?</span>
+                    <span>
+                        Who can see the dataset once it is published? (*)
+                    </span>
                 </h4>
                 <div className="input-area">
                     <ToolTip>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/DatasetOwnerSection.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddAccessAndUsePage/DatasetOwnerSection.tsx
@@ -93,7 +93,7 @@ const DatasetOwnerSection: FunctionComponent<PropsType> = (props) => {
             ) : (
                 <>
                     <h4 className="with-icon">
-                        <span>Who is the dataset owner?</span>
+                        <span>Who is the dataset owner? (*)</span>
                     </h4>
                     <div className="input-area">
                         <ToolTip>
@@ -107,6 +107,7 @@ const DatasetOwnerSection: FunctionComponent<PropsType> = (props) => {
                             </Message>
                         ) : (
                             <SelectPicker
+                                cleanable={false}
                                 placeholder={placeholderText}
                                 disabled={shouldDisabled}
                                 onChange={props.onChange}

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPage.scss
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPage.scss
@@ -18,6 +18,15 @@
 .end-preview-page-2 {
     text-align: center;
     padding-top: 1rem;
+    .data-management-image-icon {
+        font-size: 50px;
+        position: absolute;
+        left: 40px;
+    }
+    .button-text {
+        text-decoration: none;
+        font-size: 22px;
+    }
 }
 
 .draft-image-icon {

--- a/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/DatasetAddEndPage.tsx
@@ -1,13 +1,11 @@
-import "./DatasetAddEndPage.scss";
-
 import React from "react";
-import { Link } from "react-router-dom";
 
+import { useHistory } from "react-router-dom";
 import giantTickIcon from "assets/giant-tick.svg";
 import draftIcon from "assets/format-active.svg";
-import printIcon from "assets/print.svg";
+import { BsServer } from "react-icons/bs";
 
-import CommonLink from "Components/Common/CommonLink";
+import "./DatasetAddEndPage.scss";
 
 type Props = {
     datasetId: string;
@@ -21,11 +19,12 @@ export default function DatasetAddEndPage(props: Props) {
     const { datasetId, publishStatus } = props;
     const datasetPage = "/dataset/" + datasetId + "/details";
     const isEdit = typeof props?.isEdit === "undefined" ? false : props.isEdit;
+    const history = useHistory();
     let viewDatasetText;
     if (publishStatus === "draft") {
-        viewDatasetText = "View your dataset";
+        viewDatasetText = "Dataset Page";
     } else {
-        viewDatasetText = "View your dataset";
+        viewDatasetText = "Dataset Page";
     }
 
     let allDoneText: string;
@@ -47,46 +46,44 @@ export default function DatasetAddEndPage(props: Props) {
                 </div>
                 <div className="end-preview-container-2">
                     <h2 className="end-preview-subheading">{allDoneText}</h2>
-                    <p className="dataset-status-txt">
-                        You can view the status of your datasets from{" "}
-                        <CommonLink
-                            href={`/settings/datasets/${
-                                publishStatus === "published"
-                                    ? "published"
-                                    : "draft"
-                            }`}
-                        >
-                            "datasets management"
-                        </CommonLink>
-                        .
-                    </p>
                 </div>
             </div>
             <div className="col-sm-12 end-preview-page-2">
                 <div>
-                    <Link to={datasetPage}>
-                        <div className="au-btn next-button end-preview-button draft-dataset-btn">
-                            <img
-                                className="draft-image-icon"
-                                src={draftIcon}
-                                alt="dataset icon"
-                            />
-                            <span className="draft-dataset-txt">
-                                {" "}
-                                {viewDatasetText}{" "}
-                            </span>
-                        </div>
-                    </Link>
+                    <div
+                        className="au-btn next-button end-preview-button data-management-btn"
+                        onClick={() => {
+                            history.push(
+                                `/settings/datasets/${
+                                    publishStatus === "published"
+                                        ? "published"
+                                        : "draft"
+                                }`
+                            );
+                        }}
+                    >
+                        <BsServer
+                            className="data-management-image-icon"
+                            title="Go to data management"
+                        />
+                        <span className="button-text">
+                            {" "}
+                            {"Data Management"}{" "}
+                        </span>
+                    </div>
                 </div>
                 <div>
-                    <Link to={datasetPage + "?print=true"}>
-                        <div className="au-btn next-button end-preview-button print-metadata-btn">
-                            <img className="print-icon" src={printIcon} />
-                            <span className="print-metadata-txt">
-                                Print a copy of your metadata
-                            </span>
-                        </div>
-                    </Link>
+                    <div
+                        className="au-btn next-button end-preview-button draft-dataset-btn"
+                        onClick={() => history.push(datasetPage)}
+                    >
+                        <img
+                            className="draft-image-icon"
+                            src={draftIcon}
+                            alt="Go to dataset page"
+                        />
+                        <span className="button-text"> {viewDatasetText} </span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/DatasetAddPeoplePage.tsx
@@ -17,7 +17,7 @@ import OrgUnitDropDown from "../../OrgUnitDropDown";
 import YesNoReveal from "../../YesNoReveal";
 
 import ValidationRequiredLabel from "../../ValidationRequiredLabel";
-
+import { shouldValidate } from "../../ValidationManager";
 import ToolTip from "Components/Dataset/Add/ToolTip";
 
 import "./DatasetAddPeoplePage.scss";
@@ -80,6 +80,11 @@ export default function DatasetAddPeoplePage({
                             onChange={editPublishing("custodianOrgUnitId")}
                             validationFieldPath="$.datasetPublishing.custodianOrgUnitId"
                             validationFieldLabel="Data Custodian"
+                            cleanable={
+                                !shouldValidate(
+                                    "$.datasetPublishing.custodianOrgUnitId"
+                                )
+                            }
                         />
                     </div>
                 </div>
@@ -96,6 +101,11 @@ export default function DatasetAddPeoplePage({
                             onChange={editPublishing("managingOrgUnitId")}
                             validationFieldPath="$.datasetPublishing.managingOrgUnitId"
                             validationFieldLabel="Managing Team"
+                            isClearable={
+                                !shouldValidate(
+                                    "$.datasetPublishing.managingOrgUnitId"
+                                )
+                            }
                         />
                     </div>
                 </div>

--- a/magda-web-client/src/Components/Dataset/Add/Pages/People/OrgUnitDropdown.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/Pages/People/OrgUnitDropdown.tsx
@@ -16,9 +16,10 @@ import { onInputFocusOut, useValidation } from "../../ValidationManager";
 type Props = {
     orgUnitId?: string;
     custodianOrgUnitId?: string;
-    onChange: (orgUnitId: string) => void;
+    onChange: (orgUnitId?: string) => void;
     validationFieldPath?: string;
     validationFieldLabel?: string;
+    isClearable?: boolean;
 };
 
 const getOrgUnitName = async (id?: string) => {
@@ -45,7 +46,8 @@ const OrgUnitDropdown: FunctionComponent<Props> = (props) => {
         custodianOrgUnitId,
         onChange: onChangeCallback,
         validationFieldPath,
-        validationFieldLabel
+        validationFieldLabel,
+        isClearable
     } = props;
     const [
         isValidationError,
@@ -135,6 +137,9 @@ const OrgUnitDropdown: FunctionComponent<Props> = (props) => {
                     className="react-select"
                     isMulti={false}
                     isSearchable={true}
+                    isClearable={
+                        typeof isClearable === "boolean" ? isClearable : true
+                    }
                     onChange={(rawValue, action) => {
                         const value = rawValue as
                             | { value: string }
@@ -142,6 +147,9 @@ const OrgUnitDropdown: FunctionComponent<Props> = (props) => {
                             | null;
                         if (value) {
                             onChangeCallback(value.value);
+                            onInputFocusOut(validationFieldPath);
+                        } else if (value === null) {
+                            onChangeCallback(undefined);
                             onInputFocusOut(validationFieldPath);
                         }
                     }}

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { RouterProps, withRouter } from "react-router-dom";
+import { RouteChildrenProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 
 import { loadState, State } from "./DatasetAddCommon";
@@ -15,7 +15,7 @@ const Paragraph = Placeholder.Paragraph;
 
 /* eslint-disable react-hooks/rules-of-hooks */
 
-type Props = { initialState: State; user: User } & RouterProps;
+type Props = { initialState: State; user: User } & RouteChildrenProps<any>;
 
 function mapStateToProps(state: any) {
     return {
@@ -59,9 +59,13 @@ const loadingArea = (
     </>
 );
 
-export default <T extends Props>(Component: React.ComponentType<T>) => {
-    const withAddDatasetState = (props: T) => {
+const withAddDatasetState = <T extends Props>(
+    Component: React.ComponentType<T>
+) => {
+    const WithAddDatasetStateComp = (props: T) => {
         const missingOperations = hasMetaDataCreationToolAccess(props.user);
+        const datasetId = props?.match?.params?.datasetId;
+        const userId = props?.user?.id;
         const isDisabled =
             !config.featureFlags.previewAddDataset && missingOperations?.length;
 
@@ -75,7 +79,7 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
                 const datasetState = await loadState(datasetId, user);
                 updateData(datasetState);
             },
-            [isDisabled, (props as any).match.params.datasetId, props.user]
+            [isDisabled, datasetId, userId]
         );
 
         if ((props as any).isFetchingWhoAmI) {
@@ -106,7 +110,9 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
         }
     };
 
-    return connect(mapStateToProps)(withRouter(withAddDatasetState as any));
+    return connect(mapStateToProps)(withRouter(WithAddDatasetStateComp as any));
 };
+
+export default withAddDatasetState;
 
 /* eslint-enable react-hooks/rules-of-hooks */

--- a/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Add/withAddDatasetState.tsx
@@ -66,20 +66,25 @@ const withAddDatasetState = <T extends Props>(
         const missingOperations = hasMetaDataCreationToolAccess(props.user);
         const datasetId = props?.match?.params?.datasetId;
         const userId = props?.user?.id;
+        const orgUnitId = props?.user?.orgUnitId;
         const isDisabled =
             !config.featureFlags.previewAddDataset && missingOperations?.length;
 
         const [state, updateData] = useState<State | undefined>(undefined);
         const { loading, error } = useAsync(
-            async (isDisabled, datasetId, user) => {
+            async (isDisabled, datasetId, userId, orgUnitId) => {
                 if (isDisabled || !datasetId) {
                     return;
                 }
+                const user: any = {
+                    id: userId,
+                    orgUnitId
+                };
                 resetFileUploadMarkers();
                 const datasetState = await loadState(datasetId, user);
                 updateData(datasetState);
             },
-            [isDisabled, datasetId, userId]
+            [isDisabled, datasetId, userId, orgUnitId]
         );
 
         if ((props as any).isFetchingWhoAmI) {

--- a/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
@@ -70,14 +70,19 @@ const withEditDatasetState = <T extends Props>(
         const missingOperations = hasMetaDataCreationToolAccess(props.user);
         const datasetId = props?.match?.params?.datasetId;
         const userId = props?.user?.id;
+        const orgUnitId = props?.user?.orgUnitId;
         const isDisabled =
             !config.featureFlags.previewAddDataset && missingOperations?.length;
 
         const { loading, error } = useAsync(
-            async (isDisabled, datasetId, user) => {
+            async (isDisabled, datasetId, userId, orgUnitId) => {
                 if (isDisabled || !datasetId) {
                     return;
                 }
+                const user: any = {
+                    id: userId,
+                    orgUnitId
+                };
                 resetFileUploadMarkers();
                 // --- turn off cache
                 // --- edit flow will also save draft after file is uploaded to storage api
@@ -91,7 +96,7 @@ const withEditDatasetState = <T extends Props>(
 
                 updateData(loadedStateData);
             },
-            [isDisabled, datasetId, userId]
+            [isDisabled, datasetId, userId, orgUnitId]
         );
 
         if ((props as any).isFetchingWhoAmI) {

--- a/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
+++ b/magda-web-client/src/Components/Dataset/Edit/withEditDatasetState.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { RouterProps, withRouter } from "react-router-dom";
+import { RouteChildrenProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { useAsync } from "react-async-hook";
 import { State, rawDatasetDataToState } from "../Add/DatasetAddCommon";
@@ -18,7 +18,7 @@ import { resetFileUploadMarkers } from "../Add/Pages/AddFiles/uploadFile";
 const Paragraph = Placeholder.Paragraph;
 
 /* eslint-disable react-hooks/rules-of-hooks */
-type Props = { initialState: State; user: User } & RouterProps;
+type Props = { initialState: State; user: User } & RouteChildrenProps<any>;
 
 function mapStateToProps(state: any) {
     return {
@@ -62,10 +62,14 @@ const loadingArea = (
     </>
 );
 
-export default <T extends Props>(Component: React.ComponentType<T>) => {
-    const withEditDatasetState = (props: T) => {
+const withEditDatasetState = <T extends Props>(
+    Component: React.ComponentType<T>
+) => {
+    const withEditDatasetStateComp = (props: T) => {
         const [state, updateData] = useState<State | undefined>(undefined);
         const missingOperations = hasMetaDataCreationToolAccess(props.user);
+        const datasetId = props?.match?.params?.datasetId;
+        const userId = props?.user?.id;
         const isDisabled =
             !config.featureFlags.previewAddDataset && missingOperations?.length;
 
@@ -87,7 +91,7 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
 
                 updateData(loadedStateData);
             },
-            [isDisabled, (props as any).match.params.datasetId, props.user]
+            [isDisabled, datasetId, userId]
         );
 
         if ((props as any).isFetchingWhoAmI) {
@@ -118,7 +122,9 @@ export default <T extends Props>(Component: React.ComponentType<T>) => {
         }
     };
 
-    return connect(mapStateToProps)(withRouter(withEditDatasetState as any));
+    return connect(mapStateToProps)(
+        withRouter(withEditDatasetStateComp as any)
+    );
 };
-
+export default withEditDatasetState;
 /* eslint-enable react-hooks/rules-of-hooks */

--- a/magda-web-client/src/Components/Dataset/View/DatasetPageDetails.js
+++ b/magda-web-client/src/Components/Dataset/View/DatasetPageDetails.js
@@ -8,6 +8,7 @@ import defined from "helpers/defined";
 import CommonLink from "Components/Common/CommonLink";
 import DiscourseComments from "Components/Dataset/View/DiscourseComments";
 import { config } from "../../../config";
+import MagdaNamespacesConsumer from "Components/i18n/MagdaNamespacesConsumer";
 import "./DatasetDetails.scss";
 import "./DatasetPageDetails.scss";
 
@@ -22,93 +23,109 @@ class DatasetPageDetails extends Component {
         const sourceName = this.props?.dataset?.sourceDetails?.originalName
             ? this.props.dataset.sourceDetails.originalName
             : this.props.dataset?.sourceDetails?.name;
-        const source = sourceName
-            ? `This dataset was originally found on ${
-                  dataset.landingPage
-                      ? `[${sourceName}](${dataset.landingPage})`
-                      : sourceName
-              } "${dataset.title}".${
-                  dataset.landingPage
-                      ? "\nPlease visit the source to access the original metadata of the dataset:"
-                      : ""
-              }`
-            : "";
+        const sourceId = this.props?.dataset?.sourceDetails?.id;
         return (
-            <div className="dataset-details">
-                <div className="dataset-preview">
-                    <DatasetPagePreview
-                        location={this.props.location}
-                        dataset={dataset}
-                    />
-                </div>
-
-                <div className="row">
-                    <div className="col-sm-12">
-                        <div className="dataset-details-files-apis">
-                            <h3 className="clearfix section-heading">
-                                <span className="section-heading">
-                                    Files and APIs
-                                </span>
-                            </h3>
-                            <div className="clearfix">
-                                {dataset.distributions.map((s) => (
-                                    <DistributionRow
-                                        key={s.identifier}
-                                        distribution={s}
-                                        dataset={dataset}
-                                        searchText={searchText}
-                                    />
-                                ))}
+            <MagdaNamespacesConsumer ns={["global"]}>
+                {(translate) => {
+                    const appName = translate(["appName", ""]);
+                    const source =
+                        sourceId === "magda"
+                            ? `This dataset was created internally by ${appName}.`
+                            : sourceName
+                            ? `This dataset was originally found on ${
+                                  dataset.landingPage
+                                      ? `[${sourceName}](${dataset.landingPage})`
+                                      : sourceName
+                              } "${dataset.title}".${
+                                  dataset.landingPage
+                                      ? "\nPlease visit the source to access the original metadata of the dataset:"
+                                      : ""
+                              }`
+                            : "";
+                    return (
+                        <div className="dataset-details">
+                            <div className="dataset-preview">
+                                <DatasetPagePreview
+                                    location={this.props.location}
+                                    dataset={dataset}
+                                />
                             </div>
-                        </div>
-                        {(source || dataset.provenance) && (
-                            <div className="dataset-details-source">
-                                <h3 className="section-heading">Data Source</h3>
-                                {source && (
-                                    <MarkdownViewer
-                                        markdown={source}
-                                        truncate={false}
-                                    />
-                                )}
-                                {dataset?.landingPage ? (
-                                    <CommonLink
-                                        className="landing-page"
-                                        href={dataset.landingPage}
-                                    >
-                                        {dataset.landingPage}
-                                    </CommonLink>
-                                ) : null}
 
-                                {defined(dataset.provenance) &&
-                                defined(dataset.provenance.isOpenData) ? (
-                                    <h3 className="section-heading">
-                                        Type:{" "}
-                                        {dataset.provenance.isOpenData
-                                            ? "Public"
-                                            : "Private"}
-                                    </h3>
-                                ) : null}
+                            <div className="row">
+                                <div className="col-sm-12">
+                                    <div className="dataset-details-files-apis">
+                                        <h3 className="clearfix section-heading">
+                                            <span className="section-heading">
+                                                Files and APIs
+                                            </span>
+                                        </h3>
+                                        <div className="clearfix">
+                                            {dataset.distributions.map((s) => (
+                                                <DistributionRow
+                                                    key={s.identifier}
+                                                    distribution={s}
+                                                    dataset={dataset}
+                                                    searchText={searchText}
+                                                />
+                                            ))}
+                                        </div>
+                                    </div>
+                                    {(source || dataset.provenance) && (
+                                        <div className="dataset-details-source">
+                                            <h3 className="section-heading">
+                                                Data Source
+                                            </h3>
+                                            {source && (
+                                                <MarkdownViewer
+                                                    markdown={source}
+                                                    truncate={false}
+                                                />
+                                            )}
+                                            {dataset?.landingPage ? (
+                                                <CommonLink
+                                                    className="landing-page"
+                                                    href={dataset.landingPage}
+                                                >
+                                                    {dataset.landingPage}
+                                                </CommonLink>
+                                            ) : null}
+
+                                            {defined(dataset.provenance) &&
+                                            defined(
+                                                dataset.provenance.isOpenData
+                                            ) ? (
+                                                <h3 className="section-heading">
+                                                    Type:{" "}
+                                                    {dataset.provenance
+                                                        .isOpenData
+                                                        ? "Public"
+                                                        : "Private"}
+                                                </h3>
+                                            ) : null}
+                                        </div>
+                                    )}
+                                </div>
                             </div>
-                        )}
-                    </div>
-                </div>
 
-                {config.discourseSiteUrl &&
-                config.discourseIntegrationDatasetPage ? (
-                    <div className="row">
-                        <div className="col-sm-12">
-                            <DiscourseComments
-                                title={
-                                    dataset?.title
-                                        ? dataset.title
-                                        : "Untitlted Dataset"
-                                }
-                                datasetId={dataset.identifier}
-                            />
+                            {config.discourseSiteUrl &&
+                            config.discourseIntegrationDatasetPage ? (
+                                <div className="row">
+                                    <div className="col-sm-12">
+                                        <DiscourseComments
+                                            title={
+                                                dataset?.title
+                                                    ? dataset.title
+                                                    : "Untitlted Dataset"
+                                            }
+                                            datasetId={dataset.identifier}
+                                        />
+                                    </div>
+                                </div>
+                            ) : null}
                         </div>
-                    </div>
-                ) : null}
-            </div>
+                    );
+                }}
+            </MagdaNamespacesConsumer>
         );
     }
 }

--- a/magda-web-client/src/Components/Settings/RegistryRecordAspectsPanel.tsx
+++ b/magda-web-client/src/Components/Settings/RegistryRecordAspectsPanel.tsx
@@ -30,7 +30,7 @@ const DEFAULT_MAX_PAGE_RECORD_NUMBER = 10;
 const RegistryRecordAspectsPanel: FunctionComponent<PropsType> = (props) => {
     const { recordId } = props;
     const [keyword, setKeyword] = useState<string>("");
-    const [page, setPage] = useState<number>(0);
+    const [page, setPage] = useState<number>(1);
 
     const recordAspectFormRef = useRef<RecordAspectFormPopUpRefType>(null);
 
@@ -38,7 +38,7 @@ const RegistryRecordAspectsPanel: FunctionComponent<PropsType> = (props) => {
     const [aspectReloadToken, setAspectReloadToken] = useState<string>("");
 
     const [limit, setLimit] = useState(DEFAULT_MAX_PAGE_RECORD_NUMBER);
-    const offset = page * limit;
+    const offset = (page - 1) * limit;
 
     const [searchInputText, setSearchInputText] = useState<string>("");
 

--- a/magda-web-client/src/Components/VisibleForUser.tsx
+++ b/magda-web-client/src/Components/VisibleForUser.tsx
@@ -1,0 +1,56 @@
+import React, { FunctionComponent, useMemo } from "react";
+import { useSelector } from "react-redux";
+import { User, UserManagementState } from "reducers/userManagementReducer";
+import { StateType } from "reducers/reducer";
+
+type CheckUserFuncType = (user: User) => boolean;
+
+type PropsType = {
+    checkUserFunc?: CheckUserFuncType;
+    /**
+     * ValidateUser will redirect users to the original landing url after the re-authentication.
+     * If you want to redirect them to a different url rather than the original landing url, you can supply the mapping here.
+     * The `key` of the object is the original landing url, the `value` is the new redirect url.
+     */
+    redirectMappings?: {
+        [from: string]: string;
+    };
+    children?: JSX.Element;
+};
+const defaultUserChecker = (user: User) => !!user?.id;
+
+const VisibleForUser: FunctionComponent<PropsType> = (props) => {
+    const checkUserFunc = props?.checkUserFunc
+        ? props.checkUserFunc
+        : defaultUserChecker;
+
+    const userMgtData = useSelector<StateType, UserManagementState>(
+        (state) => state.userManagement
+    );
+
+    const {
+        result: checkResult,
+        loading: isWhoAmILoading,
+        error: whoAmIError
+    } = useMemo(() => {
+        try {
+            const userData = userMgtData.user;
+            const result = checkUserFunc(userData);
+            return {
+                result,
+                loading: userMgtData.isFetchingWhoAmI,
+                error: userMgtData.whoAmIError
+            };
+        } catch (e) {
+            return { result: undefined, loading: false, error: e };
+        }
+    }, [userMgtData, checkUserFunc]);
+
+    if (isWhoAmILoading || whoAmIError || !checkResult) {
+        return null;
+    }
+
+    return props?.children ? props?.children : null;
+};
+
+export default VisibleForUser;

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -831,7 +831,7 @@ export type QueryRecordAspectsReturnValueType = RecordAspectRecord[] | string[];
 export async function queryRecordAspects<T = QueryRecordAspectsReturnValueType>(
     params: QueryRecordAspectsParams
 ): Promise<T> {
-    const { noCache, recordId, ...queryParams } = params
+    const { noCache, recordId, offset, ...queryParams } = params
         ? params
         : ({} as QueryRecordAspectsParams);
     if (!recordId?.trim()) {
@@ -843,7 +843,7 @@ export async function queryRecordAspects<T = QueryRecordAspectsReturnValueType>(
         getAbsoluteUrl(
             `records/${encodeURIComponent(recordId)}/aspects`,
             config.registryReadOnlyApiUrl,
-            queryParams
+            { ...queryParams, start: offset, offset: undefined }
         ),
         noCache
     );

--- a/magda-web-client/src/api-clients/RegistryApis.ts
+++ b/magda-web-client/src/api-clients/RegistryApis.ts
@@ -968,6 +968,20 @@ export async function updateAspectOfDatasetAndDistributions<T = any>(
     }
 
     const datasetDistributionIds = await getDistributionIds(datasetId);
+    return await updateRecordsAspect(
+        [datasetId, ...datasetDistributionIds],
+        aspectId,
+        aspectData,
+        merge
+    );
+}
+
+export async function updateRecordsAspect(
+    recordIds: string[],
+    aspectId: string,
+    aspectData: any,
+    merge: boolean = true
+): Promise<number[]> {
     const url = getAbsoluteUrl(
         `records/aspects/${encodeURIComponent(aspectId)}`,
         config.registryFullApiUrl,
@@ -975,7 +989,7 @@ export async function updateAspectOfDatasetAndDistributions<T = any>(
     );
 
     return await request<number[]>("PUT", url, {
-        recordIds: [datasetId, ...datasetDistributionIds],
+        recordIds,
         data: aspectData
     });
 }

--- a/scripts/generate-connector-jobs.js
+++ b/scripts/generate-connector-jobs.js
@@ -168,7 +168,7 @@ files.forEach(function (connectorConfigFile) {
     );
 
     const cron = {
-        apiVersion: "batch/v1beta1",
+        apiVersion: "batch/v1",
         kind: "CronJob",
         metadata: {
             name: "connector-" + basename


### PR DESCRIPTION
### What this PR does

Fixes: 
- #3406
- #3410
- Increase indexer default http request / idle timeout to 90s / 120s and make them configurable via the indexer helm chart
- `/registry/hooks/{id}/ack` endpoint will assume `active` field is `true` when `active` is not specified and `succeeded` = `true`.
- `/registry/hooks/{id}/ack` endpoint will reset webhook retryCount when `active` field is `true`.
- #3410 Allow additional webhook options to be configured via minion options
- Fix `PUT` `/v0/registry/hooks/{id}`: didn't update webhook registered eventTypes properly
- Update create / update webhook API document re: required eventType data type
- The resume webhook action on minion's starting up should set the webhook to `active` (and consequently, reset the retryCount)
- Upgrade magda-minion-visualization to 2.0.0
- Upgrade magda-ckan-connector to 2.0.0
- Related to #3355, upgrade API version of all CronJob in `magda-core` to batch/v1 (for k8s 1.25 support)
- Metadata Editor: avoid dataset editor UI refresh when refresh the user state data
- Metadata Editor: make all orgUnitDropDown controls clearable configurable
- Metadata Editor: make sure orgUnitDropDown controls are only clearable when they are not compulsory fields
- Fixed: Registry Record Aspect Panel UI pagination issue
- Metadata Editor: when publishing dataset for the first time, the `hasEverPublished` field should be set to `true`
- Metadata Editor: UI adjustments on dataset published message page
- #3394 Make sure scala pods can be gracefully terminated within 15 seconds

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
