### PR TITLE
fix(ui): resolve dark-mode text inheritance in chatbot bubbles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v5.6.1
 
 - Fix: use node 22 for auto jobs as it's required min. node engine
+- Fix: resolve dark mode text inheritance bug in chatbot UI bubbles
 
 ## v5.6.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,3 +33,4 @@ The following people have contributed to Magda:
 - Other Contributors
   - [Kat Ballo](https://github.com/ketikat)
   - [Sandra Arato](https://github.com/sandra-arato)
+  - [Armon Castor](https://github.com/GlitchedCloud)

--- a/magda-web-client/src/Components/Chatbot/ChatBoxMessagePanel.scss
+++ b/magda-web-client/src/Components/Chatbot/ChatBoxMessagePanel.scss
@@ -33,17 +33,23 @@
             float: left;
             border-radius: 10px;
             border: none;
-            background-color: #e7e7e7;
+            background-color: var(--chat-bot-bg);
+            color: var(--chat-bot-text);
+            pre,
+            p {
+                color: var(--chat-bot-text);
+            }
         }
 
         .rs-list-item.user-message {
             float: right;
             border-radius: 10px;
             border: none;
-            background-color: var(--rs-btn-primary-bg);
+            background-color: var(--chat-user-bg);
+            color: var(--chat-user-text);
             pre,
             p {
-                color: #f7f7f7;
+                color: var(--chat-user-text);
             }
         }
     }

--- a/magda-web-client/src/_variables.scss
+++ b/magda-web-client/src/_variables.scss
@@ -70,3 +70,21 @@ $minimum: 300px;
 $small: 768px;
 $medium: 992px;
 $large: 1200px;
+
+:root {
+    --chat-bot-bg: #e7e7e7;
+    --chat-bot-text: #1a1a1a;
+
+    --chat-user-bg: var(--rs-btn-primary-bg);
+    --chat-user-text: #f7f7f7;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --chat-bot-bg: #2b2b2b;
+        --chat-bot-text: #f7f7f7;
+
+        --chat-user-bg: var(--rs-btn-primary-bg);
+        --chat-user-text: #ffffff;
+    }
+}


### PR DESCRIPTION
### What this PR does
Fixes a UI accessibility bug where the Magda chatbot text becomes invisible when the user's operating system is in Dark Mode. 

### Why it's needed
Previously, the `.rs-list-item.bot-message` element had a hardcoded light grey `background-color` but lacked an explicit `color` definition. When a user's OS triggers dark mode, the global wrapper forces the default text color to white, resulting in unreadable white text on a light grey bubble. 

### Implementation details
- **Refactored to Native CSS Variables:** Replaced hardcoded SCSS variables in the chatbot bubbles with dynamic Native CSS custom properties (`--chat-bot-bg`, `--chat-user-text`, etc.) defined at the `:root` level.
- **Theme Awareness:** Added an explicit `@media (prefers-color-scheme: dark)` block to the `:root` variables to handle the theme inversion automatically without fighting React Suite's default specificity.
- **Inheritance Anchoring:** Explicitly anchored the `color` property on both the user and bot bubbles to prevent global inheritance bleed.

### QA / Manual Testing
- [x] Verified chatbot UI in Light Mode (retains original styling).
- [x] Verified chatbot UI in Dark Mode (bubbles invert to dark grey with light text for accessibility).

### Contribution Standards
- [x] Added myself to `CONTRIBUTORS.md`
- [x] Added a bullet point summarizing this fix to `CHANGES.md`