### PR TITLE
fix: publish npm packages via OIDC trusted publishing, fail loudly on real errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -952,6 +952,9 @@ Release-to-Docker-Hub-Github-Container:
 
 Publish NPM Packages:
   stage: release
+  id_tokens:
+    NPM_ID_TOKEN:
+      aud: npm:registry.npmjs.org
   only:
     # Strict Semvar validation
     - /^v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/
@@ -975,11 +978,13 @@ Publish NPM Packages:
   image:
     name: registry.gitlab.com/magda-data/magda/magda-builder-nodejs:$BUILDER_IMG_TAG
   cache: {}
-  script:
-    # Setup NPM token & scoped registry
-    - npm config set @magda:registry https://registry.npmjs.org/
-    - npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-    - yarn run in-submodules -f categories.npmPackage=true run release
+  script: |
+    # npm CLI >=11.5.1 natively detects the NPM_ID_TOKEN env var (from id_tokens
+    # above) and exchanges it for a short-lived per-package publish token itself
+    # during `npm publish` - no manual token exchange needed.
+    npm --version
+    npm config set @magda:registry https://registry.npmjs.org/
+    yarn run in-submodules -f categories.npmPackage=true run release
 
 Publish Helm Chart:
   stage: release

--- a/ci-scripts/npm-publish-release.js
+++ b/ci-scripts/npm-publish-release.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Publishes the npm package in the current working directory, deriving the
+// npm dist-tag from the version's prerelease identifier (e.g. "pr", "alpha",
+// "beta", "rc"), or "latest" for stable versions. npm refuses to publish a
+// prerelease version without an explicit --tag.
+//
+// Treats "version already published" as a non-fatal outcome, since release
+// pipelines may be re-run against a version that was already published.
+const { execSync } = require("child_process");
+const path = require("path");
+
+const pkg = require(path.join(process.cwd(), "package.json"));
+const match = pkg.version.match(/-([a-zA-Z]+)/);
+const tag = match ? match[1] : "latest";
+
+try {
+    execSync(`npm publish --tag ${tag}`, {
+        stdio: ["ignore", "inherit", "pipe"]
+    });
+} catch (e) {
+    const output = e.stderr ? e.stderr.toString() : "";
+    if (
+        /EPUBLISHCONFLICT|previously published|cannot publish over/.test(output)
+    ) {
+        process.exit(0);
+    }
+    process.stderr.write(output);
+    process.exit(1);
+}

--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     node -v && npm -v
 
-RUN npm install -g npm@10.5.2 && npm install -g lerna@3.22.1 yarn@1.22.19
+RUN npm install -g npm@11.5.1 && npm install -g lerna@3.22.1 yarn@1.22.19
 
 # -----------------------------
 # Install Helm 3.13.2 (pinned)

--- a/magda-minion-framework/package.json
+++ b/magda-minion-framework/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "test": "mocha",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/minion-framework.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/magda-registry-aspects/package.json
+++ b/magda-registry-aspects/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/registry-aspects.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "dependencies": {
     "@magda/esm-utils": "^1.0.1"

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -19,7 +19,7 @@
     "generate": "generate-registry-typescript ./src/generated/registry",
     "test": "c8 mocha",
     "dev": "yarn run watch",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/typescript-common.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "devDependencies": {
     "@magda/esm-utils": "^1.0.1",

--- a/packages/acs-cmd/package.json
+++ b/packages/acs-cmd/package.json
@@ -17,7 +17,7 @@
     "acs-cmd": "./bin/acs-cmd.js",
     "prebuild": "rimraf bin",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/acs-cmd.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/arbitraries/package.json
+++ b/packages/arbitraries/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/arbitraties.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/auth-api-client/package.json
+++ b/packages/auth-api-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/auth-api-client.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/authentication-plugin-sdk/package.json
+++ b/packages/authentication-plugin-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/authentication-plugin-sdk.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/connector-sdk.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/connector-test-utils/package.json
+++ b/packages/connector-test-utils/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/connector-test-utils.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/docker-utils/package.json
+++ b/packages/docker-utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/docker-utils.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/external-ui-plugin-sdk/package.json
+++ b/packages/external-ui-plugin-sdk/package.json
@@ -6,7 +6,7 @@
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "api-extractor run -l",
     "docs": "which typedoc; if [ $? -eq 1 ]; then echo \"Error: typedoc is required.\";else typedoc;fi",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/external-ui-plugin-sdk.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "Jacky Jiang",
   "license": "Apache-2.0",

--- a/packages/minion-sdk/package.json
+++ b/packages/minion-sdk/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/minion-sdk.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/org-tree/package.json
+++ b/packages/org-tree/package.json
@@ -17,7 +17,7 @@
     "org-tree": "./dist/index.js",
     "prebuild": "rimraf dist",
     "build": "node esbuild.js",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/org-tree.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -16,7 +16,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/registry-client.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     "build-main": "node esbuild.js",
     "build-types": "tsc --emitDeclarationOnly",
     "build-types-bundle": "api-extractor run --local",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/utils.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
   "license": "Apache-2.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "echo \"ok\"",
-    "release": "npm publish || echo \"Skip releasing npm package @magda/scripts.\""
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "devDependencies": {
     "@types/pg": "^8.6.5"


### PR DESCRIPTION
Backport of #3665 (already on `next`) onto `main`. `main` currently uses the old token-based npm auth and swallows all publish errors (including real ones), which would cause the in-progress v5.6.1 production release to silently no-op the npm publish step. Needed on `main` before cutting v5.6.1.