### PR TITLE
Skips port forward setup when not running in a Kubernetes environment

### DIFF
--- a/magda-int-test-ts/src/tests/searchApi.spec.ts
+++ b/magda-int-test-ts/src/tests/searchApi.spec.ts
@@ -42,7 +42,6 @@ const indexerApiClient = new IndexerApiClient({
 });
 
 const searchApiUrl = "http://localhost:6102/v0";
-const openSearchUrl = "http://localhost:9200";
 
 async function searchDataset(q: string, userId?: string) {
     const config: RequestInit = {};
@@ -81,6 +80,9 @@ describe("search api hybrid integration tests", function (this) {
     serviceRunner.authApiDebugMode = false;
     serviceRunner.searchApiDebugMode = false;
 
+    const openSearchUrl = `http://${
+        serviceRunner.dockerServiceForwardHost || "localhost"
+    }:9200`;
     let datasetIndexName: string = "";
     let testUserId: string = "";
     // user will be set to branch B

--- a/magda-int-test-ts/src/tests/searchApiAuth.spec.ts
+++ b/magda-int-test-ts/src/tests/searchApiAuth.spec.ts
@@ -53,7 +53,6 @@ const indexerApiClient = new IndexerApiClient({
 });
 
 const searchApiUrl = "http://localhost:6102/v0";
-const openSearchUrl = "http://localhost:9200";
 
 async function getDataset(datasetId: string, userId?: string) {
     const config: RequestInit = {};
@@ -90,7 +89,9 @@ describe("search api auth integration tests", function (this) {
     serviceRunner.enableSearchApi = true;
     serviceRunner.jwtSecret = jwtSecret;
     serviceRunner.authApiDebugMode = false;
-
+    const openSearchUrl = `http://${
+        serviceRunner.dockerServiceForwardHost || "localhost"
+    }:9200`;
     let datasetIndexName: string = "";
 
     before(async function (this) {


### PR DESCRIPTION
### What this PR does

Skips port forward setup when not running in a Kubernetes environment. Hope to reduce blocking issues caused by unsuccessful cleanup of the socat process.