### PR TITLE
Added `FREEZE` to PostgreSQL DB VACUUM routine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.0.3
+
+- Added `FREEZE` to PostgreSQL DB VACUUM routine
+
 ## v3.0.2
 
 - #3513 Fixed Indexer reindex trigger job doesn't start

--- a/deploy/helm/internal-charts/registry-db/templates/registry-db-auto-vacuum-cron-job.yaml
+++ b/deploy/helm/internal-charts/registry-db/templates/registry-db-auto-vacuum-cron-job.yaml
@@ -33,7 +33,7 @@ spec:
                 # more details see the docker image repo
                 /usr/local/bin/adduser.sh
                 echo "Running DB maintenance routine:"
-                psql -c "VACUUM VERBOSE ANALYZE"
+                psql -c "VACUUM FREEZE VERBOSE ANALYZE"
                 if [ "$?" == "0" ]; then
                   echo "DB maintenance routine has been run sucessfully."
                 else 


### PR DESCRIPTION
### What this PR does

Fixes: Added `FREEZE` to PostgreSQL DB VACUUM routine

In order to avoid wraparound failure, old transaction IDs must be frozen by VACUUMs. The more old transaction IDs need to be frozen, the more expensive VACUUM becomes. It can take a really long time to finish and potentially causes overall performance degradation. The anti-wraparound autovacuum holds aSHARE UPDATE EXCLUSIVE lock, which can block DDL statements.

If transaction ID space utilization reaches to 99.85% (3M transaction IDs left), the system will shut down. This is to prevent any data corruption from happening by running out transaction IDs. Resolving this requires manual intervention.

With Postgres 14+, there is a special type of failsafe VACUUM which takes extraordinary measures to avoid the shutdown. While this is very useful, you still want to avoid this as a failsafe autovacuum ignores resource utilization constraints and can have significant performance impact.

### Checklist

-   [ ] unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
