### PR TITLE
Bump OPA to v1.3.0, and use Regal for linting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v5.1.1
 
+- Improve: Bump OPA version to latest (v1.3.0) and use Regal for linting Rego
 - Fix: SQLConsole: reference error when join JSONL data source
 - Improve: SQLConsole JSON & JSONL data error handling
 

--- a/magda-opa/Dockerfile
+++ b/magda-opa/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3
-COPY --from=openpolicyagent/opa:0.37.2-static /opa /opa
+COPY --from=openpolicyagent/opa:1.3.0-static /opa /opa
 COPY component/start.sh /bin/start.sh
 COPY component/policies /policies
 

--- a/magda-opa/docker-compose.yml
+++ b/magda-opa/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   test-opa:
-    image: openpolicyagent/opa:0.37.2-static
+    image: openpolicyagent/opa:1.3.0-static
     ports:
       - 8181:8181
     volumes:

--- a/magda-opa/package.json
+++ b/magda-opa/package.json
@@ -3,12 +3,14 @@
   "version": "5.1.0",
   "description": "MAGDA's Open Policy Agent docker image with built-in policies.",
   "scripts": {
+    "check": "docker run -v $PWD/policies:/policies openpolicyagent/opa:1.3.0-static check --strict ./policies",
     "dev": "docker-compose up",
     "dev-stop": "docker-compose down",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
+    "lint": "run -v $PWD/policies:/policies ghcr.io/styrainc/regal:0.32.0 lint /policies",
     "retag-and-push": "retag-and-push",
-    "test": "docker run -v $PWD/policies:/policies openpolicyagent/opa:0.37.2-static test -v ./policies"
+    "test": "docker run -v $PWD/policies:/policies openpolicyagent/opa:1.3.0-static test -v ./policies"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-opa/policies/.regal/config.yaml
+++ b/magda-opa/policies/.regal/config.yaml
@@ -1,0 +1,24 @@
+project:
+  rego-version: 1
+
+rules:
+  idiomatic:
+    no-defined-entrypoint:
+      level: ignore
+  imports:
+    prefer-package-imports:
+      level: ignore
+  style:
+    external-reference:
+      level: ignore
+    file-length:
+      level: ignore
+    line-length:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+    rule-length:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      level: ignore

--- a/magda-opa/policies/api/allow_test.rego
+++ b/magda-opa/policies/api/allow_test.rego
@@ -1,197 +1,193 @@
 package api
 
-test_api_allow_case_1 {
+import rego.v1
+
+test_api_allow_case_1 if {
 	allow with input as {
 		"operationUri": "api/my-api/records/ea5d2d58-165a-48cb-9b22-42edd6a3024a/POST",
 		"user": {
 			"displayName": "xxxxxx",
 			"email": "xxx@xxx.com",
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-			"permissions": [
-				{
-					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-					"name": "API create a new record",
-					"operations": [{
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "API create a new record",
+				"operations": [
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "POST",
 						"uri": "api/my-api/records/*/POST",
-					},{
+					},
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "OPTION",
 						"uri": "api/my-api/records/*/OPTION",
-					}],
-					"orgUnitOwnershipConstraint": false,
-					"preAuthorisedConstraint": false,
-					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-					"resourceUri": "api/my-api/records/*",
-					"userOwnershipConstraint": false,
-          "allowExemption": false,
-				},
-			],
-			"roles": [
-				{
-					"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
-					"name": "test API role",
-					"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
-				},
-			]
-		}
+					},
+				],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "api/my-api/records/*",
+				"userOwnershipConstraint": false,
+				"allowExemption": false,
+			}],
+			"roles": [{
+				"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
+				"name": "test API role",
+				"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			}],
+		},
 	}
 }
 
-test_api_allow_case_2 {
+test_api_allow_case_2 if {
 	allow with input as {
 		"operationUri": "api/my-api/records/ea5d2d58-165a-48cb-9b22-42edd6a3024a/OPTION",
 		"user": {
 			"displayName": "xxxxxx",
 			"email": "xxx@xxx.com",
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-			"permissions": [
-				{
-					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-					"name": "API create a new record",
-					"operations": [{
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "API create a new record",
+				"operations": [
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "POST",
 						"uri": "api/my-api/records/*/POST",
-					},{
+					},
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "OPTION",
 						"uri": "api/my-api/records/*/OPTION",
-					}],
-					"orgUnitOwnershipConstraint": false,
-					"preAuthorisedConstraint": false,
-					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-					"resourceUri": "api/my-api/records/*",
-					"userOwnershipConstraint": false,
-          "allowExemption": false,
-				},
-			],
-			"roles": [
-				{
-					"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
-					"name": "test API role",
-					"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
-				},
-			]
-		}
+					},
+				],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "api/my-api/records/*",
+				"userOwnershipConstraint": false,
+				"allowExemption": false,
+			}],
+			"roles": [{
+				"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
+				"name": "test API role",
+				"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			}],
+		},
 	}
 }
 
-
-test_api_allow_case_3 {
+test_api_allow_case_3 if {
 	not allow with input as {
 		"operationUri": "api/my-api/records/ea5d2d58-165a-48cb-9b22-42edd6a3024a/GET",
 		"user": {
 			"displayName": "xxxxxx",
 			"email": "xxx@xxx.com",
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-			"permissions": [
-				{
-					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-					"name": "API create a new record",
-					"operations": [{
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "API create a new record",
+				"operations": [
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "POST",
 						"uri": "api/my-api/records/*/POST",
-					},{
+					},
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "OPTION",
 						"uri": "api/my-api/records/*/OPTION",
-					}],
-					"orgUnitOwnershipConstraint": false,
-					"preAuthorisedConstraint": false,
-					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-					"resourceUri": "api/my-api/records/*",
-					"userOwnershipConstraint": false,
-          "allowExemption": false,
-				},
-			],
-			"roles": [
-				{
-					"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
-					"name": "test API role",
-					"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
-				},
-			]
-		}
+					},
+				],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "api/my-api/records/*",
+				"userOwnershipConstraint": false,
+				"allowExemption": false,
+			}],
+			"roles": [{
+				"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
+				"name": "test API role",
+				"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			}],
+		},
 	}
 }
 
-test_api_allow_case_4 {
+test_api_allow_case_4 if {
 	allow with input as {
 		"operationUri": "api/my-api/endpoint1/PUT",
 		"user": {
 			"displayName": "xxxxxx",
 			"email": "xxx@xxx.com",
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-			"permissions": [
-				{
-					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-					"name": "API trigger endpoint1",
-					"operations": [{
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "API trigger endpoint1",
+				"operations": [
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "PUT",
 						"uri": "api/my-api/endpoint1/PUT",
-					},{
+					},
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "OPTION",
 						"uri": "api/my-api/endpoint1/OPTION",
-					}],
-					"orgUnitOwnershipConstraint": false,
-					"preAuthorisedConstraint": false,
-					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-					"resourceUri": "api/my-api/records/*",
-					"userOwnershipConstraint": false,
-          "allowExemption": false,
-				},
-			],
-			"roles": [
-				{
-					"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
-					"name": "test API role",
-					"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
-				},
-			]
-		}
+					},
+				],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "api/my-api/records/*",
+				"userOwnershipConstraint": false,
+				"allowExemption": false,
+			}],
+			"roles": [{
+				"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
+				"name": "test API role",
+				"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			}],
+		},
 	}
 }
 
-test_api_allow_case_5 {
+test_api_allow_case_5 if {
 	not allow with input as {
 		"operationUri": "api/my-api/*/PUT",
 		"user": {
 			"displayName": "xxxxxx",
 			"email": "xxx@xxx.com",
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-			"permissions": [
-				{
-					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-					"name": "API trigger endpoint1",
-					"operations": [{
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "API trigger endpoint1",
+				"operations": [
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "PUT",
 						"uri": "api/my-api/endpoint1/PUT",
-					},{
+					},
+					{
 						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
 						"name": "OPTION",
 						"uri": "api/my-api/endpoint1/OPTION",
-					}],
-					"orgUnitOwnershipConstraint": false,
-					"preAuthorisedConstraint": false,
-					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-					"resourceUri": "api/my-api/records/*",
-					"userOwnershipConstraint": false,
-          "allowExemption": false,
-				},
-			],
-			"roles": [
-				{
-					"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
-					"name": "test API role",
-					"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
-				},
-			]
-		}
+					},
+				],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "api/my-api/records/*",
+				"userOwnershipConstraint": false,
+				"allowExemption": false,
+			}],
+			"roles": [{
+				"id": "a1f7b415-dba6-4717-bfe5-79cd10ea903f ",
+				"name": "test API role",
+				"permissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			}],
+		},
 	}
 }

--- a/magda-opa/policies/api/indexer/allow.rego
+++ b/magda-opa/policies/api/indexer/allow.rego
@@ -1,12 +1,14 @@
 package api.indexer
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
-# User has a permission to perfom operation with no constaint 
+# User has a permission to perfom operation with no constaint
 # only support the following external facing APIs: `api/indexer/reindex` & `api/indexer/reindex/in-progress`
-# 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+#
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/authObject/apiKey/allow.rego
+++ b/magda-opa/policies/authObject/apiKey/allow.rego
@@ -1,18 +1,20 @@
 package authObject.apiKey
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 import data.common.hasOwnerConstraintPermission
 
-default allow = false
+default allow := false
 
-# User has a permission to perfom operation with no constaint 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+# User has a permission to perfom operation with no constaint
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # User has a permission to perfom operation with owner / user constaint
 # i.e. Only can perform operation on user's own api key
-allow {
-    hasOwnerConstraintPermission(input.operationUri)
-    input.authObject.apiKey.user_id = input.user.id
+allow if {
+	hasOwnerConstraintPermission(input.operationUri)
+	input.authObject.apiKey.user_id == input.user.id
 }

--- a/magda-opa/policies/authObject/credential/allow.rego
+++ b/magda-opa/policies/authObject/credential/allow.rego
@@ -1,18 +1,20 @@
 package authObject.credential
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 import data.common.hasOwnerConstraintPermission
 
-default allow = false
+default allow := false
 
-# User has a permission to perfom operation with no constaint 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+# User has a permission to perfom operation with no constaint
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # User has a permission to perfom operation with owner / user constaint
 # i.e. Only can perform operation on user's own credential
-allow {
-    hasOwnerConstraintPermission(input.operationUri)
-    input.authObject.credential.user_id = input.user.id
+allow if {
+	hasOwnerConstraintPermission(input.operationUri)
+	input.authObject.credential.user_id == input.user.id
 }

--- a/magda-opa/policies/authObject/operation/allow.rego
+++ b/magda-opa/policies/authObject/operation/allow.rego
@@ -1,10 +1,12 @@
 package authObject.operation
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "operation" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/authObject/orgUnit/allow.rego
+++ b/magda-opa/policies/authObject/orgUnit/allow.rego
@@ -1,22 +1,25 @@
 package authObject.orgUnit
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 import data.common.hasOrgUnitConstaintPermission
 
-default allow = false
+default allow := false
 
 # Users has a unlimited permission to perfom the operation on "org unit" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # verify the user's permission with Org Unit Constaint
 # the user should allow to perform the operation on the user's current org unit and any children
-allow {
-    hasOrgUnitConstaintPermission(input.operationUri)
-    input.user.orgUnit.id
-    # as org units are stored in nested set model
-    # children's left is >= than parent's left but <= parent's right
-    input.authObject.orgUnit.left >= input.user.orgUnit.left
-    input.authObject.orgUnit.right <= input.user.orgUnit.right
+allow if {
+	hasOrgUnitConstaintPermission(input.operationUri)
+	input.user.orgUnit.id
+
+	# as org units are stored in nested set model
+	# children's left is >= than parent's left but <= parent's right
+	input.authObject.orgUnit.left >= input.user.orgUnit.left
+	input.authObject.orgUnit.right <= input.user.orgUnit.right
 }

--- a/magda-opa/policies/authObject/permission/allow.rego
+++ b/magda-opa/policies/authObject/permission/allow.rego
@@ -1,10 +1,12 @@
 package authObject.permission
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "permission" / "permission_operations" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/authObject/resource/allow.rego
+++ b/magda-opa/policies/authObject/resource/allow.rego
@@ -1,10 +1,12 @@
 package authObject.resource
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "resource" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/authObject/role/allow.rego
+++ b/magda-opa/policies/authObject/role/allow.rego
@@ -1,10 +1,12 @@
 package authObject.role
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "role" / "role_permissions" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/authObject/user/allow.rego
+++ b/magda-opa/policies/authObject/user/allow.rego
@@ -1,31 +1,33 @@
 package authObject.user
 
-import data.common.hasNoConstraintPermission
-import data.common.hasOwnerConstraintPermission
-import data.common.hasOrgUnitConstaintPermission
+import rego.v1
 
-default allow = false
+import data.common.hasNoConstraintPermission
+import data.common.hasOrgUnitConstaintPermission
+import data.common.hasOwnerConstraintPermission
+
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "user" / "user_role" record will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # user should always be able to read his own user record
-allow {
-    input.operationUri == "authObject/user/read"
-    input.authObject.user.id = input.user.id
+allow if {
+	input.operationUri == "authObject/user/read"
+	input.authObject.user.id == input.user.id
 }
 
 # user might be able to perform operation on his own record when he has owner constraint permission
-allow {
-    hasOwnerConstraintPermission(input.operationUri)
-    input.authObject.user.id = input.user.id
+allow if {
+	hasOwnerConstraintPermission(input.operationUri)
+	input.authObject.user.id == input.user.id
 }
 
 # user with org unit scope permission can perform operation on user records of all managing org units
-allow {
-    hasOrgUnitConstaintPermission(input.operationUri)
+allow if {
+	hasOrgUnitConstaintPermission(input.operationUri)
 
-    input.authObject.user.orgUnitId = input.user.managingOrgUnitIds[_]
+	input.authObject.user.orgUnitId in input.user.managingOrgUnitIds
 }

--- a/magda-opa/policies/common/breakdownOperationUri.rego
+++ b/magda-opa/policies/common/breakdownOperationUri.rego
@@ -1,8 +1,14 @@
 package common
 
-breakdownOperationUri(operationUri) = [resourceType, operationType, resourceUriPrefix] {
-    parts := split(operationUri, "/")
-    operationType := parts[count(parts)-1]
-    resourceType := parts[count(parts)-2]
-    resourceUriPrefix := concat("/", array.slice(parts, 0, count(parts)-2))
+import rego.v1
+
+breakdownOperationUri(operationUri) := [resourceType, operationType, resourceUriPrefix] if {
+	parts := split(operationUri, "/")
+	operationType := parts[count(parts) - 1]
+	resourceType := parts[count(parts) - 2]
+	resourceUriPrefix := concat("/", array.slice(parts, 0, count(parts) - 2))
+}
+
+hasOperationType(operationUri, operationType) if {
+	operationType == breakdownOperationUri(operationUri)[1]
 }

--- a/magda-opa/policies/common/extractApiOperationUri.rego
+++ b/magda-opa/policies/common/extractApiOperationUri.rego
@@ -1,9 +1,11 @@
 package common
 
+import rego.v1
+
 # for example, extractApiOperationUri("/api/myApi/health/get") = ["/myApi/health", "GET"]
 # extractApiOperationUri("/api/myApi/health/all") = ["/myApi/health", "ALL"]
-extractApiOperationUri(operationUri) = [requestPath, requestMethod] {
-    parts := split(operationUri, "/")
-    requestMethod := upper(parts[count(parts)-1])
-    requestPath := concat("/", array.slice(parts, 1, count(parts)-1))
+extractApiOperationUri(operationUri) := [requestPath, requestMethod] if {
+	parts := split(operationUri, "/")
+	requestMethod := upper(parts[count(parts) - 1])
+	requestPath := concat("/", array.slice(parts, 1, count(parts) - 1))
 }

--- a/magda-opa/policies/common/extractApiOperationUri_test.rego
+++ b/magda-opa/policies/common/extractApiOperationUri_test.rego
@@ -1,49 +1,51 @@
 package common
 
-test_extractApiOperationUri_1 {
+import rego.v1
+
+test_extractApiOperationUri_1 if {
 	[requestPath, requestMethod] := extractApiOperationUri("api/my-api/xxx/yyy/zzz/get")
-    requestPath == "my-api/xxx/yyy/zzz"
-    requestMethod == "GET"
+	requestPath == "my-api/xxx/yyy/zzz"
+	requestMethod == "GET"
 }
 
-test_extractApiOperationUri_2 {
+test_extractApiOperationUri_2 if {
 	[requestPath, requestMethod] := extractApiOperationUri("api/my-api/xxx/yyy/zzz/post")
-    requestPath == "my-api/xxx/yyy/zzz"
-    requestMethod == "POST"
+	requestPath == "my-api/xxx/yyy/zzz"
+	requestMethod == "POST"
 }
 
-test_extractApiOperationUri_3 {
-    [requestPath, requestMethod] := extractApiOperationUri("api/myApi/xxx/yyy/zzz/all")
-    requestPath == "myApi/xxx/yyy/zzz"
-    requestMethod == "ALL"
+test_extractApiOperationUri_3 if {
+	[requestPath, requestMethod] := extractApiOperationUri("api/myApi/xxx/yyy/zzz/all")
+	requestPath == "myApi/xxx/yyy/zzz"
+	requestMethod == "ALL"
 }
 
-test_extractApiOperationUri_4 {
-    [requestPath, requestMethod] := extractApiOperationUri("api/myApi/option")
-    requestPath == "myApi"
-    requestMethod == "OPTION"
+test_extractApiOperationUri_4 if {
+	[requestPath, requestMethod] := extractApiOperationUri("api/myApi/option")
+	requestPath == "myApi"
+	requestMethod == "OPTION"
 }
 
-test_extractApiOperationUri_5 {
-    [requestPath, requestMethod] := extractApiOperationUri("api/myApi")
-    requestPath == ""
-    requestMethod == "MYAPI"
+test_extractApiOperationUri_5 if {
+	[requestPath, requestMethod] := extractApiOperationUri("api/myApi")
+	requestPath == ""
+	requestMethod == "MYAPI"
 }
 
-test_extractApiOperationUri_6 {
-    [requestPath, requestMethod] := extractApiOperationUri("api")
-    requestPath == ""
-    requestMethod == "API"
+test_extractApiOperationUri_6 if {
+	[requestPath, requestMethod] := extractApiOperationUri("api")
+	requestPath == ""
+	requestMethod == "API"
 }
 
-test_extractApiOperationUri_7 {
+test_extractApiOperationUri_7 if {
 	[requestPath, requestMethod] := extractApiOperationUri("api/my-api/records/*/zzz/put")
-    requestPath == "my-api/records/*/zzz"
-    requestMethod == "PUT"
+	requestPath == "my-api/records/*/zzz"
+	requestMethod == "PUT"
 }
 
-test_extractApiOperationUri_8 {
-    [requestPath, requestMethod] := extractApiOperationUri("api/myApi/endpoint1/DELETE")
-    requestPath == "myApi/endpoint1"
-    requestMethod == "DELETE"
+test_extractApiOperationUri_8 if {
+	[requestPath, requestMethod] := extractApiOperationUri("api/myApi/endpoint1/DELETE")
+	requestPath == "myApi/endpoint1"
+	requestMethod == "DELETE"
 }

--- a/magda-opa/policies/common/getResourceTypeFromResourceUri.rego
+++ b/magda-opa/policies/common/getResourceTypeFromResourceUri.rego
@@ -1,6 +1,8 @@
 package common
 
-getResourceTypeFromResourceUri(resourceUri) = resourceType {
-    parts := split(resourceUri, "/")
-    resourceType := parts[count(parts)-1]
+import rego.v1
+
+getResourceTypeFromResourceUri(resourceUri) := resourceType if {
+	parts := split(resourceUri, "/")
+	resourceType := parts[count(parts) - 1]
 }

--- a/magda-opa/policies/common/hasNoConstaintPermission.rego
+++ b/magda-opa/policies/common/hasNoConstaintPermission.rego
@@ -1,19 +1,21 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 
-
 # check if the user has a no constaint permission matches requested operation
-hasNoConstraintPermission(inputOperationUri) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+hasNoConstraintPermission(inputOperationUri) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
 
-    input.user.permissions[i].userOwnershipConstraint = false
-    input.user.permissions[i].orgUnitOwnershipConstraint = false
-    input.user.permissions[i].preAuthorisedConstraint = false
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == false
 
-    input.user.permissions[i].operations[_].uri = inputOperationUri
+	permission.operations[_].uri == inputOperationUri
 }

--- a/magda-opa/policies/common/hasOrgUnitConstaintPermission.rego
+++ b/magda-opa/policies/common/hasOrgUnitConstaintPermission.rego
@@ -1,18 +1,21 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 
 # check if the user has a ownership constaint permission matches requested operation
-hasOrgUnitConstaintPermission(inputOperationUri) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+hasOrgUnitConstaintPermission(inputOperationUri) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
-    
-    input.user.permissions[i].userOwnershipConstraint = false
-    input.user.permissions[i].orgUnitOwnershipConstraint = true
-    input.user.permissions[i].preAuthorisedConstraint = false
-    
-    input.user.permissions[i].operations[_].uri = inputOperationUri
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
+
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == true
+	permission.preAuthorisedConstraint == false
+
+	permission.operations[_].uri == inputOperationUri
 }

--- a/magda-opa/policies/common/hasOwnerConstaintPermission.rego
+++ b/magda-opa/policies/common/hasOwnerConstaintPermission.rego
@@ -1,18 +1,21 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 
 # check if the user has a ownership constaint permission matches requested operation
-hasOwnerConstraintPermission(inputOperationUri) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+hasOwnerConstraintPermission(inputOperationUri) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
-    
-    input.user.permissions[i].userOwnershipConstraint = true
-    input.user.permissions[i].orgUnitOwnershipConstraint = false
-    input.user.permissions[i].preAuthorisedConstraint = false
-    
-    input.user.permissions[i].operations[_].uri = inputOperationUri
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
+
+	permission.userOwnershipConstraint == true
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == false
+
+	permission.operations[_].uri == inputOperationUri
 }

--- a/magda-opa/policies/common/hasPermissionAllowExemption.rego
+++ b/magda-opa/policies/common/hasPermissionAllowExemption.rego
@@ -1,15 +1,18 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 
 # has permission allow constraint exemption
-hasPermissionAllowExemption(inputOperationUri) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+hasPermissionAllowExemption(inputOperationUri) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
-    input.user.permissions[i].operations[_].uri = inputOperationUri
-    
-    input.user.permissions[i].allowExemption = true
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == inputOperationUri
+
+	permission.allowExemption == true
 }

--- a/magda-opa/policies/common/hasPreAuthConstaintPermission.rego
+++ b/magda-opa/policies/common/hasPreAuthConstaintPermission.rego
@@ -1,21 +1,24 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 
 # check if the user has a permission (with pre-authorised constaint) matches requested operation
 # please note: you can't combine the usage of this rule with checking like:
 # input.user.permissions[i].id = input.object[xxxx]["access-control"].preAuthorisedPermissionIds[_]
 # Why? because `i` is unbound, it will match any user permissions, not have to be the one previous checked by hasPreAuthConstaintPermission
-hasPreAuthConstaintPermission(inputOperationUri) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+hasPreAuthConstaintPermission(inputOperationUri) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
-    
-    input.user.permissions[i].userOwnershipConstraint = false
-    input.user.permissions[i].orgUnitOwnershipConstraint = false
-    input.user.permissions[i].preAuthorisedConstraint = true
-    
-    input.user.permissions[i].operations[_].uri = inputOperationUri
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
+
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == true
+
+	permission.operations[_].uri == inputOperationUri
 }

--- a/magda-opa/policies/common/isDraftDataset.rego
+++ b/magda-opa/policies/common/isDraftDataset.rego
@@ -1,7 +1,9 @@
 package common
 
+import rego.v1
+
 # a record can with publishing.state = "draft" must be a draft dataset
 # input.object.record["dataset-draft"] could not exist
-isDraftDataset(inputObjectRefName) {
-    input.object[inputObjectRefName].publishing.state = "draft"
+isDraftDataset(inputObjectRefName) if {
+	input.object[inputObjectRefName].publishing.state == "draft"
 }

--- a/magda-opa/policies/common/isDraftDistribution.rego
+++ b/magda-opa/policies/common/isDraftDistribution.rego
@@ -1,6 +1,8 @@
 package common
 
+import rego.v1
+
 # a record can with publishing.state = "draft" must be a draft distribution
-isDraftDistribution(inputObjectRefName) {
-    input.object[inputObjectRefName].publishing.state = "draft"
+isDraftDistribution(inputObjectRefName) if {
+	input.object[inputObjectRefName].publishing.state == "draft"
 }

--- a/magda-opa/policies/common/isEmpty.rego
+++ b/magda-opa/policies/common/isEmpty.rego
@@ -1,8 +1,8 @@
 package common
 
+import rego.v1
+
 # unfortunately, we can't use isEmpty to handle undefined value as `undefined` is not a scalar value that rego supports
 # the rule will fail before enter isEmpty
 # We don't want use `null` as valid "empty" value due to the difficulty of handling null
-isEmpty(v) {
-    v == ""
-}
+isEmpty("")

--- a/magda-opa/policies/common/isPublishedDataset.rego
+++ b/magda-opa/policies/common/isPublishedDataset.rego
@@ -1,12 +1,14 @@
 package common
 
-isPublishedDataset(inputObjectRefName) {
-    input.object[inputObjectRefName]["dcat-dataset-strings"]
-    input.object[inputObjectRefName].publishing.state = "published"
+import rego.v1
+
+isPublishedDataset(inputObjectRefName) if {
+	input.object[inputObjectRefName]["dcat-dataset-strings"]
+	input.object[inputObjectRefName].publishing.state == "published"
 }
 
 # for historical reason, records without `publishing` aspect `state` field set will be considered as published dataset as well
-isPublishedDataset(inputObjectRefName) {
-    input.object[inputObjectRefName]["dcat-dataset-strings"]
-    not input.object[inputObjectRefName].publishing.state
+isPublishedDataset(inputObjectRefName) if {
+	input.object[inputObjectRefName]["dcat-dataset-strings"]
+	not input.object[inputObjectRefName].publishing.state
 }

--- a/magda-opa/policies/common/isPublishedDistribution.rego
+++ b/magda-opa/policies/common/isPublishedDistribution.rego
@@ -1,12 +1,14 @@
 package common
 
-isPublishedDistribution(inputObjectRefName) {
-    input.object[inputObjectRefName]["dcat-distribution-strings"]
-    input.object[inputObjectRefName].publishing.state = "published"
+import rego.v1
+
+isPublishedDistribution(inputObjectRefName) if {
+	input.object[inputObjectRefName]["dcat-distribution-strings"]
+	input.object[inputObjectRefName].publishing.state == "published"
 }
 
 # for historical reason, records without `publishing` aspect `state` field set will be considered as published distribution as well
-isPublishedDistribution(inputObjectRefName) {
-    input.object[inputObjectRefName]["dcat-distribution-strings"]
-    not input.object[inputObjectRefName].publishing.state
+isPublishedDistribution(inputObjectRefName) if {
+	input.object[inputObjectRefName]["dcat-distribution-strings"]
+	not input.object[inputObjectRefName].publishing.state
 }

--- a/magda-opa/policies/common/verifyPublishingStatus.rego
+++ b/magda-opa/policies/common/verifyPublishingStatus.rego
@@ -1,17 +1,19 @@
 package common
 
-verifyPublishingStatus(inputObjectRefName, expectedStatus) {
+import rego.v1
+
+verifyPublishingStatus(inputObjectRefName, expectedStatus) if {
 	expectedStatus == "published"
 	input.object[inputObjectRefName].publishing.state == "published"
 }
 
 # for historical reason, some published dataset might not have `publishing` aspect
-verifyPublishingStatus(inputObjectRefName, expectedStatus) {
+verifyPublishingStatus(inputObjectRefName, expectedStatus) if {
 	expectedStatus == "published"
 	not input.object[inputObjectRefName].publishing.state
 }
 
-verifyPublishingStatus(inputObjectRefName, expectedStatus) {
+verifyPublishingStatus(inputObjectRefName, expectedStatus) if {
 	expectedStatus != "published"
 	input.object[inputObjectRefName].publishing.state == expectedStatus
 }

--- a/magda-opa/policies/common/verifyRecordPermission.rego
+++ b/magda-opa/policies/common/verifyRecordPermission.rego
@@ -1,68 +1,69 @@
 package common
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
-import data.common.hasOwnerConstraintPermission
+import data.common.hasOperationType
 import data.common.hasOrgUnitConstaintPermission
-import data.common.hasPreAuthConstaintPermission
+import data.common.hasOwnerConstraintPermission
 import data.common.isEmpty
 
-
 # if find a permission with no any constraints
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    hasNoConstraintPermission(inputOperationUri)
+verifyRecordPermission(inputOperationUri, _) if {
+	hasNoConstraintPermission(inputOperationUri)
 }
 
 # if find a permission allow exemption and resource set constraint exemption
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    hasPermissionAllowExemption(inputOperationUri)
-    input.object[inputObjectRefName]["access-control"].constraintExemption = true
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	hasPermissionAllowExemption(inputOperationUri)
+	input.object[inputObjectRefName]["access-control"].constraintExemption == true
 }
 
 # if find a permission with user ownership constraint
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    hasOwnerConstraintPermission(inputOperationUri)
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	hasOwnerConstraintPermission(inputOperationUri)
 
-    # use inputObjectRefName and avoid hard code context data field name
-    # In this way, we can control the reference output in residual rules
-    input.object[inputObjectRefName]["access-control"].ownerId = input.user.id
+	# use inputObjectRefName and avoid hard code context data field name
+	# In this way, we can control the reference output in residual rules
+	input.object[inputObjectRefName]["access-control"].ownerId == input.user.id
 }
 
 # if find a permission with org unit ownership constraint
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    hasOrgUnitConstaintPermission(inputOperationUri)
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	hasOrgUnitConstaintPermission(inputOperationUri)
 
-    input.user.managingOrgUnitIds[_] = input.object[inputObjectRefName]["access-control"].orgUnitId
+	input.object[inputObjectRefName]["access-control"].orgUnitId in input.user.managingOrgUnitIds
 }
 
 # or when a user has org unit ownership constraint permission, he also can access (read permission only) all records with NO org unit assigned
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
-    operationType == "read"
-    hasOrgUnitConstaintPermission(inputOperationUri)
-    # unfortunately, we can't use isEmpty to handle undefined value 
-    not input.object[inputObjectRefName]["access-control"].orgUnitId
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	hasOperationType(inputOperationUri, "read")
+	hasOrgUnitConstaintPermission(inputOperationUri)
+
+	# unfortunately, we can't use isEmpty to handle undefined value
+	not input.object[inputObjectRefName]["access-control"].orgUnitId
 }
 
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
-    operationType == "read"
-    hasOrgUnitConstaintPermission(inputOperationUri)
-    isEmpty(input.object[inputObjectRefName]["access-control"].orgUnitId)
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	hasOperationType(inputOperationUri, "read")
+	hasOrgUnitConstaintPermission(inputOperationUri)
+	isEmpty(input.object[inputObjectRefName]["access-control"].orgUnitId)
 }
 
 # if find a permission with pre-authorised constraint
-verifyRecordPermission(inputOperationUri, inputObjectRefName) {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+verifyRecordPermission(inputOperationUri, inputObjectRefName) if {
+	[resourceType, _, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    resourceUri := concat("/", [resourceUriPrefix, resourceType])
+	resourceUri := concat("/", [resourceUriPrefix, resourceType])
 
-    input.user.permissions[i].resourceUri = resourceUri
-    
-    input.user.permissions[i].userOwnershipConstraint = false
-    input.user.permissions[i].orgUnitOwnershipConstraint = false
-    input.user.permissions[i].preAuthorisedConstraint = true
-    
-    input.user.permissions[i].operations[_].uri = inputOperationUri
+	some permission in input.user.permissions
+	permission.resourceUri == resourceUri
 
-    input.user.permissions[i].id = input.object[inputObjectRefName]["access-control"].preAuthorisedPermissionIds[_]
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == true
+
+	permission.operations[_].uri == inputOperationUri
+
+	permission.id in input.object[inputObjectRefName]["access-control"].preAuthorisedPermissionIds
 }

--- a/magda-opa/policies/common/verifyRecordPermission_test.rego
+++ b/magda-opa/policies/common/verifyRecordPermission_test.rego
@@ -1,146 +1,117 @@
 package common
 
-test_verifyRecordPermission_preAuthConstaintPermission_incorrect_permission_id {
-    not verifyRecordPermission("object/dataset/read", "dataset") with input as {
-        "operationUri": "object/dataset/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "preAuthorisedPermissionIds": [
-                        # this is not a valid permission id, 
-                        # permission has userOwnershipConstraint but not preAuthorisedConstraint
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                }
-            }
-        },
-        "user": {
-            "displayName": "xxxxxxx",
-            "email": "xxxxxxxx@sss.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "permission with preAuthConstaint",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "permission with preAuthConstaint",
-                            "uri": "object/dataset/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": true,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset",
-                    "userOwnershipConstraint": true
-                }
-            ],
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Test Roles",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ]
-        }
-    }
+import rego.v1
+
+test_verifyRecordPermission_preAuthConstaintPermission_incorrect_permission_id if {
+	not verifyRecordPermission("object/dataset/read", "dataset") with input as {
+		"operationUri": "object/dataset/read",
+		"object": {"dataset": {"access-control": {"preAuthorisedPermissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"]}}}, # permission has userOwnershipConstraint but not preAuthorisedConstraint # this is not a valid permission id,
+		"user": {
+			"displayName": "xxxxxxx",
+			"email": "xxxxxxxx@sss.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "permission with preAuthConstaint",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "permission with preAuthConstaint",
+						"uri": "object/dataset/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": true,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset",
+					"userOwnershipConstraint": true,
+				},
+			],
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Test Roles",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+		},
+	}
 }
 
-test_verifyRecordPermission_preAuthConstaintPermission_correct_permission_id {
-    verifyRecordPermission("object/dataset/read", "dataset") with input as {
-        "operationUri": "object/dataset/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "preAuthorisedPermissionIds": [
-                        # this is a correct permission id
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            }
-        },
-        "user": {
-            "displayName": "xxxxxxx",
-            "email": "xxxxxxxx@sss.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "permission with preAuthConstaint",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "permission with preAuthConstaint",
-                            "uri": "object/dataset/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": true,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset",
-                    "userOwnershipConstraint": true
-                }
-            ],
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Test Roles",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ]
-        }
-    }
+test_verifyRecordPermission_preAuthConstaintPermission_correct_permission_id if {
+	verifyRecordPermission("object/dataset/read", "dataset") with input as {
+		"operationUri": "object/dataset/read",
+		"object": {"dataset": {"access-control": {"preAuthorisedPermissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"]}}}, # this is a correct permission id
+		"user": {
+			"displayName": "xxxxxxx",
+			"email": "xxxxxxxx@sss.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "permission with preAuthConstaint",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "permission with preAuthConstaint",
+						"uri": "object/dataset/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": true,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset",
+					"userOwnershipConstraint": true,
+				},
+			],
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Test Roles",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+		},
+	}
 }

--- a/magda-opa/policies/common/verifyRecordWithPublishingStatusPermission.rego
+++ b/magda-opa/policies/common/verifyRecordWithPublishingStatusPermission.rego
@@ -1,15 +1,17 @@
 package common
 
+import rego.v1
+
 import data.common.breakdownOperationUri
 import data.common.getResourceTypeFromResourceUri
+import data.common.isEmpty
 import data.common.verifyPublishingStatus
 import data.common.verifyRecordPermission
-import data.common.isEmpty
 
 # when resource type contains no wildcard type "*", e.g.  object.dataset.published
 # generic record access control rules applies (via verifyRecordPermission)
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
-	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	[resourceType, _, _] := breakdownOperationUri(inputOperationUri)
 
 	resourceType != "*"
 
@@ -20,151 +22,161 @@ verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName
 
 ##### Rules for wildcard resouce type e.g. object.dataset.*
 # if find a permission with no any constraints
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = false
-	input.user.permissions[i].orgUnitOwnershipConstraint = false
-	input.user.permissions[i].preAuthorisedConstraint = false
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == false
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
-    verifyPublishingStatus(inputObjectRefName, permissionResourceType)
+	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
 }
 
 # if find a permission allows exemption
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	input.object[inputObjectRefName]["access-control"].constraintExemption == true
+
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	resourceType == "*"
 
-	input.user.permissions[i].allowExemption = true
+	some permission in input.user.permissions
+	permission.allowExemption == true
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
-    verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-	input.object[inputObjectRefName]["access-control"].constraintExemption = true
+	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
 }
 
 # if find a permission with user ownership constraint
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	input.object[inputObjectRefName]["access-control"].ownerId == input.user.id
+
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = true
-	input.user.permissions[i].orgUnitOwnershipConstraint = false
-	input.user.permissions[i].preAuthorisedConstraint = false
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == true
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == false
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
 	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-	input.object[inputObjectRefName]["access-control"].ownerId = input.user.id
 }
 
 # if find a permission with org unit ownership constraint
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	input.object[inputObjectRefName]["access-control"].orgUnitId in input.user.managingOrgUnitIds
+
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = false
-	input.user.permissions[i].orgUnitOwnershipConstraint = true
-	input.user.permissions[i].preAuthorisedConstraint = false
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == true
+	permission.preAuthorisedConstraint == false
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
 	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-	input.user.managingOrgUnitIds[_] = input.object[inputObjectRefName]["access-control"].orgUnitId
 }
 
 # if find a permission with org unit ownership constraint, plus dataset have NOT been assigned org unit
 # e.g. anonymous users can access (`read` permission only) all datasets that not belongs to an org unit
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	not input.object[inputObjectRefName]["access-control"].orgUnitId
+
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	# we only want to allow this special permission grant for "read" operation (issue: #3426)
 	operationType == "read"
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = false
-	input.user.permissions[i].orgUnitOwnershipConstraint = true
-	input.user.permissions[i].preAuthorisedConstraint = false
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == true
+	permission.preAuthorisedConstraint == false
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
 	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-
-	not input.object[inputObjectRefName]["access-control"].orgUnitId
 }
 
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
+	isEmpty(input.object[inputObjectRefName]["access-control"].orgUnitId)
+
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
-    # we only want to allow this special permission grant for "read" operation (issue: #3426)
+	# we only want to allow this special permission grant for "read" operation (issue: #3426)
 	operationType == "read"
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = false
-	input.user.permissions[i].orgUnitOwnershipConstraint = true
-	input.user.permissions[i].preAuthorisedConstraint = false
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == true
+	permission.preAuthorisedConstraint == false
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
 	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-
-	isEmpty(input.object[inputObjectRefName]["access-control"].orgUnitId)
 }
 
 # if find a permission with pre-authorised constraint
-verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) {
+verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName) if {
 	[resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(inputOperationUri)
 
 	resourceType == "*"
 
-	input.user.permissions[i].userOwnershipConstraint = false
-	input.user.permissions[i].orgUnitOwnershipConstraint = false
-	input.user.permissions[i].preAuthorisedConstraint = true
+	some permission in input.user.permissions
+	permission.userOwnershipConstraint == false
+	permission.orgUnitOwnershipConstraint == false
+	permission.preAuthorisedConstraint == true
 
-	permissionResourceType := getResourceTypeFromResourceUri(input.user.permissions[i].resourceUri)
+	permissionResourceType := getResourceTypeFromResourceUri(permission.resourceUri)
 	operationUri := concat("/", [resourceUriPrefix, permissionResourceType, operationType])
 	resourceUri := concat("/", [resourceUriPrefix, permissionResourceType])
 
-	input.user.permissions[i].resourceUri = resourceUri
-	input.user.permissions[i].operations[_].uri = operationUri
+	permission.resourceUri == resourceUri
+	permission.operations[_].uri == operationUri
 
 	verifyPublishingStatus(inputObjectRefName, permissionResourceType)
-	input.object[inputObjectRefName]["access-control"].preAuthorisedPermissionIds[_] = input.user.permissions[i].id
+	permission.id in input.object[inputObjectRefName]["access-control"].preAuthorisedPermissionIds
 }

--- a/magda-opa/policies/entrypoint/allow.rego
+++ b/magda-opa/policies/entrypoint/allow.rego
@@ -1,145 +1,147 @@
 package entrypoint
 
-# When no rule match, the decision will be `denied` 
-default allow = false
+import rego.v1
 
-allow {
-    # users with admin roles will have access to everything
-    input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
+# When no rule match, the decision will be `denied`
+default allow := false
+
+allow if {
+	# users with admin roles will have access to everything
+	input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
 }
 
-allow {
-    ## delegate generic record related decision to record_allow
-    startswith(input.operationUri, "object/record/")
-    data.object.record.allow
+allow if {
+	## delegate generic record related decision to record_allow
+	startswith(input.operationUri, "object/record/")
+	data.object.record.allow
 }
 
-allow {
-    ## delegate dataset related decision to dataset_allow
-    startswith(input.operationUri, "object/dataset/")
-    data.object.dataset.allow
+allow if {
+	## delegate dataset related decision to dataset_allow
+	startswith(input.operationUri, "object/dataset/")
+	data.object.dataset.allow
 }
 
-allow {
-    ## delegate organization related decision to organization_allow
-    startswith(input.operationUri, "object/organization/")
-    data.object.organization.allow
+allow if {
+	## delegate organization related decision to organization_allow
+	startswith(input.operationUri, "object/organization/")
+	data.object.organization.allow
 }
 
-allow {
-    ## delegate distribution related decision to organization_allow
-    startswith(input.operationUri, "object/distribution/")
-    data.object.distribution.allow
+allow if {
+	## delegate distribution related decision to organization_allow
+	startswith(input.operationUri, "object/distribution/")
+	data.object.distribution.allow
 }
 
-allow {
-    ## delegate aspect related decision to aspect_allow
-    startswith(input.operationUri, "object/aspect/")
-    data.object.aspect.allow
+allow if {
+	## delegate aspect related decision to aspect_allow
+	startswith(input.operationUri, "object/aspect/")
+	data.object.aspect.allow
 }
 
-allow {
-    ## delegate webhook related decision to webhook rules
-    startswith(input.operationUri, "object/webhook/")
-    data.object.webhook.allow
+allow if {
+	## delegate webhook related decision to webhook rules
+	startswith(input.operationUri, "object/webhook/")
+	data.object.webhook.allow
 }
 
-allow {
-    ## delegate event related decision to event rules
-    startswith(input.operationUri, "object/event/")
-    data.object.event.allow
+allow if {
+	## delegate event related decision to event rules
+	startswith(input.operationUri, "object/event/")
+	data.object.event.allow
 }
 
-allow {
-    ## delegate content related decision to content rules
-    startswith(input.operationUri, "object/content/")
-    data.object.content.allow
+allow if {
+	## delegate content related decision to content rules
+	startswith(input.operationUri, "object/content/")
+	data.object.content.allow
 }
 
-allow {
-    ## delegate connector related decision to connector rules
-    startswith(input.operationUri, "object/connector/")
-    data.object.connector.allow
+allow if {
+	## delegate connector related decision to connector rules
+	startswith(input.operationUri, "object/connector/")
+	data.object.connector.allow
 }
 
-allow {
-    ## delegate tenant related decision to tenant rules
-    startswith(input.operationUri, "object/tenant/")
-    data.object.tenant.allow
+allow if {
+	## delegate tenant related decision to tenant rules
+	startswith(input.operationUri, "object/tenant/")
+	data.object.tenant.allow
 }
 
-allow {
-    ## delegate access group related decision to access group rules
-    startswith(input.operationUri, "object/accessGroup/")
-    data.object.accessGroup.allow
+allow if {
+	## delegate access group related decision to access group rules
+	startswith(input.operationUri, "object/accessGroup/")
+	data.object.accessGroup.allow
 }
 
-allow {
-    ## delegate FaaS function related decision to FaaS function rules
-    startswith(input.operationUri, "object/faas/function/")
-    data.object.faas.function.allow
+allow if {
+	## delegate FaaS function related decision to FaaS function rules
+	startswith(input.operationUri, "object/faas/function/")
+	data.object.faas.function.allow
 }
 
-allow {
-    ## delegate storage bucket related decision to storage bucket rules
-    startswith(input.operationUri, "storage/bucket/")
-    data.storage.bucket.allow
+allow if {
+	## delegate storage bucket related decision to storage bucket rules
+	startswith(input.operationUri, "storage/bucket/")
+	data.storage.bucket.allow
 }
 
-allow {
-    ## delegate storage object related decision to storage object rules
-    startswith(input.operationUri, "storage/object/")
-    data.storage.object.allow
+allow if {
+	## delegate storage object related decision to storage object rules
+	startswith(input.operationUri, "storage/object/")
+	data.storage.object.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/apiKey/")
-    data.authObject.apiKey.allow
+allow if {
+	startswith(input.operationUri, "authObject/apiKey/")
+	data.authObject.apiKey.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/credential/")
-    data.authObject.credential.allow
+allow if {
+	startswith(input.operationUri, "authObject/credential/")
+	data.authObject.credential.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/operation/")
-    data.authObject.operation.allow
+allow if {
+	startswith(input.operationUri, "authObject/operation/")
+	data.authObject.operation.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/orgUnit/")
-    data.authObject.orgUnit.allow
+allow if {
+	startswith(input.operationUri, "authObject/orgUnit/")
+	data.authObject.orgUnit.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/permission/")
-    data.authObject.permission.allow
+allow if {
+	startswith(input.operationUri, "authObject/permission/")
+	data.authObject.permission.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/resource/")
-    data.authObject.resource.allow
+allow if {
+	startswith(input.operationUri, "authObject/resource/")
+	data.authObject.resource.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/role/")
-    data.authObject.role.allow
+allow if {
+	startswith(input.operationUri, "authObject/role/")
+	data.authObject.role.allow
 }
 
-allow {
-    startswith(input.operationUri, "authObject/user/")
-    data.authObject.user.allow
+allow if {
+	startswith(input.operationUri, "authObject/user/")
+	data.authObject.user.allow
 }
 
-allow {
-    startswith(input.operationUri, "api/indexer/")
-    data.api.indexer.allow
+allow if {
+	startswith(input.operationUri, "api/indexer/")
+	data.api.indexer.allow
 }
 
-allow {
-    # allow all other api calls to generic gateway level enforcement policy based on HTTP request path & method
-    startswith(input.operationUri, "api/")
-    startswith(input.operationUri, "api/indexer/") != true
-    data.api.allow
+allow if {
+	# allow all other api calls to generic gateway level enforcement policy based on HTTP request path & method
+	startswith(input.operationUri, "api/")
+	startswith(input.operationUri, "api/indexer/") != true
+	data.api.allow
 }

--- a/magda-opa/policies/entrypoint/allow_test.rego
+++ b/magda-opa/policies/entrypoint/allow_test.rego
@@ -1,6 +1,8 @@
 package entrypoint
 
-test_allow_non_admin_should_have_no_permission_to_not_defined_resource {
+import rego.v1
+
+test_allow_non_admin_should_have_no_permission_to_not_defined_resource if {
 	not allow with input as {
 		"operationUri": "object/test-any-object/test-any-operation",
 		"user": {
@@ -58,7 +60,7 @@ test_allow_non_admin_should_have_no_permission_to_not_defined_resource {
 	}
 }
 
-test_allow_admin_should_have_permission_to_not_defined_resource {
+test_allow_admin_should_have_permission_to_not_defined_resource if {
 	allow with input as {
 		"operationUri": "object/test-any-object/test-any-operation",
 		"user": {
@@ -67,13 +69,11 @@ test_allow_admin_should_have_permission_to_not_defined_resource {
 			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
 			"permissions": [],
 			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-			"roles": [
-				{
-					"id": "00000000-0000-0003-0000-000000000000",
-					"name": "Admin Users",
-					"permissionIds": []
-				}
-			],
+			"roles": [{
+				"id": "00000000-0000-0003-0000-000000000000",
+				"name": "Admin Users",
+				"permissionIds": [],
+			}],
 			"source": "ckan",
 		},
 	}

--- a/magda-opa/policies/object/accessGroup/allow.rego
+++ b/magda-opa/policies/object/accessGroup/allow.rego
@@ -1,8 +1,10 @@
 package object.accessGroup
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # `object/accessGroup` resource currently only support two operations: `object/accessGroup/create` & `object/accessGroup/read`
 # the creation should done via API `POST /auth/accessGroup`
@@ -11,7 +13,6 @@ default allow = false
 # e.g. `object/record/update` or `object/record/delete`
 # `object/accessGroup/read` is only created for frontend to determine whether the access group related UI is available to a user.
 # The actual read access is secured via resource operation `object/record/read` over access group records
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
-

--- a/magda-opa/policies/object/aspect/allow.rego
+++ b/magda-opa/policies/object/aspect/allow.rego
@@ -1,11 +1,13 @@
 package object.aspect
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "aspect" will be allowed
 # Please note: this policy is for "aspect definition" not "record's aspect"
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/connector/allow.rego
+++ b/magda-opa/policies/object/connector/allow.rego
@@ -1,9 +1,11 @@
 package object.connector
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/content/allow.rego
+++ b/magda-opa/policies/object/content/allow.rego
@@ -1,39 +1,41 @@
 package object.content
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 import data.object.dataset.hasAnyDraftReadPermission
 import data.object.dataset.hasAnyPublishedReadPermission
 
-default allow = false
+default allow := false
 
 # handle all operations except "read"
-allow {
-    input.operationUri != "object/content/read"
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	input.operationUri != "object/content/read"
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # handle "read" operation for `header/navigation/drafts`
 # the legacy rule is created for backward compatibility
-allow {
-    input.operationUri == "object/content/read"
-    hasNoConstraintPermission(input.operationUri)
-    input.object.content.id = "header/navigation/drafts"
-    hasAnyDraftReadPermission
+allow if {
+	input.operationUri == "object/content/read"
+	hasNoConstraintPermission(input.operationUri)
+	input.object.content.id == "header/navigation/drafts"
+	hasAnyDraftReadPermission
 }
 
 # handle "read" operation for `header/navigation/datasets`
 # the legacy rule is created for backward compatibility
-allow {
-    input.operationUri == "object/content/read"
-    hasNoConstraintPermission(input.operationUri)
-    input.object.content.id = "header/navigation/datasets"
-    hasAnyPublishedReadPermission
+allow if {
+	input.operationUri == "object/content/read"
+	hasNoConstraintPermission(input.operationUri)
+	input.object.content.id == "header/navigation/datasets"
+	hasAnyPublishedReadPermission
 }
 
 # handle "read" operation for any other cases
-allow {
-    input.operationUri == "object/content/read"
-    hasNoConstraintPermission(input.operationUri)
-    input.object.content.id != "header/navigation/datasets"
-    input.object.content.id != "header/navigation/drafts"
+allow if {
+	input.operationUri == "object/content/read"
+	hasNoConstraintPermission(input.operationUri)
+	input.object.content.id != "header/navigation/datasets"
+	input.object.content.id != "header/navigation/drafts"
 }

--- a/magda-opa/policies/object/dataset/allow.rego
+++ b/magda-opa/policies/object/dataset/allow.rego
@@ -1,14 +1,16 @@
 package object.dataset
 
+import rego.v1
+
 import data.common.verifyRecordWithPublishingStatusPermission
 
-default allow = false
+default allow := false
 
-allow {
+allow if {
 	verifyPermission(input.operationUri, "dataset")
 }
 
 # interface for external policy to forward decision request related to "dataset"
-verifyPermission(inputOperationUri, inputObjectRefName) {
+verifyPermission(inputOperationUri, inputObjectRefName) if {
 	verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName)
 }

--- a/magda-opa/policies/object/dataset/allow_test.rego
+++ b/magda-opa/policies/object/dataset/allow_test.rego
@@ -1,1026 +1,864 @@
 package object.dataset
 
-test_allow_no_constraints_permission_user_without_no_constraints_permission {
-    not allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+import rego.v1
+
+test_allow_no_constraints_permission_user_without_no_constraints_permission if {
+	not allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_no_constraints_permission_user_has_no_constraints_permission {
-    allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "3d913ce7-e728-4bd2-9542-5e9983e45fe1",
-                    "name": "View Draft Dataset",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                        "3d913ce7-e728-4bd2-9542-5e9983e45fe1"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_no_constraints_permission_user_has_no_constraints_permission if {
+	allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "3d913ce7-e728-4bd2-9542-5e9983e45fe1",
+					"name": "View Draft Dataset",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+						"3d913ce7-e728-4bd2-9542-5e9983e45fe1",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_user_ownership_constraint_permission_user_is_not_owner {
-    not allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_user_ownership_constraint_permission_user_is_not_owner if {
+	not allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_user_ownership_constraint_permission_user_is_owner {
-    allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_user_ownership_constraint_permission_user_is_owner if {
+	allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_user_ownership_constraint_permission_user_is_owner_wildcard_res_uri_test1 {
-    allow with input as {
-        "operationUri": "object/dataset/*/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_user_ownership_constraint_permission_user_is_owner_wildcard_res_uri_test1 if {
+	allow with input as {
+		"operationUri": "object/dataset/*/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_user_ownership_constraint_permission_user_is_owner_wildcard_res_uri_test2 {
-    allow with input as {
-        "operationUri": "object/dataset/*/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_user_ownership_constraint_permission_user_is_owner_wildcard_res_uri_test2 if {
+	allow with input as {
+		"operationUri": "object/dataset/*/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_pre_Authorised_constraint_permission_user_permission_is_not_pre_authorised {
-    not allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (pre-authorised)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": true,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_pre_Authorised_constraint_permission_user_permission_is_not_pre_authorised if {
+	not allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (pre-authorised)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": true,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_pre_Authorised_constraint_permission_user_permission_is_pre_authorised {
-    allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"]
-                },
-                "publishing": {
-                    "state": "draft"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (pre-authorised)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": true,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_pre_Authorised_constraint_permission_user_permission_is_pre_authorised if {
+	allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			},
+			"publishing": {"state": "draft"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (pre-authorised)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": true,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_pre_authorised_constraint_permission_user_permission_is_pre_authorised_for_incorrect_publishing_state {
-    not allow with input as {
-        "operationUri": "object/dataset/draft/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "preAuthorisedPermissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"]
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (pre-authorised)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": true,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": false
-                },
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_allow_pre_authorised_constraint_permission_user_permission_is_pre_authorised_for_incorrect_publishing_state if {
+	not allow with input as {
+		"operationUri": "object/dataset/draft/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"preAuthorisedPermissionIds": ["72d52505-cf96-47b2-9b74-d0fdc1f5aee7"],
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (pre-authorised)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": true,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset",
+					"operations": [{
+						"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+						"name": "Read Publish Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_allow_empty_string_orgUnitId {
-    allow with input as {
-        "operationUri": "object/dataset/published/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": ""
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_allow_empty_string_orgUnitId if {
+	allow with input as {
+		"operationUri": "object/dataset/published/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "",
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_not_allow_empty_string_orgUnitId_non_read_operation {
-    not allow with input as {
-        "operationUri": "object/dataset/published/update",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": ""
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_not_allow_empty_string_orgUnitId_non_read_operation if {
+	not allow with input as {
+		"operationUri": "object/dataset/published/update",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "",
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_allow_undefined_orgUnitId {
-    allow with input as {
-        "operationUri": "object/dataset/published/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_allow_undefined_orgUnitId if {
+	allow with input as {
+		"operationUri": "object/dataset/published/read",
+		"object": {"dataset": {
+			"access-control": {"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_not_allow_undefined_orgUnitId_non_read {
-    not allow with input as {
-        "operationUri": "object/dataset/published/update",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_not_allow_undefined_orgUnitId_non_read if {
+	not allow with input as {
+		"operationUri": "object/dataset/published/update",
+		"object": {"dataset": {
+			"access-control": {"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_allow_empty_string_orgUnitId_any_publishing_status {
-    allow with input as {
-        "operationUri": "object/dataset/*/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": ""
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_allow_empty_string_orgUnitId_any_publishing_status if {
+	allow with input as {
+		"operationUri": "object/dataset/*/read",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "",
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_not_allow_empty_string_orgUnitId_any_publishing_status_non_read {
-    not allow with input as {
-        "operationUri": "object/dataset/*/update",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
-                    "orgUnitId": ""
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_not_allow_empty_string_orgUnitId_any_publishing_status_non_read if {
+	not allow with input as {
+		"operationUri": "object/dataset/*/update",
+		"object": {"dataset": {
+			"access-control": {
+				"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx",
+				"orgUnitId": "",
+			},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_allow_undefined_orgUnitId_any_publishing_status {
-    allow with input as {
-        "operationUri": "object/dataset/*/read",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_allow_undefined_orgUnitId_any_publishing_status if {
+	allow with input as {
+		"operationUri": "object/dataset/*/read",
+		"object": {"dataset": {
+			"access-control": {"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }
 
-test_not_allow_undefined_orgUnitId_any_publishing_status_non_read {
-    not allow with input as {
-        "operationUri": "object/dataset/*/delete",
-        "object": {
-            "dataset": {
-                "access-control": {
-                    "ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
-                },
-                "publishing": {
-                    "state": "published"
-                }
-            }
-        },
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
-            "permissions": [
-                {
-                    "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                    "name": "View Published Dataset",
-                    "operations": [
-                        {
-                            "id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
-                            "name": "Read Publish Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": true,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
-                    "resourceUri": "object/dataset/published",
-                    "userOwnershipConstraint": false
-                }
-            ]
-        }
-    }
+test_not_allow_undefined_orgUnitId_any_publishing_status_non_read if {
+	not allow with input as {
+		"operationUri": "object/dataset/*/delete",
+		"object": {"dataset": {
+			"access-control": {"ownerId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"},
+			"publishing": {"state": "published"},
+		}},
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"managingOrgUnitIds": ["90a9dce4-91af-44e2-a2f4-9ddccb3f4c5f"],
+			"permissions": [{
+				"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+				"name": "View Published Dataset",
+				"operations": [{
+					"id": "f1e2af3e-5d98-4081-a4ff-7016f43002fa",
+					"name": "Read Publish Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": true,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ef3b767f-d06b-46f4-9302-031ae5004275",
+				"resourceUri": "object/dataset/published",
+				"userOwnershipConstraint": false,
+			}],
+		},
+	}
 }

--- a/magda-opa/policies/object/dataset/hasAnyDraftReadPermission.rego
+++ b/magda-opa/policies/object/dataset/hasAnyDraftReadPermission.rego
@@ -1,12 +1,14 @@
 package object.dataset
 
-default hasAnyDraftReadPermission = false
+import rego.v1
 
-hasAnyDraftReadPermission {
-    input.user.permissions[_].operations[_].uri = "object/dataset/draft/read"
+default hasAnyDraftReadPermission := false
+
+hasAnyDraftReadPermission if {
+	input.user.permissions[_].operations[_].uri == "object/dataset/draft/read"
 }
 
-hasAnyDraftReadPermission {
-    # users with admin roles will have access to everything
-    input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
+hasAnyDraftReadPermission if {
+	# users with admin roles will have access to everything
+	input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
 }

--- a/magda-opa/policies/object/dataset/hasAnyDraftReadPermission_test.rego
+++ b/magda-opa/policies/object/dataset/hasAnyDraftReadPermission_test.rego
@@ -1,113 +1,103 @@
 package object.dataset
 
-test_hasAnyDraftReadPermission_with_correct_permission {
-    hasAnyDraftReadPermission with input as {
-        "operationUri": "object/dataset/draft/read",
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/draft/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                },
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+import rego.v1
+
+test_hasAnyDraftReadPermission_with_correct_permission if {
+	hasAnyDraftReadPermission with input as {
+		"operationUri": "object/dataset/draft/read",
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/draft/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+				{
+					"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					"name": "View Draft Dataset (Own)",
+					"operations": [{
+						"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+						"name": "Read Draft Dataset",
+						"uri": "object/dataset/published/read",
+					}],
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+				},
+			],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }
 
-test_hasAnyDraftReadPermission_with_no_correct_permission {
-    not hasAnyDraftReadPermission with input as {
-        "operationUri": "object/dataset/draft/read",
-        "user": {
-            "displayName": "Jacky Jiang",
-            "email": "t83714@gmail.com",
-            "id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
-            "permissions": [
-                {
-                    "id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
-                    "name": "View Draft Dataset (Own)",
-                    "operations": [
-                        {
-                            "id": "bf946197-392a-4dbb-a7e1-789424e231a4",
-                            "name": "Read Draft Dataset",
-                            "uri": "object/dataset/published/read"
-                        }
-                    ],
-                    "orgUnitOwnershipConstraint": false,
-                    "preAuthorisedConstraint": false,
-                    "resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
-                    "resourceUri": "object/dataset/draft",
-                    "userOwnershipConstraint": true
-                }
-            ],
-            "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
-            "roles": [
-                {
-                    "id": "00000000-0000-0002-0000-000000000000",
-                    "name": "Authenticated Users",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-                    ]
-                },
-                {
-                    "id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
-                    "name": "Approvers",
-                    "permissionIds": [
-                        "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-                        "72d52505-cf96-47b2-9b74-d0fdc1f5aee7"
-                    ]
-                }
-            ],
-            "source": "ckan"
-        }
-    }
+test_hasAnyDraftReadPermission_with_no_correct_permission if {
+	not hasAnyDraftReadPermission with input as {
+		"operationUri": "object/dataset/draft/read",
+		"user": {
+			"displayName": "Jacky Jiang",
+			"email": "t83714@gmail.com",
+			"id": "80a9dce4-91af-44e2-a2f4-9ddccb3f4c5e",
+			"permissions": [{
+				"id": "72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+				"name": "View Draft Dataset (Own)",
+				"operations": [{
+					"id": "bf946197-392a-4dbb-a7e1-789424e231a4",
+					"name": "Read Draft Dataset",
+					"uri": "object/dataset/published/read",
+				}],
+				"orgUnitOwnershipConstraint": false,
+				"preAuthorisedConstraint": false,
+				"resourceId": "ea5d2d58-165a-48cb-9b22-42edd6a3024a",
+				"resourceUri": "object/dataset/draft",
+				"userOwnershipConstraint": true,
+			}],
+			"photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": ["e5ce2fc4-9f38-4f52-8190-b770ed2074e6"],
+				},
+				{
+					"id": "14ff3f57-e8ea-4771-93af-c6ea91a798d5",
+					"name": "Approvers",
+					"permissionIds": [
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+						"72d52505-cf96-47b2-9b74-d0fdc1f5aee7",
+					],
+				},
+			],
+			"source": "ckan",
+		},
+	}
 }

--- a/magda-opa/policies/object/dataset/hasAnyPublishedReadPermission.rego
+++ b/magda-opa/policies/object/dataset/hasAnyPublishedReadPermission.rego
@@ -1,12 +1,14 @@
 package object.dataset
 
-default hasAnyPublishedReadPermission = false
+import rego.v1
 
-hasAnyPublishedReadPermission {
-    input.user.permissions[_].operations[_].uri = "object/dataset/published/read"
+default hasAnyPublishedReadPermission := false
+
+hasAnyPublishedReadPermission if {
+	input.user.permissions[_].operations[_].uri == "object/dataset/published/read"
 }
 
-hasAnyPublishedReadPermission {
-    # users with admin roles will have access to everything
-    input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
+hasAnyPublishedReadPermission if {
+	# users with admin roles will have access to everything
+	input.user.roles[_].id == "00000000-0000-0003-0000-000000000000"
 }

--- a/magda-opa/policies/object/distribution/allow.rego
+++ b/magda-opa/policies/object/distribution/allow.rego
@@ -1,14 +1,16 @@
 package object.distribution
 
+import rego.v1
+
 import data.common.verifyRecordWithPublishingStatusPermission
 
-default allow = false
+default allow := false
 
-allow {
-    verifyPermission(input.operationUri, "distribution")
+allow if {
+	verifyPermission(input.operationUri, "distribution")
 }
 
 # interface for external policy to forward decision request related to "distribution"
-verifyPermission(inputOperationUri, inputObjectRefName) {
+verifyPermission(inputOperationUri, inputObjectRefName) if {
 	verifyRecordWithPublishingStatusPermission(inputOperationUri, inputObjectRefName)
 }

--- a/magda-opa/policies/object/event/allow.rego
+++ b/magda-opa/policies/object/event/allow.rego
@@ -1,10 +1,12 @@
 package object.event
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
 # Users has a unlimited permission to perfom the operation on "event" will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/faas/function/allow.rego
+++ b/magda-opa/policies/object/faas/function/allow.rego
@@ -1,9 +1,11 @@
 package object.faas.function
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/organization/allow.rego
+++ b/magda-opa/policies/object/organization/allow.rego
@@ -1,16 +1,18 @@
 package object.organization
 
+import rego.v1
+
 import data.common.verifyRecordPermission
 
-default allow = false
+default allow := false
 
-allow {
-    verifyPermission(input.operationUri, "organization")
+allow if {
+	verifyPermission(input.operationUri, "organization")
 }
 
 # we don't required any extra access control logic rather than standard verifyRecordPermission
 # We still need this policy file in order to allow seperate resource type `object.organization`
 # Therefore, we can assign permissions only apply to organization records.
-verifyPermission(inputOperationUri, inputObjectRefName) {
-    verifyRecordPermission(inputOperationUri, inputObjectRefName)
+verifyPermission(inputOperationUri, inputObjectRefName) if {
+	verifyRecordPermission(inputOperationUri, inputObjectRefName)
 }

--- a/magda-opa/policies/object/record/allow.rego
+++ b/magda-opa/policies/object/record/allow.rego
@@ -1,98 +1,107 @@
 package object.record
 
+import rego.v1
+
 import data.common.breakdownOperationUri
-import data.common.verifyRecordPermission
-import data.common.isPublishedDataset
 import data.common.isDraftDataset
-import data.common.isPublishedDistribution
 import data.common.isDraftDistribution
+import data.common.isPublishedDataset
+import data.common.isPublishedDistribution
+import data.common.verifyRecordPermission
 import data.object.dataset.verifyPermission as verifyDatasetPermission
-import data.object.organization.verifyPermission as verifyOrgPermission
 import data.object.distribution.verifyPermission as verifyDistributionPermission
+import data.object.organization.verifyPermission as verifyOrgPermission
 
-default allow = false
+default allow := false
 
-allow {
-    verifyPermission(input.operationUri)
+allow if {
+	verifyPermission(input.operationUri)
 }
 
 # delegated to published dataset rules
-verifyPermission(operationUri) {
-    isPublishedDataset("record")
+verifyPermission(operationUri) if {
+	isPublishedDataset("record")
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "dataset", "published", operationType])
-    # proxy to dataset related permission decision
-    verifyDatasetPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "dataset", "published", operationType])
+
+	# proxy to dataset related permission decision
+	verifyDatasetPermission(inputOperationUri, "record")
 }
 
 # delegated to draft dataset rules
-verifyPermission(operationUri) {
-    isDraftDataset("record")
+verifyPermission(operationUri) if {
+	isDraftDataset("record")
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "dataset", "draft", operationType])
-    # proxy to dataset related permission decision
-    verifyDatasetPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "dataset", "draft", operationType])
+
+	# proxy to dataset related permission decision
+	verifyDatasetPermission(inputOperationUri, "record")
 }
 
 # delegated to rules for other dataset type (reserved for future)
-verifyPermission(operationUri) {
-    input.object.record["dcat-dataset-strings"]
-    not isDraftDataset("record")
-    not isPublishedDataset("record")
-    input.object.record.publishing.state
+verifyPermission(operationUri) if {
+	input.object.record["dcat-dataset-strings"]
+	not isDraftDataset("record")
+	not isPublishedDataset("record")
+	input.object.record.publishing.state
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "dataset", "*", operationType])
-    # proxy to dataset related permission decision
-    verifyDatasetPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "dataset", "*", operationType])
+
+	# proxy to dataset related permission decision
+	verifyDatasetPermission(inputOperationUri, "record")
 }
 
 # delegated to published distribution rules
-verifyPermission(operationUri) {
-    isPublishedDistribution("record")
+verifyPermission(operationUri) if {
+	isPublishedDistribution("record")
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "distribution", "published", operationType])
-    # proxy to distribution related permission decision
-    verifyDistributionPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "distribution", "published", operationType])
+
+	# proxy to distribution related permission decision
+	verifyDistributionPermission(inputOperationUri, "record")
 }
 
 # delegated to draft distribution rules
-verifyPermission(operationUri) {
-    isDraftDistribution("record")
+verifyPermission(operationUri) if {
+	isDraftDistribution("record")
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "distribution", "draft", operationType])
-    # proxy to distribution related permission decision
-    verifyDistributionPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "distribution", "draft", operationType])
+
+	# proxy to distribution related permission decision
+	verifyDistributionPermission(inputOperationUri, "record")
 }
 
 # delegated to rules for other distribution type (reserved for future)
-verifyPermission(operationUri) {
-    input.object.record["dcat-distribution-strings"]
-    not isDraftDistribution("record")
-    not isPublishedDistribution("record")
-    input.object.record.publishing.state
+verifyPermission(operationUri) if {
+	input.object.record["dcat-distribution-strings"]
+	not isDraftDistribution("record")
+	not isPublishedDistribution("record")
+	input.object.record.publishing.state
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "distribution", "*", operationType])
-    # proxy to distribution related permission decision
-    verifyDistributionPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "distribution", "*", operationType])
+
+	# proxy to distribution related permission decision
+	verifyDistributionPermission(inputOperationUri, "record")
 }
 
-verifyPermission(operationUri) {
-    # organization-details' existence proves it's a organization record
-    input.object.record["organization-details"]
+verifyPermission(operationUri) if {
+	# organization-details' existence proves it's a organization record
+	input.object.record["organization-details"]
 
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(operationUri)
-    inputOperationUri := concat("/", ["object", "organization", operationType])
-    # proxy to organization related permission decision
-    verifyOrgPermission(inputOperationUri, "record")
+	[_, operationType, _] := breakdownOperationUri(operationUri)
+	inputOperationUri := concat("/", ["object", "organization", operationType])
+
+	# proxy to organization related permission decision
+	verifyOrgPermission(inputOperationUri, "record")
 }
 
 # handle all other not specified record types with general access control rules
-verifyPermission(operationUri) {
-    verifyRecordPermission(operationUri, "record")
+verifyPermission(operationUri) if {
+	verifyRecordPermission(operationUri, "record")
 }

--- a/magda-opa/policies/object/record/allow_test.rego
+++ b/magda-opa/policies/object/record/allow_test.rego
@@ -1,974 +1,912 @@
 package object.record
 
-test_not_allow_data_steward_user_create_his_own_record {
-    # data_steward only alow create dataset not record
-     # "dcat-dataset-strings" is required
-    not allow with input as {
-      "object": {
-        "record": {
-          "name": "",
-          "lastUpdate": null,
-          "sourceTag": "",
-          "id": "40a390dc-d008-4765-9e84-28cacae49751",
-          "publishing": {
-            "state": "published"
-          },
-          "dataset-draft": {
-            "data": "{}",
-            "dataset": {
-              "name": "test dataset"
-            },
-            "timestamp": "2022-04-11T12:52:24.278Z"
-          },
-          "tenantId": 0,
-          "access-control": {
-            "ownerId": "8f414dab-cc51-4b5b-b790-4271da4f75a9"
-          }
-        }
-      },
-      "user": {
-        "id": "8f414dab-cc51-4b5b-b790-4271da4f75a9",
-        "displayName": "Test dataStewardUser",
-        "email": "dataStewward@test.com",
-        "photoURL": "",
-        "source": "internal",
-        "sourceId": "8da06331-5f56-4951-b126-f057e8709bad",
-        "orgUnitId": null,
-        "roles": [
-          {
-            "id": "00000000-0000-0002-0000-000000000000",
-            "name": "Authenticated Users",
-            "permissionIds": [
-              "4ce18e69-0df7-4799-9d69-baa01152dd95",
-              "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
-              "d2974d9b-e965-403b-86b4-d5e143be6349",
-              "e204f8ca-718b-4a29-bea3-554a4551ed20",
-              "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
-              "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
-              "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-            ]
-          },
-          {
-            "id": "4154bf84-d36e-4551-9734-4666f5b1e1c0",
-            "name": "Data Stewards",
-            "permissionIds": [
-              "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
-              "60ea27d1-5772-4e11-823d-92f88f927745",
-              "6a54f495-bcd0-4474-be12-60e1454aec7e",
-              "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
-              "5f89bd45-899a-4c37-9f71-3da878ad247b",
-              "45247ef8-68b9-4dab-a5d5-a23143503887",
-              "7293dae6-9235-43ec-ae43-b90c0e89fdee",
-              "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
-              "6f431941-e937-489b-b252-6f8dd3d4d57f",
-              "769d99b6-32a1-4f61-b4c0-662e46e94766",
-              "1b3380a8-a888-43f7-bf92-6410e1306c75",
-              "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5"
-            ]
-          }
-        ],
-        "permissions": [
-          {
-            "id": "1b3380a8-a888-43f7-bf92-6410e1306c75",
-            "name": "Published Dataset Permission with Ownership Constraint",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1e6ed77c-4558-4fd6-9d29-352ac59d44ff",
-                "uri": "object/dataset/published/update",
-                "name": "Update Published Dataset"
-              },
-              {
-                "id": "2d36ba79-70e7-408d-b09b-62f394862749",
-                "uri": "object/dataset/published/create",
-                "name": "Create Published Dataset"
-              },
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              },
-              {
-                "id": "a4bdb24a-4ba4-40a7-bb91-c3ecfd0a4fce",
-                "uri": "object/dataset/published/delete",
-                "name": "Delete Published Dataset"
-              }
-            ]
-          },
-          {
-            "id": "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
-            "name": "Draft Dataset Permission with Ownership Constraint",
-            "resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
-            "resourceUri": "object/dataset/draft",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "09fb2938-7dd4-454f-89d3-7651e741d6f5",
-                "uri": "object/dataset/draft/update",
-                "name": "Update Draft Dataset"
-              },
-              {
-                "id": "123aa97c-2e65-42ef-ba09-0fbc971a3d96",
-                "uri": "object/dataset/draft/delete",
-                "name": "Delete Draft Dataset"
-              },
-              {
-                "id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
-                "uri": "object/dataset/draft/read",
-                "name": "Read Draft Dataset"
-              },
-              {
-                "id": "8907505c-f275-42e7-aacc-b4fffce7c642",
-                "uri": "object/dataset/draft/create",
-                "name": "Create Draft Dataset"
-              }
-            ]
-          },
-          {
-            "id": "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
-            "name": "View Published Distribution within Org Units",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              }
-            ]
-          },
-          {
-            "id": "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
-            "name": "Read / invoke FaaS functions",
-            "resourceId": "ef870309-c98c-48e6-ba85-3e556a2a6178",
-            "resourceUri": "object/faas/function",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "109247a6-6388-4076-b1cf-f5518c2cb30f",
-                "uri": "object/faas/function/read",
-                "name": "Read any information of a FaaS function"
-              },
-              {
-                "id": "8438c912-aee9-41d2-b600-06ab12667918",
-                "uri": "object/faas/function/invoke",
-                "name": "Invoke a FaaS function"
-              }
-            ]
-          },
-          {
-            "id": "45247ef8-68b9-4dab-a5d5-a23143503887",
-            "name": "View Published Datasets within Org Units",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              }
-            ]
-          },
-          {
-            "id": "4ce18e69-0df7-4799-9d69-baa01152dd95",
-            "name": "Update own credential",
-            "resourceId": "609db0f6-f021-411d-ba07-f47ad3e385fd",
-            "resourceUri": "authObject/credential",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "9efa4e87-fb0c-4e4d-bab5-c6fd9b55cd8f",
-                "uri": "authObject/credential/update",
-                "name": "Update Credentials"
-              }
-            ]
-          },
-          {
-            "id": "5f89bd45-899a-4c37-9f71-3da878ad247b",
-            "name": "View Draft Distribution within Org Units",
-            "resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
-            "resourceUri": "object/distribution/draft",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
-                "uri": "object/distribution/draft/read",
-                "name": "Read Draft Distribution"
-              }
-            ]
-          },
-          {
-            "id": "60ea27d1-5772-4e11-823d-92f88f927745",
-            "name": "Read Org Units with own org units",
-            "resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
-            "resourceUri": "authObject/orgUnit",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
-                "uri": "authObject/orgUnit/read",
-                "name": "Read Organization Unit"
-              }
-            ]
-          },
-          {
-            "id": "6a54f495-bcd0-4474-be12-60e1454aec7e",
-            "name": "View Orgnisation (Publisher) within Org Units",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "6f431941-e937-489b-b252-6f8dd3d4d57f",
-            "name": "Published Distribution Permission with Ownership Constraint",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1dc51b0e-ca95-4a91-bd16-2f7c622e3ebd",
-                "uri": "object/distribution/published/create",
-                "name": "Create Published Distribution"
-              },
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              },
-              {
-                "id": "e31c717a-0a47-4e31-8e28-5e5d6806757b",
-                "uri": "object/distribution/published/delete",
-                "name": "Delete Published Distribution"
-              },
-              {
-                "id": "f9144799-ee7e-4625-9ee7-875c9467c42f",
-                "uri": "object/distribution/published/update",
-                "name": "Update Published Distribution"
-              }
-            ]
-          },
-          {
-            "id": "7293dae6-9235-43ec-ae43-b90c0e89fdee",
-            "name": "View Draft Datasets within Org Units",
-            "resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
-            "resourceUri": "object/dataset/draft",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
-                "uri": "object/dataset/draft/read",
-                "name": "Read Draft Dataset"
-              }
-            ]
-          },
-          {
-            "id": "769d99b6-32a1-4f61-b4c0-662e46e94766",
-            "name": "Draft Distribution Permission with Ownership Constraint",
-            "resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
-            "resourceUri": "object/distribution/draft",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1c7c37d8-97e5-4d5e-9b21-4de8a7e4924c",
-                "uri": "object/distribution/draft/update",
-                "name": "Update Draft Distribution"
-              },
-              {
-                "id": "28d21042-5980-4bc0-9292-5dde9a74c0cc",
-                "uri": "object/distribution/draft/create",
-                "name": "Create Draft Distribution"
-              },
-              {
-                "id": "7cb86119-f99c-4c52-a907-d75dcc697efe",
-                "uri": "object/distribution/draft/delete",
-                "name": "Delete Draft Distribution"
-              },
-              {
-                "id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
-                "uri": "object/distribution/draft/read",
-                "name": "Read Draft Distribution"
-              }
-            ]
-          },
-          {
-            "id": "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
-            "name": "Orgnisation (Publisher) Permission within Ownership Constraint",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              },
-              {
-                "id": "ecc2e046-ed0e-433f-806a-d1f9ad6ce39a",
-                "uri": "object/organization/create",
-                "name": "Create Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
-            "name": "Manage own API keys",
-            "resourceId": "6ee09044-eb64-43e6-a4c0-eab4fd79df62",
-            "resourceUri": "authObject/apiKey",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "14642045-b23c-47c5-b59c-0e4e823971a8",
-                "uri": "authObject/apiKey/read",
-                "name": "Read API key"
-              },
-              {
-                "id": "18c4591a-ac53-4523-986f-6bb5bb4c5015",
-                "uri": "authObject/apiKey/create",
-                "name": "Create API key"
-              },
-              {
-                "id": "c1fbbfef-c685-48ed-9d06-0b1fffa976e7",
-                "uri": "authObject/apiKey/update",
-                "name": "Update API key"
-              },
-              {
-                "id": "cb855842-54ea-4f20-b4b7-6aabacb11354",
-                "uri": "authObject/apiKey/delete",
-                "name": "Delete API key"
-              }
-            ]
-          },
-          {
-            "id": "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
-            "name": "Read Org Units with own org units",
-            "resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
-            "resourceUri": "authObject/orgUnit",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
-                "uri": "authObject/orgUnit/read",
-                "name": "Read Organization Unit"
-              }
-            ]
-          },
-          {
-            "id": "d2974d9b-e965-403b-86b4-d5e143be6349",
-            "name": "Read content objects",
-            "resourceId": "b2c08eba-b408-4cbe-a9e2-777f9d7c0931",
-            "resourceUri": "object/content",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "0b98f026-97b4-4ac5-b316-0faa3d50e204",
-                "uri": "object/content/read",
-                "name": "Read content objects"
-              }
-            ]
-          },
-          {
-            "id": "e204f8ca-718b-4a29-bea3-554a4551ed20",
-            "name": "Read Orgnisation (Publisher) with own org units",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-            "name": "View Published Dataset (Org Unit Constraint)",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              }
-            ]
-          },
-          {
-            "id": "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
-            "name": "Read Published Distribution with own org units",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              }
-            ]
-          }
-        ],
-        "managingOrgUnitIds": [],
-        "orgUnit": null
-      },
-      "timestamp": 1692684812027,
-      "operationUri": "object/record/create",
-      "resourceUri": "object/record"
-    }
+import rego.v1
+
+test_not_allow_data_steward_user_create_his_own_record if {
+	# data_steward only alow create dataset not record
+	# "dcat-dataset-strings" is required
+	not allow with input as {
+		"object": {"record": {
+			"name": "",
+			"lastUpdate": null,
+			"sourceTag": "",
+			"id": "40a390dc-d008-4765-9e84-28cacae49751",
+			"publishing": {"state": "published"},
+			"dataset-draft": {
+				"data": "{}",
+				"dataset": {"name": "test dataset"},
+				"timestamp": "2022-04-11T12:52:24.278Z",
+			},
+			"tenantId": 0,
+			"access-control": {"ownerId": "8f414dab-cc51-4b5b-b790-4271da4f75a9"},
+		}},
+		"user": {
+			"id": "8f414dab-cc51-4b5b-b790-4271da4f75a9",
+			"displayName": "Test dataStewardUser",
+			"email": "dataStewward@test.com",
+			"photoURL": "",
+			"source": "internal",
+			"sourceId": "8da06331-5f56-4951-b126-f057e8709bad",
+			"orgUnitId": null,
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": [
+						"4ce18e69-0df7-4799-9d69-baa01152dd95",
+						"ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
+						"d2974d9b-e965-403b-86b4-d5e143be6349",
+						"e204f8ca-718b-4a29-bea3-554a4551ed20",
+						"fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
+						"b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					],
+				},
+				{
+					"id": "4154bf84-d36e-4551-9734-4666f5b1e1c0",
+					"name": "Data Stewards",
+					"permissionIds": [
+						"2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
+						"60ea27d1-5772-4e11-823d-92f88f927745",
+						"6a54f495-bcd0-4474-be12-60e1454aec7e",
+						"1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
+						"5f89bd45-899a-4c37-9f71-3da878ad247b",
+						"45247ef8-68b9-4dab-a5d5-a23143503887",
+						"7293dae6-9235-43ec-ae43-b90c0e89fdee",
+						"a45132c8-a43b-41ac-bd83-c9eb0a83be00",
+						"6f431941-e937-489b-b252-6f8dd3d4d57f",
+						"769d99b6-32a1-4f61-b4c0-662e46e94766",
+						"1b3380a8-a888-43f7-bf92-6410e1306c75",
+						"1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
+					],
+				},
+			],
+			"permissions": [
+				{
+					"id": "1b3380a8-a888-43f7-bf92-6410e1306c75",
+					"name": "Published Dataset Permission with Ownership Constraint",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1e6ed77c-4558-4fd6-9d29-352ac59d44ff",
+							"uri": "object/dataset/published/update",
+							"name": "Update Published Dataset",
+						},
+						{
+							"id": "2d36ba79-70e7-408d-b09b-62f394862749",
+							"uri": "object/dataset/published/create",
+							"name": "Create Published Dataset",
+						},
+						{
+							"id": "6e210917-03ec-4134-b787-947e78491259",
+							"uri": "object/dataset/published/read",
+							"name": "Read Publish Dataset",
+						},
+						{
+							"id": "a4bdb24a-4ba4-40a7-bb91-c3ecfd0a4fce",
+							"uri": "object/dataset/published/delete",
+							"name": "Delete Published Dataset",
+						},
+					],
+				},
+				{
+					"id": "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
+					"name": "Draft Dataset Permission with Ownership Constraint",
+					"resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "09fb2938-7dd4-454f-89d3-7651e741d6f5",
+							"uri": "object/dataset/draft/update",
+							"name": "Update Draft Dataset",
+						},
+						{
+							"id": "123aa97c-2e65-42ef-ba09-0fbc971a3d96",
+							"uri": "object/dataset/draft/delete",
+							"name": "Delete Draft Dataset",
+						},
+						{
+							"id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
+							"uri": "object/dataset/draft/read",
+							"name": "Read Draft Dataset",
+						},
+						{
+							"id": "8907505c-f275-42e7-aacc-b4fffce7c642",
+							"uri": "object/dataset/draft/create",
+							"name": "Create Draft Dataset",
+						},
+					],
+				},
+				{
+					"id": "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
+					"name": "View Published Distribution within Org Units",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+						"uri": "object/distribution/published/read",
+						"name": "Read Published Distribution",
+					}],
+				},
+				{
+					"id": "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
+					"name": "Read / invoke FaaS functions",
+					"resourceId": "ef870309-c98c-48e6-ba85-3e556a2a6178",
+					"resourceUri": "object/faas/function",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "109247a6-6388-4076-b1cf-f5518c2cb30f",
+							"uri": "object/faas/function/read",
+							"name": "Read any information of a FaaS function",
+						},
+						{
+							"id": "8438c912-aee9-41d2-b600-06ab12667918",
+							"uri": "object/faas/function/invoke",
+							"name": "Invoke a FaaS function",
+						},
+					],
+				},
+				{
+					"id": "45247ef8-68b9-4dab-a5d5-a23143503887",
+					"name": "View Published Datasets within Org Units",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6e210917-03ec-4134-b787-947e78491259",
+						"uri": "object/dataset/published/read",
+						"name": "Read Publish Dataset",
+					}],
+				},
+				{
+					"id": "4ce18e69-0df7-4799-9d69-baa01152dd95",
+					"name": "Update own credential",
+					"resourceId": "609db0f6-f021-411d-ba07-f47ad3e385fd",
+					"resourceUri": "authObject/credential",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "9efa4e87-fb0c-4e4d-bab5-c6fd9b55cd8f",
+						"uri": "authObject/credential/update",
+						"name": "Update Credentials",
+					}],
+				},
+				{
+					"id": "5f89bd45-899a-4c37-9f71-3da878ad247b",
+					"name": "View Draft Distribution within Org Units",
+					"resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
+					"resourceUri": "object/distribution/draft",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
+						"uri": "object/distribution/draft/read",
+						"name": "Read Draft Distribution",
+					}],
+				},
+				{
+					"id": "60ea27d1-5772-4e11-823d-92f88f927745",
+					"name": "Read Org Units with own org units",
+					"resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
+					"resourceUri": "authObject/orgUnit",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
+						"uri": "authObject/orgUnit/read",
+						"name": "Read Organization Unit",
+					}],
+				},
+				{
+					"id": "6a54f495-bcd0-4474-be12-60e1454aec7e",
+					"name": "View Orgnisation (Publisher) within Org Units",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+						"uri": "object/organization/read",
+						"name": "Read Organization Record",
+					}],
+				},
+				{
+					"id": "6f431941-e937-489b-b252-6f8dd3d4d57f",
+					"name": "Published Distribution Permission with Ownership Constraint",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1dc51b0e-ca95-4a91-bd16-2f7c622e3ebd",
+							"uri": "object/distribution/published/create",
+							"name": "Create Published Distribution",
+						},
+						{
+							"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+							"uri": "object/distribution/published/read",
+							"name": "Read Published Distribution",
+						},
+						{
+							"id": "e31c717a-0a47-4e31-8e28-5e5d6806757b",
+							"uri": "object/distribution/published/delete",
+							"name": "Delete Published Distribution",
+						},
+						{
+							"id": "f9144799-ee7e-4625-9ee7-875c9467c42f",
+							"uri": "object/distribution/published/update",
+							"name": "Update Published Distribution",
+						},
+					],
+				},
+				{
+					"id": "7293dae6-9235-43ec-ae43-b90c0e89fdee",
+					"name": "View Draft Datasets within Org Units",
+					"resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
+						"uri": "object/dataset/draft/read",
+						"name": "Read Draft Dataset",
+					}],
+				},
+				{
+					"id": "769d99b6-32a1-4f61-b4c0-662e46e94766",
+					"name": "Draft Distribution Permission with Ownership Constraint",
+					"resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
+					"resourceUri": "object/distribution/draft",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1c7c37d8-97e5-4d5e-9b21-4de8a7e4924c",
+							"uri": "object/distribution/draft/update",
+							"name": "Update Draft Distribution",
+						},
+						{
+							"id": "28d21042-5980-4bc0-9292-5dde9a74c0cc",
+							"uri": "object/distribution/draft/create",
+							"name": "Create Draft Distribution",
+						},
+						{
+							"id": "7cb86119-f99c-4c52-a907-d75dcc697efe",
+							"uri": "object/distribution/draft/delete",
+							"name": "Delete Draft Distribution",
+						},
+						{
+							"id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
+							"uri": "object/distribution/draft/read",
+							"name": "Read Draft Distribution",
+						},
+					],
+				},
+				{
+					"id": "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
+					"name": "Orgnisation (Publisher) Permission within Ownership Constraint",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+							"uri": "object/organization/read",
+							"name": "Read Organization Record",
+						},
+						{
+							"id": "ecc2e046-ed0e-433f-806a-d1f9ad6ce39a",
+							"uri": "object/organization/create",
+							"name": "Create Organization Record",
+						},
+					],
+				},
+				{
+					"id": "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
+					"name": "Manage own API keys",
+					"resourceId": "6ee09044-eb64-43e6-a4c0-eab4fd79df62",
+					"resourceUri": "authObject/apiKey",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "14642045-b23c-47c5-b59c-0e4e823971a8",
+							"uri": "authObject/apiKey/read",
+							"name": "Read API key",
+						},
+						{
+							"id": "18c4591a-ac53-4523-986f-6bb5bb4c5015",
+							"uri": "authObject/apiKey/create",
+							"name": "Create API key",
+						},
+						{
+							"id": "c1fbbfef-c685-48ed-9d06-0b1fffa976e7",
+							"uri": "authObject/apiKey/update",
+							"name": "Update API key",
+						},
+						{
+							"id": "cb855842-54ea-4f20-b4b7-6aabacb11354",
+							"uri": "authObject/apiKey/delete",
+							"name": "Delete API key",
+						},
+					],
+				},
+				{
+					"id": "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
+					"name": "Read Org Units with own org units",
+					"resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
+					"resourceUri": "authObject/orgUnit",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
+						"uri": "authObject/orgUnit/read",
+						"name": "Read Organization Unit",
+					}],
+				},
+				{
+					"id": "d2974d9b-e965-403b-86b4-d5e143be6349",
+					"name": "Read content objects",
+					"resourceId": "b2c08eba-b408-4cbe-a9e2-777f9d7c0931",
+					"resourceUri": "object/content",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "0b98f026-97b4-4ac5-b316-0faa3d50e204",
+						"uri": "object/content/read",
+						"name": "Read content objects",
+					}],
+				},
+				{
+					"id": "e204f8ca-718b-4a29-bea3-554a4551ed20",
+					"name": "Read Orgnisation (Publisher) with own org units",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+						"uri": "object/organization/read",
+						"name": "Read Organization Record",
+					}],
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset (Org Unit Constraint)",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "6e210917-03ec-4134-b787-947e78491259",
+						"uri": "object/dataset/published/read",
+						"name": "Read Publish Dataset",
+					}],
+				},
+				{
+					"id": "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
+					"name": "Read Published Distribution with own org units",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+						"uri": "object/distribution/published/read",
+						"name": "Read Published Distribution",
+					}],
+				},
+			],
+			"managingOrgUnitIds": [],
+			"orgUnit": null,
+		},
+		"timestamp": 1692684812027,
+		"operationUri": "object/record/create",
+		"resourceUri": "object/record",
+	}
 }
 
-test_allow_data_steward_user_create_his_own_dataset {
-    # data_steward only alow create dataset not record
-    # "dcat-dataset-strings" is required
-    allow with input as {
-      "object": {
-        "record": {
-          "name": "",
-          "lastUpdate": null,
-          "sourceTag": "",
-          "id": "40a390dc-d008-4765-9e84-28cacae49751",
-          "publishing": {
-            "state": "published"
-          },
-          "dcat-dataset-strings": {},
-          "dataset-draft": {
-            "data": "{}",
-            "dataset": {
-              "name": "test dataset"
-            },
-            "timestamp": "2022-04-11T12:52:24.278Z"
-          },
-          "tenantId": 0,
-          "access-control": {
-            "ownerId": "8f414dab-cc51-4b5b-b790-4271da4f75a9"
-          }
-        }
-      },
-      "user": {
-        "id": "8f414dab-cc51-4b5b-b790-4271da4f75a9",
-        "displayName": "Test dataStewardUser",
-        "email": "dataStewward@test.com",
-        "photoURL": "",
-        "source": "internal",
-        "sourceId": "8da06331-5f56-4951-b126-f057e8709bad",
-        "orgUnitId": null,
-        "roles": [
-          {
-            "id": "00000000-0000-0002-0000-000000000000",
-            "name": "Authenticated Users",
-            "permissionIds": [
-              "4ce18e69-0df7-4799-9d69-baa01152dd95",
-              "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
-              "d2974d9b-e965-403b-86b4-d5e143be6349",
-              "e204f8ca-718b-4a29-bea3-554a4551ed20",
-              "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
-              "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
-              "e5ce2fc4-9f38-4f52-8190-b770ed2074e6"
-            ]
-          },
-          {
-            "id": "4154bf84-d36e-4551-9734-4666f5b1e1c0",
-            "name": "Data Stewards",
-            "permissionIds": [
-              "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
-              "60ea27d1-5772-4e11-823d-92f88f927745",
-              "6a54f495-bcd0-4474-be12-60e1454aec7e",
-              "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
-              "5f89bd45-899a-4c37-9f71-3da878ad247b",
-              "45247ef8-68b9-4dab-a5d5-a23143503887",
-              "7293dae6-9235-43ec-ae43-b90c0e89fdee",
-              "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
-              "6f431941-e937-489b-b252-6f8dd3d4d57f",
-              "769d99b6-32a1-4f61-b4c0-662e46e94766",
-              "1b3380a8-a888-43f7-bf92-6410e1306c75",
-              "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5"
-            ]
-          }
-        ],
-        "permissions": [
-          {
-            "id": "1b3380a8-a888-43f7-bf92-6410e1306c75",
-            "name": "Published Dataset Permission with Ownership Constraint",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1e6ed77c-4558-4fd6-9d29-352ac59d44ff",
-                "uri": "object/dataset/published/update",
-                "name": "Update Published Dataset"
-              },
-              {
-                "id": "2d36ba79-70e7-408d-b09b-62f394862749",
-                "uri": "object/dataset/published/create",
-                "name": "Create Published Dataset"
-              },
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              },
-              {
-                "id": "a4bdb24a-4ba4-40a7-bb91-c3ecfd0a4fce",
-                "uri": "object/dataset/published/delete",
-                "name": "Delete Published Dataset"
-              }
-            ]
-          },
-          {
-            "id": "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
-            "name": "Draft Dataset Permission with Ownership Constraint",
-            "resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
-            "resourceUri": "object/dataset/draft",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "09fb2938-7dd4-454f-89d3-7651e741d6f5",
-                "uri": "object/dataset/draft/update",
-                "name": "Update Draft Dataset"
-              },
-              {
-                "id": "123aa97c-2e65-42ef-ba09-0fbc971a3d96",
-                "uri": "object/dataset/draft/delete",
-                "name": "Delete Draft Dataset"
-              },
-              {
-                "id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
-                "uri": "object/dataset/draft/read",
-                "name": "Read Draft Dataset"
-              },
-              {
-                "id": "8907505c-f275-42e7-aacc-b4fffce7c642",
-                "uri": "object/dataset/draft/create",
-                "name": "Create Draft Dataset"
-              }
-            ]
-          },
-          {
-            "id": "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
-            "name": "View Published Distribution within Org Units",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              }
-            ]
-          },
-          {
-            "id": "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
-            "name": "Read / invoke FaaS functions",
-            "resourceId": "ef870309-c98c-48e6-ba85-3e556a2a6178",
-            "resourceUri": "object/faas/function",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "109247a6-6388-4076-b1cf-f5518c2cb30f",
-                "uri": "object/faas/function/read",
-                "name": "Read any information of a FaaS function"
-              },
-              {
-                "id": "8438c912-aee9-41d2-b600-06ab12667918",
-                "uri": "object/faas/function/invoke",
-                "name": "Invoke a FaaS function"
-              }
-            ]
-          },
-          {
-            "id": "45247ef8-68b9-4dab-a5d5-a23143503887",
-            "name": "View Published Datasets within Org Units",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              }
-            ]
-          },
-          {
-            "id": "4ce18e69-0df7-4799-9d69-baa01152dd95",
-            "name": "Update own credential",
-            "resourceId": "609db0f6-f021-411d-ba07-f47ad3e385fd",
-            "resourceUri": "authObject/credential",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "9efa4e87-fb0c-4e4d-bab5-c6fd9b55cd8f",
-                "uri": "authObject/credential/update",
-                "name": "Update Credentials"
-              }
-            ]
-          },
-          {
-            "id": "5f89bd45-899a-4c37-9f71-3da878ad247b",
-            "name": "View Draft Distribution within Org Units",
-            "resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
-            "resourceUri": "object/distribution/draft",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
-                "uri": "object/distribution/draft/read",
-                "name": "Read Draft Distribution"
-              }
-            ]
-          },
-          {
-            "id": "60ea27d1-5772-4e11-823d-92f88f927745",
-            "name": "Read Org Units with own org units",
-            "resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
-            "resourceUri": "authObject/orgUnit",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
-                "uri": "authObject/orgUnit/read",
-                "name": "Read Organization Unit"
-              }
-            ]
-          },
-          {
-            "id": "6a54f495-bcd0-4474-be12-60e1454aec7e",
-            "name": "View Orgnisation (Publisher) within Org Units",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "6f431941-e937-489b-b252-6f8dd3d4d57f",
-            "name": "Published Distribution Permission with Ownership Constraint",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1dc51b0e-ca95-4a91-bd16-2f7c622e3ebd",
-                "uri": "object/distribution/published/create",
-                "name": "Create Published Distribution"
-              },
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              },
-              {
-                "id": "e31c717a-0a47-4e31-8e28-5e5d6806757b",
-                "uri": "object/distribution/published/delete",
-                "name": "Delete Published Distribution"
-              },
-              {
-                "id": "f9144799-ee7e-4625-9ee7-875c9467c42f",
-                "uri": "object/distribution/published/update",
-                "name": "Update Published Distribution"
-              }
-            ]
-          },
-          {
-            "id": "7293dae6-9235-43ec-ae43-b90c0e89fdee",
-            "name": "View Draft Datasets within Org Units",
-            "resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
-            "resourceUri": "object/dataset/draft",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
-                "uri": "object/dataset/draft/read",
-                "name": "Read Draft Dataset"
-              }
-            ]
-          },
-          {
-            "id": "769d99b6-32a1-4f61-b4c0-662e46e94766",
-            "name": "Draft Distribution Permission with Ownership Constraint",
-            "resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
-            "resourceUri": "object/distribution/draft",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "1c7c37d8-97e5-4d5e-9b21-4de8a7e4924c",
-                "uri": "object/distribution/draft/update",
-                "name": "Update Draft Distribution"
-              },
-              {
-                "id": "28d21042-5980-4bc0-9292-5dde9a74c0cc",
-                "uri": "object/distribution/draft/create",
-                "name": "Create Draft Distribution"
-              },
-              {
-                "id": "7cb86119-f99c-4c52-a907-d75dcc697efe",
-                "uri": "object/distribution/draft/delete",
-                "name": "Delete Draft Distribution"
-              },
-              {
-                "id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
-                "uri": "object/distribution/draft/read",
-                "name": "Read Draft Distribution"
-              }
-            ]
-          },
-          {
-            "id": "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
-            "name": "Orgnisation (Publisher) Permission within Ownership Constraint",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              },
-              {
-                "id": "ecc2e046-ed0e-433f-806a-d1f9ad6ce39a",
-                "uri": "object/organization/create",
-                "name": "Create Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
-            "name": "Manage own API keys",
-            "resourceId": "6ee09044-eb64-43e6-a4c0-eab4fd79df62",
-            "resourceUri": "authObject/apiKey",
-            "userOwnershipConstraint": true,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "14642045-b23c-47c5-b59c-0e4e823971a8",
-                "uri": "authObject/apiKey/read",
-                "name": "Read API key"
-              },
-              {
-                "id": "18c4591a-ac53-4523-986f-6bb5bb4c5015",
-                "uri": "authObject/apiKey/create",
-                "name": "Create API key"
-              },
-              {
-                "id": "c1fbbfef-c685-48ed-9d06-0b1fffa976e7",
-                "uri": "authObject/apiKey/update",
-                "name": "Update API key"
-              },
-              {
-                "id": "cb855842-54ea-4f20-b4b7-6aabacb11354",
-                "uri": "authObject/apiKey/delete",
-                "name": "Delete API key"
-              }
-            ]
-          },
-          {
-            "id": "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
-            "name": "Read Org Units with own org units",
-            "resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
-            "resourceUri": "authObject/orgUnit",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
-                "uri": "authObject/orgUnit/read",
-                "name": "Read Organization Unit"
-              }
-            ]
-          },
-          {
-            "id": "d2974d9b-e965-403b-86b4-d5e143be6349",
-            "name": "Read content objects",
-            "resourceId": "b2c08eba-b408-4cbe-a9e2-777f9d7c0931",
-            "resourceUri": "object/content",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": false,
-            "preAuthorisedConstraint": false,
-            "allowExemption": false,
-            "operations": [
-              {
-                "id": "0b98f026-97b4-4ac5-b316-0faa3d50e204",
-                "uri": "object/content/read",
-                "name": "Read content objects"
-              }
-            ]
-          },
-          {
-            "id": "e204f8ca-718b-4a29-bea3-554a4551ed20",
-            "name": "Read Orgnisation (Publisher) with own org units",
-            "resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
-            "resourceUri": "object/organization",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
-                "uri": "object/organization/read",
-                "name": "Read Organization Record"
-              }
-            ]
-          },
-          {
-            "id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
-            "name": "View Published Dataset (Org Unit Constraint)",
-            "resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
-            "resourceUri": "object/dataset/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "6e210917-03ec-4134-b787-947e78491259",
-                "uri": "object/dataset/published/read",
-                "name": "Read Publish Dataset"
-              }
-            ]
-          },
-          {
-            "id": "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
-            "name": "Read Published Distribution with own org units",
-            "resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
-            "resourceUri": "object/distribution/published",
-            "userOwnershipConstraint": false,
-            "orgUnitOwnershipConstraint": true,
-            "preAuthorisedConstraint": false,
-            "allowExemption": true,
-            "operations": [
-              {
-                "id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
-                "uri": "object/distribution/published/read",
-                "name": "Read Published Distribution"
-              }
-            ]
-          }
-        ],
-        "managingOrgUnitIds": [],
-        "orgUnit": null
-      },
-      "timestamp": 1692684812027,
-      "operationUri": "object/record/create",
-      "resourceUri": "object/record"
-    }
+test_allow_data_steward_user_create_his_own_dataset if {
+	# data_steward only alow create dataset not record
+	# "dcat-dataset-strings" is required
+	allow with input as {
+		"object": {"record": {
+			"name": "",
+			"lastUpdate": null,
+			"sourceTag": "",
+			"id": "40a390dc-d008-4765-9e84-28cacae49751",
+			"publishing": {"state": "published"},
+			"dcat-dataset-strings": {},
+			"dataset-draft": {
+				"data": "{}",
+				"dataset": {"name": "test dataset"},
+				"timestamp": "2022-04-11T12:52:24.278Z",
+			},
+			"tenantId": 0,
+			"access-control": {"ownerId": "8f414dab-cc51-4b5b-b790-4271da4f75a9"},
+		}},
+		"user": {
+			"id": "8f414dab-cc51-4b5b-b790-4271da4f75a9",
+			"displayName": "Test dataStewardUser",
+			"email": "dataStewward@test.com",
+			"photoURL": "",
+			"source": "internal",
+			"sourceId": "8da06331-5f56-4951-b126-f057e8709bad",
+			"orgUnitId": null,
+			"roles": [
+				{
+					"id": "00000000-0000-0002-0000-000000000000",
+					"name": "Authenticated Users",
+					"permissionIds": [
+						"4ce18e69-0df7-4799-9d69-baa01152dd95",
+						"ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
+						"d2974d9b-e965-403b-86b4-d5e143be6349",
+						"e204f8ca-718b-4a29-bea3-554a4551ed20",
+						"fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
+						"b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
+						"e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					],
+				},
+				{
+					"id": "4154bf84-d36e-4551-9734-4666f5b1e1c0",
+					"name": "Data Stewards",
+					"permissionIds": [
+						"2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
+						"60ea27d1-5772-4e11-823d-92f88f927745",
+						"6a54f495-bcd0-4474-be12-60e1454aec7e",
+						"1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
+						"5f89bd45-899a-4c37-9f71-3da878ad247b",
+						"45247ef8-68b9-4dab-a5d5-a23143503887",
+						"7293dae6-9235-43ec-ae43-b90c0e89fdee",
+						"a45132c8-a43b-41ac-bd83-c9eb0a83be00",
+						"6f431941-e937-489b-b252-6f8dd3d4d57f",
+						"769d99b6-32a1-4f61-b4c0-662e46e94766",
+						"1b3380a8-a888-43f7-bf92-6410e1306c75",
+						"1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
+					],
+				},
+			],
+			"permissions": [
+				{
+					"id": "1b3380a8-a888-43f7-bf92-6410e1306c75",
+					"name": "Published Dataset Permission with Ownership Constraint",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1e6ed77c-4558-4fd6-9d29-352ac59d44ff",
+							"uri": "object/dataset/published/update",
+							"name": "Update Published Dataset",
+						},
+						{
+							"id": "2d36ba79-70e7-408d-b09b-62f394862749",
+							"uri": "object/dataset/published/create",
+							"name": "Create Published Dataset",
+						},
+						{
+							"id": "6e210917-03ec-4134-b787-947e78491259",
+							"uri": "object/dataset/published/read",
+							"name": "Read Publish Dataset",
+						},
+						{
+							"id": "a4bdb24a-4ba4-40a7-bb91-c3ecfd0a4fce",
+							"uri": "object/dataset/published/delete",
+							"name": "Delete Published Dataset",
+						},
+					],
+				},
+				{
+					"id": "1c2e3c8d-b96d-43c0-ac21-4a0481f523a5",
+					"name": "Draft Dataset Permission with Ownership Constraint",
+					"resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "09fb2938-7dd4-454f-89d3-7651e741d6f5",
+							"uri": "object/dataset/draft/update",
+							"name": "Update Draft Dataset",
+						},
+						{
+							"id": "123aa97c-2e65-42ef-ba09-0fbc971a3d96",
+							"uri": "object/dataset/draft/delete",
+							"name": "Delete Draft Dataset",
+						},
+						{
+							"id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
+							"uri": "object/dataset/draft/read",
+							"name": "Read Draft Dataset",
+						},
+						{
+							"id": "8907505c-f275-42e7-aacc-b4fffce7c642",
+							"uri": "object/dataset/draft/create",
+							"name": "Create Draft Dataset",
+						},
+					],
+				},
+				{
+					"id": "1f7bd3d4-1ec4-4a5b-8ff0-a3bf4fc4b8aa",
+					"name": "View Published Distribution within Org Units",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+						"uri": "object/distribution/published/read",
+						"name": "Read Published Distribution",
+					}],
+				},
+				{
+					"id": "2c1f7e2e-3ff2-460f-95b4-fef8b6698ac1",
+					"name": "Read / invoke FaaS functions",
+					"resourceId": "ef870309-c98c-48e6-ba85-3e556a2a6178",
+					"resourceUri": "object/faas/function",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "109247a6-6388-4076-b1cf-f5518c2cb30f",
+							"uri": "object/faas/function/read",
+							"name": "Read any information of a FaaS function",
+						},
+						{
+							"id": "8438c912-aee9-41d2-b600-06ab12667918",
+							"uri": "object/faas/function/invoke",
+							"name": "Invoke a FaaS function",
+						},
+					],
+				},
+				{
+					"id": "45247ef8-68b9-4dab-a5d5-a23143503887",
+					"name": "View Published Datasets within Org Units",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6e210917-03ec-4134-b787-947e78491259",
+						"uri": "object/dataset/published/read",
+						"name": "Read Publish Dataset",
+					}],
+				},
+				{
+					"id": "4ce18e69-0df7-4799-9d69-baa01152dd95",
+					"name": "Update own credential",
+					"resourceId": "609db0f6-f021-411d-ba07-f47ad3e385fd",
+					"resourceUri": "authObject/credential",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "9efa4e87-fb0c-4e4d-bab5-c6fd9b55cd8f",
+						"uri": "authObject/credential/update",
+						"name": "Update Credentials",
+					}],
+				},
+				{
+					"id": "5f89bd45-899a-4c37-9f71-3da878ad247b",
+					"name": "View Draft Distribution within Org Units",
+					"resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
+					"resourceUri": "object/distribution/draft",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
+						"uri": "object/distribution/draft/read",
+						"name": "Read Draft Distribution",
+					}],
+				},
+				{
+					"id": "60ea27d1-5772-4e11-823d-92f88f927745",
+					"name": "Read Org Units with own org units",
+					"resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
+					"resourceUri": "authObject/orgUnit",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
+						"uri": "authObject/orgUnit/read",
+						"name": "Read Organization Unit",
+					}],
+				},
+				{
+					"id": "6a54f495-bcd0-4474-be12-60e1454aec7e",
+					"name": "View Orgnisation (Publisher) within Org Units",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+						"uri": "object/organization/read",
+						"name": "Read Organization Record",
+					}],
+				},
+				{
+					"id": "6f431941-e937-489b-b252-6f8dd3d4d57f",
+					"name": "Published Distribution Permission with Ownership Constraint",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1dc51b0e-ca95-4a91-bd16-2f7c622e3ebd",
+							"uri": "object/distribution/published/create",
+							"name": "Create Published Distribution",
+						},
+						{
+							"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+							"uri": "object/distribution/published/read",
+							"name": "Read Published Distribution",
+						},
+						{
+							"id": "e31c717a-0a47-4e31-8e28-5e5d6806757b",
+							"uri": "object/distribution/published/delete",
+							"name": "Delete Published Distribution",
+						},
+						{
+							"id": "f9144799-ee7e-4625-9ee7-875c9467c42f",
+							"uri": "object/distribution/published/update",
+							"name": "Update Published Distribution",
+						},
+					],
+				},
+				{
+					"id": "7293dae6-9235-43ec-ae43-b90c0e89fdee",
+					"name": "View Draft Datasets within Org Units",
+					"resourceId": "4b73034a-f9c1-4dbe-ab1b-1cb78308df61",
+					"resourceUri": "object/dataset/draft",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "53a9ff97-d853-415f-9fae-33f1de4c0b46",
+						"uri": "object/dataset/draft/read",
+						"name": "Read Draft Dataset",
+					}],
+				},
+				{
+					"id": "769d99b6-32a1-4f61-b4c0-662e46e94766",
+					"name": "Draft Distribution Permission with Ownership Constraint",
+					"resourceId": "bd6ca9ea-43a6-4ed5-8be7-5025b4e8d36a",
+					"resourceUri": "object/distribution/draft",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "1c7c37d8-97e5-4d5e-9b21-4de8a7e4924c",
+							"uri": "object/distribution/draft/update",
+							"name": "Update Draft Distribution",
+						},
+						{
+							"id": "28d21042-5980-4bc0-9292-5dde9a74c0cc",
+							"uri": "object/distribution/draft/create",
+							"name": "Create Draft Distribution",
+						},
+						{
+							"id": "7cb86119-f99c-4c52-a907-d75dcc697efe",
+							"uri": "object/distribution/draft/delete",
+							"name": "Delete Draft Distribution",
+						},
+						{
+							"id": "de247c3f-9012-4b87-80db-be9d1cb791d5",
+							"uri": "object/distribution/draft/read",
+							"name": "Read Draft Distribution",
+						},
+					],
+				},
+				{
+					"id": "a45132c8-a43b-41ac-bd83-c9eb0a83be00",
+					"name": "Orgnisation (Publisher) Permission within Ownership Constraint",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+							"uri": "object/organization/read",
+							"name": "Read Organization Record",
+						},
+						{
+							"id": "ecc2e046-ed0e-433f-806a-d1f9ad6ce39a",
+							"uri": "object/organization/create",
+							"name": "Create Organization Record",
+						},
+					],
+				},
+				{
+					"id": "ac98c25f-09ab-43ff-bdbd-5a21499be6a3",
+					"name": "Manage own API keys",
+					"resourceId": "6ee09044-eb64-43e6-a4c0-eab4fd79df62",
+					"resourceUri": "authObject/apiKey",
+					"userOwnershipConstraint": true,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [
+						{
+							"id": "14642045-b23c-47c5-b59c-0e4e823971a8",
+							"uri": "authObject/apiKey/read",
+							"name": "Read API key",
+						},
+						{
+							"id": "18c4591a-ac53-4523-986f-6bb5bb4c5015",
+							"uri": "authObject/apiKey/create",
+							"name": "Create API key",
+						},
+						{
+							"id": "c1fbbfef-c685-48ed-9d06-0b1fffa976e7",
+							"uri": "authObject/apiKey/update",
+							"name": "Update API key",
+						},
+						{
+							"id": "cb855842-54ea-4f20-b4b7-6aabacb11354",
+							"uri": "authObject/apiKey/delete",
+							"name": "Delete API key",
+						},
+					],
+				},
+				{
+					"id": "b8ca1f22-1faa-4c23-bcc2-c0051df9bccf",
+					"name": "Read Org Units with own org units",
+					"resourceId": "85ad4109-5d16-452b-a2dc-ff695aa85b60",
+					"resourceUri": "authObject/orgUnit",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "6d444cd6-16c7-44ca-bf2d-975f3baebbe3",
+						"uri": "authObject/orgUnit/read",
+						"name": "Read Organization Unit",
+					}],
+				},
+				{
+					"id": "d2974d9b-e965-403b-86b4-d5e143be6349",
+					"name": "Read content objects",
+					"resourceId": "b2c08eba-b408-4cbe-a9e2-777f9d7c0931",
+					"resourceUri": "object/content",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": false,
+					"preAuthorisedConstraint": false,
+					"allowExemption": false,
+					"operations": [{
+						"id": "0b98f026-97b4-4ac5-b316-0faa3d50e204",
+						"uri": "object/content/read",
+						"name": "Read content objects",
+					}],
+				},
+				{
+					"id": "e204f8ca-718b-4a29-bea3-554a4551ed20",
+					"name": "Read Orgnisation (Publisher) with own org units",
+					"resourceId": "4dbcab94-8de3-4e49-abdc-679642b2a936",
+					"resourceUri": "object/organization",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "94331a4d-873b-4454-8493-0f15c5dfb40d",
+						"uri": "object/organization/read",
+						"name": "Read Organization Record",
+					}],
+				},
+				{
+					"id": "e5ce2fc4-9f38-4f52-8190-b770ed2074e6",
+					"name": "View Published Dataset (Org Unit Constraint)",
+					"resourceId": "b226cad0-a2a4-45ac-871e-7f63ac8afb3d",
+					"resourceUri": "object/dataset/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "6e210917-03ec-4134-b787-947e78491259",
+						"uri": "object/dataset/published/read",
+						"name": "Read Publish Dataset",
+					}],
+				},
+				{
+					"id": "fe2ea6f1-192a-423c-9ae0-acb9f5d2dc48",
+					"name": "Read Published Distribution with own org units",
+					"resourceId": "0bb9288c-dfcd-4c1a-ae24-1915bd4b0773",
+					"resourceUri": "object/distribution/published",
+					"userOwnershipConstraint": false,
+					"orgUnitOwnershipConstraint": true,
+					"preAuthorisedConstraint": false,
+					"allowExemption": true,
+					"operations": [{
+						"id": "a8eef19d-7ea9-453c-985c-db10dfb49416",
+						"uri": "object/distribution/published/read",
+						"name": "Read Published Distribution",
+					}],
+				},
+			],
+			"managingOrgUnitIds": [],
+			"orgUnit": null,
+		},
+		"timestamp": 1692684812027,
+		"operationUri": "object/record/create",
+		"resourceUri": "object/record",
+	}
 }

--- a/magda-opa/policies/object/tenant/allow.rego
+++ b/magda-opa/policies/object/tenant/allow.rego
@@ -1,9 +1,11 @@
 package object.tenant
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 
-default allow = false
+default allow := false
 
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }

--- a/magda-opa/policies/object/webhook/allow.rego
+++ b/magda-opa/policies/object/webhook/allow.rego
@@ -1,21 +1,24 @@
 package object.webhook
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
 import data.common.hasOwnerConstraintPermission
 
-default allow = false
+default allow := false
 
 # Only users has a unlimited permission to perfom the operation on "webhook" will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # Rules for permissions with ownership constaint
 # i.e. only owner of the webhook can perform the operation
-allow {
-    hasOwnerConstraintPermission(input.operationUri)
-    # webhook field name should match table column name
-    # as we didn't quoted column name when create the table
-    # either uppercase or lowercase will work
-    input.object.webhook.ownerId = input.user.id
+allow if {
+	hasOwnerConstraintPermission(input.operationUri)
+
+	# webhook field name should match table column name
+	# as we didn't quoted column name when create the table
+	# either uppercase or lowercase will work
+	input.object.webhook.ownerId == input.user.id
 }

--- a/magda-opa/policies/storage/object/allow.rego
+++ b/magda-opa/policies/storage/object/allow.rego
@@ -1,97 +1,92 @@
 package storage.object
 
+import rego.v1
+
 import data.common.hasNoConstraintPermission
-import data.common.hasOwnerConstraintPermission
+import data.common.hasOperationType
 import data.common.hasOrgUnitConstaintPermission
-import data.common.breakdownOperationUri
+import data.common.hasOwnerConstraintPermission
 import data.common.isEmpty
 
-default allow = false
+default allow := false
 
 # Users has a unlimited permission to perform the operation on storage object will be allowed
-allow {
-    hasNoConstraintPermission(input.operationUri)
+allow if {
+	hasNoConstraintPermission(input.operationUri)
 }
 
 # Rules for permissions with ownership constraint
 # i.e. only owner of the storage object (file) can perform the operation
-allow {
-    hasOwnerConstraintPermission(input.operationUri)
-    # storage object metadata ownerId should match current user's id
-    input.storage.object.ownerId = input.user.id
+allow if {
+	hasOwnerConstraintPermission(input.operationUri)
+
+	# storage object metadata ownerId should match current user's id
+	input.storage.object.ownerId == input.user.id
 }
 
 # Rules for permissions with org unit constraint
-allow {
-    hasOrgUnitConstaintPermission(input.operationUri)
-    # storage object metadata orgUnitId should match current user's managingOrgUnitIds
-    input.user.managingOrgUnitIds[_] = input.storage.object.orgUnitId
+allow if {
+	hasOrgUnitConstaintPermission(input.operationUri)
+
+	# storage object metadata orgUnitId should match current user's managingOrgUnitIds
+	input.storage.object.orgUnitId in input.user.managingOrgUnitIds
 }
 
 # or when a user has org unit ownership constraint permission, he also can access (read only) all objects with NO org unit assigned
-allow {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType == "read"
-    hasOrgUnitConstaintPermission(input.operationUri)
-    not input.storage.object.orgUnitId
+allow if {
+	hasOperationType(input.operationUri, "read")
+	hasOrgUnitConstaintPermission(input.operationUri)
+	not input.storage.object.orgUnitId
 }
 
 # or when a user has org unit ownership constraint permission, he also can access (read only) all objects with NO org unit assigned
-allow {
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType == "read"
-    hasOrgUnitConstaintPermission(input.operationUri)
-    isEmpty(input.storage.object.orgUnitId)
+allow if {
+	hasOperationType(input.operationUri, "read")
+	hasOrgUnitConstaintPermission(input.operationUri)
+	isEmpty(input.storage.object.orgUnitId)
 }
-
 
 # If user has access to the record that the file has attach to, he has access to the file (same operation) as well
 # This rule deals with `read` operation
 # users with either "object/record/read" are allow to access
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "read"
-    data.object.record.verifyPermission("object/record/read")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "read")
+	data.object.record.verifyPermission("object/record/read")
 }
 
 # If user has access to the record that the file has attach to, he has access to the file (same operation) as well
 # This rule deals with `upload` operation
 # users with either "object/record/create" or "object/record/update" are allow to access
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "upload"
-    data.object.record.verifyPermission("object/record/create")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "upload")
+	data.object.record.verifyPermission("object/record/create")
 }
 
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "upload"
-    data.object.record.verifyPermission("object/record/update")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "upload")
+	data.object.record.verifyPermission("object/record/update")
 }
 
 # If user has access to the record that the file has attach to, he has access to the file (same operation) as well
 # This rule deals with `delete` operation
 # users with either "object/record/create" or "object/record/update" or "object/record/delete" are allow to access
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "delete"
-    data.object.record.verifyPermission("object/record/create")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "delete")
+	data.object.record.verifyPermission("object/record/create")
 }
 
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "delete"
-    data.object.record.verifyPermission("object/record/update")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "delete")
+	data.object.record.verifyPermission("object/record/update")
 }
 
-allow {
-    input.storage.object.recordId = input.object.record.id
-    [resourceType, operationType, resourceUriPrefix] := breakdownOperationUri(input.operationUri)
-    operationType = "delete"
-    data.object.record.verifyPermission("object/record/delete")
+allow if {
+	input.storage.object.recordId == input.object.record.id
+	hasOperationType(input.operationUri, "delete")
+	data.object.record.verifyPermission("object/record/delete")
 }

--- a/magda-opa/policies/system/echo.rego
+++ b/magda-opa/policies/system/echo.rego
@@ -1,5 +1,5 @@
 package system
 
-echo[x] {
-    x := input
-}
+import rego.v1
+
+echo contains input


### PR DESCRIPTION
### What this PR does

As part of improving our linter [Regal](https://github.com/StyraInc/regal/), I tend to run it against Rego projects I can find in the wild, and this was one I hadn't seen before.

Since the version of OPA used was ancient, my first move was to have that bumped to the latest version, which entails also moving over to more modern syntax, keywords, etc.. where applicapble. With that out of the way, I addressed the few hundred issues reported by Regal. I've obviously made sure all the unit tests are passing, and I don't think there have been any changes in behavior. But if you have a more holistic way of testing that, that would of course be great.

I found at least one issue that Regal didn't correctly detect in this repo, so a small win! Anyway, I figured I'd submit back my fixes.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
