### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/magda-scala-common/build.sbt
+++ b/magda-scala-common/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= {
     "org.scalikejdbc"              %% "scalikejdbc"                 % "3.2.4",
     "org.json4s"                   % "json4s-native_2.12"           % "4.0.5",
     "com.jayway.jsonpath"          % "json-path"                    % "2.7.0",
-    "io.github.hakky54"            % "sslcontext-kickstart"         % "8.3.2",
-    "io.github.hakky54"            % "sslcontext-kickstart-for-pem" % "8.3.2"
+    "io.github.hakky54"            % "ayza"                         % "10.0.0",
+    "io.github.hakky54"            % "ayza-for-pem"                 % "10.0.0"
   )
 }


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience