### PR TITLE
storage-api: large file upload/download support (S3 multipart + HTTP Range)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v6.1.0
+
+- #3672: Add large file upload & download support to `storage-api` — S3 multipart upload proxy endpoints (`/v0/storage/multipart/{initiate,part,parts,complete,abort}`) and HTTP Range support on object download, enabling resumable transfers of large (multi-GB) files without raising the ingress body-size limit. Adds `recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry` & `incompleteUploadExpiryDays` chart options.
+- #3678: Fix `storage-api` create-bucket route being registered at `/v0/storage/{bucketid}` instead of the documented `/v0/storage/buckets/{bucketid}`
+
 ## v6.0.0
 
 - #3598: Add configurable `on_disk` KNN vector workload mode for OpenSearch (foundation for semantic indexing); upgrade bundled OpenSearch and OpenSearch Dashboards from 2.17.1 to 2.19.1

--- a/deploy/helm/internal-charts/storage-api/README.md
+++ b/deploy/helm/internal-charts/storage-api/README.md
@@ -24,7 +24,9 @@ Kubernetes: `>= 1.14.0-0`
 | defaultImage.pullSecrets | bool | `false` |  |
 | defaultImage.repository | string | `"ghcr.io/magda-io"` |  |
 | image.name | string | `"magda-storage-api"` |  |
+| incompleteUploadExpiryDays | int | `7` | Days after which incomplete multipart uploads are auto-aborted via a bucket lifecycle rule. |
 | listenPort | int | `6121` | The port for storage api to listen on |
+| maxPartSize | string | `"64mb"` | The maximum accepted size of a single multipart upload part. Bounds per-part memory in the pod. |
 | minio.DeploymentUpdate.type | string | `"Recreate"` |  |
 | minio.existingSecret | string | `"storage-secrets"` |  |
 | minio.fullnameOverride | string | `"magda-minio"` |  |
@@ -35,6 +37,8 @@ Kubernetes: `>= 1.14.0-0`
 | minio.resources.requests.memory | string | `"256Mi"` |  |
 | minioEnableSSL | bool | `false` | Whether or not to connect to minio server with SSL connection |
 | minioRegion | string | "unspecified-region" | specify bucket region |
+| multipartUploadExpiry | string | `"24h"` | Lifetime of a multipart upload session token (any jsonwebtoken expiry expression). |
+| recommendedPartSize | string | `"16mb"` | The multipart upload part size advertised to clients. |
 | registryApiUrl | string | `"http://registry-api/v0"` | The URL of the registry API |
 | resources.limits.cpu | string | `"50m"` |  |
 | resources.requests.cpu | string | `"10m"` |  |

--- a/deploy/helm/internal-charts/storage-api/templates/deployment.yaml
+++ b/deploy/helm/internal-charts/storage-api/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
             "--authApiUrl", {{ .Values.authApiUrl | quote }},
             "--tenantId", {{ .Values.tenantId | quote }},
             "--uploadLimit", {{ .Values.uploadLimit | quote }},
+            "--recommendedPartSize", {{ .Values.recommendedPartSize | quote }},
+            "--maxPartSize", {{ .Values.maxPartSize | quote }},
+            "--multipartUploadExpiry", {{ .Values.multipartUploadExpiry | quote }},
+            "--incompleteUploadExpiryDays", {{ .Values.incompleteUploadExpiryDays | quote }},
             "--registryApiUrl", {{ .Values.registryApiUrl | quote }},
 {{- if .Values.defaultBuckets }}
             "--defaultBuckets", {{ range .Values.defaultBuckets }} {{ . | quote }},  {{- end }}

--- a/deploy/helm/internal-charts/storage-api/values.yaml
+++ b/deploy/helm/internal-charts/storage-api/values.yaml
@@ -56,6 +56,18 @@ tenantId: 0
 # -- the file upload size limit of the storage API
 uploadLimit: "100mb"
 
+# -- The multipart upload part size advertised to clients.
+recommendedPartSize: "16mb"
+
+# -- The maximum accepted size of a single multipart upload part. Bounds per-part memory in the pod.
+maxPartSize: "64mb"
+
+# -- Lifetime of a multipart upload session token (any jsonwebtoken expiry expression).
+multipartUploadExpiry: "24h"
+
+# -- Days after which incomplete multipart uploads are auto-aborted via a bucket lifecycle rule.
+incompleteUploadExpiryDays: 7
+
 # -- when set to true, API will not query policy engine for auth decision but assume it's always permitted. 
 # It's for debugging only.
 skipAuth: false

--- a/docs/docs/adrs/0001-large-file-storage-support.md
+++ b/docs/docs/adrs/0001-large-file-storage-support.md
@@ -1,0 +1,118 @@
+# ADR 0001: Large file upload/download support for magda-storage-api
+
+- **Status:** Accepted
+- **Date:** 2026-07-04
+- **Component:** `magda-storage-api` (+ its Helm chart)
+- **Related:** epic [#3672](https://github.com/magda-io/magda/issues/3672) and sub-issues [#3673](https://github.com/magda-io/magda/issues/3673)–[#3676](https://github.com/magda-io/magda/issues/3676); [#3678](https://github.com/magda-io/magda/issues/3678) (create-bucket route path); [ts-module-alias-transformer#15](https://github.com/magda-io/ts-module-alias-transformer/issues/15); [#3680](https://github.com/magda-io/magda/issues/3680) (jsonwebtoken consolidation)
+
+## Context
+
+`magda-storage-api` is an authorization proxy in front of a MinIO gateway. The
+original upload paths (`POST /v0/storage/upload/...` and `PUT /v0/storage/:bucket/*`)
+buffered the **entire file into memory** before writing to MinIO (capped at
+`uploadLimit`, default `100mb`), and downloads (`GET /v0/storage/:bucket/*`)
+streamed but ignored the `Range` header. This meant: memory pressure scaling with
+file size, a hard ~100 MB ceiling, single non-resumable requests, and no
+resumable/seekable downloads.
+
+We needed to support files up to ~10 GB (with headroom) while **preserving the
+existing OPA + record-linked authorization model** and **without forcing an
+ingress body-size increase** on every deployment.
+
+## Decision
+
+Two additive changes; all existing routes preserved.
+
+1. **Download:** add HTTP Range support to the existing `GET /v0/storage/:bucket/*`
+   route (`Accept-Ranges: bytes`; `206` + `Content-Range` for a satisfiable single
+   range via `minio.getPartialObject`; `416` for unsatisfiable; full `200`
+   otherwise). Authorization unchanged.
+
+2. **Upload:** add S3 **multipart upload proxy** endpoints under
+   `/v0/storage/multipart/{initiate,part,parts,complete,abort}/:bucket/*` that
+   relay **one bounded part at a time** through storage-api to MinIO.
+
+Key sub-decisions:
+
+- **Proxy the bytes through storage-api** (rather than issuing presigned URLs for
+  direct-to-MinIO transfer). This preserves the authorization model exactly and
+  needs no MinIO exposure through the gateway. Cost: storage-api stays in the byte
+  path. Memory is bounded by reading at most one part (`express.raw` limit =
+  `maxPartSize`); the whole file is never buffered.
+- **Stateless, signed upload session.** `initiate` returns a JWT (signed with the
+  existing `jwtSecret`) as the `uploadId`, embedding `{bucket, objectKey, s3UploadId, userId, recordId, orgUnitId, contentType, exp}`. It's verified on
+  every subsequent call and must match the URL's bucket/key — so it can't be
+  replayed against a different object, and no server-side session store is needed.
+- **Authorization timing.** The full `storage/object/upload` OPA decision runs at
+  **initiate** and again at **complete** (where the object materializes). Part
+  upload / list / abort are gated by the signed token only (no per-part OPA call);
+  a large upload is hundreds of parts and permissions don't meaningfully change
+  mid-upload.
+- **Per-request body ≤ one part decouples ingress from file size.** With multipart
+  the largest request body is a single part, so a modest, already-configured
+  ingress limit supports arbitrarily large total files. Defaults:
+  `recommendedPartSize=16mb` (advertised to clients — fits under the shipped
+  `proxyBodySize: 100M` with no reconfiguration, is ~3× the 5 MB S3 part floor,
+  keeps 10 GB ≈ 640 parts and 100 GB under the 10,000-part cap, and stays under
+  Node's 300 s `requestTimeout` even on slow links) and `maxPartSize=64mb` (server
+  `express.raw` ceiling that bounds per-part memory).
+- **Housekeeping.** A MinIO bucket lifecycle rule auto-aborts incomplete multipart
+  uploads after `incompleteUploadExpiryDays` (default 7); the abort endpoint
+  cleans up immediately. Applied at bucket creation; non-fatal if the backend
+  doesn't support lifecycle config.
+
+## Consequences
+
+- Resumable, memory-bounded uploads to ~10 GB and resumable/seekable downloads,
+  with the existing auth model intact and no ingress changes on a default deploy.
+- storage-api CPU/network sits in the transfer path (accepted trade-off for
+  keeping authorization centralized and MinIO unexposed).
+- New config surface (`recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry`,
+  `incompleteUploadExpiryDays`) across `index.ts` yargs + Helm values/deployment.
+- Clients must send auth (session or API key) on `initiate` **and** `complete`.
+
+## Alternatives considered
+
+- **Presigned URLs, direct to MinIO** (client uploads parts / downloads straight
+  from MinIO): best offload/scalability, but requires exposing MinIO through the
+  gateway and turns each presigned URL into a bearer token that bypasses
+  fine-grained per-object authorization once issued. Rejected to keep the auth
+  model and avoid MinIO exposure. (Dead presign helpers already in
+  `MagdaMinioClient` were left untouched; removing them is future cleanup.)
+- **Hybrid** (presigned for the heavy part transfer, storage-api orchestrates):
+  balances offload vs. control but is the most complex. Rejected for this scope.
+
+## Implementation notes / non-obvious decisions
+
+- **minio v8 `uploadPart` is unusable for normal parts.** It parses the ETag from
+  the response _body_ (expecting a `CopyPartResult`), but a plain `UploadPart`
+  returns an empty body with the ETag in the response _header_ → it throws. We
+  issue the part request directly (same shape minio builds) and read the ETag from
+  the header. See `MagdaMinioClient.uploadPart`.
+- **Route registration order is load-bearing.** Multipart routes are registered
+  before the global body parsers (so the part route controls its own parsing) and
+  before the generic `/:bucket/*` routes (so `multipart` isn't matched as a bucket).
+- **Build: `compile` strips `.d.ts` before `ts-module-alias-transformer`.** The
+  transformer aborts on a `.d.ts` containing declaration syntax / a
+  `resolution-mode` reference directive (emitted once the client's public
+  signatures reference Node types), silently leaving `.js` module aliases
+  un-rewritten → runtime `Cannot find package 'magda-typescript-common'`. Stripping
+  `.d.ts` (an app whose declarations nothing consumes) is the safe local fix;
+  upstream fix tracked in
+  [ts-module-alias-transformer#15](https://github.com/magda-io/ts-module-alias-transformer/issues/15).
+- **`@types/jsonwebtoken` pinned to `9.0.5`.** 9.0.6+ imports `ms`'s `StringValue`,
+  which breaks `tsc` (no `skipLibCheck` in the shared tsconfig). `jsonwebtoken`
+  itself is `^9.0.2`, matching `magda-typescript-common`; repo-wide consolidation
+  tracked in [#3680](https://github.com/magda-io/magda/issues/3680).
+- The web client is intentionally **not** changed here; it keeps the single-shot
+  upload for small files. Wiring it to the multipart flow is future work.
+
+## Verification
+
+Unit/integration tests (Mocha, against a local MinIO) cover range parsing, the
+signed token, the MinIO client multipart methods, the Range download route, and
+the multipart endpoints. End-to-end verification against a minikube deployment —
+through the gateway, authenticated with an API key, as both the default admin and
+a freshly-created admin user — is scripted in
+`magda-storage-api/scripts/verify-large-file.mjs` (see
+[E2E test case: Large file storage](../e2e-test-cases/large-file-storage.md)).

--- a/docs/docs/adrs/README.md
+++ b/docs/docs/adrs/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+
+This folder records significant architectural / design decisions made in Magda —
+the context, the decision, its consequences, and the alternatives considered — so
+the reasoning behind non-obvious choices isn't lost.
+
+Use an ADR when a change involves a decision that is expensive to reverse, affects
+a public interface or the security model, or would otherwise leave future readers
+wondering "why was it done this way?".
+
+## Format & conventions
+
+- One decision per file, named `NNNN-short-title.md` (zero-padded, incrementing).
+- Suggested sections: **Status** (Proposed / Accepted / Superseded), **Context**,
+  **Decision**, **Consequences**, **Alternatives considered**, and any
+  implementation notes worth preserving near the decision.
+- Prefer linking to GitHub issues/PRs for tracking, and to the relevant code.
+
+## Index
+
+- [0001 — Large file upload/download support for magda-storage-api](./0001-large-file-storage-support.md)

--- a/docs/docs/e2e-cluster-deployment-test.md
+++ b/docs/docs/e2e-cluster-deployment-test.md
@@ -171,6 +171,91 @@ Confirms the registry API accepts writes, the indexer picks up the change, and i
 
 The checks above are the baseline smoke test suite. If the PR under test changes a specific feature (semantic search access control, a connector, a minion), add targeted checks for that feature on top of this baseline rather than replacing it — e.g. creating a dataset with a distribution, waiting for the relevant indexer to build its index, and testing the feature's specific API/behavior with both anonymous and authenticated requests.
 
+### Feature-specific testing through the gateway with an API key
+
+The baseline checks above act as the internal admin using an `X-Magda-Session`
+JWT minted from the cluster secret — a convenient **internal** shortcut that
+bypasses the gateway's real authentication. To verify a feature the way an
+external client actually uses it, test **through the gateway authenticated with
+an API key** instead. (A minted JWT is an internal auth method; real external
+clients authenticate with an API key — see
+[How to create API key](./how-to-create-api-key.md) and the
+[Guide to Magda Internals](<./architecture/Guide to Magda Internals.md>).)
+
+The steps below establish that external path once — host → gateway
+(authentication + routing) → service. Concrete, repeatable feature checks that
+build on it live under [E2E test cases](./e2e-test-cases/) — for example
+[Large file storage (multipart upload + Range download)](./e2e-test-cases/large-file-storage.md).
+
+#### 1. Expose the gateway to the host via `minikube tunnel`
+
+On the docker driver the NodePort's `minikube ip` address isn't routable from the
+host, so switch the gateway to a `LoadBalancer` and run `minikube tunnel`. Use a
+**non-privileged port** (e.g. 8080) so the tunnel doesn't need `sudo` (privileged
+ports like 80 make `minikube tunnel` prompt for a password):
+
+```bash
+kubectl patch svc gateway -n magda -p '{"spec":{"type":"LoadBalancer"}}'
+kubectl patch svc gateway -n magda --type=json \
+  -p='[{"op":"replace","path":"/spec/ports/0/port","value":8080}]'
+minikube tunnel &            # keep running; serves the LB at 127.0.0.1:8080
+export BASE=http://127.0.0.1:8080
+curl -s -o /dev/null -w "%{http_code}\n" "$BASE/api/v0/auth/users/whoami"   # 200 = reachable
+```
+
+(`kubectl port-forward -n magda svc/gateway 18080:80 &` is a simpler alternative
+that also routes through the gateway if you can't use a tunnel.)
+
+#### 2. Bootstrap an admin API key (JWT used only to create the key)
+
+```bash
+ADMIN_ID=00000000-0000-4000-8000-000000000000
+JWT_SECRET=$(kubectl get secret -n magda auth-secrets -o jsonpath='{.data.jwt-secret}' | base64 -d)
+yarn --silent acs-cmd jwt "$ADMIN_ID" "$JWT_SECRET" | tail -1 > /tmp/admin.jwt
+curl -s -X POST "$BASE/api/v0/auth/users/$ADMIN_ID/apiKeys" \
+  -H "X-Magda-Session: $(cat /tmp/admin.jwt)" -H "Content-Type: application/json" -d '{}'
+# -> {"id":"<API_KEY_ID>","key":"<API_KEY>"}
+```
+
+Supply the key on subsequent requests as `X-Magda-API-Key-Id` / `X-Magda-API-Key`.
+
+#### 3. (Optional) create a dedicated admin test user via the API
+
+Using the admin API key from step 2 (`-H X-Magda-API-Key-Id:.. -H X-Magda-API-Key:..`):
+
+```bash
+# create user -> returns {"id": "<NEW_USER_ID>", ...}
+curl -s "${AUTH[@]}" -X POST "$BASE/api/v0/auth/users" -H "Content-Type: application/json" \
+  -d '{"displayName":"E2E Admin","email":"e2e@example.com","source":"e2e-test","sourceId":"e2e-1"}'
+# grant the "Admin Users" role (id 00000000-0000-0003-0000-000000000000)
+curl -s "${AUTH[@]}" -X POST "$BASE/api/v0/auth/users/<NEW_USER_ID>/roles" \
+  -H "Content-Type: application/json" -d '["00000000-0000-0003-0000-000000000000"]'
+# create an API key for the new user -> {"id":..,"key":..}
+curl -s "${AUTH[@]}" -X POST "$BASE/api/v0/auth/users/<NEW_USER_ID>/apiKeys" \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+#### 4. Run your feature's checks
+
+With `$BASE` reachable and an API key in hand, exercise the feature's endpoints —
+always sending the `X-Magda-API-Key-Id` / `X-Magda-API-Key` headers. Prefer a
+scripted, checksum/assertion-based driver so the case is repeatable. Ready-to-run
+examples live under [E2E test cases](./e2e-test-cases/), e.g.
+[Large file storage (multipart upload + Range download)](./e2e-test-cases/large-file-storage.md).
+
+#### Cleanup
+
+Restore the gateway service and stop the tunnel when finished:
+
+```bash
+kubectl patch svc gateway -n magda --type=json -p='[{"op":"replace","path":"/spec/ports/0/port","value":80}]'
+kubectl patch svc gateway -n magda -p '{"spec":{"type":"NodePort"}}'
+# then stop the `minikube tunnel` process you started
+```
+
+Also remove any throwaway users / API keys you created and delete uploaded test
+objects (see each test case's own cleanup notes).
+
 ## Step 5: Retrieve DB Credentials Safely
 
 Several checks (e.g. running [`@magda/acs-cmd`](https://www.npmjs.com/package/@magda/acs-cmd) against Postgres) need the DB password from the `db-main-account-secret` Secret. Capture it into a shell variable — **do not print it to stdout/logs**:

--- a/docs/docs/e2e-test-cases/README.md
+++ b/docs/docs/e2e-test-cases/README.md
@@ -1,0 +1,24 @@
+# E2E Test Cases
+
+Concrete, repeatable end-to-end test cases for specific Magda features. They are
+run against a real cluster (e.g. minikube) **through the gateway**, on top of the
+shared setup described in
+[Feature-specific testing through the gateway with an API key](../e2e-cluster-deployment-test.md#feature-specific-testing-through-the-gateway-with-an-api-key)
+(expose the gateway to the host, then authenticate with an API key — optionally
+as a purpose-built test user).
+
+Each case is self-contained: it lists what it verifies, how to run it (prefer a
+scripted, assertion/checksum-based driver), and how to clean up.
+
+## Cases
+
+- [Large file storage (multipart upload + Range download)](./large-file-storage.md)
+
+## Adding a new case
+
+- Add a `*.md` file here describing the case and (ideally) referencing a scripted
+  driver checked into the relevant component.
+- Link it from this index and, if broadly useful, from
+  [End-to-End Full Cluster Deployment Test](../e2e-cluster-deployment-test.md).
+- Reuse the shared gateway + API-key setup rather than repeating it; only document
+  what's specific to the feature under test.

--- a/docs/docs/e2e-test-cases/large-file-storage.md
+++ b/docs/docs/e2e-test-cases/large-file-storage.md
@@ -1,0 +1,69 @@
+# E2E Test Case: Large file storage (multipart upload + Range download)
+
+A concrete, scripted end-to-end test case for `magda-storage-api`'s large-file
+support, run **through the gateway with an API key**. It builds on the shared
+setup in
+[Feature-specific testing through the gateway with an API key](../e2e-cluster-deployment-test.md#feature-specific-testing-through-the-gateway-with-an-api-key)
+— follow steps 1–3 there first to expose the gateway (`$BASE`) and obtain an API
+key (`API_KEY_ID` / `API_KEY`).
+
+## What it covers
+
+`magda-storage-api` supports resumable large-file uploads via S3 multipart proxy
+endpoints and resumable/seekable downloads via HTTP Range on the existing
+`GET /api/v0/storage/{bucket}/{path}` route. The multipart endpoints are:
+
+- `POST /api/v0/storage/multipart/initiate/{bucket}/{path}` — authorize + start; returns a signed `uploadId` and part-size guidance.
+- `PUT /api/v0/storage/multipart/part/{bucket}/{path}?uploadId=&partNumber=N` — upload one part.
+- `GET /api/v0/storage/multipart/parts/{bucket}/{path}?uploadId=` — list uploaded parts (resume).
+- `POST /api/v0/storage/multipart/complete/{bucket}/{path}?uploadId=` — finalize (body `{parts:[{partNumber,etag}]}`).
+- `DELETE /api/v0/storage/multipart/abort/{bucket}/{path}?uploadId=` — discard.
+
+Key properties this case verifies:
+
+- Because each request carries at most one part, the per-request body stays under
+  the default `proxyBodySize: 100M` ingress limit regardless of total file size —
+  so a **> 100 MB** file uploads with **no ingress reconfiguration**.
+- `initiate` and `complete` run the full `storage/object/upload` authorization
+  decision, so **both must be authenticated** (part / list / abort are gated by
+  the signed `uploadId` token only).
+- Downloads advertise `Accept-Ranges: bytes` and return `206 Partial Content`
+  with a correct `Content-Range` for `Range` requests, so a large object can be
+  fetched (and resumed) in pieces with matching checksums.
+- A bucket lifecycle rule auto-aborts incomplete uploads after
+  `incompleteUploadExpiryDays` (default 7).
+
+## Run the driver script
+
+A driver script exercises the whole flow (initiate → upload parts → complete →
+full + ranged download with checksum match → abort). With `$BASE` reachable and
+an API key from the shared setup:
+
+```bash
+BASE_URL=$BASE/api/v0/storage API_KEY_ID=<API_KEY_ID> API_KEY=<API_KEY> \
+  SIZE_MB=200 KEY="verify/large-file/e2e-$(date +%s).bin" \
+  node magda-storage-api/scripts/verify-large-file.mjs
+```
+
+Expected output ends with `ALL CHECKS PASSED`.
+
+The script's auth is pluggable: pass `API_KEY_ID` + `API_KEY` (the real external
+path, recommended) or, for a quick internal check, `JWT` (an `X-Magda-Session`
+token). Other env vars: `BUCKET` (default `magda-datasets`), `SIZE_MB` (default
+`500`), and `KEY` (the object key — use a fresh one per run).
+
+## Notes
+
+- **Use a fresh object key per run** (`KEY=...`). Re-running against a key that
+  has a leftover incomplete multipart upload (e.g. from an interrupted run) can
+  make `complete` return `400`.
+- Verified against a real minikube deployment for both the default admin and a
+  freshly-created admin user, each authenticating solely with their API key.
+
+## Cleanup
+
+The script deletes the object it uploads. Additionally, per the shared setup,
+restore the gateway service, stop `minikube tunnel`, and remove any throwaway
+test user / API key you created. Abandoned incomplete multipart uploads (if any)
+are cleaned up automatically by the bucket lifecycle rule after
+`incompleteUploadExpiryDays`.

--- a/docs/docs/how-to-update-helm-chart-docs.md
+++ b/docs/docs/how-to-update-helm-chart-docs.md
@@ -1,0 +1,73 @@
+# How to update Helm chart docs (helm-docs)
+
+Each Magda Helm chart's `README.md` is **auto-generated** from the chart's
+`values.yaml` (using the `# --` value comments), `Chart.yaml`, and the chart's
+`README.md.gotmpl` template, via [helm-docs](https://github.com/norwoodj/helm-docs).
+**Do not hand-edit a chart `README.md`** — edit the source (`values.yaml` /
+`Chart.yaml` / `README.md.gotmpl`) and regenerate.
+
+> CI enforces this. If a chart `README.md` is out of date relative to its
+> sources, the `buildtest:helm-docs-check` job fails the pipeline (see below).
+> So whenever you change a chart's `values.yaml`, `Chart.yaml`, or
+> `README.md.gotmpl`, you must regenerate and commit the `README.md`.
+
+## When you need to run it
+
+Any change to a chart under `deploy/helm/**` that affects generated docs, most
+commonly:
+
+- adding / removing / renaming a value in `values.yaml`, or editing its `# --`
+  doc comment or default;
+- changing `Chart.yaml` metadata (description, version, dependencies);
+- editing a chart's `README.md.gotmpl`.
+
+## How to regenerate
+
+From the repository root (requires Docker; matches the version CI uses,
+`helm-docs` v1.13.1):
+
+```bash
+cd deploy
+yarn helm-docs
+```
+
+`yarn helm-docs` runs the pinned helm-docs Docker image over the repo and
+regenerates every chart `README.md` from its sources. Only charts whose sources
+changed will show a diff. Review the changes and commit the updated `README.md`
+file(s):
+
+```bash
+git status                 # see which README.md files changed
+git add deploy/helm/**/README.md
+```
+
+(There is also `yarn add-all-helm-docs-changes`, which runs helm-docs and
+`git add`s the changed `README.md` files in one step. The `version` script runs
+it automatically during a release.)
+
+## How CI checks it
+
+`buildtest:helm-docs-check` in `.gitlab-ci.yml` runs helm-docs (v1.13.1) and then
+checks whether any `README.md` became modified:
+
+```
+git ls-files -m | grep -i readme.md
+```
+
+If any chart `README.md` is modified after regeneration, the docs were stale and
+the job fails with a message asking you to run helm-docs and commit the result.
+So a clean run locally (no `README.md` diffs after `yarn helm-docs`) means CI
+will pass.
+
+## Writing good value docs
+
+The quality of the generated table comes from the `# --` comments above each
+value in `values.yaml`, e.g.:
+
+```yaml
+# -- the file upload size limit of the storage API
+uploadLimit: "100mb"
+```
+
+Keep these comments accurate and concise — they are what users read in the
+published [Helm Chart Reference](./helm-charts-docs-index.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,12 +1,14 @@
 # Magda Documentation
 
 - [How to build and run](./building-and-running.md)
+- [Architecture Decision Records (ADRs)](./adrs/)
 - [How to Release a New Version](./ci-version-release.md)
 - [Testing a PR with a Preview Release Before Merging](./pr-preview-release-testing.md)
 - [End-to-End Full Cluster Deployment Test](./e2e-cluster-deployment-test.md)
 - [Migration & Upgrade Documents](./migration/)
 - [Deploy Magda with helm charts release](https://github.com/magda-io/magda-config)
 - [Magda Helm Chart Reference](./helm-charts-docs-index.md)
+- [How to update Helm chart docs (helm-docs)](./how-to-update-helm-chart-docs.md)
 - [How to deploy Magda on Google Cloud GKE](./deploying-for-production-on-gke.md)
 - [How to deploy Magda on Amazon AWS EKS](./deploy-to-aws.md)
 - [How to deploy Magda on Microsoft Azure Cloud AKS](./deploy-to-azure.md)

--- a/magda-int-test-ts/src/tests/storageApiAuth.spec.ts
+++ b/magda-int-test-ts/src/tests/storageApiAuth.spec.ts
@@ -102,7 +102,10 @@ async function createBucket(bucketName: string, userId?: string) {
         };
     }
     const res = await fetch(
-        urijs(storageApiUrl).segmentCoded(bucketName).toString(),
+        urijs(storageApiUrl)
+            .segmentCoded("buckets")
+            .segmentCoded(bucketName)
+            .toString(),
         config
     );
     return res;

--- a/magda-storage-api/README.md
+++ b/magda-storage-api/README.md
@@ -12,14 +12,14 @@ expected config file. Create a `config.json` file with the appropriate parameter
 ```json5
 // Example Config
 {
-    listenPort: 6121,
-    minioAccessKey: "", // You would have specified this when creating the MinIO server
-    minioSecretKey: "", // You would have specified this when creating the MinIO server
-    minioEnableSSL: true,
-    minioHost: "localhost",
-    minioPort: 9000,
-    tenantId: 0,
-    uploadLimit: "100mb"
+  listenPort: 6121,
+  minioAccessKey: "", // You would have specified this when creating the MinIO server
+  minioSecretKey: "", // You would have specified this when creating the MinIO server
+  minioEnableSSL: true,
+  minioHost: "localhost",
+  minioPort: 9000,
+  tenantId: 0,
+  uploadLimit: "100mb"
 }
 ```
 
@@ -39,7 +39,7 @@ Storage API started on port 6121
 
 ## API
 
-### PUT /:bucketid
+### PUT /buckets/:bucketid
 
 Attempts to create a bucket with the name `<bucketid>`.
 
@@ -48,7 +48,7 @@ _Note:_ If the bucket exists, the request will not fail.
 #### Example usage
 
 ```console
-$ curl -X PUT localhost:6121/v0/test-bucket
+$ curl -X PUT localhost:6121/v0/buckets/test-bucket
 {"message":"Bucket test-bucket created successfully in unspecified region 🎉"}
 ```
 
@@ -101,3 +101,29 @@ $ curl -X DELETE localhost:6121/v0/test-bucket/myFavouriteCSV
 ### Note
 
 The service does not come with authentication or authorization on all endpoints.
+
+## Large file support
+
+Large files are supported via S3 **multipart upload** proxy endpoints
+(`/v0/storage/multipart/{initiate,part,parts,complete,abort}/...`) and **HTTP
+Range** requests on `GET /v0/storage/:bucket/:fileid`. See the apidoc comments in
+`src/` (rendered by the apidocs-server) for the full contract, and
+[ADR 0001: Large file storage support](../docs/docs/adrs/0001-large-file-storage-support.md)
+for the design rationale and key decisions.
+
+## Build notes
+
+Two non-obvious choices live in `package.json` — which, being JSON, can't carry
+inline comments (both also covered in [ADR 0001](../docs/docs/adrs/0001-large-file-storage-support.md)):
+
+- **`compile` strips `.d.ts` before running `ts-module-alias-transformer`**
+  (`tsc -b && rimraf "dist/**/*.d.ts" && ts-module-alias-transformer dist`). The
+  transformer aborts when it hits a `.d.ts` containing declaration syntax / a
+  `resolution-mode` reference directive, silently leaving the `.js` module
+  aliases un-rewritten (runtime `Cannot find package 'magda-typescript-common'`).
+  This service is an app whose `.d.ts` nothing consumes, so stripping them is
+  safe. Tracked upstream:
+  <https://github.com/magda-io/ts-module-alias-transformer/issues/15>
+- **`@types/jsonwebtoken` is pinned to `9.0.5`** (not `^9.0.6`). 9.0.6+ imports
+  `ms`'s `StringValue`, which breaks `tsc` because the shared `tsconfig-global`
+  has no `skipLibCheck`.

--- a/magda-storage-api/package.json
+++ b/magda-storage-api/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "yarn run compile",
-    "compile": "tsc -b && ts-module-alias-transformer dist",
+    "compile": "tsc -b && rimraf \"dist/**/*.d.ts\" && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "start": "node dist/index.js",
     "dev": "MINIO_HOST=localhost MINIO_PORT=9000 MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123  run-typescript-in-nodemon src/index.ts",
@@ -28,7 +28,9 @@
   "dependencies": {
     "@magda/esm-utils": "^1.0.1",
     "@magda/typescript-common": "^6.0.0",
+    "bytes": "^3.1.2",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
     "express-multipart-file-parser": "^0.1.2",
     "http-terminator": "^3.2.0",
     "minio": "^8.0.5",
@@ -37,7 +39,9 @@
   },
   "devDependencies": {
     "@magda/scripts": "^6.0.0",
+    "@types/bytes": "^3.1.4",
     "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "9.0.5",
     "@types/minio": "^7.0.12",
     "@types/urijs": "^1.19.19",
     "@types/yargs": "^12.0.8",

--- a/magda-storage-api/scripts/verify-large-file.mjs
+++ b/magda-storage-api/scripts/verify-large-file.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * End-to-end verification driver for large-file storage support.
+ *
+ * Exercises the multipart upload flow, Range download (resume), and abort
+ * against a running Magda (through the gateway or directly against storage-api).
+ *
+ * Auth (choose one; API key is the real external path through the gateway):
+ *   API_KEY_ID + API_KEY   A Magda API key id & key (sent as X-Magda-API-Key-Id /
+ *                          X-Magda-API-Key headers). Preferred for e2e via gateway.
+ *   JWT                    An internal session JWT (X-Magda-Session). This is an
+ *                          internal auth method — use only to bootstrap.
+ *
+ * Env vars:
+ *   BASE_URL   Base storage API URL, e.g. http://localhost:18080/api/v0/storage
+ *              (through gateway) or http://localhost:6121/v0 (direct).
+ *   BUCKET     Target bucket (default: magda-datasets).
+ *   SIZE_MB    Test file size in MB (default: 500).
+ *   KEY        Optional object key to use (default: verify/large-file/test-<size>mb-<n>.bin).
+ *              Use a fresh key per run — a key with a leftover incomplete upload can 400 on complete.
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:18080/api/v0/storage \
+ *     API_KEY_ID=... API_KEY=... node scripts/verify-large-file.mjs
+ */
+import crypto from "crypto";
+
+const BASE_URL = process.env.BASE_URL;
+const API_KEY_ID = process.env.API_KEY_ID;
+const API_KEY = process.env.API_KEY;
+const JWT = process.env.JWT;
+const BUCKET = process.env.BUCKET || "magda-datasets";
+const SIZE_MB = parseInt(process.env.SIZE_MB || "500", 10);
+
+const authHeaders =
+    API_KEY_ID && API_KEY
+        ? { "X-Magda-API-Key-Id": API_KEY_ID, "X-Magda-API-Key": API_KEY }
+        : JWT
+        ? { "X-Magda-Session": JWT }
+        : null;
+
+if (!BASE_URL || !authHeaders) {
+    console.error(
+        "BASE_URL and (API_KEY_ID + API_KEY, or JWT) env vars are required."
+    );
+    process.exit(1);
+}
+
+const key = process.env.KEY || `verify/large-file/test-${SIZE_MB}mb.bin`;
+
+function assert(cond, msg) {
+    if (!cond) {
+        console.error("FAIL:", msg);
+        process.exit(1);
+    }
+    console.log("ok:", msg);
+}
+
+async function main() {
+    // 1. initiate
+    let res = await fetch(`${BASE_URL}/multipart/initiate/${BUCKET}/${key}`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/octet-stream" }
+    });
+    assert(res.ok, `initiate returned ${res.status}`);
+    const { uploadId, recommendedPartSizeBytes } = await res.json();
+    const partSize = recommendedPartSizeBytes || 16 * 1024 * 1024;
+
+    // 2. upload parts (generate deterministic content, track a hash)
+    const totalBytes = SIZE_MB * 1024 * 1024;
+    const hash = crypto.createHash("sha256");
+    const parts = [];
+    let uploaded = 0;
+    let partNumber = 1;
+    while (uploaded < totalBytes) {
+        const thisSize = Math.min(partSize, totalBytes - uploaded);
+        const chunk = crypto.randomBytes(thisSize);
+        hash.update(chunk);
+        res = await fetch(
+            `${BASE_URL}/multipart/part/${BUCKET}/${key}?uploadId=${encodeURIComponent(
+                uploadId
+            )}&partNumber=${partNumber}`,
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/octet-stream" },
+                body: chunk
+            }
+        );
+        assert(res.ok, `upload part ${partNumber} returned ${res.status}`);
+        const { etag } = await res.json();
+        parts.push({ partNumber, etag });
+        uploaded += thisSize;
+        partNumber++;
+    }
+    const expectedHash = hash.digest("hex");
+    console.log(`uploaded ${parts.length} parts, ${uploaded} bytes`);
+
+    // 3. complete
+    res = await fetch(
+        `${BASE_URL}/multipart/complete/${BUCKET}/${key}?uploadId=${encodeURIComponent(
+            uploadId
+        )}`,
+        {
+            method: "POST",
+            headers: { ...authHeaders, "Content-Type": "application/json" },
+            body: JSON.stringify({ parts })
+        }
+    );
+    assert(
+        res.ok,
+        `complete returned ${res.status} ${res.ok ? "" : await res.text()}`
+    );
+
+    // 4. full download + hash match
+    res = await fetch(`${BASE_URL}/${BUCKET}/${key}`, { headers: authHeaders });
+    assert(res.ok, `full download returned ${res.status}`);
+    assert(
+        res.headers.get("accept-ranges") === "bytes",
+        "download advertises Accept-Ranges: bytes"
+    );
+    const dlBuf = Buffer.from(await res.arrayBuffer());
+    assert(
+        dlBuf.length === totalBytes,
+        `downloaded size ${dlBuf.length} === ${totalBytes}`
+    );
+    const dlHash = crypto.createHash("sha256").update(dlBuf).digest("hex");
+    assert(dlHash === expectedHash, "downloaded content hash matches upload");
+
+    // 5. range download (resume simulation) — fetch two halves and reassemble
+    const mid = Math.floor(totalBytes / 2);
+    const r1 = await fetch(`${BASE_URL}/${BUCKET}/${key}`, {
+        headers: { ...authHeaders, Range: `bytes=0-${mid - 1}` }
+    });
+    assert(
+        r1.status === 206,
+        `first range returned ${r1.status} (expected 206)`
+    );
+    // drain each range body before issuing the next request so the HTTP
+    // connection isn't left with an unconsumed body (which resets the pool)
+    const b1 = Buffer.from(await r1.arrayBuffer());
+    const r2 = await fetch(`${BASE_URL}/${BUCKET}/${key}`, {
+        headers: { ...authHeaders, Range: `bytes=${mid}-` }
+    });
+    assert(
+        r2.status === 206,
+        `second range returned ${r2.status} (expected 206)`
+    );
+    const b2 = Buffer.from(await r2.arrayBuffer());
+    const reassembled = Buffer.concat([b1, b2]);
+    const reHash = crypto
+        .createHash("sha256")
+        .update(reassembled)
+        .digest("hex");
+    assert(reHash === expectedHash, "reassembled ranged download hash matches");
+
+    // 6. abort flow
+    res = await fetch(
+        `${BASE_URL}/multipart/initiate/${BUCKET}/verify/large-file/abort-me.bin`,
+        {
+            method: "POST",
+            headers: {
+                ...authHeaders,
+                "Content-Type": "application/octet-stream"
+            }
+        }
+    );
+    assert(res.ok, `initiate (abort test) returned ${res.status}`);
+    const abortSession = await res.json();
+    res = await fetch(
+        `${BASE_URL}/multipart/part/${BUCKET}/verify/large-file/abort-me.bin?uploadId=${encodeURIComponent(
+            abortSession.uploadId
+        )}&partNumber=1`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/octet-stream" },
+            body: crypto.randomBytes(5 * 1024 * 1024)
+        }
+    );
+    assert(res.ok, `abort-test part upload returned ${res.status}`);
+    res = await fetch(
+        `${BASE_URL}/multipart/abort/${BUCKET}/verify/large-file/abort-me.bin?uploadId=${encodeURIComponent(
+            abortSession.uploadId
+        )}`,
+        { method: "DELETE" }
+    );
+    assert(res.ok, `abort returned ${res.status}`);
+
+    // 7. cleanup the completed object
+    await fetch(`${BASE_URL}/${BUCKET}/${key}`, {
+        method: "DELETE",
+        headers: authHeaders
+    });
+
+    console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/magda-storage-api/src/MagdaMinioClient.ts
+++ b/magda-storage-api/src/MagdaMinioClient.ts
@@ -2,6 +2,7 @@ import ObjectFromStore from "./ObjectFromStore.js";
 import { CreateBucketResponse } from "./ObjectStoreClient.js";
 import { Client, ClientOptions } from "minio";
 import urijs from "urijs";
+import { Readable } from "stream";
 
 export default class MagdaMinioClient {
     public readonly client: Client;
@@ -175,6 +176,194 @@ export default class MagdaMinioClient {
                 }
             }
         };
+    }
+
+    /**
+     * Build S3-style headers from a flat metadata map. Standard headers are
+     * passed through; everything else is prefixed with `X-Amz-Meta-` so that a
+     * later `statObject` exposes it under its bare name (matching how the
+     * existing single-shot upload metadata is read back).
+     */
+    toS3MetaHeaders(
+        metaData: Record<string, string | undefined>
+    ): {
+        [key: string]: string;
+    } {
+        const passthrough = new Set([
+            "content-type",
+            "content-encoding",
+            "cache-control",
+            "content-length"
+        ]);
+        const headers: { [key: string]: string } = {};
+        for (const [key, value] of Object.entries(metaData)) {
+            if (value === undefined || value === null || value === "") {
+                continue;
+            }
+            if (passthrough.has(key.toLowerCase())) {
+                headers[key] = String(value);
+            } else {
+                headers[`X-Amz-Meta-${key}`] = String(value);
+            }
+        }
+        return headers;
+    }
+
+    /**
+     * Stream a byte range of an object. `length` of 0 means "read to the end".
+     */
+    async getPartialObject(
+        bucket: string,
+        objectName: string,
+        offset: number,
+        length: number
+    ): Promise<Readable> {
+        return await this.client.getPartialObject(
+            bucket,
+            objectName,
+            offset,
+            length
+        );
+    }
+
+    /**
+     * Start a multipart upload. Returns the S3 uploadId.
+     * `initiateNewMultipartUpload` is marked `@internal` in the minio typings,
+     * hence the cast.
+     */
+    async initiateMultipartUpload(
+        bucket: string,
+        objectName: string,
+        metaHeaders: { [key: string]: string }
+    ): Promise<string> {
+        return await (this.client as any).initiateNewMultipartUpload(
+            bucket,
+            objectName,
+            metaHeaders
+        );
+    }
+
+    /**
+     * Upload a single part (a Buffer) and return its ETag.
+     *
+     * NOTE: minio v8's public `client.uploadPart` parses the ETag out of the
+     * response *body* (expecting a `CopyPartResult` XML element). A plain
+     * (non-copy) UploadPart returns an empty body with the ETag in the response
+     * `etag` *header*, so that code path throws
+     * "Cannot read properties of undefined (reading 'ETag')". We therefore issue
+     * the PUT part request directly (same request shape minio builds internally)
+     * and read the ETag from the response header.
+     */
+    async uploadPart(
+        bucket: string,
+        objectName: string,
+        uploadId: string,
+        partNumber: number,
+        body: Buffer
+    ): Promise<string> {
+        const query = `uploadId=${uploadId}&partNumber=${partNumber}`;
+        const res: any = await (this.client as any).makeRequestAsyncOmit(
+            {
+                method: "PUT",
+                bucketName: bucket,
+                objectName,
+                query,
+                headers: { "Content-Length": body.length }
+            },
+            body
+        );
+        const rawEtag: string | undefined =
+            res?.headers?.etag ?? res?.headers?.ETag;
+        if (!rawEtag) {
+            throw new Error(
+                `uploadPart did not return an ETag for part ${partNumber} of ${bucket}/${objectName}`
+            );
+        }
+        // strip the surrounding quotes S3 wraps ETags in
+        return rawEtag.replace(/^"/, "").replace(/"$/, "");
+    }
+
+    /**
+     * List the parts already uploaded for a multipart upload (for resume).
+     * `listParts` is `protected` in the minio typings, hence the cast.
+     */
+    async listParts(
+        bucket: string,
+        objectName: string,
+        uploadId: string
+    ): Promise<{ partNumber: number; etag: string; size: number }[]> {
+        const parts: any[] = await (this.client as any).listParts(
+            bucket,
+            objectName,
+            uploadId
+        );
+        return parts.map((p) => ({
+            partNumber: p.part,
+            etag: p.etag,
+            size: p.size
+        }));
+    }
+
+    /**
+     * Complete a multipart upload from a list of {partNumber, etag}.
+     */
+    async completeMultipartUpload(
+        bucket: string,
+        objectName: string,
+        uploadId: string,
+        parts: { partNumber: number; etag: string }[]
+    ): Promise<{ etag: string; versionId: string | null }> {
+        const etags = parts
+            .slice()
+            .sort((a, b) => a.partNumber - b.partNumber)
+            .map((p) => ({ part: p.partNumber, etag: p.etag }));
+        return await this.client.completeMultipartUpload(
+            bucket,
+            objectName,
+            uploadId,
+            etags
+        );
+    }
+
+    /**
+     * Abort a multipart upload, discarding any uploaded parts.
+     */
+    async abortMultipartUpload(
+        bucket: string,
+        objectName: string,
+        uploadId: string
+    ): Promise<void> {
+        await this.client.abortMultipartUpload(bucket, objectName, uploadId);
+    }
+
+    /**
+     * Ensure the bucket has a lifecycle rule that auto-aborts incomplete
+     * multipart uploads after `days`. Non-fatal: logs a warning on failure
+     * (e.g. gateway modes that don't support lifecycle config).
+     */
+    async ensureIncompleteUploadExpiryRule(
+        bucket: string,
+        days: number
+    ): Promise<void> {
+        try {
+            await this.client.setBucketLifecycle(bucket, {
+                Rule: [
+                    {
+                        ID: "magda-abort-incomplete-multipart-uploads",
+                        Status: "Enabled",
+                        Filter: { Prefix: "" },
+                        AbortIncompleteMultipartUpload: {
+                            DaysAfterInitiation: days
+                        }
+                    }
+                ]
+            } as any);
+        } catch (err) {
+            console.warn(
+                `Could not set incomplete-multipart-upload lifecycle rule on bucket ${bucket}:`,
+                err
+            );
+        }
     }
 
     /**

--- a/magda-storage-api/src/createApiRouter.ts
+++ b/magda-storage-api/src/createApiRouter.ts
@@ -12,6 +12,8 @@ import {
 import { StorageBucketMetaData, StorageObjectMetaData } from "./common.js";
 import ServerError from "magda-typescript-common/src/ServerError.js";
 import { isValidS3ObjectKey } from "magda-typescript-common/src/getStorageUrl.js";
+import { parseRangeHeader } from "./rangeHeader.js";
+import registerMultipartRoutes from "./registerMultipartRoutes.js";
 export interface ApiRouterOptions {
     registryClient: AuthorizedRegistryClient;
     objectStoreClient: MagdaMinioClient;
@@ -21,6 +23,10 @@ export interface ApiRouterOptions {
     authDecisionClient: AuthDecisionQueryClient;
     autoCreateBuckets: boolean;
     defaultBuckets: string[];
+    recommendedPartSize: string;
+    maxPartSize: string;
+    multipartUploadExpiry: string;
+    incompleteUploadExpiryDays: number;
 }
 
 interface FileRequest extends Request {
@@ -45,6 +51,10 @@ export default function createApiRouter(options: ApiRouterOptions) {
                 for (const bucket of options.defaultBuckets) {
                     console.info(`Creating default bucket ${bucket}`);
                     await options.objectStoreClient.createBucket(bucket);
+                    await options.objectStoreClient.ensureIncompleteUploadExpiryRule(
+                        bucket,
+                        options.incompleteUploadExpiryDays
+                    );
                 }
                 console.info("Finished creating default buckets");
             } else {
@@ -79,6 +89,11 @@ export default function createApiRouter(options: ApiRouterOptions) {
         }
     });
 
+    // Multipart upload routes MUST be registered before the global body parsers
+    // (so the part route controls its own body parsing) and before the generic
+    // `/:bucket/*` routes (so `multipart` isn't matched as a bucket name).
+    registerMultipartRoutes(router, options);
+
     // JSON files are interpreted as text
     router.use(express.text({ type: ["text/*", "application/json"] }));
     router.use(express.raw({ type: ["image/*", "application/octet-stream"] }));
@@ -86,7 +101,7 @@ export default function createApiRouter(options: ApiRouterOptions) {
     /**
      * @apiGroup Storage
      *
-     * @api {PUT} /v0/storage/buckets/{bucketid} Request to create a new bucket
+     * @api {put} /v0/storage/buckets/{bucketid} Request to create a new bucket
      *
      * @apiDescription Creates a new bucket with a specified name.
      *
@@ -143,6 +158,10 @@ export default function createApiRouter(options: ApiRouterOptions) {
                 const createBucketRes = await options.objectStoreClient.createBucket(
                     encodedBucketname
                 );
+                await options.objectStoreClient.ensureIncompleteUploadExpiryRule(
+                    encodedBucketname,
+                    options.incompleteUploadExpiryDays
+                );
                 return res.status(201).send({
                     message: createBucketRes.message
                 });
@@ -165,7 +184,17 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *
      * @api {get} /v0/storage/{bucket}/{path} Request to download an object in {bucket} at path {path}
      *
-     * @apiDescription Downloads an object
+     * @apiDescription Downloads an object.
+     *
+     * Supports HTTP range requests. The response always advertises an
+     * `Accept-Ranges: bytes` header. When the request carries a `Range` header
+     * with a single satisfiable byte range (e.g. `bytes=0-1023`, `bytes=1024-`,
+     * or `bytes=-512`), the response is `206 Partial Content` containing only the
+     * requested bytes plus a `Content-Range: bytes {start}-{end}/{size}` header —
+     * enabling resumable and seekable downloads of large objects. A request with
+     * no `Range` header returns the full object with `200`. Only a single range is
+     * supported (multipart/byteranges responses are not returned).
+     *
      * Please note:
      * Besides users have `storage/object/read` permission, a user also has access to a file when:
      * - the file is associated with a record
@@ -173,12 +202,19 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *
      * @apiParam (Request path) {string} bucket The name of the bucket under which the requested object is
      * @apiParam (Request path) {string} path The name of the object being requested
+     * @apiParam (Request header) {string} [Range] Optional single byte range (e.g. `bytes=0-1023`). When present and satisfiable, the response is `206 Partial Content`.
      *
      * @apiSuccessExample {binary} 200
-     *      <Contents of a file>
+     *      <Full contents of the file. Response includes `Accept-Ranges: bytes`.>
+     *
+     * @apiSuccessExample {binary} 206
+     *      <Requested byte range of the file. Response includes `Content-Range: bytes {start}-{end}/{size}`.>
      *
      * @apiErrorExample {text} 404
-     *      "No such object with path {path} in bucket {bucket}"
+     *      "Cannot locate storage object: {bucket}/{path}"
+     *
+     * @apiErrorExample {text} 416
+     *      (Requested range not satisfiable. Empty body; the `Content-Range` response header reports the total object size.)
      *
      * @apiErrorExample {text} 500
      *      "Unknown error"
@@ -214,15 +250,68 @@ export default function createApiRouter(options: ApiRouterOptions) {
                 );
 
                 const headers = await object.headers();
+
+                const rawContentLength = headers["Content-Length"];
+                const totalSize =
+                    typeof rawContentLength === "number"
+                        ? rawContentLength
+                        : parseInt(rawContentLength as any, 10);
+
+                res.setHeader("Accept-Ranges", "bytes");
+
+                // copy through all headers except Content-Length (set per response type)
                 if (typeof headers === "object") {
                     Object.keys(headers).forEach((headerName) => {
                         const value = headers[headerName];
-                        if (typeof value !== "undefined") {
-                            res.setHeader(headerName, headers[headerName]);
+                        if (
+                            typeof value !== "undefined" &&
+                            headerName !== "Content-Length"
+                        ) {
+                            res.setHeader(headerName, value as any);
                         }
                     });
                 }
 
+                const parsedRange = parseRangeHeader(
+                    req.headers.range,
+                    totalSize
+                );
+
+                if (parsedRange === "invalid") {
+                    res.setHeader("Content-Range", `bytes */${totalSize}`);
+                    res.status(416).end();
+                    return;
+                }
+
+                if (parsedRange) {
+                    const { start, end } = parsedRange;
+                    const chunkLength = end - start + 1;
+                    res.status(206);
+                    res.setHeader(
+                        "Content-Range",
+                        `bytes ${start}-${end}/${totalSize}`
+                    );
+                    res.setHeader("Content-Length", chunkLength);
+                    const stream = await options.objectStoreClient.getPartialObject(
+                        encodeBucketname,
+                        path,
+                        start,
+                        chunkLength
+                    );
+                    stream.on("error", (_e: any) => {
+                        if (!res.headersSent) {
+                            res.status(500);
+                        }
+                        res.end();
+                    });
+                    stream.pipe(res);
+                    return;
+                }
+
+                // no range → full object
+                if (!isNaN(totalSize)) {
+                    res.setHeader("Content-Length", totalSize);
+                }
                 const stream = await object.createStream();
                 if (stream) {
                     stream.on("error", (_e: any) => {

--- a/magda-storage-api/src/createApiRouter.ts
+++ b/magda-storage-api/src/createApiRouter.ts
@@ -112,7 +112,7 @@ export default function createApiRouter(options: ApiRouterOptions) {
      *    }
      */
     router.put(
-        "/:bucketid",
+        "/buckets/:bucketid",
         getUserId(options.jwtSecret),
         requireStorageBucketPermission(
             options.authDecisionClient,

--- a/magda-storage-api/src/index.ts
+++ b/magda-storage-api/src/index.ts
@@ -80,6 +80,30 @@ const argv = addJwtSecretFromEnvVar(
             type: "string",
             default: "100mb"
         })
+        .option("recommendedPartSize", {
+            describe:
+                "The multipart upload part size advertised to clients (e.g. '16mb').",
+            type: "string",
+            default: "16mb"
+        })
+        .option("maxPartSize", {
+            describe:
+                "The maximum accepted size of a single multipart upload part (e.g. '64mb'). Bounds per-part memory.",
+            type: "string",
+            default: "64mb"
+        })
+        .option("multipartUploadExpiry", {
+            describe:
+                "Lifetime of a multipart upload session token (any jsonwebtoken expiry expression, e.g. '24h').",
+            type: "string",
+            default: "24h"
+        })
+        .option("incompleteUploadExpiryDays", {
+            describe:
+                "Days after which incomplete multipart uploads are auto-aborted via a bucket lifecycle rule.",
+            type: "number",
+            default: 7
+        })
         .option("defaultBuckets", {
             describe: "Buckets to create on startup.",
             type: "array",
@@ -137,7 +161,11 @@ app.use(
         authDecisionClient,
         jwtSecret: argv.jwtSecret as string,
         autoCreateBuckets: argv.autoCreateBuckets,
-        defaultBuckets: argv.defaultBuckets
+        defaultBuckets: argv.defaultBuckets,
+        recommendedPartSize: argv.recommendedPartSize,
+        maxPartSize: argv.maxPartSize,
+        multipartUploadExpiry: argv.multipartUploadExpiry,
+        incompleteUploadExpiryDays: argv.incompleteUploadExpiryDays
     })
 );
 

--- a/magda-storage-api/src/multipartToken.ts
+++ b/magda-storage-api/src/multipartToken.ts
@@ -1,0 +1,55 @@
+import jwt from "jsonwebtoken";
+import ServerError from "magda-typescript-common/src/ServerError.js";
+
+/**
+ * The context of an in-progress multipart upload, carried inside the signed
+ * `uploadId` token so storage-api stays stateless.
+ */
+export interface UploadSession {
+    bucket: string;
+    objectKey: string;
+    s3UploadId: string;
+    userId?: string;
+    recordId?: string;
+    orgUnitId?: string;
+    contentType?: string;
+}
+
+const TOKEN_TYPE = "magda-multipart-upload";
+
+/**
+ * Sign an upload session into a JWT used as the opaque `uploadId`.
+ * @param expiresIn any `jsonwebtoken` expiry expression, e.g. "24h".
+ */
+export function signUploadToken(
+    session: UploadSession,
+    secret: string,
+    expiresIn: string
+): string {
+    return jwt.sign({ typ: TOKEN_TYPE, session }, secret, {
+        expiresIn
+    } as jwt.SignOptions);
+}
+
+/**
+ * Verify + decode an `uploadId` token. Throws `ServerError(401)` if the token
+ * is missing/invalid/expired or is not a multipart upload token.
+ */
+export function verifyUploadToken(
+    token: string,
+    secret: string
+): UploadSession {
+    let payload: any;
+    try {
+        payload = jwt.verify(token, secret);
+    } catch (e) {
+        throw new ServerError(`Invalid or expired uploadId: ${e}`, 401);
+    }
+    if (!payload || payload.typ !== TOKEN_TYPE || !payload.session) {
+        throw new ServerError(
+            "uploadId is not a valid multipart upload token.",
+            401
+        );
+    }
+    return payload.session as UploadSession;
+}

--- a/magda-storage-api/src/rangeHeader.ts
+++ b/magda-storage-api/src/rangeHeader.ts
@@ -1,0 +1,57 @@
+/**
+ * Result of parsing a `Range` request header against a known object size.
+ * - `{start, end}`: a satisfiable single byte range (inclusive).
+ * - `"invalid"`: a syntactically valid but unsatisfiable range → caller responds 416.
+ * - `null`: no range / malformed range / unknown size → caller serves the full object (200).
+ */
+export type ParsedRange = { start: number; end: number } | "invalid" | null;
+
+/**
+ * Parse a single-range HTTP `Range` header (`bytes=start-end`, `bytes=start-`,
+ * `bytes=-suffix`). Multi-range headers are treated as "no range" (null).
+ *
+ * @param rangeHeader raw `Range` header value (may be undefined)
+ * @param totalSize   total object size in bytes (NaN if unknown)
+ */
+export function parseRangeHeader(
+    rangeHeader: string | undefined,
+    totalSize: number
+): ParsedRange {
+    if (!rangeHeader || isNaN(totalSize)) {
+        return null;
+    }
+    const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+    if (!match) {
+        // malformed or multi-range → fall back to full response
+        return null;
+    }
+    const startStr = match[1];
+    const endStr = match[2];
+    if (startStr === "" && endStr === "") {
+        return null;
+    }
+
+    let start: number;
+    let end: number;
+
+    if (startStr === "") {
+        // suffix range: last N bytes
+        const suffix = parseInt(endStr, 10);
+        if (suffix <= 0) {
+            return "invalid";
+        }
+        start = Math.max(totalSize - suffix, 0);
+        end = totalSize - 1;
+    } else {
+        start = parseInt(startStr, 10);
+        end = endStr === "" ? totalSize - 1 : parseInt(endStr, 10);
+    }
+
+    if (start > end || start >= totalSize) {
+        return "invalid";
+    }
+    if (end >= totalSize) {
+        end = totalSize - 1;
+    }
+    return { start, end };
+}

--- a/magda-storage-api/src/registerMultipartRoutes.ts
+++ b/magda-storage-api/src/registerMultipartRoutes.ts
@@ -1,0 +1,562 @@
+import express, { Request, Response, NextFunction } from "express";
+import { require } from "@magda/esm-utils";
+import { getUserId } from "magda-typescript-common/src/authorization-api/authMiddleware.js";
+import ServerError from "magda-typescript-common/src/ServerError.js";
+import { isValidS3ObjectKey } from "magda-typescript-common/src/getStorageUrl.js";
+import { requireStorageObjectPermission } from "./storageAuthMiddlewares.js";
+import { StorageObjectMetaData } from "./common.js";
+import {
+    signUploadToken,
+    verifyUploadToken,
+    UploadSession
+} from "./multipartToken.js";
+import type { ApiRouterOptions } from "./createApiRouter.js";
+
+const bytes = require("bytes");
+
+/**
+ * Register the S3 multipart upload proxy endpoints on `router`. Must be called
+ * BEFORE the global body parsers and the generic `/:bucket/*` routes so that
+ * (a) the part route controls its own body parsing and (b) `multipart` is not
+ * matched as a bucket name.
+ *
+ * Routes (all under `/v0/storage/multipart`):
+ * - POST   /multipart/initiate/:bucket/*        (auth: storage/object/upload)
+ * - PUT    /multipart/part/:bucket/*            (auth: valid uploadId token)
+ * - GET    /multipart/parts/:bucket/*           (auth: valid uploadId token)
+ * - POST   /multipart/complete/:bucket/*        (auth: valid token + storage/object/upload)
+ * - DELETE /multipart/abort/:bucket/*           (auth: valid uploadId token)
+ */
+export default function registerMultipartRoutes(
+    router: express.Router,
+    options: ApiRouterOptions
+) {
+    const maxPartSizeBytes = bytes(options.maxPartSize) as number;
+    const recommendedPartSizeBytes = bytes(
+        options.recommendedPartSize
+    ) as number;
+    const MIN_PART_SIZE = 5 * 1024 * 1024;
+
+    function requireValidUploadToken() {
+        return (req: Request, res: Response, next: NextFunction) => {
+            try {
+                const token = req.query.uploadId as string;
+                if (!token) {
+                    throw new ServerError("Missing uploadId query param.", 400);
+                }
+                const uploadSession = verifyUploadToken(
+                    token,
+                    options.jwtSecret
+                );
+                const bucket = req.params.bucket;
+                const objectKey = req.params[0];
+                if (
+                    uploadSession.bucket !== bucket ||
+                    uploadSession.objectKey !== objectKey
+                ) {
+                    throw new ServerError(
+                        "uploadId does not match the target object.",
+                        401
+                    );
+                }
+                res.locals.uploadSession = uploadSession;
+                next();
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    res.status(e.statusCode).send({ message: e.message });
+                } else {
+                    res.status(401).send({ message: `Invalid uploadId: ${e}` });
+                }
+            }
+        };
+    }
+
+    /**
+     * @apiGroup Storage
+     *
+     * @api {post} /v0/storage/multipart/initiate/{bucket}/{path} Initiate a multipart upload
+     *
+     * @apiDescription Starts a resumable S3 multipart upload for a large object and
+     * returns a signed `uploadId` token plus recommended part-size guidance. The
+     * client then uploads the object in parts (see "Upload a multipart part"),
+     * lists/resumes parts if needed, and finally completes (or aborts) the upload.
+     *
+     * Because each part is uploaded in its own request, the per-request body stays
+     * small regardless of the total object size — so no ingress body-size increase
+     * is required for arbitrarily large uploads.
+     *
+     * Authorization is enforced here (and again at "complete") using the same
+     * `storage/object/upload` decision as the single-shot upload endpoints. In
+     * addition to users who have `storage/object/upload` permission, a user also
+     * has access when:
+     * - the object is (to be) associated with a record via `recordId`, and
+     * - the user has `object/record/create` or `object/record/update` permission to that record.
+     *
+     * The returned `uploadId` is a signed token that binds the upload session to
+     * this user, bucket, and object key; supply it on all subsequent part / list /
+     * complete / abort requests.
+     *
+     * @apiParam (Request path) {string} bucket The name of the bucket to upload to.
+     * @apiParam (Request path) {string} path The object key (path) to create within the bucket.
+     * @apiParam (Request query) {string} [recordId] A record id to associate the object with. A user will only be allowed to access the object if they're also allowed to access the associated record. Should be url encoded.
+     * @apiParam (Request query) {string} [orgUnitId] (Optional) The id of the orgUnit that the object belongs to.
+     * @apiParam (Request header) {string} [Content-Type] Content type to store with the object (applied on completion).
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *        "uploadId": "eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...(signed token)",
+     *        "recommendedPartSize": "16mb",
+     *        "recommendedPartSizeBytes": 16777216,
+     *        "maxPartSize": "64mb",
+     *        "maxPartSizeBytes": 67108864,
+     *        "minPartSize": 5242880
+     *    }
+     *
+     * @apiErrorExample {text} 400
+     *      "object key: {path} is not valid storage object key."
+     *
+     * @apiErrorExample {json} 500
+     *    {
+     *        "message": "Failed to initiate multipart upload: {error}"
+     *    }
+     */
+    // 1. INITIATE
+    router.post(
+        "/multipart/initiate/:bucket/*",
+        getUserId(options.jwtSecret),
+        requireStorageObjectPermission(
+            options.authDecisionClient,
+            options.registryClient,
+            options.objectStoreClient,
+            "storage/object/upload",
+            async (req: Request) => req?.params?.bucket,
+            async (req: Request) => {
+                const objectKey = req?.params?.[0] ? req.params[0] : "";
+                if (!objectKey || !isValidS3ObjectKey(objectKey)) {
+                    throw new ServerError(
+                        `object key: ${objectKey} is not valid storage object key.`,
+                        400
+                    );
+                }
+                return objectKey;
+            },
+            async (req: Request, res: Response) => {
+                const metaData: StorageObjectMetaData = {
+                    recordId: req?.query?.recordId as string,
+                    contentType: req?.headers?.["content-type"] as string,
+                    cacheControl: req?.headers?.["cache-control"] as string,
+                    ownerId: res?.locals?.userId,
+                    orgUnitId: req?.query?.orgUnitId as string
+                };
+                return metaData;
+            }
+        ),
+        async (req: Request, res: Response) => {
+            try {
+                const bucket = req.params.bucket;
+                const objectKey = req.params[0];
+                const encodeBucketname = encodeURIComponent(bucket);
+                const recordId = req.query.recordId
+                    ? decodeURIComponent(req.query.recordId as string)
+                    : undefined;
+                const contentType = req.headers["content-type"] as string;
+                const orgUnitId = req.query.orgUnitId as string;
+
+                const metaHeaders = options.objectStoreClient.toS3MetaHeaders({
+                    "Content-Type": contentType,
+                    "Cache-Control": req.headers["cache-control"] as string,
+                    "magda-record-id": recordId,
+                    "magda-user-id": res.locals.userId,
+                    "magda-org-unit-id": orgUnitId
+                });
+
+                const s3UploadId = await options.objectStoreClient.initiateMultipartUpload(
+                    encodeBucketname,
+                    objectKey,
+                    metaHeaders
+                );
+
+                const uploadSession: UploadSession = {
+                    bucket,
+                    objectKey,
+                    s3UploadId,
+                    userId: res.locals.userId,
+                    recordId,
+                    orgUnitId,
+                    contentType
+                };
+                const uploadId = signUploadToken(
+                    uploadSession,
+                    options.jwtSecret,
+                    options.multipartUploadExpiry
+                );
+
+                res.status(200).send({
+                    uploadId,
+                    recommendedPartSize: options.recommendedPartSize,
+                    recommendedPartSizeBytes,
+                    maxPartSize: options.maxPartSize,
+                    maxPartSizeBytes,
+                    minPartSize: MIN_PART_SIZE
+                });
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    res.status(e.statusCode).send({ message: e.message });
+                } else {
+                    res.status(500).send({
+                        message: `Failed to initiate multipart upload: ${e}`
+                    });
+                }
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Storage
+     *
+     * @api {put} /v0/storage/multipart/part/{bucket}/{path} Upload a multipart part
+     *
+     * @apiDescription Uploads a single part of an in-progress multipart upload. The
+     * raw part bytes are sent as the request body (any content type). Parts may be
+     * uploaded in any order and, where the client supports it, concurrently.
+     *
+     * Each part except the last must be at least 5 MB (the S3 minimum), and a part
+     * must not exceed the server's configured `maxPartSize` (returned by "initiate"),
+     * otherwise the request is rejected with `413`. Capture the returned `etag` for
+     * each part — it is required (paired with the part number) to complete the upload.
+     *
+     * This endpoint is authorized solely by the signed `uploadId` token issued at
+     * "initiate" (no separate permission check runs per part).
+     *
+     * @apiParam (Request path) {string} bucket The bucket of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request path) {string} path The object key of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request query) {string} uploadId The signed upload session token returned by "initiate".
+     * @apiParam (Request query) {number} partNumber The part number, an integer between 1 and 10000.
+     * @apiParam (Request body) {binary} body The raw bytes of this part.
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *        "partNumber": 1,
+     *        "etag": "d41d8cd98f00b204e9800998ecf8427e"
+     *    }
+     *
+     * @apiErrorExample {json} 400
+     *    {
+     *        "message": "partNumber must be an integer between 1 and 10000."
+     *    }
+     *
+     * @apiErrorExample {json} 401
+     *    {
+     *        "message": "uploadId does not match the target object."
+     *    }
+     *
+     * @apiErrorExample {json} 413
+     *      (Part body exceeds the configured maxPartSize.)
+     *
+     * @apiErrorExample {json} 502
+     *    {
+     *        "message": "Failed to upload part: {error}"
+     *    }
+     */
+    // 2. UPLOAD PART
+    router.put(
+        "/multipart/part/:bucket/*",
+        requireValidUploadToken(),
+        // Buffer at most ONE part in memory: express.raw caps the body at
+        // maxPartSize (parts over the cap get a 413), so peak memory is
+        // (concurrent in-flight parts × part size) — never the whole file.
+        // minio's uploadPart requires a Buffer, so we can't stream the part.
+        express.raw({ limit: options.maxPartSize, type: () => true }),
+        async (req: Request, res: Response) => {
+            try {
+                const uploadSession: UploadSession = res.locals.uploadSession;
+                const partNumber = parseInt(req.query.partNumber as string, 10);
+                if (isNaN(partNumber) || partNumber < 1 || partNumber > 10000) {
+                    return res.status(400).send({
+                        message:
+                            "partNumber must be an integer between 1 and 10000."
+                    });
+                }
+                const body = req.body;
+                if (!Buffer.isBuffer(body) || body.length === 0) {
+                    return res
+                        .status(400)
+                        .send({ message: "Empty or missing part body." });
+                }
+                const encodeBucketname = encodeURIComponent(
+                    uploadSession.bucket
+                );
+                const etag = await options.objectStoreClient.uploadPart(
+                    encodeBucketname,
+                    uploadSession.objectKey,
+                    uploadSession.s3UploadId,
+                    partNumber,
+                    body
+                );
+                return res.status(200).send({ partNumber, etag });
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    return res
+                        .status(e.statusCode)
+                        .send({ message: e.message });
+                } else {
+                    return res.status(502).send({
+                        message: `Failed to upload part: ${e}`
+                    });
+                }
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Storage
+     *
+     * @api {get} /v0/storage/multipart/parts/{bucket}/{path} List uploaded multipart parts
+     *
+     * @apiDescription Lists the parts that have already been uploaded for an
+     * in-progress multipart upload. Useful for resuming an interrupted upload:
+     * the client can skip parts already present and re-upload only the missing ones.
+     *
+     * Authorized solely by the signed `uploadId` token.
+     *
+     * @apiParam (Request path) {string} bucket The bucket of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request path) {string} path The object key of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request query) {string} uploadId The signed upload session token returned by "initiate".
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *        "parts": [
+     *            { "partNumber": 1, "etag": "d41d8cd98f00b204e9800998ecf8427e", "size": 16777216 },
+     *            { "partNumber": 2, "etag": "e2fc714c4727ee9395f324cd2e7f331f", "size": 16777216 }
+     *        ]
+     *    }
+     *
+     * @apiErrorExample {json} 401
+     *    {
+     *        "message": "Invalid or expired uploadId: {error}"
+     *    }
+     *
+     * @apiErrorExample {json} 500
+     *    {
+     *        "message": "Failed to list parts: {error}"
+     *    }
+     */
+    // 3. LIST PARTS
+    router.get(
+        "/multipart/parts/:bucket/*",
+        requireValidUploadToken(),
+        async (_req: Request, res: Response) => {
+            try {
+                const uploadSession: UploadSession = res.locals.uploadSession;
+                const encodeBucketname = encodeURIComponent(
+                    uploadSession.bucket
+                );
+                const parts = await options.objectStoreClient.listParts(
+                    encodeBucketname,
+                    uploadSession.objectKey,
+                    uploadSession.s3UploadId
+                );
+                res.status(200).send({ parts });
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    res.status(e.statusCode).send({ message: e.message });
+                } else {
+                    res.status(500).send({
+                        message: `Failed to list parts: ${e}`
+                    });
+                }
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Storage
+     *
+     * @api {post} /v0/storage/multipart/complete/{bucket}/{path} Complete a multipart upload
+     *
+     * @apiDescription Finalizes an in-progress multipart upload, assembling the
+     * uploaded parts into the final object and applying the metadata captured at
+     * "initiate" (content type, record association, owner, org unit).
+     *
+     * The request body must list every uploaded part as `{partNumber, etag}` using
+     * the etags returned by the "Upload a multipart part" responses. Parts may be
+     * supplied in any order (the server sorts them by part number).
+     *
+     * In addition to the signed `uploadId` token, this endpoint re-runs the full
+     * `storage/object/upload` authorization decision (the object materializes here),
+     * so the request must be authenticated — supply the caller's session/API key —
+     * and, if a `recordId` was provided at initiate, the user must have the
+     * corresponding `object/record/create` or `object/record/update` permission.
+     *
+     * @apiParam (Request path) {string} bucket The bucket of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request path) {string} path The object key of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request query) {string} uploadId The signed upload session token returned by "initiate".
+     * @apiParam (Request body) {Object[]} parts The uploaded parts.
+     * @apiParam (Request body) {number} parts.partNumber The part number (1-10000).
+     * @apiParam (Request body) {string} parts.etag The etag returned when the part was uploaded.
+     *
+     * @apiParamExample {json} Request-Example:
+     *     {
+     *        "parts": [
+     *            { "partNumber": 1, "etag": "d41d8cd98f00b204e9800998ecf8427e" },
+     *            { "partNumber": 2, "etag": "e2fc714c4727ee9395f324cd2e7f331f" }
+     *        ]
+     *     }
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *        "message": "File uploaded successfully",
+     *        "etag": "3858f62230ac3c915f300c664312c11f-2",
+     *        "versionId": null
+     *    }
+     *
+     * @apiErrorExample {json} 400
+     *    {
+     *        "message": "Request body must include a non-empty `parts` array."
+     *    }
+     *
+     * @apiErrorExample {json} 401
+     *    {
+     *        "message": "Invalid or expired uploadId: {error}"
+     *    }
+     */
+    // 4. COMPLETE
+    router.post(
+        "/multipart/complete/:bucket/*",
+        requireValidUploadToken(),
+        express.json(),
+        requireStorageObjectPermission(
+            options.authDecisionClient,
+            options.registryClient,
+            options.objectStoreClient,
+            "storage/object/upload",
+            async (req: Request) => req?.params?.bucket,
+            async (req: Request) => req.params[0],
+            async (_req: Request, res: Response) => {
+                const uploadSession: UploadSession = res.locals.uploadSession;
+                const metaData: StorageObjectMetaData = {
+                    recordId: uploadSession.recordId,
+                    contentType: uploadSession.contentType,
+                    ownerId: uploadSession.userId,
+                    orgUnitId: uploadSession.orgUnitId
+                };
+                return metaData;
+            }
+        ),
+        async (req: Request, res: Response) => {
+            try {
+                const uploadSession: UploadSession = res.locals.uploadSession;
+                const parts = req.body?.parts;
+                if (!Array.isArray(parts) || !parts.length) {
+                    return res.status(400).send({
+                        message:
+                            "Request body must include a non-empty `parts` array."
+                    });
+                }
+                for (const p of parts) {
+                    if (
+                        typeof p?.partNumber !== "number" ||
+                        typeof p?.etag !== "string"
+                    ) {
+                        return res.status(400).send({
+                            message:
+                                "Each part must have a numeric partNumber and a string etag."
+                        });
+                    }
+                }
+                const encodeBucketname = encodeURIComponent(
+                    uploadSession.bucket
+                );
+                const result = await options.objectStoreClient.completeMultipartUpload(
+                    encodeBucketname,
+                    uploadSession.objectKey,
+                    uploadSession.s3UploadId,
+                    parts
+                );
+                return res.status(200).send({
+                    message: "File uploaded successfully",
+                    etag: result.etag,
+                    versionId: result.versionId
+                });
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    return res
+                        .status(e.statusCode)
+                        .send({ message: e.message });
+                } else {
+                    return res.status(400).send({
+                        message: `Failed to complete multipart upload: ${e}`
+                    });
+                }
+            }
+        }
+    );
+
+    /**
+     * @apiGroup Storage
+     *
+     * @api {delete} /v0/storage/multipart/abort/{bucket}/{path} Abort a multipart upload
+     *
+     * @apiDescription Aborts an in-progress multipart upload and discards any parts
+     * that have already been uploaded. The operation is idempotent — aborting an
+     * upload that no longer exists still returns `200`.
+     *
+     * Incomplete multipart uploads that are never completed or aborted are also
+     * cleaned up automatically by a bucket lifecycle rule after
+     * `incompleteUploadExpiryDays` (default 7).
+     *
+     * Authorized solely by the signed `uploadId` token.
+     *
+     * @apiParam (Request path) {string} bucket The bucket of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request path) {string} path The object key of the in-progress upload (must match the `uploadId`).
+     * @apiParam (Request query) {string} uploadId The signed upload session token returned by "initiate".
+     *
+     * @apiSuccessExample {json} 200
+     *    {
+     *        "aborted": true
+     *    }
+     *
+     * @apiErrorExample {json} 401
+     *    {
+     *        "message": "Invalid or expired uploadId: {error}"
+     *    }
+     *
+     * @apiErrorExample {json} 500
+     *    {
+     *        "message": "Failed to abort multipart upload: {error}"
+     *    }
+     */
+    // 5. ABORT
+    router.delete(
+        "/multipart/abort/:bucket/*",
+        requireValidUploadToken(),
+        async (_req: Request, res: Response) => {
+            try {
+                const uploadSession: UploadSession = res.locals.uploadSession;
+                const encodeBucketname = encodeURIComponent(
+                    uploadSession.bucket
+                );
+                try {
+                    await options.objectStoreClient.abortMultipartUpload(
+                        encodeBucketname,
+                        uploadSession.objectKey,
+                        uploadSession.s3UploadId
+                    );
+                } catch (err) {
+                    if (err?.code !== "NoSuchUpload") {
+                        throw err;
+                    }
+                }
+                res.status(200).send({ aborted: true });
+            } catch (e) {
+                if (e instanceof ServerError) {
+                    res.status(e.statusCode).send({ message: e.message });
+                } else {
+                    res.status(500).send({
+                        message: `Failed to abort multipart upload: ${e}`
+                    });
+                }
+            }
+        }
+    );
+}

--- a/magda-storage-api/src/registerMultipartRoutes.ts
+++ b/magda-storage-api/src/registerMultipartRoutes.ts
@@ -543,7 +543,7 @@ export default function registerMultipartRoutes(
                         uploadSession.s3UploadId
                     );
                 } catch (err) {
-                    if (err?.code !== "NoSuchUpload") {
+                    if ((err as any)?.code !== "NoSuchUpload") {
                         throw err;
                     }
                 }

--- a/magda-storage-api/src/test/multipartClient.spec.ts
+++ b/magda-storage-api/src/test/multipartClient.spec.ts
@@ -1,0 +1,102 @@
+import {} from "mocha";
+import { expect } from "chai";
+import { Client } from "minio";
+import crypto from "crypto";
+import MagdaMinioClient from "../MagdaMinioClient.js";
+
+const opts = {
+    endPoint: process.env["MINIO_HOST"] as string,
+    port: Number(process.env["MINIO_PORT"]),
+    useSSL: false,
+    accessKey: process.env["MINIO_ACCESS_KEY"] as string,
+    secretKey: process.env["MINIO_SECRET_KEY"] as string,
+    region: "unspecified-region"
+};
+
+async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(chunk as Buffer);
+    }
+    return Buffer.concat(chunks);
+}
+
+describe("MagdaMinioClient multipart + partial get", () => {
+    const bucket = "magda-mpu-test-bucket";
+    const rawClient = new Client(opts);
+    const magda = new MagdaMinioClient(opts);
+
+    before(async () => {
+        try {
+            await rawClient.makeBucket(bucket, opts.region);
+        } catch (err) {
+            // ignore BucketAlreadyOwnedByYou
+        }
+    });
+
+    it("uploads an object in multiple parts and stores metadata", async () => {
+        const key = "mpu/multi-part-object.bin";
+        // part 1 must be >= 5MB (S3 minimum for non-final parts)
+        const part1 = crypto.randomBytes(5 * 1024 * 1024);
+        const part2 = crypto.randomBytes(1024);
+
+        const uploadId = await magda.initiateMultipartUpload(
+            bucket,
+            key,
+            magda.toS3MetaHeaders({
+                "Content-Type": "application/octet-stream",
+                "magda-record-id": "record-xyz"
+            })
+        );
+        expect(uploadId).to.be.a("string").and.not.empty;
+
+        const etag1 = await magda.uploadPart(bucket, key, uploadId, 1, part1);
+        const etag2 = await magda.uploadPart(bucket, key, uploadId, 2, part2);
+        expect(etag1).to.be.a("string").and.not.empty;
+
+        const listed = await magda.listParts(bucket, key, uploadId);
+        expect(listed.map((p) => p.partNumber).sort()).to.deep.equal([1, 2]);
+
+        const result = await magda.completeMultipartUpload(
+            bucket,
+            key,
+            uploadId,
+            [
+                { partNumber: 1, etag: etag1 },
+                { partNumber: 2, etag: etag2 }
+            ]
+        );
+        expect(result.etag).to.be.a("string").and.not.empty;
+
+        const stat = await rawClient.statObject(bucket, key);
+        expect(stat.size).to.equal(part1.length + part2.length);
+        expect(stat.metaData["magda-record-id"]).to.equal("record-xyz");
+    });
+
+    it("aborts a multipart upload", async () => {
+        const key = "mpu/aborted-object.bin";
+        const part1 = crypto.randomBytes(5 * 1024 * 1024);
+        const uploadId = await magda.initiateMultipartUpload(bucket, key, {});
+        await magda.uploadPart(bucket, key, uploadId, 1, part1);
+        await magda.abortMultipartUpload(bucket, key, uploadId);
+        // after abort, completing with the old id must fail
+        let failed = false;
+        try {
+            await magda.completeMultipartUpload(bucket, key, uploadId, [
+                { partNumber: 1, etag: "whatever" }
+            ]);
+        } catch (e) {
+            failed = true;
+        }
+        expect(failed).to.equal(true);
+    });
+
+    it("reads a byte range with getPartialObject", async () => {
+        const key = "mpu/range-object.bin";
+        const data = Buffer.from("0123456789ABCDEF");
+        await rawClient.putObject(bucket, key, data);
+        const stream = await magda.getPartialObject(bucket, key, 4, 4);
+        const buf = await streamToBuffer(stream);
+        expect(buf.toString()).to.equal("4567");
+    });
+});

--- a/magda-storage-api/src/test/multipartRoutes.spec.ts
+++ b/magda-storage-api/src/test/multipartRoutes.spec.ts
@@ -1,0 +1,189 @@
+import {} from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import crypto from "crypto";
+import { Client } from "minio";
+import createApiRouter from "../createApiRouter.js";
+import MagdaMinioClient from "../MagdaMinioClient.js";
+import AuthorizedRegistryClient, {
+    AuthorizedRegistryOptions
+} from "magda-typescript-common/src/registry/AuthorizedRegistryClient.js";
+import AuthDecisionQueryClient from "magda-typescript-common/src/opa/AuthDecisionQueryClient.js";
+import { AuthDecisionReqConfig } from "magda-typescript-common/src/opa/AuthDecisionQueryClient.js";
+import { UnconditionalTrueDecision } from "magda-typescript-common/src/opa/AuthDecision.js";
+
+const jwtSecret = "squirrel";
+const USER_ID = "b1fddd6f-e230-4068-bd2c-1a21844f1598";
+
+const minioClientOpts = {
+    endPoint: process.env["MINIO_HOST"] as string,
+    port: Number(process.env["MINIO_PORT"]),
+    useSSL: false,
+    accessKey: process.env["MINIO_ACCESS_KEY"] as string,
+    secretKey: process.env["MINIO_SECRET_KEY"] as string,
+    region: "unspecified-region"
+};
+
+function session() {
+    return jwt.sign({ userId: USER_ID }, jwtSecret);
+}
+
+describe("Multipart routes", () => {
+    const bucketName = "magda-mpu-routes-bucket";
+    const rawClient = new Client(minioClientOpts);
+    let app: express.Application;
+
+    before(async () => {
+        try {
+            await rawClient.makeBucket(bucketName, minioClientOpts.region);
+        } catch (e) {
+            // ignore
+        }
+    });
+
+    beforeEach(() => {
+        app = express();
+        const registryOptions: AuthorizedRegistryOptions = {
+            baseUrl: "http://registry.example.com",
+            jwtSecret,
+            userId: "00000000-0000-4000-8000-000000000000",
+            tenantId: 0,
+            maxRetries: 0
+        };
+        const authDecisionClient = sinon.createStubInstance(
+            AuthDecisionQueryClient
+        );
+        authDecisionClient.getAuthDecision = authDecisionClient.getAuthDecision.callsFake(
+            async (_c: AuthDecisionReqConfig, _t?: string) =>
+                UnconditionalTrueDecision
+        );
+        app.use(
+            "/v0",
+            createApiRouter({
+                jwtSecret,
+                objectStoreClient: new MagdaMinioClient(minioClientOpts),
+                authDecisionClient,
+                registryClient: new AuthorizedRegistryClient(registryOptions),
+                tenantId: 0,
+                uploadLimit: "100mb",
+                autoCreateBuckets: false,
+                defaultBuckets: [],
+                recommendedPartSize: "16mb",
+                maxPartSize: "64mb",
+                multipartUploadExpiry: "24h",
+                incompleteUploadExpiryDays: 7
+            })
+        );
+    });
+
+    it("uploads a large object end to end via multipart", async () => {
+        const key = "ds/dist/big.bin";
+        const part1 = crypto.randomBytes(5 * 1024 * 1024);
+        const part2 = crypto.randomBytes(2048);
+
+        const initRes = await request(app)
+            .post(`/v0/multipart/initiate/${bucketName}/${key}`)
+            .set("X-Magda-Session", session())
+            .set("Content-Type", "application/octet-stream")
+            .expect(200);
+        const uploadId = initRes.body.uploadId;
+        expect(uploadId).to.be.a("string").and.not.empty;
+        expect(initRes.body.recommendedPartSizeBytes).to.equal(
+            16 * 1024 * 1024
+        );
+
+        const p1 = await request(app)
+            .put(`/v0/multipart/part/${bucketName}/${key}`)
+            .query({ uploadId, partNumber: 1 })
+            .set("Content-Type", "application/octet-stream")
+            .send(part1)
+            .expect(200);
+        const p2 = await request(app)
+            .put(`/v0/multipart/part/${bucketName}/${key}`)
+            .query({ uploadId, partNumber: 2 })
+            .set("Content-Type", "application/octet-stream")
+            .send(part2)
+            .expect(200);
+
+        const listRes = await request(app)
+            .get(`/v0/multipart/parts/${bucketName}/${key}`)
+            .query({ uploadId })
+            .expect(200);
+        expect(listRes.body.parts.length).to.equal(2);
+
+        await request(app)
+            .post(`/v0/multipart/complete/${bucketName}/${key}`)
+            .query({ uploadId })
+            .set("Content-Type", "application/json")
+            .send({
+                parts: [
+                    { partNumber: 1, etag: p1.body.etag },
+                    { partNumber: 2, etag: p2.body.etag }
+                ]
+            })
+            .expect(200);
+
+        const stat = await rawClient.statObject(bucketName, key);
+        expect(stat.size).to.equal(part1.length + part2.length);
+    });
+
+    it("rejects a part upload with an invalid uploadId", async () => {
+        await request(app)
+            .put(`/v0/multipart/part/${bucketName}/ds/dist/x.bin`)
+            .query({ uploadId: "not-a-real-token", partNumber: 1 })
+            .set("Content-Type", "application/octet-stream")
+            .send(Buffer.from("hello"))
+            .expect(401);
+    });
+
+    it("rejects a token minted for a different object key", async () => {
+        const initRes = await request(app)
+            .post(`/v0/multipart/initiate/${bucketName}/ds/dist/keyA.bin`)
+            .set("X-Magda-Session", session())
+            .set("Content-Type", "application/octet-stream")
+            .expect(200);
+        await request(app)
+            .put(`/v0/multipart/part/${bucketName}/ds/dist/keyB.bin`)
+            .query({ uploadId: initRes.body.uploadId, partNumber: 1 })
+            .set("Content-Type", "application/octet-stream")
+            .send(Buffer.from("hello"))
+            .expect(401);
+    });
+
+    it("rejects an out-of-range partNumber", async () => {
+        const initRes = await request(app)
+            .post(`/v0/multipart/initiate/${bucketName}/ds/dist/keyC.bin`)
+            .set("X-Magda-Session", session())
+            .set("Content-Type", "application/octet-stream")
+            .expect(200);
+        await request(app)
+            .put(`/v0/multipart/part/${bucketName}/ds/dist/keyC.bin`)
+            .query({ uploadId: initRes.body.uploadId, partNumber: 0 })
+            .set("Content-Type", "application/octet-stream")
+            .send(Buffer.from("hello"))
+            .expect(400);
+    });
+
+    it("aborts an upload", async () => {
+        const key = "ds/dist/abort-me.bin";
+        const initRes = await request(app)
+            .post(`/v0/multipart/initiate/${bucketName}/${key}`)
+            .set("X-Magda-Session", session())
+            .set("Content-Type", "application/octet-stream")
+            .expect(200);
+        const uploadId = initRes.body.uploadId;
+        await request(app)
+            .put(`/v0/multipart/part/${bucketName}/${key}`)
+            .query({ uploadId, partNumber: 1 })
+            .set("Content-Type", "application/octet-stream")
+            .send(crypto.randomBytes(5 * 1024 * 1024))
+            .expect(200);
+        await request(app)
+            .delete(`/v0/multipart/abort/${bucketName}/${key}`)
+            .query({ uploadId })
+            .expect(200, { aborted: true });
+    });
+});

--- a/magda-storage-api/src/test/multipartToken.spec.ts
+++ b/magda-storage-api/src/test/multipartToken.spec.ts
@@ -1,0 +1,45 @@
+import {} from "mocha";
+import { expect } from "chai";
+import jwt from "jsonwebtoken";
+import ServerError from "magda-typescript-common/src/ServerError.js";
+import {
+    signUploadToken,
+    verifyUploadToken,
+    UploadSession
+} from "../multipartToken.js";
+
+describe("multipartToken", () => {
+    const secret = "test-secret";
+    const session: UploadSession = {
+        bucket: "magda-datasets",
+        objectKey: "ds1/dist1/file.csv",
+        s3UploadId: "s3-upload-id-123",
+        userId: "user-1",
+        recordId: "record-1",
+        orgUnitId: "org-1",
+        contentType: "text/csv"
+    };
+
+    it("round-trips a session through sign/verify", () => {
+        const token = signUploadToken(session, secret, "1h");
+        const decoded = verifyUploadToken(token, secret);
+        expect(decoded).to.deep.equal(session);
+    });
+
+    it("rejects a token signed with a different secret", () => {
+        const token = signUploadToken(session, secret, "1h");
+        expect(() => verifyUploadToken(token, "wrong-secret")).to.throw(
+            ServerError
+        );
+    });
+
+    it("rejects an expired token", () => {
+        const token = signUploadToken(session, secret, "-1s");
+        expect(() => verifyUploadToken(token, secret)).to.throw(ServerError);
+    });
+
+    it("rejects a valid JWT that is not a multipart upload token", () => {
+        const token = jwt.sign({ hello: "world" }, secret);
+        expect(() => verifyUploadToken(token, secret)).to.throw(ServerError);
+    });
+});

--- a/magda-storage-api/src/test/rangeDownload.spec.ts
+++ b/magda-storage-api/src/test/rangeDownload.spec.ts
@@ -1,0 +1,133 @@
+import {} from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { Client } from "minio";
+import createApiRouter from "../createApiRouter.js";
+import MagdaMinioClient from "../MagdaMinioClient.js";
+import AuthorizedRegistryClient, {
+    AuthorizedRegistryOptions
+} from "magda-typescript-common/src/registry/AuthorizedRegistryClient.js";
+import AuthDecisionQueryClient from "magda-typescript-common/src/opa/AuthDecisionQueryClient.js";
+import { AuthDecisionReqConfig } from "magda-typescript-common/src/opa/AuthDecisionQueryClient.js";
+import { UnconditionalTrueDecision } from "magda-typescript-common/src/opa/AuthDecision.js";
+
+const jwtSecret = "squirrel";
+const USER_ID = "b1fddd6f-e230-4068-bd2c-1a21844f1598";
+
+const minioClientOpts = {
+    endPoint: process.env["MINIO_HOST"] as string,
+    port: Number(process.env["MINIO_PORT"]),
+    useSSL: false,
+    accessKey: process.env["MINIO_ACCESS_KEY"] as string,
+    secretKey: process.env["MINIO_SECRET_KEY"] as string,
+    region: "unspecified-region"
+};
+
+function sessionHeader() {
+    return jwt.sign({ userId: USER_ID }, jwtSecret);
+}
+
+describe("Range download", () => {
+    const bucketName = "magda-range-test-bucket";
+    const rawClient = new Client(minioClientOpts);
+    const body = Buffer.from("0123456789ABCDEFGHIJ"); // 20 bytes
+    let app: express.Application;
+
+    before(async () => {
+        try {
+            await rawClient.makeBucket(bucketName, minioClientOpts.region);
+        } catch (e) {
+            // ignore already-exists
+        }
+        await rawClient.putObject(
+            bucketName,
+            "range-file.txt",
+            body,
+            body.length,
+            {
+                "Content-Type": "text/plain"
+            }
+        );
+    });
+
+    beforeEach(() => {
+        app = express();
+        const registryOptions: AuthorizedRegistryOptions = {
+            baseUrl: "http://registry.example.com",
+            jwtSecret,
+            userId: "00000000-0000-4000-8000-000000000000",
+            tenantId: 0,
+            maxRetries: 0
+        };
+        const authDecisionClient = sinon.createStubInstance(
+            AuthDecisionQueryClient
+        );
+        authDecisionClient.getAuthDecision = authDecisionClient.getAuthDecision.callsFake(
+            async (_c: AuthDecisionReqConfig, _t?: string) =>
+                UnconditionalTrueDecision
+        );
+        app.use(
+            "/v0",
+            createApiRouter({
+                jwtSecret,
+                objectStoreClient: new MagdaMinioClient(minioClientOpts),
+                authDecisionClient,
+                registryClient: new AuthorizedRegistryClient(registryOptions),
+                tenantId: 0,
+                uploadLimit: "100mb",
+                autoCreateBuckets: false,
+                defaultBuckets: [],
+                recommendedPartSize: "16mb",
+                maxPartSize: "64mb",
+                multipartUploadExpiry: "24h",
+                incompleteUploadExpiryDays: 7
+            })
+        );
+    });
+
+    it("advertises Accept-Ranges and serves the full object without a Range", async () => {
+        const res = await request(app)
+            .get(`/v0/${bucketName}/range-file.txt`)
+            .set("X-Magda-Session", sessionHeader())
+            .expect(200);
+        expect(res.headers["accept-ranges"]).to.equal("bytes");
+        expect(res.text).to.equal(body.toString());
+    });
+
+    it("serves a closed byte range with 206 + Content-Range", async () => {
+        const res = await request(app)
+            .get(`/v0/${bucketName}/range-file.txt`)
+            .set("X-Magda-Session", sessionHeader())
+            .set("Range", "bytes=0-3")
+            .expect(206);
+        expect(res.headers["content-range"]).to.equal(
+            `bytes 0-3/${body.length}`
+        );
+        expect(res.headers["content-length"]).to.equal("4");
+        expect(res.text).to.equal("0123");
+    });
+
+    it("serves an open-ended range with 206", async () => {
+        const res = await request(app)
+            .get(`/v0/${bucketName}/range-file.txt`)
+            .set("X-Magda-Session", sessionHeader())
+            .set("Range", "bytes=16-")
+            .expect(206);
+        expect(res.headers["content-range"]).to.equal(
+            `bytes 16-19/${body.length}`
+        );
+        expect(res.text).to.equal("GHIJ");
+    });
+
+    it("returns 416 for an unsatisfiable range", async () => {
+        const res = await request(app)
+            .get(`/v0/${bucketName}/range-file.txt`)
+            .set("X-Magda-Session", sessionHeader())
+            .set("Range", "bytes=100-200")
+            .expect(416);
+        expect(res.headers["content-range"]).to.equal(`bytes */${body.length}`);
+    });
+});

--- a/magda-storage-api/src/test/rangeHeader.spec.ts
+++ b/magda-storage-api/src/test/rangeHeader.spec.ts
@@ -1,0 +1,56 @@
+import {} from "mocha";
+import { expect } from "chai";
+import { parseRangeHeader } from "../rangeHeader.js";
+
+describe("parseRangeHeader", () => {
+    const total = 1000;
+
+    it("returns null when no range header", () => {
+        expect(parseRangeHeader(undefined, total)).to.equal(null);
+    });
+
+    it("returns null for a malformed range header", () => {
+        expect(parseRangeHeader("chunks=0-10", total)).to.equal(null);
+        expect(parseRangeHeader("bytes=abc", total)).to.equal(null);
+    });
+
+    it("parses a closed range", () => {
+        expect(parseRangeHeader("bytes=0-99", total)).to.deep.equal({
+            start: 0,
+            end: 99
+        });
+    });
+
+    it("parses an open-ended range to the last byte", () => {
+        expect(parseRangeHeader("bytes=200-", total)).to.deep.equal({
+            start: 200,
+            end: 999
+        });
+    });
+
+    it("parses a suffix range (last N bytes)", () => {
+        expect(parseRangeHeader("bytes=-50", total)).to.deep.equal({
+            start: 950,
+            end: 999
+        });
+    });
+
+    it("clamps an end beyond the object size", () => {
+        expect(parseRangeHeader("bytes=990-100000", total)).to.deep.equal({
+            start: 990,
+            end: 999
+        });
+    });
+
+    it("returns 'invalid' when start is beyond the object size", () => {
+        expect(parseRangeHeader("bytes=1000-1100", total)).to.equal("invalid");
+    });
+
+    it("returns 'invalid' when start > end", () => {
+        expect(parseRangeHeader("bytes=500-400", total)).to.equal("invalid");
+    });
+
+    it("returns null when total size is unknown (NaN)", () => {
+        expect(parseRangeHeader("bytes=0-99", NaN)).to.equal(null);
+    });
+});

--- a/magda-storage-api/src/test/storage.spec.ts
+++ b/magda-storage-api/src/test/storage.spec.ts
@@ -156,7 +156,7 @@ describe("Storage API tests", () => {
             await mockAuthorization(
                 jwtSecret,
                 request(app)
-                    .put("/v0/" + dummyBucket)
+                    .put("/v0/buckets/" + dummyBucket)
                     .expect(201, {
                         message:
                             "Bucket " +
@@ -201,7 +201,7 @@ describe("Storage API tests", () => {
             return mockAuthorization(
                 jwtSecret,
                 request(app)
-                    .put("/v0/" + dummyBucket)
+                    .put("/v0/buckets/" + dummyBucket)
                     .expect(201, {
                         message: "Bucket " + dummyBucket + " already exists 👍"
                     })

--- a/magda-storage-api/src/test/storage.spec.ts
+++ b/magda-storage-api/src/test/storage.spec.ts
@@ -109,7 +109,11 @@ describe("Storage API tests", () => {
                 tenantId: 0,
                 uploadLimit,
                 autoCreateBuckets: false,
-                defaultBuckets: []
+                defaultBuckets: [],
+                recommendedPartSize: "16mb",
+                maxPartSize: "64mb",
+                multipartUploadExpiry: "24h",
+                incompleteUploadExpiryDays: 7
             })
         );
         registryScope = nock(registryApiUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4794,6 +4794,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bytes@^3.1.4":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.1.5.tgz#22fb92839f37bd5490e0dcd411999bb1c16ddaa0"
+  integrity sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==
+
 "@types/caseless@*":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
@@ -5176,7 +5181,7 @@
   resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
   integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
 
-"@types/jsonwebtoken@^9.0.5":
+"@types/jsonwebtoken@9.0.5", "@types/jsonwebtoken@^9.0.5":
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz#0bd9b841c9e6c5a937c17656e2368f65da025588"
   integrity sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==
@@ -7724,7 +7729,7 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -22944,7 +22949,7 @@ string-similarity@^4.0.1:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22969,6 +22974,15 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -23143,7 +23157,7 @@ stringstream@~0.0.4:
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
   integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23177,6 +23191,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -25470,7 +25491,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25495,6 +25516,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## Summary

Adds **large file upload & download support** to `magda-storage-api` (epic #3672), plus a related create-bucket route-path fix (#3678). Files up to multi-GB can now be uploaded and downloaded resumably, without buffering whole files in memory or raising the ingress body-size limit, while preserving the existing OPA + record-linked authorization model.

## What's included

**Feature — large file support (#3672)**

- **Multipart upload proxy** endpoints under `/v0/storage/multipart/...` that relay one bounded part at a time to MinIO:
  - `POST .../initiate/:bucket/*`, `PUT .../part/:bucket/*`, `GET .../parts/:bucket/*`, `POST .../complete/:bucket/*`, `DELETE .../abort/:bucket/*`
- **HTTP Range** support on the existing `GET /v0/storage/:bucket/*` (`Accept-Ranges`, `206`/`Content-Range`, `416`) for resumable/seekable downloads.
- **Stateless signed `uploadId` token** binding the session to user + bucket + object key + expiry. The full `storage/object/upload` OPA decision runs at `initiate` and `complete`; part/list/abort are gated by the token only.
- **Memory-bounded**: at most one part (`maxPartSize`) is buffered; the whole file is never held in memory. Because each request carries a single part, a modest ingress limit supports arbitrarily large files — no reconfiguration needed.
- **New config** (yargs + Helm values/deployment): `recommendedPartSize` (16mb), `maxPartSize` (64mb), `multipartUploadExpiry` (24h), `incompleteUploadExpiryDays` (7). A bucket lifecycle rule auto-aborts incomplete multipart uploads.

**Fix — create-bucket route path (#3678)**

- Registered the create-bucket route at the documented `/v0/storage/buckets/:bucketid` (was `/:bucketid`, so the documented path was unreachable and overlapped with object routes).

## Testing

- **Unit/integration** (Mocha, against a local MinIO): range parser, signed token, MinIO client multipart methods, Range download route, and the multipart endpoints — all green (`44 passing`).
- **End-to-end on minikube, through the gateway authenticated with an API key** (the real external path), as both the default admin and a freshly-created admin user: multipart upload of a >100 MB file → complete → full + ranged download with checksum match → abort. Driven by `magda-storage-api/scripts/verify-large-file.mjs` (`ALL CHECKS PASSED`).

## Docs

- apiDoc for all storage routes (incl. the new multipart endpoints and Range behavior).
- [ADR 0001](https://github.com/magda-io/magda/blob/storage-api-large-file-support/docs/docs/adrs/0001-large-file-storage-support.md) capturing the design decisions and alternatives.
- Generalized the e2e testing guide (gateway + API-key setup, optional dedicated test user) and moved the large-file case into `docs/docs/e2e-test-cases/`.
- Added a `helm-docs` how-to; regenerated the storage-api chart README.

## Notes

- Two small build adjustments were required and are documented in the storage-api README / ADR: pin `@types/jsonwebtoken` to `9.0.5` (9.0.6+ breaks `tsc`) and strip `.d.ts` before `ts-module-alias-transformer` (upstream fix tracked in magda-io/ts-module-alias-transformer#15).
- The web client is intentionally unchanged (keeps the single-shot upload for small files); wiring it to the multipart flow is future work.

Closes #3672, #3673, #3674, #3675, #3676, #3678
