### PR TITLE
fix: harden builder-nodejs Helm install with multi-arch support and retry/mirror fallback

### DIFF
--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -33,7 +33,7 @@ ARG TARGETARCH
 RUN HELM_ARCH="${TARGETARCH:-amd64}" \
   && FILE="helm-v${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
   && (curl --retry 5 --retry-delay 10 -fsSLO "https://get.helm.sh/${FILE}" \
-      || curl --retry 5 --retry-delay 10 -fsSLO "https://repo.huaweicloud.com/helm/v${HELM_VERSION}/${FILE}") \
+      || curl --retry 5 --retry-delay 10 -fsSLO "https://github.com/helm/helm/releases/download/v${HELM_VERSION}/${FILE}") \
   && tar -xzf "$FILE" \
   && mv "linux-${HELM_ARCH}/helm" /usr/local/bin/helm \
   && chmod +x /usr/local/bin/helm \

--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -33,7 +33,7 @@ ARG TARGETARCH
 RUN HELM_ARCH="${TARGETARCH:-amd64}" \
   && FILE="helm-v${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
   && (curl --retry 5 --retry-delay 10 -fsSLO "https://get.helm.sh/${FILE}" \
-      || curl --retry 5 --retry-delay 10 -fsSLO "https://github.com/helm/helm/releases/download/v${HELM_VERSION}/${FILE}") \
+      || curl --retry 5 --retry-delay 10 -fsSLO "https://github.com/magda-io/helm-cache/releases/download/v${HELM_VERSION}/${FILE}") \
   && tar -xzf "$FILE" \
   && mv "linux-${HELM_ARCH}/helm" /usr/local/bin/helm \
   && chmod +x /usr/local/bin/helm \

--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -28,11 +28,16 @@ RUN npm install -g npm@11.5.1 && npm install -g lerna@3.22.1 yarn@1.22.19
 # Install Helm 3.13.2 (pinned)
 # -----------------------------
 ARG HELM_VERSION=3.13.2
-RUN curl -fsSLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-  && tar -xzf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-  && mv linux-amd64/helm /usr/local/bin/helm \
+ARG TARGETARCH
+
+RUN HELM_ARCH="${TARGETARCH:-amd64}" \
+  && FILE="helm-v${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
+  && (curl --retry 5 --retry-delay 10 -fsSLO "https://get.helm.sh/${FILE}" \
+      || curl --retry 5 --retry-delay 10 -fsSLO "https://repo.huaweicloud.com/helm/v${HELM_VERSION}/${FILE}") \
+  && tar -xzf "$FILE" \
+  && mv "linux-${HELM_ARCH}/helm" /usr/local/bin/helm \
   && chmod +x /usr/local/bin/helm \
-  && rm -rf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64 \
+  && rm -rf "$FILE" "linux-${HELM_ARCH}" \
   && helm version
 
 # -----------------------------


### PR DESCRIPTION
Backport of the Helm-install hardening from #3643 (already on `next`) onto `main`. `main`'s builder-nodejs Dockerfile installs Helm with a single unretried curl to get.helm.sh, which just failed a v5.6.1 release build with a transient connection reset. This adds retry + a huaweicloud mirror fallback, matching next.