### PR TITLE
#3527 correspondence API might reset the preset email resources to the default data unexpectedly during the service restart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.0.4
+
+- #3527 correspondence API might reset the preset email resources to the default data unexpectedly during the service restart
+
 ## v3.0.3
 
 - #3193 auto-remove Null byte from JSON input so it won't be rejected by registry

--- a/magda-correspondence-api/src/ContentApiDirMapper.ts
+++ b/magda-correspondence-api/src/ContentApiDirMapper.ts
@@ -27,7 +27,7 @@ class ContentApiDirMapper {
         this.jwtSecret = jwtSecret;
         if (this.url === "") {
             throw new Error(
-                "ContentApiDirMapper: content API URL canot be empty!"
+                "ContentApiDirMapper: content API URL cannot be empty!"
             );
         }
     }
@@ -80,8 +80,14 @@ class ContentApiDirMapper {
         const res = await fetch(`${this.url}/${localPath}`, {
             method: "HEAD"
         });
-        if (!res.ok) return false;
-        else return true;
+        if (!res.ok) {
+            if (res.status !== 404) {
+                throw new Error(
+                    `Failed to check file existence from ${this.url}/${localPath}: ${res.status} ${res.statusText}`
+                );
+            }
+            return false;
+        } else return true;
     }
 
     /**

--- a/magda-correspondence-api/src/test/ContentApiDirMapper.spec.ts
+++ b/magda-correspondence-api/src/test/ContentApiDirMapper.spec.ts
@@ -1,0 +1,66 @@
+import {} from "mocha";
+import { expect } from "chai";
+import nock from "nock";
+import ContentApiDirMapper from "../ContentApiDirMapper.js";
+
+const CONTENT_API_URL: string = "https://content-api.example.com";
+const userId = "a3ed2cb6-9d5a-4689-a080-a09cf060d93a";
+const jwtSecret = "408e19bf-3a2b-4701-a2c8-3b81508ef810";
+
+describe("ContentApiDirMapper", function (this) {
+    let contentDirMapper: ContentApiDirMapper;
+    let contentApi: nock.Scope;
+
+    this.beforeEach(() => {
+        nock.cleanAll();
+        nock.disableNetConnect();
+        contentApi = nock(CONTENT_API_URL);
+        contentDirMapper = new ContentApiDirMapper(
+            CONTENT_API_URL,
+            userId,
+            jwtSecret
+        );
+    });
+
+    this.afterEach(() => {
+        nock.cleanAll();
+        nock.enableNetConnect();
+    });
+
+    it("Should conclude none-existence of resource when receive 404", async () => {
+        contentApi.head("/emailTemplates/assets/top-left-logo.jpg").reply(404);
+        const r = await contentDirMapper.fileExist(
+            "emailTemplates/assets/top-left-logo.jpg"
+        );
+        expect(r).to.be.false;
+    });
+
+    it("Should throw an error when receive 500", async () => {
+        contentApi
+            .head("/emailTemplates/assets/top-left-logo.jpg")
+            .reply(500, "Internal Server Error");
+        try {
+            await contentDirMapper.fileExist(
+                "emailTemplates/assets/top-left-logo.jpg"
+            );
+            expect.fail("Should throw an error when receive 500 response");
+        } catch (e) {
+            expect((e as Error).message).to.equal(
+                "Failed to check file existence from https://content-api.example.com/emailTemplates/assets/top-left-logo.jpg: 500 "
+            );
+        }
+    });
+
+    it("Should conclude existence of resource when receive 200 or 202", async () => {
+        contentApi.head("/emailTemplates/assets/top-left-logo.jpg").reply(200);
+        contentApi.head("/emailTemplates/assets/top-left-logo2.jpg").reply(202);
+        let r = await contentDirMapper.fileExist(
+            "emailTemplates/assets/top-left-logo.jpg"
+        );
+        expect(r).to.be.true;
+        r = await contentDirMapper.fileExist(
+            "emailTemplates/assets/top-left-logo2.jpg"
+        );
+        expect(r).to.be.true;
+    });
+});


### PR DESCRIPTION
### What this PR does

Fixes:
- #3527 correspondence API might reset the preset email resources to the default data unexpectedly during the service restart

### Checklist

-   [ ] There are unit tests to verify my changes are correct
-   [ ] I've updated CHANGES.md with what I changed.
