### PR TITLE
replace chatbot dataset search with semantic indexer api

### DIFF
--- a/magda-web-client/src/Components/Chatbot/tools/searchDatasets.ts
+++ b/magda-web-client/src/Components/Chatbot/tools/searchDatasets.ts
@@ -1,4 +1,9 @@
-import { searchDatasets as searchDatasetsApi } from "api-clients/SearchApis";
+import { getRecordAspect } from "api-clients/RegistryApis";
+import {
+    search as semanticSearch,
+    retrieve as semanticRetrieve,
+    SearchResultItem
+} from "api-clients/SemanticSearchApis";
 import { createChatEventMessageCompleteMsg } from "../Messaging";
 import { markdownTable } from "markdown-table";
 import { config } from "../../../config";
@@ -6,45 +11,177 @@ import { ChainInput } from "../commons";
 import { WebLLMTool } from "../ChatWebLLM";
 
 const MAX_DESC_DISPLAY_LENGTH = 250;
+const MAX_CHUNK_DISPLAY_LENGTH = 500;
+const OVERFETCH_FACTOR = 5;
 const { uiBaseUrl } = config;
 
-async function retrieveDatasets(question: string, limit: number = 5) {
+async function retrieveDatasets(
+    question: string,
+    limit: number = 3,
+    fileTypes?: string
+) {
     const notFound =
         "Sorry, I didn't find any datasets related to your inquiry.";
     if (!question) {
         return notFound;
     }
-    const result = await searchDatasetsApi({ q: question, limit });
-    if (!result?.dataSets?.length) {
+
+    // 1) semantci search, get top-N results
+    // Setting OVERFETCH_FACTOR to get more results in case some result are from the same dataset
+    const searchResult: SearchResultItem[] = await semanticSearch(
+        {
+            query: question,
+            max_num_results: limit * OVERFETCH_FACTOR,
+            fileFormat: fileTypes?.toUpperCase()
+        },
+        "POST"
+    );
+    if (!searchResult?.length) {
         return notFound;
     }
-    const datasets = result.dataSets.map((item) => {
-        const desc = (item?.description?.length > MAX_DESC_DISPLAY_LENGTH
-            ? item.description.substring(0, MAX_DESC_DISPLAY_LENGTH + 1) + "..."
-            : item.description
-        ).replace(/\n|\r|<br\s*\/>/g, " ");
-        const datasetId = encodeURIComponent(
-            encodeURIComponent(item.identifier)
-        );
-        const title = `[${item.title}](${
-            uiBaseUrl === "/"
-                ? `/dataset/${datasetId}`
-                : `${uiBaseUrl}/dataset/${datasetId}`
-        })`;
-        return [title, desc];
-    });
 
-    const table = markdownTable([["Title", "Description"], ...datasets]);
+    const bestByRecord = new Map<string, SearchResultItem>();
+    for (const item of searchResult) {
+        const key = item.recordId;
+        if (!key) continue;
+        const prev = bestByRecord.get(key);
+        if (!prev || (item.score ?? 0) > (prev.score ?? 0)) {
+            bestByRecord.set(key, item);
+        }
+    }
+
+    const result = Array.from(bestByRecord.values())
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, limit);
+
+    if (!result.length) return notFound;
+
+    // 2) fetch metadata (title/description) from registry
+    const recordIds = Array.from(
+        new Set(result.map((r) => r.recordId).filter(Boolean))
+    ).slice(0, limit);
+
+    const recordMap = new Map<string, any>();
+    await Promise.all(
+        recordIds.map(async (id) => {
+            try {
+                const searchItem = result.find((item) => item.recordId === id);
+                const recordIdToUse = searchItem?.parentRecordId || id;
+
+                const record = await getRecordAspect(
+                    recordIdToUse,
+                    "dcat-dataset-strings",
+                    true
+                );
+                recordMap.set(id, record);
+            } catch {
+                // pass
+            }
+        })
+    );
+
+    // 3) Title / Description
+    const datasets = await Promise.all(
+        result.map(async (item) => {
+            const datasetRecordId = item.recordId;
+            const dcat = recordMap.get(datasetRecordId);
+
+            const titleText = dcat?.title || datasetRecordId;
+            const descSrc = dcat?.description || item.text || "";
+            const desc = truncateText(descSrc, MAX_DESC_DISPLAY_LENGTH);
+
+            const datasetId = encodeURIComponent(
+                encodeURIComponent(datasetRecordId)
+            );
+            const title = `[${titleText}](${
+                uiBaseUrl === "/"
+                    ? `/dataset/${datasetId}`
+                    : `${uiBaseUrl}/dataset/${datasetId}`
+            })`;
+
+            let chunkText = item.text;
+            if (item.fileFormat?.toUpperCase().includes("CSV")) {
+                try {
+                    // retrieve the full text of the chunk to get all the column names
+                    const retrieveResult = await semanticRetrieve({
+                        ids: [item.id],
+                        mode: "full"
+                    });
+                    let columnNames: string[] = [];
+                    if (retrieveResult && retrieveResult.length > 0) {
+                        const fullText = retrieveResult[0].text;
+                        columnNames = getColumnNames(fullText);
+                    } else {
+                        columnNames = getColumnNames(item.text);
+                    }
+                    chunkText = renderColumns(columnNames);
+                } catch (error) {
+                    // if error, use the original chunk text
+                    const columnNames = getColumnNames(item.text);
+                    chunkText = renderColumns(columnNames);
+                }
+            } else if (item.fileFormat?.toUpperCase().includes("PDF")) {
+                chunkText = item.text;
+            } else {
+                chunkText = item.text;
+            }
+
+            chunkText = truncateText(chunkText, MAX_CHUNK_DISPLAY_LENGTH);
+
+            return [title, deleteNewLine(desc), deleteNewLine(chunkText)];
+        })
+    );
+
+    const table = markdownTable([
+        ["Title", "Description", "Data Preview"],
+        ...datasets
+    ]);
     return `I found the following datasets might be related to your inquiry:\n ${table}`;
 }
 
+const deleteNewLine = (text: string) => {
+    return text.replace(/\n|\r|<br\s*\/>/g, " ");
+};
+
+const getColumnNames = (text: string): string[] => {
+    return text
+        .split("Column names:")[1]
+        .trim()
+        .split("-")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+};
+
+const renderColumns = (cols: string[], limit = 10): string => {
+    if (!cols.length) return "-";
+    const wrap = (x: string) => "`" + x + "`";
+    if (cols.length <= limit) return cols.map(wrap).join(", ");
+    const first = cols.slice(0, limit).map(wrap).join(", ");
+    const more = cols.length - limit;
+    return `${first} … (+${more} more)`;
+};
+
+const truncateText = (
+    text: string,
+    maxLength: number = MAX_CHUNK_DISPLAY_LENGTH
+): string => {
+    if (text.length > maxLength) {
+        return text.substring(0, maxLength) + "...";
+    }
+    return text;
+};
+
 const searchDatasets: WebLLMTool = {
     name: "searchDatasets",
-    func: async function (queryString: string) {
+    func: async function (
+        queryString: string,
+        limit: number = 5,
+        fileTypes?: string
+    ) {
         const context = (this as unknown) as ChainInput;
         const { queue } = context;
         queue.push(createChatEventMessageCompleteMsg("Searching datasets..."));
-        return await retrieveDatasets(queryString);
+        return await retrieveDatasets(queryString, limit, fileTypes);
     },
     description:
         "This tool can be used to search datasets relevant to the user's inquiry and present the dataset list to user as the answer. You must use this call when there is no better tool to use." +
@@ -61,6 +198,12 @@ const searchDatasets: WebLLMTool = {
             type: "number" as const,
             description:
                 "The max. number of datasets that you want to return. This is not a compulsory parameter. Default value is 5."
+        },
+        {
+            name: "fileFormat",
+            type: "string" as const,
+            description:
+                "Optional file format to filter results. Current supported file formats are 'CSV' and 'PDF'. If not specified, all file formats will be included."
         }
     ],
     requiredParameters: ["queryString"]

--- a/magda-web-client/src/api-clients/SemanticSearchApis.ts
+++ b/magda-web-client/src/api-clients/SemanticSearchApis.ts
@@ -1,0 +1,132 @@
+import { config } from "../config";
+
+export interface SearchParams {
+    query: string;
+    max_num_results?: number;
+    itemType?: "storageObject" | "registryRecord";
+    fileFormat?: string;
+    recordId?: string;
+    subObjectId?: string;
+    subObjectType?: string;
+    minScore?: number;
+}
+
+export function buildSemanticSearchQueryString(params: SearchParams): string {
+    const parts: string[] = [];
+    const add = (k: string, v: any) => {
+        if (v !== undefined && v !== null && v !== "") {
+            parts.push(
+                `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`
+            );
+        }
+    };
+
+    add("query", params.query);
+    add("max_num_results", params.max_num_results);
+    add("itemType", params.itemType);
+    add("fileFormat", params.fileFormat);
+    add("recordId", params.recordId);
+    add("subObjectId", params.subObjectId);
+    add("subObjectType", params.subObjectType);
+    add("minScore", params.minScore);
+
+    return parts.join("&");
+}
+
+export type SearchResultItem = {
+    id: string;
+    itemType: string;
+    recordId: string;
+    parentRecordId: string;
+    fileFormat: string;
+    subObjectId: string;
+    subObjectType: string;
+    text: string;
+    only_one_index_text_chunk: boolean;
+    index_text_chunk_length: number;
+    index_text_chunk_position: number;
+    index_text_chunk_overlap: number;
+    score: number;
+};
+
+export async function search(
+    params: SearchParams,
+    method: "GET" | "POST" = "GET"
+): Promise<SearchResultItem[]> {
+    const baseUrl = config.semanticSearchApiBaseUrl + "search";
+    const baseOpts = config.commonFetchRequestOptions;
+
+    let url = baseUrl;
+    let fetchOptions: RequestInit = { ...baseOpts, method };
+
+    if (method === "GET") {
+        const qs = buildSemanticSearchQueryString(params);
+        url = qs ? `${baseUrl}?${qs}` : baseUrl;
+        if (fetchOptions.headers) {
+            const h = { ...(fetchOptions.headers as Record<string, string>) };
+            delete h["Content-Type"];
+            fetchOptions.headers = h;
+        }
+    } else {
+        fetchOptions = {
+            ...fetchOptions,
+            headers: {
+                ...(baseOpts.headers || {}),
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(params)
+        };
+    }
+
+    const res = await fetch(url, fetchOptions);
+    if (!res.ok) {
+        const bodyText = await res.text().catch(() => "");
+        throw new Error(`${res.statusText}${bodyText ? "\n" + bodyText : ""}`);
+    }
+    return res.json();
+}
+
+export const searchGet = (params: SearchParams) => search(params, "GET");
+
+export const searchPost = (params: SearchParams) => search(params, "POST");
+
+export type RetrieveParams = {
+    ids: string[];
+    mode?: "full" | "partial";
+    precedingChunksNum?: number;
+    subsequentChunksNum?: number;
+};
+
+export type RetrieveResultItem = {
+    id: string;
+    itemType: string;
+    recordId: string;
+    parentRecordId: string;
+    fileFormat: string;
+    subObjectId: string;
+    subObjectType: string;
+    text: string;
+};
+
+export async function retrieve(
+    params: RetrieveParams
+): Promise<RetrieveResultItem[]> {
+    const url = config.semanticSearchApiBaseUrl + "retrieve";
+    return fetch(url, {
+        ...config.commonFetchRequestOptions,
+        method: "POST",
+        headers: {
+            ...(config.commonFetchRequestOptions.headers || {}),
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(params)
+    }).then((response: any) => {
+        if (response.status === 200) {
+            return response.json();
+        }
+        let errorMessage = response.statusText;
+        if (!errorMessage)
+            errorMessage = "Failed to retrieve network resource.";
+        throw new Error(errorMessage);
+    });
+}

--- a/magda-web-client/src/config.ts
+++ b/magda-web-client/src/config.ts
@@ -261,6 +261,15 @@ export interface ConfigDataType {
     searchApiBaseUrl: string;
 
     /**
+     * The semantic search API base URL config value that is supplied by the web server.
+     * When this value is not available from the server (e.g. when run web client locally), the default "fallback" API server url will be used to generate this value.
+     *
+     * @type {string}
+     * @memberof ConfigDataType
+     */
+    semanticSearchApiBaseUrl: string;
+
+    /**
      * The correspondence API base URL config value that is supplied by the web server.
      * When this value is not available from the server (e.g. when run web client locally), the default "fallback" API server url will be used to generate this value.
      *
@@ -966,6 +975,9 @@ export const config: ConfigDataType = {
     contentApiBaseUrl,
     searchApiBaseUrl:
         serverConfig.searchApiBaseUrl || fallbackApiHost + "api/v0/search/",
+    semanticSearchApiBaseUrl:
+        serverConfig.semanticSearchApiBaseUrl ||
+        fallbackApiHost + "api/v0/semantic-search/",
     indexerApiBaseUrl:
         serverConfig?.indexerApiBaseUrl || fallbackApiHost + "api/v0/indexer/",
     registryApiReadOnlyBaseUrl:


### PR DESCRIPTION
### What this PR does

1. Add new Semantic Search API client
2. Replace Search Datasets implementation
   - Use the semantic-indexer-api instead of the original search API.
3. Display chunk text in results
   - PDF files: Display only the most relevant chunk.
   - CSV files: First call `/retrieve` to get all chunks, then display them.
4. Support file format filtering
   - Allow user to specify file format (e.g., `CSV` or `PDF`) in queries.
   - Example: "Find some CSV files about endangered species in Australia".