### PR TITLE
Upgrade to Qwen3 model for in-browser LLM

### DIFF
--- a/magda-web-client/.eslintrc
+++ b/magda-web-client/.eslintrc
@@ -7,7 +7,7 @@
     "plugins": ["@typescript-eslint", "prettier"],
     "rules": {
         "no-use-before-define": "off",
-        "prettier/prettier": "error",
+        "prettier/prettier": ["error", { "endOfLine": "auto" }],
         "no-var": "warn",
         "prefer-const": "warn",
         "no-unused-expressions": "off",

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -31,7 +31,7 @@
     "@magda/registry-aspects": "^5.6.0",
     "@magda/scripts": "^5.6.0",
     "@magda/typescript-common": "^5.6.0",
-    "@mlc-ai/web-llm": "0.2.73",
+    "@mlc-ai/web-llm": "https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz",
     "@types/debounce-promise": "^3.1.1",
     "@types/is-uuid": "^1.0.0",
     "@types/jsonpath": "^0.2.0",

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -31,7 +31,7 @@
     "@magda/registry-aspects": "^5.6.0",
     "@magda/scripts": "^5.6.0",
     "@magda/typescript-common": "^5.6.0",
-    "@mlc-ai/web-llm": "https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz",
+    "@mlc-ai/web-llm": "https://github.com/magda-io/web-llm/releases/download/v0.2.83-magda/mlc-ai-web-llm-v0.2.83.tgz",
     "@types/debounce-promise": "^3.1.1",
     "@types/is-uuid": "^1.0.0",
     "@types/jsonpath": "^0.2.0",

--- a/magda-web-client/src/Components/Chatbot/ChatWebLLM.ts
+++ b/magda-web-client/src/Components/Chatbot/ChatWebLLM.ts
@@ -111,7 +111,8 @@ export const defaultContextWindowSize = defaultContextWindowSizeOption?.value
     : 4096;
 
 const DEFAULT_MODEL_CONFIG: WebLLMInputs = {
-    model: "Hermes-2-Pro-Llama-3-8B-q4f16_1-MLC",
+    //model: "Qwen3-0.6B-q4f16_1-MLC",
+    model: "Qwen3-4B-q4f16_1-MLC",
     chatOptions: {
         temperature: 0,
         context_window_size: defaultContextWindowSize

--- a/magda-web-client/src/Components/Chatbot/ChatWebLLM.ts
+++ b/magda-web-client/src/Components/Chatbot/ChatWebLLM.ts
@@ -111,7 +111,6 @@ export const defaultContextWindowSize = defaultContextWindowSizeOption?.value
     : 4096;
 
 const DEFAULT_MODEL_CONFIG: WebLLMInputs = {
-    //model: "Qwen3-0.6B-q4f16_1-MLC",
     model: "Qwen3-4B-q4f16_1-MLC",
     chatOptions: {
         temperature: 0,
@@ -335,19 +334,47 @@ export default class ChatWebLLM extends SimpleChatModel<WebLLMCallOptions> {
                 function: functionDef
             };
         });
+
+        const magdaIdentity = {
+            role: "system",
+            content: `You are Magda, the intelligent, expert AI assistant for Magda, a federated, open-source data catalog for big data and small data.
+
+CORE MISSION:
+Guide users to relevant open datasets and provide actionable data insights. You are the specific interface to this data catalog, not a general chatbot.
+
+GUIDELINES:
+1. **Prioritize Tools**: Your primary power comes from your tools (Search, Analysis). Always look for opportunities to use them rather than answering from general knowledge.
+2. **Be Proactive**: Instead of generic offers ("How can I help?"), propose specific actions based on the user's input (e.g., "I can search the catalog for 'population growth' for you.").
+3. **Accuracy First**: Never make up dataset names or IDs. Only reference data returned by your tools.
+4. **Tone**: Confident, professional, and data-literate. You own your capabilities.`
+        };
+
+        const messages =
+            typeof userMessage === "string"
+                ? [
+                      {
+                          role: "user",
+                          content: userMessage
+                      }
+                  ]
+                : Array.isArray(userMessage)
+                ? userMessage
+                : [userMessage];
+
+        // Filter out any existing system messages to ensure magdaIdentity is the only one and is first
+        const userMessagesFiltered = messages.filter(
+            (m) => m?.role !== "system"
+        );
+
         const request: webllm.ChatCompletionRequest = {
             stream: false,
-            messages:
-                typeof userMessage === "string"
-                    ? [
-                          {
-                              role: "user",
-                              content: userMessage
-                          }
-                      ]
-                    : [userMessage],
+            messages: [magdaIdentity, ...userMessagesFiltered] as any,
             tool_choice: "auto",
-            tools: toolDefs
+            tools: toolDefs,
+            extra_body: {
+                enable_latency_breakdown: false,
+                enable_thinking: false
+            }
         };
         const engine = await this.getEngine();
         const reply = await engine.chat.completions.create(request);
@@ -361,12 +388,16 @@ export default class ChatWebLLM extends SimpleChatModel<WebLLMCallOptions> {
                 throw new Error(
                     "The LLM could not process your request as it was aborted."
                 );
-            case "stop":
-                throw new Error(
-                    "The LLM could not process your request as it was stopped."
-                );
         }
         if (!reply?.choices?.[0]?.message?.tool_calls?.length) {
+            const content = reply?.choices?.[0]?.message?.content;
+            if (content) {
+                return {
+                    name: "Conversational Response",
+                    value: content as T
+                };
+            }
+
             return undefined;
         }
         const toolCall = reply.choices[0].message.tool_calls[0].function;

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,6 +4,7 @@ module.exports = {
     printWidth: 80,
     trailingComma: "none",
     useTabs: false,
+    endOfLine: "auto",
     overrides: [
         {
             files: ["**/package.json", "lerna.json"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4084,10 +4084,9 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@mlc-ai/web-llm@0.2.73":
-  version "0.2.73"
-  resolved "https://registry.yarnpkg.com/@mlc-ai/web-llm/-/web-llm-0.2.73.tgz#42c208cac7f5efdd0df4ad5f974101437a094e49"
-  integrity sha512-v9eS05aptZYNBhRZ7KEq5dr1kMESHvkdwru9tNY1oS1GDDEBjUt4Y/u06ejvP3qF4VatCakEezzJT3SkuMhDnQ==
+"@mlc-ai/web-llm@https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz":
+  version "0.2.82"
+  resolved "https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz#0839de12e73ee00ce59479fdfa8f77fab1bb2b8c"
   dependencies:
     loglevel "^1.9.1"
 
@@ -15962,9 +15961,9 @@ logform@^2.7.0:
     triple-beam "^1.3.0"
 
 loglevel@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.1.tgz#d63976ac9bcd03c7c873116d41c2a85bafff1be7"
-  integrity sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -22944,7 +22943,7 @@ string-similarity@^4.0.1:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22969,6 +22968,15 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -23143,7 +23151,7 @@ stringstream@~0.0.4:
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
   integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23177,6 +23185,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -25470,7 +25485,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25495,6 +25510,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4084,9 +4084,9 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@mlc-ai/web-llm@https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz":
-  version "0.2.82"
-  resolved "https://github.com/KIT300-Project-Nine/web-llm/releases/download/v0.2.82/mlc-ai-web-llm-v0.2.82.tgz#0839de12e73ee00ce59479fdfa8f77fab1bb2b8c"
+"@mlc-ai/web-llm@https://github.com/magda-io/web-llm/releases/download/v0.2.83-magda/mlc-ai-web-llm-v0.2.83.tgz":
+  version "0.2.83-magda"
+  resolved "https://github.com/magda-io/web-llm/releases/download/v0.2.83-magda/mlc-ai-web-llm-v0.2.83.tgz#3e5892b31e1d83acaa0c8c2bbc0085613e251d88"
   dependencies:
     loglevel "^1.9.1"
 


### PR DESCRIPTION
### What this PR does

Fixes #3617 

This PR upgrades the in-browser LLM agent from the legacy `Hermes-2-Pro-Llama-3-8B-q4f16_1-MLC` model to the agentic `Qwen3-4B-q4f16_1-MLC` model to maximize function calling performance. 

To support Qwen3's specific tool-calling requirements and resolve internal framework validation errors within the frontend, this PR implements the following:

* **Model Configuration:** Swaps the `DEFAULT_MODEL_CONFIG` in `ChatWebLLM.ts` to `Qwen3-4B-q4f16_1-MLC`. 
* **Custom Engine Integration:** Updates the `@mlc-ai/web-llm` dependency in `package.json` to our custom `v0.2.82` GitHub release tarball, as Qwen3 is not yet officially supported in the upstream package. (Pending PR)
* **Persona Preservation:** Refactors message handling in `ChatWebLLM.ts` to filter out conflicting system messages and dynamically inject the `magdaIdentity` prompt at index 0, satisfying the engine's strict validation rules.
* **Code Standardization:** Updates `.eslintrc` and `prettier.config.js` to enforce `"endOfLine": "auto"` to prevent cross-platform formatting conflicts.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.

### Testing Performed

The following verifications were completed for the `magda-web-client`:

* **Configuration Load:** Verified that the frontend successfully targets and requests the `Qwen3-4B-q4f16_1-MLC` model upon initialization.
* **Message Array Validation:** Confirmed via local execution that the `magdaIdentity` string is correctly merged at index 0 of the `messages` array, resolving previous `SystemMessageOrderError` crashes.
* **Dependency Resolution:** Ensured `yarn.lock` correctly resolves the custom tarball URL without breaking the frontend build process.