### PR TITLE
Test Docker-in-Docker MTU setting for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,9 @@ build-builder-image:
   before_script:
     - ./gitlab-ci-buildx-setup.sh
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   # Build all three builder images and push to gitlab registry
   script:
     - cd magda-builder-nodejs && docker buildx build --push -t "${CI_REGISTRY}/magda-data/magda/magda-builder-nodejs:${CI_COMMIT_REF_SLUG}" --platform linux/arm64,linux/amd64 -f Dockerfile . 
@@ -154,7 +156,9 @@ buildtest:search-with-index-cache:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
     CRYPTOGRAPHY_ALLOW_OPENSSL_102: 1
@@ -218,7 +222,9 @@ buildtest:search-no-index-cache:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
     - postgres:13.7
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
     CRYPTOGRAPHY_ALLOW_OPENSSL_102: 1
@@ -376,7 +382,9 @@ buildtest:typescript-apis-with-pg:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
     - postgres:13.7
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
     CRYPTOGRAPHY_ALLOW_OPENSSL_102: 1
@@ -424,7 +432,9 @@ buildtest:typescript-apis-with-es:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
     CRYPTOGRAPHY_ALLOW_OPENSSL_102: 1
@@ -469,7 +479,9 @@ buildtest:storage-api:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     # allow openssl 1.02 until we upgrade builder to use node12/alpine3.9 
     CRYPTOGRAPHY_ALLOW_OPENSSL_102: 1
@@ -510,7 +522,9 @@ buildtest:integration-tests:
     paths:
       - "$CI_PROJECT_DIR/pip-cache"
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   variables:
     POSTGRES_URL: "jdbc:postgresql://localhost/postgres"
     POSTGRES_DB: postgres
@@ -538,7 +552,9 @@ buildtest:opa-policies:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
     - cd magda-opa
     - yarn test
@@ -583,7 +599,9 @@ buildtest:helm-docs-check:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
     - code=0
     - docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.13.1 || code=$?;
@@ -613,7 +631,9 @@ dockerize:scala:
     - buildtest:search-no-index-cache
     - buildtest:search-with-index-cache
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
     - ./gitlab-ci-buildx-setup.sh
     # output stage docker image content without build it
@@ -629,7 +649,9 @@ dockerize:ui:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   needs:
     - yarn-install
     - registry-typescript-api
@@ -648,7 +670,9 @@ dockerize:ui-scss-compiler:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   needs:
     - yarn-install
     - registry-typescript-api
@@ -666,7 +690,9 @@ dockerize:typescript:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   needs:
     - yarn-install
     - registry-typescript-api
@@ -690,7 +716,9 @@ dockerize:migrators:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
     - ./gitlab-ci-buildx-setup.sh
     - yarn run in-submodules -- -f categories.migrator=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG  --platform linux/arm64,linux/amd64 
@@ -708,7 +736,9 @@ dockerize:opa:
   before_script:
     - ./gitlab-ci-buildx-setup.sh
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
   - cd magda-opa
   - yarn docker-build-prod --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG  --platform linux/arm64,linux/amd64
@@ -723,7 +753,9 @@ dockerize:dockerExtensions:
   cache:
     paths: []
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   script:
     - ./gitlab-ci-buildx-setup.sh
     # disable multi-arch docker image build for postgreSQL for now
@@ -898,7 +930,9 @@ pre-release:check-release-version:
 Release-to-Docker-Hub-Github-Container:
   stage: release
   services:
-    - docker:28.5.0-dind
+    - name: docker:28.5.0-dind
+      alias: docker
+      command: ["--mtu=1400"]
   rules:
     # Strict Semvar validation. match any version string. Should release version tag
     - if: $CI_COMMIT_TAG =~ /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/


### PR DESCRIPTION
This PR tests whether setting the Docker-in-Docker service MTU to `1400` fixes the recent GitLab CI network instability.

GitLab's hosted runner documentation mentions that Linux Arm runners using Docker-in-Docker may experience network connectivity issues when the Google Cloud MTU and Docker MTU do not match. This change applies the suggested MTU value to all `docker:28.5.0-dind` services used by the CI pipeline.

If this confirms the fix, the same change can be applied to `main` and then merged into `next`.

### What this PR does

This PR updates the GitLab CI Docker-in-Docker service definitions from:

```yaml
- docker:28.5.0-dind