### PR TITLE
Migrate Google Universal Analytics settings to GA4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.2.4
+
+- #3452 Add support of [Google Analytics 4](https://support.google.com/analytics/answer/10089681?hl=en) using [react-ga4](https://www.npmjs.com/package/react-ga4)
+
 ## v2.2.3
 
 - Fixed an issue that zendesk integration feedback form might not always be opened via footer link

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -129,7 +129,6 @@ magda:
         - sourceDataDomain: "nsw.gov.au"
           url: "https://nsw.digitaltwin.terria.io/"
       gapiIds:
-        - UA-92539508-6
         - G-3LGQ7FWH1B
 
     correspondence-api:

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -128,6 +128,9 @@ magda:
         "3dDatasetDigitalTwinInstances":
         - sourceDataDomain: "nsw.gov.au"
           url: "https://nsw.digitaltwin.terria.io/"
+      gapiIds:
+        - UA-92539508-6
+        - G-3LGQ7FWH1B
 
     correspondence-api:
       alwaysSendToDefaultRecipient: true

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -123,7 +123,7 @@
     "react-dom": "^16.3.2",
     "react-drag-and-drop": "^3.0.0",
     "react-file-drop": "^0.2.7",
-    "react-ga": "^2.5.3",
+    "react-ga4": "^2.1.0",
     "react-i18next": "^8.1.0",
     "react-is": "^18.2.0",
     "react-json-tree": "^0.10.9",

--- a/magda-web-client/src/analytics/ga.js
+++ b/magda-web-client/src/analytics/ga.js
@@ -1,32 +1,18 @@
-import ReactGA from "react-ga";
+import ReactGA from "react-ga4";
 
 import { config } from "../config";
 
 const gapiIds = config.gapiIds || [];
 const trackers = gapiIds.map((trackingId) => ({
     trackingId: trackingId,
-    gaOptions: {
-        name: trackingId.replace(/-/g, "")
+    gtagOptions: {
+        send_page_view: false
     }
 }));
-const trackerNames = trackers.map((tracker) => tracker.gaOptions.name);
 
 // Initialize Google Analytics with tracker provided to web-server
 ReactGA.initialize(trackers, {
-    debug: false,
-    alwaysSendToDefaultTracker: false
+    testMode: false
 });
-
-// Make all the ReactGA functions automatically pass our list of trackers
-Object.keys(ReactGA)
-    .filter((key) => typeof ReactGA[key] === "function")
-    .forEach((key) => {
-        const oldFn = ReactGA[key];
-
-        ReactGA[key] = function (...args) {
-            const newArgs = args.concat([trackerNames]);
-            oldFn(...newArgs);
-        };
-    });
 
 export const gapi = ReactGA;

--- a/magda-web-client/src/index.js
+++ b/magda-web-client/src/index.js
@@ -46,7 +46,11 @@ class GAListener extends React.Component {
 
     sendPageView(location) {
         // Send pageview event to the initialised tracker(s).
-        gapi.pageview(location.pathname);
+        gapi.send({
+            hitType: "pageview",
+            page: location.pathname,
+            location: window.location.href
+        });
     }
 
     render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18270,10 +18270,10 @@ react-file-drop@^0.2.7:
   dependencies:
     prop-types "^15.6.1"
 
-react-ga@^2.5.3:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
-  integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
 react-i18next@^8.1.0:
   version "8.4.0"


### PR DESCRIPTION
### What this PR does

Fixes 
- #3452 
  - migrated to ga4
  - don't need to pass trackerNames array for gtag api


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
