### PR TITLE
#3564: Add rel="canonical" annotations to dataset & distribution page crawler views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Increase indexer client connection idle-timeout to avoid encountering connection reset error for downloading large region files
 - Upgraded OpenSearch to v2.16.0
 - #3556: Serves robots.txt as content-type `text/plain` instead and other sitemap & crawler view related improvements.
+- #3564: Add rel="canonical" annotations to dataset & distribution page crawler views
 
 ## v4.2.3
 

--- a/magda-web-server/src/crawlerViews/commonView.ts
+++ b/magda-web-server/src/crawlerViews/commonView.ts
@@ -1,12 +1,14 @@
 import markdownToHtml from "magda-typescript-common/src/markdownToHtml.js";
 
-type ContentType = {
-    title: string;
+interface ContentType {
+    title?: string;
     __content: string;
-};
+    canonicalUrl: string;
+    sitemapUrl: string;
+}
 
 const commonView = (
-    { title, __content }: ContentType,
+    { title, __content, canonicalUrl, sitemapUrl }: ContentType,
     shouldShowFullVersionLink: boolean = false,
     fullVersionUrl: string = ""
 ) => {
@@ -15,7 +17,16 @@ const commonView = (
         <head>
             <meta charset="UTF-8">
             <title>${title}</title>
-            <style></style>
+            ${
+                canonicalUrl
+                    ? `<link rel="canonical" href="${canonicalUrl}">`
+                    : ""
+            }
+            ${
+                sitemapUrl
+                    ? `<link rel="sitemap" type="application/xml" href="${sitemapUrl}">`
+                    : ""
+            }
         </head>
         <body>
             ${markdownToHtml(__content, true)}

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -519,6 +519,7 @@ if (argv.enableCrawlerViews || enableDiscourseSupport) {
         createCrawlerViewRouter({
             registryApiBaseUrl: argv.registryApiBaseUrlInternal,
             enableDiscourseSupport: enableDiscourseSupport,
+            baseExternalUrl,
             uiBaseUrl
         })
     );

--- a/magda-web-server/src/shouldRenderCrawlerView.ts
+++ b/magda-web-server/src/shouldRenderCrawlerView.ts
@@ -12,6 +12,7 @@ const browserNames = [
 
 const crawlerPatterns = [
     "Googlebot\\/", // Google
+    "Google-InspectionTool\\/", // Google inspectionTool
     "bingbot", // Bing
     "Slurp", // Yahoo
     "DuckDuckBot", // DuckDuckGo


### PR DESCRIPTION
### What this PR does

Fixes:
- #3564: Add rel="canonical" annotations to dataset & distribution page crawler views

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
