### PR TITLE
Fix tree kill & upgrade postgres

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,7 +217,7 @@ buildtest:search-no-index-cache:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - postgres:13.5
+    - postgres:13.6
     - docker:dind
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
@@ -293,7 +293,7 @@ buildtest:registry:
     - sbt-prebuild
   timeout: 30 minutes
   services:
-    - postgres:13.5
+    - postgres:13.6
   variables:
     POSTGRES_URL: "jdbc:postgresql://postgres/postgres"
     POSTGRES_DB: postgres
@@ -375,7 +375,7 @@ buildtest:typescript-apis-with-pg:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - postgres:13.5
+    - postgres:13.6
     - docker:dind
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v5.5.0
 
 - Fix: search-api-auto-ping job "Couldn't find the binary git" error
+- Upgraded local in cluster use PostgreSQL build from 13.3 to [13.6](https://www.postgresql.org/docs/release/13.6/)
 
 ## v5.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.5.0
+
+- Fix: search-api-auto-ping job "Couldn't find the binary git" error
+
 ## v5.4.0
 
 - #3612: Fix indexer failed to handle invalid contact data type

--- a/magda-postgres/Dockerfile
+++ b/magda-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/magda-io/postgresql:13.5.0-debian-10-r87
+FROM ghcr.io/magda-io/postgresql:13.6.0-debian-10-r87
 
 # copy wal-g from pre-built image
 COPY --from=ghcr.io/magda-io/magda-wal-g:1.1.0 /usr/local/bin/wal-g /usr/local/bin/wal-g

--- a/magda-postgres/Dockerfile
+++ b/magda-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/magda-io/postgresql:13.6.0-debian-10-r87
+FROM ghcr.io/magda-io/postgresql:13.6.0-debian-10-r92
 
 # copy wal-g from pre-built image
 COPY --from=ghcr.io/magda-io/magda-wal-g:1.1.0 /usr/local/bin/wal-g /usr/local/bin/wal-g

--- a/magda-postgres/docker-compose.yml
+++ b/magda-postgres/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   test-postgres:
-    image: postgres:13.5
+    image: postgres:13.6
     expose:
       - 5432
     ports:

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -72,7 +72,7 @@
     "read-pkg-up": "^3.0.0",
     "resolve": "^1.15.0",
     "sql-syntax": "^2.0.1",
-    "tree-kill": "https://github.com/magda-io/node-tree-kill.git#magda",
+    "@magda/tree-kill": "^1.2.3",
     "urijs": "^1.19.11",
     "uuid": "^8.2.0",
     "yargs": "^12.0.5"

--- a/magda-typescript-common/src/treeKill.ts
+++ b/magda-typescript-common/src/treeKill.ts
@@ -1,4 +1,4 @@
-import treeKillSync from "tree-kill";
+import treeKillSync from "@magda/tree-kill";
 
 async function treeKill(
     pid: number,

--- a/packages/utils/src/index-web.ts
+++ b/packages/utils/src/index-web.ts
@@ -26,3 +26,4 @@ export {
 export { default as getRequest } from "@magda/typescript-common/dist/getRequest.js";
 export { default as getRequestNoCache } from "@magda/typescript-common/dist/getRequestNoCache.js";
 export { default as createNoCacheFetchOptions } from "@magda/typescript-common/dist/createNoCacheFetchOptions.js";
+export { default as getAbsoluteUrl } from "@magda/typescript-common/dist/getAbsoluteUrl.js";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,3 +29,4 @@ export {
     BadRequestError
 } from "@magda/typescript-common/dist/createServiceError.js";
 export { default as getStorageApiResourceAccessUrl } from "@magda/typescript-common/dist/getStorageApiResourceAccessUrl.js";
+export { default as getAbsoluteUrl } from "@magda/typescript-common/dist/getAbsoluteUrl.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,6 +3972,11 @@
   resolved "https://registry.yarnpkg.com/@magda/esm-utils/-/esm-utils-1.0.1.tgz#1d5e9882958aefa879106e55d32421874baae559"
   integrity sha512-A300Mds4wl41axrqcrqrw4y1EjUIcrVWipaZpTwlf6ChDLnI57bEqL9EVQLm8muW/qMnY3QzNjxg7EEYly18yA==
 
+"@magda/tree-kill@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@magda/tree-kill/-/tree-kill-1.2.3.tgz#a4e5329d759da0985a8818e6b808aa4ccafe1c97"
+  integrity sha512-QZ9pAuU1yDWx8z4dVAtR4w5wVMb++hmBCYi9Rj864TobnuG29gqVHmRuwcPAvFL8qjMfn5Z0Mcu4eCI5dmD1Sg==
+
 "@magda/tsmonad@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@magda/tsmonad/-/tsmonad-0.9.0.tgz#6ddcc1e78fb1606306b923968a1d2f8c3a7e3576"
@@ -23903,10 +23908,6 @@ traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
-
-"tree-kill@https://github.com/magda-io/node-tree-kill.git#magda":
-  version "1.2.2"
-  resolved "https://github.com/magda-io/node-tree-kill.git#34a14d315939566035be249a0772f0e1921d911e"
 
 trim-lines@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
### What this PR does

- Fix: search-api-auto-ping job "Couldn't find the binary git" error (By using released kill-tree)
- Upgraded local in cluster use PostgreSQL build from 13.3 to [13.6](https://www.postgresql.org/docs/release/13.6/)
- include getAbsoluteUrl in @magda/utils

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
