### PR TITLE
fix: add global.searchEngine.semanticIndexer defaults to magda-core values

### DIFF
--- a/deploy/helm/magda-core/values.yaml
+++ b/deploy/helm/magda-core/values.yaml
@@ -1,6 +1,32 @@
 global:
   searchEngine:
-    hybridSearch: 
+    semanticIndexer:
+      indexName: "semantic-index"
+      # -- System wide agreed version.
+      indexVersion: 1
+      numberOfShards: 1
+      numberOfReplicas: 0
+      knnVectorFieldConfig:
+        # -- Vector workload mode: `on_disk` or `in_memory`.
+        mode: "on_disk"
+        # -- Dimension of the embedding vectors.
+        dimension: 768
+        # -- The compression_level mapping parameter selects a quantization encoder that reduces vector memory consumption by the given factor.
+        compressionLevel: 32x
+        # Supported values: l1, l2, innerProduct, cosine, linf
+        spaceType: "l2"
+        # -- Similar to efSearch but used during index construction. Higher values improve search quality but increase index build time.
+        efConstruction: 100
+        # -- The size of the candidate queue during search. Larger values may improve search quality but increase search latency.
+        efSearch: 100
+        # -- The maximum number of graph edges per vector. Higher values increase memory usage but may improve search quality.
+        m: 16
+        # -- FAISS Encoder configuration (If compressionLevel is set, encoder will be ignored).
+        encoder: null
+          # name: "sq"
+          # type: "fp16"
+          # clip: false
+    hybridSearch:
       # -- whether to enable hybrid search.
       # When `true`, Magda will combine the both LLM powered semantic (vector) & lexical (keyword) search to improve search relevance.
       # [magda-embedding-api](https://github.com/magda-io/magda-embedding-api) will be enabled and used for embedding generation at both indexing & search stage for the semantic search.


### PR DESCRIPTION
## Summary

- Adds `global.searchEngine.semanticIndexer.*` defaults to `magda-core/values.yaml`, mirroring the block already present in `magda/values.yaml`
- Fixes a nil pointer when templating `magda-core` standalone (without the umbrella `magda` chart supplying the `semanticIndexer` values)

## Root cause

`semantic-search-api/templates/deployment.yaml` references `.Values.global.searchEngine.semanticIndexer.{indexName,indexVersion,knnVectorFieldConfig.mode}` with a `| default` fallback on chart-local config. When `semanticIndexer` is entirely absent from `.Values.global.searchEngine` (as was the case in `magda-core/values.yaml`), Helm throws a nil pointer error at render time.

## Test plan

- [x] `helm template magda ./deploy/helm/magda-core` renders cleanly — no nil pointer, `semanticIndexName=semantic-index`, `semanticIndexVersion=1`, `semanticIndexerMode=on_disk` emitted correctly
- [x] No regression in the umbrella `magda` chart (its own `semanticIndexer` block is unchanged and takes precedence)

Closes #3659