### PR TITLE
fix: publish npm packages via OIDC trusted publishing, fail loudly on real errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -990,7 +990,7 @@ Publish NPM Packages:
   stage: release
   id_tokens:
     OIDC_TOKEN:
-      aud: https://registry.npmjs.org
+      aud: npm:registry.npmjs.org
   only:
     # Strict Semvar validation
     - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
@@ -1016,9 +1016,17 @@ Publish NPM Packages:
   cache: {}
   script: |
     # Exchange GitLab OIDC token for a short-lived npm publish token (Trusted Publishers)
-    NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token \
+    OIDC_EXCHANGE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token \
       -H "Content-Type: application/json" \
-      -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).token)")
+      -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}")
+    OIDC_HTTP_STATUS=$(echo "$OIDC_EXCHANGE_RESPONSE" | tail -n1)
+    OIDC_RESPONSE_BODY=$(echo "$OIDC_EXCHANGE_RESPONSE" | sed '$d')
+    if [ "$OIDC_HTTP_STATUS" != "200" ]; then
+      echo "ERROR: npm OIDC token exchange failed with HTTP $OIDC_HTTP_STATUS" >&2
+      echo "$OIDC_RESPONSE_BODY" >&2
+      exit 1
+    fi
+    NPM_TOKEN=$(echo "$OIDC_RESPONSE_BODY" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).token)")
     if [ -z "$NPM_TOKEN" ]; then
       echo "ERROR: failed to obtain npm token via OIDC" >&2
       exit 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -988,6 +988,9 @@ Release-to-Docker-Hub-Github-Container:
 
 Publish NPM Packages:
   stage: release
+  id_tokens:
+    OIDC_TOKEN:
+      aud: https://registry.npmjs.org
   only:
     # Strict Semvar validation
     - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
@@ -1012,7 +1015,12 @@ Publish NPM Packages:
     name: registry.gitlab.com/magda-data/magda/magda-builder-nodejs:$BUILDER_IMG_TAG
   cache: {}
   script:
-    # Setup NPM token & scoped registry
+    # Exchange GitLab OIDC token for a short-lived npm publish token (Trusted Publishers)
+    - NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token
+        -H "Content-Type: application/json"
+        -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | jq -r '.token')
+    - '[[ -n "$NPM_TOKEN" ]] || { echo "ERROR: failed to obtain npm token via OIDC" >&2; exit 1; }'
+    # Setup scoped registry and auth token
     - npm config set @magda:registry https://registry.npmjs.org/
     - npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
     - yarn run in-submodules -f categories.npmPackage=true run release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1014,14 +1014,19 @@ Publish NPM Packages:
   image:
     name: registry.gitlab.com/magda-data/magda/magda-builder-nodejs:$BUILDER_IMG_TAG
   cache: {}
-  script:
+  script: |
     # Exchange GitLab OIDC token for a short-lived npm publish token (Trusted Publishers)
-    - 'NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token -H "Content-Type: application/json" -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | jq -r .token)'
-    - '[[ -n "$NPM_TOKEN" ]] || { echo "ERROR: failed to obtain npm token via OIDC" >&2; exit 1; }'
+    NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token \
+      -H "Content-Type: application/json" \
+      -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).token)")
+    if [ -z "$NPM_TOKEN" ]; then
+      echo "ERROR: failed to obtain npm token via OIDC" >&2
+      exit 1
+    fi
     # Setup scoped registry and auth token
-    - npm config set @magda:registry https://registry.npmjs.org/
-    - npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-    - yarn run in-submodules -f categories.npmPackage=true run release
+    npm config set @magda:registry https://registry.npmjs.org/
+    npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+    yarn run in-submodules -f categories.npmPackage=true run release
 
 Publish Helm Chart:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -989,7 +989,7 @@ Release-to-Docker-Hub-Github-Container:
 Publish NPM Packages:
   stage: release
   id_tokens:
-    OIDC_TOKEN:
+    NPM_ID_TOKEN:
       aud: npm:registry.npmjs.org
   only:
     # Strict Semvar validation
@@ -1015,25 +1015,11 @@ Publish NPM Packages:
     name: registry.gitlab.com/magda-data/magda/magda-builder-nodejs:$BUILDER_IMG_TAG
   cache: {}
   script: |
-    # Exchange GitLab OIDC token for a short-lived npm publish token (Trusted Publishers)
-    OIDC_EXCHANGE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token \
-      -H "Content-Type: application/json" \
-      -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}")
-    OIDC_HTTP_STATUS=$(echo "$OIDC_EXCHANGE_RESPONSE" | tail -n1)
-    OIDC_RESPONSE_BODY=$(echo "$OIDC_EXCHANGE_RESPONSE" | sed '$d')
-    if [ "$OIDC_HTTP_STATUS" != "200" ]; then
-      echo "ERROR: npm OIDC token exchange failed with HTTP $OIDC_HTTP_STATUS" >&2
-      echo "$OIDC_RESPONSE_BODY" >&2
-      exit 1
-    fi
-    NPM_TOKEN=$(echo "$OIDC_RESPONSE_BODY" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).token)")
-    if [ -z "$NPM_TOKEN" ]; then
-      echo "ERROR: failed to obtain npm token via OIDC" >&2
-      exit 1
-    fi
-    # Setup scoped registry and auth token
+    # npm CLI >=11.5.1 natively detects the NPM_ID_TOKEN env var (from id_tokens
+    # above) and exchanges it for a short-lived per-package publish token itself
+    # during `npm publish` - no manual token exchange needed.
+    npm --version
     npm config set @magda:registry https://registry.npmjs.org/
-    npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
     yarn run in-submodules -f categories.npmPackage=true run release
 
 Publish Helm Chart:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1016,9 +1016,7 @@ Publish NPM Packages:
   cache: {}
   script:
     # Exchange GitLab OIDC token for a short-lived npm publish token (Trusted Publishers)
-    - NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token
-        -H "Content-Type: application/json"
-        -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | jq -r '.token')
+    - 'NPM_TOKEN=$(curl -sf -X POST https://registry.npmjs.org/-/npm/v1/login/oidc/token -H "Content-Type: application/json" -d "{\"oidcToken\":\"${OIDC_TOKEN}\"}" | jq -r .token)'
     - '[[ -n "$NPM_TOKEN" ]] || { echo "ERROR: failed to obtain npm token via OIDC" >&2; exit 1; }'
     # Setup scoped registry and auth token
     - npm config set @magda:registry https://registry.npmjs.org/

--- a/ci-scripts/npm-publish-release.js
+++ b/ci-scripts/npm-publish-release.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Publishes the npm package in the current working directory, deriving the
+// npm dist-tag from the version's prerelease identifier (e.g. "pr", "alpha",
+// "beta", "rc"), or "latest" for stable versions. npm refuses to publish a
+// prerelease version without an explicit --tag.
+//
+// Treats "version already published" as a non-fatal outcome, since release
+// pipelines may be re-run against a version that was already published.
+const { execSync } = require("child_process");
+const path = require("path");
+
+const pkg = require(path.join(process.cwd(), "package.json"));
+const match = pkg.version.match(/-([a-zA-Z]+)/);
+const tag = match ? match[1] : "latest";
+
+try {
+    execSync(`npm publish --tag ${tag}`, {
+        stdio: ["ignore", "inherit", "pipe"]
+    });
+} catch (e) {
+    const output = e.stderr ? e.stderr.toString() : "";
+    if (
+        /EPUBLISHCONFLICT|previously published|cannot publish over/.test(output)
+    ) {
+        process.exit(0);
+    }
+    process.stderr.write(output);
+    process.exit(1);
+}

--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     node -v && npm -v
 
-RUN npm install -g npm@10.5.2 && npm install -g lerna@3.22.1 yarn@1.22.19
+RUN npm install -g npm@11.5.1 && npm install -g lerna@3.22.1 yarn@1.22.19
 
 # -----------------------------
 # Install Helm 3.13.2 (pinned)

--- a/magda-minion-framework/package.json
+++ b/magda-minion-framework/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "test": "mocha",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/minion-framework.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-minion-framework/package.json
+++ b/magda-minion-framework/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "test": "mocha",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-registry-aspects/package.json
+++ b/magda-registry-aspects/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "dependencies": {
     "@magda/esm-utils": "^1.0.1"

--- a/magda-registry-aspects/package.json
+++ b/magda-registry-aspects/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/registry-aspects.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "dependencies": {
     "@magda/esm-utils": "^1.0.1"

--- a/magda-semantic-indexer-framework/package.json
+++ b/magda-semantic-indexer-framework/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "test": "mocha",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/semantic-indexer-framework.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-semantic-indexer-framework/package.json
+++ b/magda-semantic-indexer-framework/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "test": "mocha",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -19,7 +19,7 @@
     "generate": "generate-registry-typescript ./src/generated/registry",
     "test": "c8 mocha",
     "dev": "yarn run watch",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "devDependencies": {
     "@magda/esm-utils": "^1.0.1",

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -19,7 +19,7 @@
     "generate": "generate-registry-typescript ./src/generated/registry",
     "test": "c8 mocha",
     "dev": "yarn run watch",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/typescript-common.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "devDependencies": {
     "@magda/esm-utils": "^1.0.1",

--- a/packages/acs-cmd/package.json
+++ b/packages/acs-cmd/package.json
@@ -17,7 +17,7 @@
     "acs-cmd": "./bin/acs-cmd.js",
     "prebuild": "rimraf bin",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/acs-cmd.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/acs-cmd/package.json
+++ b/packages/acs-cmd/package.json
@@ -17,7 +17,7 @@
     "acs-cmd": "./bin/acs-cmd.js",
     "prebuild": "rimraf bin",
     "build": "node esbuild.js",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/arbitraries/package.json
+++ b/packages/arbitraries/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/arbitraries/package.json
+++ b/packages/arbitraries/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/arbitraties.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/auth-api-client/package.json
+++ b/packages/auth-api-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/auth-api-client.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/auth-api-client/package.json
+++ b/packages/auth-api-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/authentication-plugin-sdk/package.json
+++ b/packages/authentication-plugin-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/authentication-plugin-sdk.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/authentication-plugin-sdk/package.json
+++ b/packages/authentication-plugin-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/connector-sdk.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-test-utils/package.json
+++ b/packages/connector-test-utils/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/connector-test-utils.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-test-utils/package.json
+++ b/packages/connector-test-utils/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/docker-utils/package.json
+++ b/packages/docker-utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/docker-utils/package.json
+++ b/packages/docker-utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/docker-utils.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/external-ui-plugin-sdk/package.json
+++ b/packages/external-ui-plugin-sdk/package.json
@@ -6,7 +6,7 @@
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "api-extractor run -l",
     "docs": "which typedoc; if [ $? -eq 1 ]; then echo \"Error: typedoc is required.\";else typedoc;fi",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/external-ui-plugin-sdk.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "Jacky Jiang",
   "license": "Apache-2.0",

--- a/packages/external-ui-plugin-sdk/package.json
+++ b/packages/external-ui-plugin-sdk/package.json
@@ -6,7 +6,7 @@
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "api-extractor run -l",
     "docs": "which typedoc; if [ $? -eq 1 ]; then echo \"Error: typedoc is required.\";else typedoc;fi",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "Jacky Jiang",
   "license": "Apache-2.0",

--- a/packages/minion-sdk/package.json
+++ b/packages/minion-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/minion-sdk.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/minion-sdk/package.json
+++ b/packages/minion-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/org-tree/package.json
+++ b/packages/org-tree/package.json
@@ -17,7 +17,7 @@
     "org-tree": "./dist/index.js",
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/org-tree/package.json
+++ b/packages/org-tree/package.json
@@ -17,7 +17,7 @@
     "org-tree": "./dist/index.js",
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/org-tree.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/registry-client.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/semantic-indexer-sdk/package.json
+++ b/packages/semantic-indexer-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/semantic-indexer-sdk.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/semantic-indexer-sdk/package.json
+++ b/packages/semantic-indexer-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/utils.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/scripts.\""
+    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
   },
   "devDependencies": {
     "@types/pg": "^8.6.5"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish 2>/tmp/npm-pub.log || grep -qE 'EPUBLISHCONFLICT|previously published|cannot publish over' /tmp/npm-pub.log || (cat /tmp/npm-pub.log >&2; false)"
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "devDependencies": {
     "@types/pg": "^8.6.5"


### PR DESCRIPTION
## Summary

Fixes #3661. Two related bugs caused every `@magda/*` npm package to silently fail to publish on every tagged release build for the last ~4 months, with CI reporting green throughout:

- **Root cause**: npm now requires [trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC) for these packages, but the `Publish NPM Packages` GitLab job was still using a static `NPM_TOKEN` env var, which no longer authenticated successfully.
- **Masking bug**: every package's `release` script was `npm publish || echo "Skip releasing..."`, which swallowed *any* failure (auth errors included), so the CI job always reported success.
- **Downstream effect**: the `search-api-auto-ping` CronJob pins an exact `@magda/typescript-common` version via `{{ .Chart.Version }}`. Since recent versions were never actually published to npm, that CronJob crash-loops in any deployment built from a recent tag.

## Changes

- `.gitlab-ci.yml`: `Publish NPM Packages` job now requests a GitLab OIDC token (`id_tokens: NPM_ID_TOKEN`, `aud: npm:registry.npmjs.org`). npm CLI >=11.5.1 natively detects this env var and performs the OIDC token exchange itself during `npm publish` — no manual token exchange script needed, matching the trusted-publisher config already set up on npmjs.org for all `@magda/*` packages.
- `ci-scripts/npm-publish-release.js` (new, shared script): each package's `release` script now calls this one file instead of duplicating logic. It:
  - Derives the npm dist-tag from the version's prerelease identifier (e.g. `pr`, `alpha`, `beta`, `rc`), defaulting to `latest` for stable versions, and passes it via `npm publish --tag <tag>`. npm refuses to publish a prerelease version without an explicit `--tag`, since the default tag is `latest` — this was a second, previously-masked bug discovered while validating the OIDC fix on a real PR-preview release.
  - Treats "already published" (`EPUBLISHCONFLICT` / `previously published` / `cannot publish over`) as a safe skip; any other failure (auth, network, etc.) prints the error and fails the job instead of being silently swallowed.
  - Resolves the repo root via `git rev-parse --show-toplevel` so it works both in CI and when run locally.
- 18 `package.json` files: `release` script updated to `node "$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js"`.

## Not included

Chart-level defensive pinning (making `search-api-auto-ping` tolerant of a missing exact version) was considered but is unnecessary — once publish reliably succeeds on every tagged build (including PR preview tags, which use the same job), the exact version the chart references will always exist on npm.

## Test plan

- [x] Merge and cut a release tag (or PR preview tag) to confirm `Publish NPM Packages` succeeds via OIDC and packages appear on npmjs.org — validated end-to-end via PR-preview tag `v6.0.0-pr.3665.5`: [GitLab pipeline](https://gitlab.com/magda-data/magda/-/pipelines/2645596824) job `Publish NPM Packages` succeeded, and `@magda/typescript-common@6.0.0-pr.3665.5` is live on npmjs.org tagged `pr`.
- [x] Confirm a deliberately broken OIDC exchange causes the CI job to fail loudly rather than silently pass — confirmed indirectly: the prerelease `--tag` bug (a real failure introduced by npm's own safety check) surfaced as a hard CI failure on the first `.4` release attempt, proving the masking bug is gone and real errors now fail the job.
- [x] Confirm `search-api-auto-ping` CronJob starts successfully in a preview deployment built from the next tagged release