### PR TITLE
Upgrade minion connector versions

### DIFF
--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -1,0 +1,46 @@
+name: set-version
+
+run-name: Set version ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Please input the new version number. e.g. `v2.0.0-alpha.0` with leading `v`"
+        required: true
+        type: string
+
+jobs:
+  log-the-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Version validation
+        env:
+          SELECTED_VERSION: ${{ inputs.version }}
+        run: |
+          SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+          [[ "${SELECTED_VERSION}" =~ $SEMVER_REGEX ]] || { echo "Invalid version number '$SELECTED_VERSION'. Should be e.g. 'v2.0.0-alpha.0' with leading 'v'." ; exit 1; }
+
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: "yarn"
+
+      - name: Install Utilities
+        run: yarn install
+
+      - name: Setup Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set version
+        env:
+          SELECTED_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION_NUM=$(echo ${SELECTED_VERSION} | cut -b 2-)
+          yarn set-version ${VERSION_NUM}
+          git push

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers
 - Upgraded indexer weekly reindexer trigger container to node14
 - Distribution page UI minor improvements: display file size (when available) & adjust margins between information blocks
+- Improve the error message for `false` unconditional decision.
 
 ## v2.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Upgrade default connectors & minions version (to v2.0.0)
 - Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers
 - Upgraded indexer weekly reindexer trigger container to node14
+- Distribution page UI minor improvements: display file size (when available) & adjust margins between information blocks
 
 ## v2.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Upgrade default connectors & minions version (to v2.0.0)
 - Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers
+- Upgraded indexer weekly reindexer trigger container to node14
 
 ## v2.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v2.2.0
 
 - Upgrade default connectors & minions version (to v2.0.0)
+- Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers
 
 ## v2.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v2.2.0
+## v2.1.2
 
 - Upgrade default connectors & minions version (to v2.0.0)
 - Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.2.0
+
+- Upgrade default connectors & minions version (to v2.0.0)
+
 ## v2.1.1
 
 - #3412 Metadata Editor: improve the default empty value handling for `access-control` aspect `orgUnitId` field

--- a/deploy/helm/internal-charts/indexer/README.md
+++ b/deploy/helm/internal-charts/indexer/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>= 1.21.0`
 | reindexJobImage.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexJobImage.pullSecrets | bool | `false` |  |
 | reindexJobImage.repository | string | `"docker.io"` |  |
-| reindexJobImage.tag | string | `"12-alpine"` |  |
+| reindexJobImage.tag | string | `"14-alpine"` |  |
 | resources.limits.cpu | string | `"250m"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"250Mi"` |  |

--- a/deploy/helm/internal-charts/indexer/values.yaml
+++ b/deploy/helm/internal-charts/indexer/values.yaml
@@ -8,7 +8,7 @@ image:
 reindexJobImage: 
   name: "node"
   repository: "docker.io"
-  tag: "12-alpine"
+  tag: "14-alpine"
   pullPolicy: IfNotPresent
   pullSecrets: false
 

--- a/deploy/helm/internal-charts/registry-api/templates/_helpers.tpl
+++ b/deploy/helm/internal-charts/registry-api/templates/_helpers.tpl
@@ -72,7 +72,7 @@ spec:
           httpGet:
             path: /v0/status/ready
             port: 6101
-          initialDelaySeconds: 10
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 10
 {{- end }}

--- a/deploy/helm/internal-charts/search-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/search-api/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           httpGet:
             path: /v0/status/ready
             port: 6102
-          initialDelaySeconds: 10
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 10
 {{- end }}

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -19,64 +19,19 @@ dependencies:
   version: 2.0.0
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-ckan-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0
-- name: magda-ckan-connector
-  repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-project-open-data-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-csw-connector
-  repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-- name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-csw-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
@@ -85,13 +40,58 @@ dependencies:
   version: 2.0.0
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-csw-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-csw-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-ckan-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-ckan-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-ckan-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-project-open-data-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
+- name: magda-csw-connector
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
@@ -100,15 +100,15 @@ dependencies:
   version: 2.0.0
 - name: magda-dap-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
-digest: sha256:32dbf1e8639d97a3d5c8407d05764e906ea0cc009256942edb56ae47b1aef6e9
-generated: "2022-10-18T15:48:24.036734+11:00"
+  version: 2.0.0
+digest: sha256:d17c32aff9204988582cc4902595de770b0752a5ef433f52a8e5ccb52e27444c
+generated: "2022-10-31T15:13:15.124029+11:00"

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -18,20 +18,20 @@ dependencies:
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
@@ -39,44 +39,44 @@ dependencies:
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
@@ -84,14 +84,14 @@ dependencies:
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-csw-connector
-  repository: https://charts.magda.io
-  version: 1.1.1
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
@@ -99,16 +99,16 @@ dependencies:
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-dap-connector
-  repository: https://charts.magda.io
-  version: 1.0.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-project-open-data-connector
-  repository: https://charts.magda.io
-  version: 1.1.0
-digest: sha256:a6e5d186405e703c2aa7b8e64d6608d3d218e59201c818f41d9e21917abe80d3
-generated: "2022-10-10T10:39:38.983024+11:00"
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
+digest: sha256:32dbf1e8639d97a3d5c8407d05764e906ea0cc009256942edb56ae47b1aef6e9
+generated: "2022-10-18T15:48:24.036734+11:00"

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -47,38 +47,38 @@ dependencies:
       - connector-dga
 
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-act
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-act
 
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-actmapi
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-actmapi
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-aims
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-aims
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-aodn
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-aodn
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-bom
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-bom
@@ -97,79 +97,79 @@ dependencies:
       - connectors
       - connector-brisbane
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-hobart
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-hobart
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-launceston
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-launceston
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-marlin
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-marlin
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-environment
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-environment
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-ga
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-ga
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-logan
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-logan
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-melbournewater
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-melbournewater
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-melbourne
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-melbourne
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-mrt
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-mrt
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-moretonbay
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-moretonbay
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-neii
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-neii
@@ -181,9 +181,9 @@ dependencies:
       - connectors
       - connector-nsw
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-sdinsw
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-sdinsw
@@ -202,23 +202,23 @@ dependencies:
       - connectors
       - connector-sa
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-southerngrampians
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-southerngrampians
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-listtas
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-listtas
   - name: magda-csw-connector
-    version: "1.1.1"
+    version: "2.0.0-alpha.0"
     alias: connector-tern
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-tern
@@ -237,30 +237,30 @@ dependencies:
       - connectors
       - connector-wa
   - name: magda-dap-connector
-    version: "1.0.0"
+    version: "2.0.0-alpha.0"
     alias: connector-dap
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-dap
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-vic-cardinia
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-vic-cardinia
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-nt-darwin
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-nt-darwin
   - name: magda-project-open-data-connector
-    version: "1.1.0"
+    version: "2.0.0-alpha.0"
     alias: connector-southern-grampians
-    repository: https://charts.magda.io
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-southern-grampians

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -47,7 +47,7 @@ dependencies:
       - connector-dga
 
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-act
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
@@ -55,28 +55,28 @@ dependencies:
       - connector-act
 
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-actmapi
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-actmapi
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-aims
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-aims
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-aodn
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-aodn
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-bom
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
@@ -97,77 +97,77 @@ dependencies:
       - connectors
       - connector-brisbane
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-hobart
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-hobart
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-launceston
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-launceston
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-marlin
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-marlin
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-environment
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-environment
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-ga
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-ga
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-logan
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-logan
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-melbournewater
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-melbournewater
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-melbourne
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-melbourne
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-mrt
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-mrt
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-moretonbay
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-moretonbay
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-neii
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
@@ -181,7 +181,7 @@ dependencies:
       - connectors
       - connector-nsw
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-sdinsw
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
@@ -202,21 +202,21 @@ dependencies:
       - connectors
       - connector-sa
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-southerngrampians
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-southerngrampians
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-listtas
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-listtas
   - name: magda-csw-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-tern
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
@@ -237,28 +237,28 @@ dependencies:
       - connectors
       - connector-wa
   - name: magda-dap-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-dap
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-dap
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-vic-cardinia
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-vic-cardinia
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-nt-darwin
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - connectors
       - connector-nt-darwin
   - name: magda-project-open-data-connector
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     alias: connector-southern-grampians
     repository: "oci://ghcr.io/magda-io/charts"
     tags:

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -10,24 +10,24 @@ dependencies:
   version: 1.1.0
 - name: magda-minion-broken-link
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-minion-format
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-minion-linked-data-rating
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-minion-visualization
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-minion-ckan-exporter
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0-alpha.0
+  version: 2.0.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:f3c74ebb70f939a7b4b75ea2a4b405e6094c582df8db92c6a782e03a82e51ac6
-generated: "2022-10-18T15:48:05.759806+11:00"
+digest: sha256:4824ca7a1ebdfe540eae2bdd595d0755b33f5f054496d260017dca119a13b22d
+generated: "2022-10-31T16:09:38.289968+11:00"

--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -9,25 +9,25 @@ dependencies:
   repository: https://charts.magda.io
   version: 1.1.0
 - name: magda-minion-broken-link
-  repository: https://charts.magda.io
-  version: 1.0.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-minion-format
-  repository: https://charts.magda.io
-  version: 1.1.2
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-minion-linked-data-rating
-  repository: https://charts.magda.io
-  version: 1.1.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-minion-visualization
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-minion-ckan-exporter
-  repository: https://charts.magda.io
-  version: 1.0.0
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
 - name: magda-function-esri-url-processor
   repository: https://charts.magda.io
   version: 1.1.0
-digest: sha256:1f441d8473a403852a3435b8d01aafd638ec10536a0e75256105c4285b5e6066
-generated: "2022-10-10T10:39:24.512705+11:00"
+digest: sha256:f3c74ebb70f939a7b4b75ea2a4b405e6094c582df8db92c6a782e03a82e51ac6
+generated: "2022-10-18T15:48:05.759806+11:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -32,24 +32,24 @@ dependencies:
 
   - name: magda-minion-broken-link
     alias: minion-broken-link
-    version: "1.0.0"
-    repository: https://charts.magda.io
+    version: "2.0.0-alpha.0"
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
       - minion-broken-link
 
   - name: magda-minion-format
     alias: minion-format
-    version: "1.1.2"
-    repository: https://charts.magda.io
+    version: "2.0.0-alpha.0"
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
       - minion-format
 
   - name: magda-minion-linked-data-rating
     alias: minion-linked-data-rating
-    version: "1.1.0"
-    repository: https://charts.magda.io
+    version: "2.0.0-alpha.0"
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
       - minion-linked-data-rating
@@ -63,8 +63,8 @@ dependencies:
       - minion-visualization
 
   - name: magda-minion-ckan-exporter
-    version: "1.0.0"
-    repository: https://charts.magda.io
+    version: "2.0.0-alpha.0"
+    repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minion-ckan-exporter
 

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -8,7 +8,7 @@ home: "https://github.com/magda-io/magda"
 sources: [ "https://github.com/magda-io/magda" ]
 dependencies:
   - name: magda-core
-    version: 2.1.1
+    version: "2.1.1"
     repository: file://../magda-core
 
   - name: openfaas
@@ -32,7 +32,7 @@ dependencies:
 
   - name: magda-minion-broken-link
     alias: minion-broken-link
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
@@ -40,7 +40,7 @@ dependencies:
 
   - name: magda-minion-format
     alias: minion-format
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
@@ -48,7 +48,7 @@ dependencies:
 
   - name: magda-minion-linked-data-rating
     alias: minion-linked-data-rating
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minions
@@ -63,7 +63,7 @@ dependencies:
       - minion-visualization
 
   - name: magda-minion-ckan-exporter
-    version: "2.0.0-alpha.0"
+    version: "2.0.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - minion-ckan-exporter

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -17,12 +17,12 @@ A complete solution for managing, publishing and discovering government data, pr
 | file://../magda-core | magda-core | 2.1.1 |
 | https://charts.magda.io | magda-function-esri-url-processor | 1.1.0 |
 | https://charts.magda.io | magda-function-history-report | 1.1.0 |
-| https://charts.magda.io | minion-broken-link(magda-minion-broken-link) | 1.0.0 |
-| https://charts.magda.io | magda-minion-ckan-exporter | 1.0.0 |
-| https://charts.magda.io | minion-format(magda-minion-format) | 1.1.2 |
-| https://charts.magda.io | minion-linked-data-rating(magda-minion-linked-data-rating) | 1.1.0 |
 | https://charts.magda.io | openfaas | 5.5.5-magda.2 |
 | oci://ghcr.io/magda-io/charts | ckan-connector-functions(magda-ckan-connector) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | minion-broken-link(magda-minion-broken-link) | 2.0.0-alpha.0 |
+| oci://ghcr.io/magda-io/charts | magda-minion-ckan-exporter | 2.0.0-alpha.0 |
+| oci://ghcr.io/magda-io/charts | minion-format(magda-minion-format) | 2.0.0-alpha.0 |
+| oci://ghcr.io/magda-io/charts | minion-linked-data-rating(magda-minion-linked-data-rating) | 2.0.0-alpha.0 |
 | oci://ghcr.io/magda-io/charts | minion-visualization(magda-minion-visualization) | 2.0.0 |
 
 ## Values

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -19,10 +19,10 @@ A complete solution for managing, publishing and discovering government data, pr
 | https://charts.magda.io | magda-function-history-report | 1.1.0 |
 | https://charts.magda.io | openfaas | 5.5.5-magda.2 |
 | oci://ghcr.io/magda-io/charts | ckan-connector-functions(magda-ckan-connector) | 2.0.0 |
-| oci://ghcr.io/magda-io/charts | minion-broken-link(magda-minion-broken-link) | 2.0.0-alpha.0 |
-| oci://ghcr.io/magda-io/charts | magda-minion-ckan-exporter | 2.0.0-alpha.0 |
-| oci://ghcr.io/magda-io/charts | minion-format(magda-minion-format) | 2.0.0-alpha.0 |
-| oci://ghcr.io/magda-io/charts | minion-linked-data-rating(magda-minion-linked-data-rating) | 2.0.0-alpha.0 |
+| oci://ghcr.io/magda-io/charts | minion-broken-link(magda-minion-broken-link) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | magda-minion-ckan-exporter | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | minion-format(magda-minion-format) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | minion-linked-data-rating(magda-minion-linked-data-rating) | 2.0.0 |
 | oci://ghcr.io/magda-io/charts | minion-visualization(magda-minion-visualization) | 2.0.0 |
 
 ## Values

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -574,7 +574,7 @@ object Generators {
       license <- someBiasedOption(licenseGen)
       rights <- someBiasedOption(arbitrary[String].map(_.take(50).trim))
       accessURL <- someBiasedOption(arbitrary[String].map(_.take(50).trim))
-      byteSize <- someBiasedOption(arbitrary[Int])
+      byteSize <- someBiasedOption(arbitrary[Long])
       format <- someBiasedOption(formatGen(inputCache))
     } yield
       Distribution(

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/Conversions.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/client/Conversions.scala
@@ -314,8 +314,7 @@ object Conversions {
       accessURL = dcatStrings.extract[String]('accessURL.?),
       downloadURL = urlString,
       byteSize = dcatStrings
-        .extract[Int]('byteSize.?)
-        .flatMap(bs => Try(bs.toInt).toOption),
+        .extract[Long]('byteSize.?),
       mediaType = Distribution.parseMediaType(mediaTypeString, None, None),
       format = betterFormatString match {
         case Some(format) => Some(format)

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/directives/AuthDirectives.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/directives/AuthDirectives.scala
@@ -106,7 +106,7 @@ object AuthDirectives {
           } else {
             complete(
               Forbidden,
-              s"you are not permitted to perform `${operationUri}`: no unconditional decision can be made."
+              s"you are not permitted to perform `${operationUri}`."
             )
           }
         }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -343,7 +343,7 @@ package misc {
       rights: Option[String] = None,
       accessURL: Option[String] = None,
       downloadURL: Option[String] = None,
-      byteSize: Option[Int] = None,
+      byteSize: Option[Long] = None,
       mediaType: Option[MediaType] = None,
       source: Option[DataSouce] = None,
       format: Option[String] = None

--- a/magda-web-client/src/Components/Dataset/DatasetPage.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetPage.scss
@@ -184,6 +184,12 @@
     }
 }
 
+.record--distribution {
+    .description-box {
+        margin-top: 20px;
+    }
+}
+
 .dataset-heading {
     margin-top: 10px;
 }

--- a/magda-web-client/src/Components/Dataset/DistributionPage.tsx
+++ b/magda-web-client/src/Components/Dataset/DistributionPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "api-clients/RegistryApis";
 import RecordVersionList from "./RecordVersionList";
 import getStorageApiResourceAccessUrl from "helpers/getStorageApiResourceAccessUrl";
+import humanFileSize from "helpers/humanFileSize";
 import "./DatasetPage.scss";
 
 interface PropsType {
@@ -107,6 +108,12 @@ const DistributionPageMainContent: FunctionComponent<{
                 )}
             </div>
             <div className="distribution-format">{distribution.format}</div>
+            {typeof distribution?.byteSize === "number" ? (
+                <span className="distribution-size">
+                    <span className="separator hidden-sm">&nbsp;/&nbsp;</span>
+                    {humanFileSize(distribution.byteSize)}
+                </span>
+            ) : null}
             {defined(distribution.license) && (
                 <span className="distribution-license">
                     <span className="separator hidden-sm">&nbsp;/&nbsp;</span>

--- a/magda-web-client/src/Components/Dataset/View/DistributionDetails.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionDetails.tsx
@@ -60,7 +60,7 @@ class DistributionDetails extends Component<{
         );
         const accessText = distribution.accessURL && (
             <div key={"accessText"}>
-                This dataset can be accessed from: <br />{" "}
+                This data file or API can be accessed from: <br />{" "}
                 <CommonLink className="url" href={distribution.accessURL}>
                     {distribution.accessURL}
                 </CommonLink>
@@ -80,7 +80,7 @@ class DistributionDetails extends Component<{
                     ]);
                     return (
                         <React.Fragment>
-                            <div className="heading">Access Notes: </div>
+                            <h3 className="section-heading">Access Notes:</h3>
                             <div className="access-notes">
                                 {accessNotesPrefix &&
                                     accessNotesPrefix.length && (

--- a/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
+++ b/magda-web-client/src/Components/Dataset/View/DistributionRow.tsx
@@ -14,6 +14,7 @@ import CommonLink from "Components/Common/CommonLink";
 import { getFormatIcon, determineFormatIcon } from "./DistributionIcon";
 import { licenseLevel } from "constants/DatasetConstants";
 import getStorageApiResourceAccessUrl from "helpers/getStorageApiResourceAccessUrl";
+import humanFileSize from "helpers/humanFileSize";
 
 export type PropType = {
     dataset: Dataset;
@@ -118,6 +119,11 @@ class DistributionRow extends Component<PropType> {
                                 className="distribution-row-link-license"
                                 itemProp="license"
                             >
+                                {typeof distribution?.byteSize === "number"
+                                    ? `${humanFileSize(
+                                          distribution.byteSize
+                                      )} | `
+                                    : null}
                                 {(distribution.license &&
                                     licenseLevel[distribution.license]) ||
                                     distribution.license}

--- a/magda-web-client/src/helpers/record.ts
+++ b/magda-web-client/src/helpers/record.ts
@@ -53,6 +53,7 @@ export type dcatDistributionStrings = {
     description: string;
     title: string;
     useStorageApi?: boolean;
+    byteSize: number;
 };
 
 export type DcatDatasetStrings = {
@@ -229,6 +230,7 @@ export type ParsedDistribution = {
         preAuthorisedPermissionIds: string[];
     };
     version?: VersionAspectData;
+    byteSize?: number;
 };
 
 export type ParsedProvenance = {
@@ -479,7 +481,8 @@ export function parseDistribution(
         ckanResource: aspects["ckan-resource"],
         accessControl,
         publishingState: publishing["state"],
-        version: aspects["version"]
+        version: aspects["version"],
+        byteSize: info?.byteSize
     };
 }
 
@@ -611,7 +614,8 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
             compatiblePreviews,
             visualizationInfo: visualizationInfo ? visualizationInfo : null,
             sourceDetails: distributionAspects["source"],
-            ckanResource: distributionAspects["ckan-resource"]
+            ckanResource: distributionAspects["ckan-resource"],
+            byteSize: info?.byteSize
         };
     });
     return {


### PR DESCRIPTION
### What this PR does

- Upgrade default connectors & minions version (to v2.0.0)
- Fixed indexer error: distribution/byteSize field should be in `long` type to support possible larger numbers
- Upgraded indexer weekly reindexer trigger container to node14
- Distribution page UI minor improvements: display file size (when available) & adjust margins between information blocks

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
