### PR TITLE
fix: use magda-io/helm-cache as builder-nodejs Helm install fallback

### DIFF
--- a/magda-builder-nodejs/Dockerfile
+++ b/magda-builder-nodejs/Dockerfile
@@ -27,20 +27,13 @@ RUN npm install -g npm@11.5.1 && npm install -g lerna@3.22.1 yarn@1.22.19
 # -----------------------------
 # Install Helm 3.13.2 (pinned)
 # -----------------------------
-#ARG HELM_VERSION=3.13.2
-#RUN curl -fsSLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-#  && tar -xzf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
-#  && mv linux-amd64/helm /usr/local/bin/helm \
-#  && chmod +x /usr/local/bin/helm \
-#  && rm -rf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64 \
-#  && helm version
 ARG HELM_VERSION=3.13.2
 ARG TARGETARCH
 
 RUN HELM_ARCH="${TARGETARCH:-amd64}" \
   && FILE="helm-v${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
   && (curl --retry 5 --retry-delay 10 -fsSLO "https://get.helm.sh/${FILE}" \
-      || curl --retry 5 --retry-delay 10 -fsSLO "https://repo.huaweicloud.com/helm/v${HELM_VERSION}/${FILE}") \
+      || curl --retry 5 --retry-delay 10 -fsSLO "https://github.com/magda-io/helm-cache/releases/download/v${HELM_VERSION}/${FILE}") \
   && tar -xzf "$FILE" \
   && mv "linux-${HELM_ARCH}/helm" /usr/local/bin/helm \
   && chmod +x /usr/local/bin/helm \


### PR DESCRIPTION
## Summary
- Port of #3667 (already merged/validated on \`main\`) to \`next\`.
- Replaces the fallback mirror with \`magda-io/helm-cache\`, a dedicated repo we control that hosts checksum-verified copies of the exact Helm release binaries (following the same pattern as \`magda-io/node-sass-cache\`).
- Also removes a stale commented-out single-arch install block left over from before multi-arch support was added.

## Test plan
- [x] Verified the \`get.helm.sh\` primary / \`helm-cache\` fallback logic end-to-end on \`main\`'s \`v5.6.1\` release pipeline: the real GitLab CI runner hit a genuine \`get.helm.sh\` SSL connection reset for both \`amd64\` and \`arm64\`, and the fallback to \`helm-cache\` succeeded both times, producing valid \`helm v3.13.2\` binaries.
- [x] Checksums of the \`helm-cache\` assets verified to match Helm's official \`sha256\` values exactly.