### PR TITLE
Fix: sitemap will respond 404 with plain text error for invalid `afterToken`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -736,6 +736,8 @@ dockerize:dockerExtensions:
     - cd $CI_PROJECT_DIR/magda-postgres && yarn docker-build-prod --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG
 
 (Full) Run As Preview: &runAsPreview
+  tags:
+    - api-server
   stage: preview
   when: manual
   only:
@@ -787,7 +789,7 @@ dockerize:dockerExtensions:
 (UI) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.searchEngine.hybridSearch.enabled=false,global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.hostname=$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,tags.minion-linked-data-rating=false,tags.minion-visualization=false,tags.minion-format=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://$CI_COMMIT_REF_SLUG.dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}.dev.magda.io"
 
 (UI - Auto) Run As Preview:
@@ -837,6 +839,8 @@ Stop Preview: &stopPreview
 
 Deploy Main Branch To Dev:
   stage: deploy-dev
+  tags:
+    - api-server
   only:
     - main
   cache: {}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.3.1
+
+- Fix: sitemap will respond 404 with plain text error for invalid `afterToken` values
+
 ## v5.3.0
 
 - New feature: Access Group UI, useful when you need arbitrary access control management of datasets. Related to: #3269

--- a/deploy/kubernetes/dev-cluster-issuer.yaml
+++ b/deploy/kubernetes/dev-cluster-issuer.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: contact@magda.io
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - dns01:
+        cloudflare:
+          apiTokenSecretRef:
+            name: cloudflare-api-token-secret
+            key: api-token

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -192,6 +192,14 @@ export default function buildSitemapRouter({
                 false
             );
             const records = handleError(result);
+            if (!records?.records?.length) {
+                res.status(404)
+                    .set("Content-Type", "text/plain")
+                    .send(
+                        `Sitemap page not found: token "${afterToken}" is out of range or does not exist.`
+                    );
+                return;
+            }
             records?.records?.forEach((record) =>
                 sms.write({
                     url: baseExternalUri


### PR DESCRIPTION
### What this PR does

- Fix: sitemap will respond 404 with plain text error for invalid `afterToken`
- CI deployment adjustment for local-dev cluster
- 
### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
