### PR TITLE
feat(mgd): add @magda/mgd local CLI with coding-agent skills

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v6.1.0
 
 - Added `@magda/mgd`: a local MAGDA CLI (`mgd`) with profile/API-key auth, keyword & semantic search, dataset/distribution inspection and mutation commands, large-file upload/download (multipart + HTTP Range resume), custom aspect support, a raw API fallback, and coding-agent skills (tool-agnostic workflow + dataset-elicitation instructions, plus a Claude Code skill wrapper) that let AI coding assistants such as Claude Code, Codex and opencode drive the catalog (#3648, #3649, #3650)
+- `@magda/mgd`: added `mgd skills install` / `mgd skills uninstall` — installs the coding-agent skill (`SKILL.md`) into Claude Code, Codex and opencode; installs for all three globally by default (`--agent` to pick one, `--project` for repo-local), so the skill is available from any working directory (#3682)
 - #3672: Add large file upload & download support to `storage-api` — S3 multipart upload proxy endpoints (`/v0/storage/multipart/{initiate,part,parts,complete,abort}`) and HTTP Range support on object download, enabling resumable transfers of large (multi-GB) files without raising the ingress body-size limit. Adds `recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry` & `incompleteUploadExpiryDays` chart options.
 - #3678: Fix `storage-api` create-bucket route being registered at `/v0/storage/{bucketid}` instead of the documented `/v0/storage/buckets/{bucketid}`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v6.1.0
 
+- Added `@magda/mgd`: a local MAGDA CLI (`mgd`) with profile/API-key auth, keyword & semantic search, dataset/distribution inspection and mutation commands, large-file upload/download (multipart + HTTP Range resume), custom aspect support, a raw API fallback, and coding-agent skills (tool-agnostic workflow + dataset-elicitation instructions, plus a Claude Code skill wrapper) that let AI coding assistants such as Claude Code, Codex and opencode drive the catalog (#3648, #3649, #3650)
 - #3672: Add large file upload & download support to `storage-api` — S3 multipart upload proxy endpoints (`/v0/storage/multipart/{initiate,part,parts,complete,abort}`) and HTTP Range support on object download, enabling resumable transfers of large (multi-GB) files without raising the ingress body-size limit. Adds `recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry` & `incompleteUploadExpiryDays` chart options.
 - #3678: Fix `storage-api` create-bucket route being registered at `/v0/storage/{bucketid}` instead of the documented `/v0/storage/buckets/{bucketid}`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,6 +214,7 @@ echo $(kubectl get svc --namespace magda gateway --template "{{ range (index .st
 
 If you are interested in playing more, you might find useful docs from [here](./docs/). Particularly:
 
+- [End-to-End Full Cluster Deployment Test](./docs/e2e-cluster-deployment-test.html) — the canonical runbook for deploying the published chart on a local (minikube) cluster, exposing the gateway, and accessing it with an admin API key
 - [Magda Charts Docs Index](./docs/helm-charts-docs-index.html)
 - [How to create a local testing user](./docs/how-to-create-local-users.html)
 - [How to set a user as admin user](./docs/how-to-set-user-as-admin-user.html)
@@ -250,6 +251,7 @@ We welcome new contributors too! please check out our [Contributor's Guide](http
 
 - [Our Github](https://github.com/magda-io/magda)
 - [Magda API Reference](https://magda-io.github.io/api-docs/index.html)
+- [`mgd` CLI (terminal & coding-agent catalog access)](https://github.com/magda-io/magda/tree/main/packages/mgd)
 - [Magda Helm Chart Reference](/docs/helm-charts-docs-index)
 - [Useful common documentations](./docs/index.md)
 - [Other documentations](https://github.com/magda-io/magda/tree/master/docs/docs)

--- a/docs/docs/e2e-test-cases/README.md
+++ b/docs/docs/e2e-test-cases/README.md
@@ -13,6 +13,7 @@ scripted, assertion/checksum-based driver), and how to clean up.
 ## Cases
 
 - [Large file storage (multipart upload + Range download)](./large-file-storage.md)
+- [mgd CLI (auth, search, dataset/dist CRUD, large-file round-trip)](./mgd-cli.md)
 
 ## Adding a new case
 

--- a/docs/docs/e2e-test-cases/mgd-cli.md
+++ b/docs/docs/e2e-test-cases/mgd-cli.md
@@ -1,0 +1,64 @@
+# mgd CLI End-to-End Test
+
+## Purpose
+
+Verify that the `@magda/mgd` CLI works correctly against a live MAGDA deployment, exercising the full authentication, search, dataset creation, file upload (small and multipart), file download with checksum verification, file replacement, dataset metadata update, custom aspect management, and cleanup flow — all through the gateway with an API key.
+
+## Prerequisites
+
+- A deployed MAGDA cluster accessible through the gateway (see [Feature-specific testing through the gateway with an API key](../e2e-cluster-deployment-test.md#feature-specific-testing-through-the-gateway-with-an-api-key)).
+- An admin-level API key for the target deployment. The test account needs permission to create dataset and distribution records, upload storage objects, create aspect definitions, and delete records.
+- Node.js ≥ 22 on the host running the script.
+- The `@magda/mgd` package built locally (run `yarn build` in `packages/mgd/` first), or installed globally via `npm install -g @magda/mgd`.
+
+## How to Run
+
+From the repository root, build the package first:
+
+```sh
+cd packages/mgd
+yarn build
+```
+
+Then run the verification script with the required environment variables:
+
+```sh
+MGD_E2E_BASE_URL=https://<your-gateway-url> \
+MGD_E2E_API_KEY_ID=<your-api-key-id> \
+MGD_E2E_API_KEY=<your-api-key-value> \
+  node scripts/verify-mgd.mjs
+```
+
+The script resolves the `mgd` binary from `packages/mgd/bin/mgd.js` relative to itself, so no global installation is needed when running from a local build.
+
+## What the Script Verifies
+
+1. **auth status** — the API key authenticates successfully.
+2. **search datasets** — keyword search returns results without error.
+3. **dataset create** — a throwaway dataset record is created and its ID matches the `magda-ds-` prefix.
+4. **add-file small** — a small CSV is uploaded and a distribution is created with a `magda-dist-` ID.
+5. **add-file large (multipart)** — a 20 MB binary (above the 16 MB multipart threshold) is uploaded via multipart, then downloaded and compared with a SHA-256 checksum to confirm round-trip integrity.
+6. **replace-file bumps version** — the small distribution's backing file is replaced and the returned `versionNumber` is at least 1.
+7. **dataset update + custom aspect** — the dataset description is updated and a custom aspect definition is created and attached to the dataset.
+8. **cleanup** — all distribution records and the dataset record are deleted via raw API calls.
+
+## Expected Output
+
+```
+ok   - auth status
+ok   - search datasets
+ok   - dataset create
+ok   - add-file small
+ok   - add-file large (multipart)
+ok   - replace-file bumps version
+ok   - dataset update + custom aspect
+ok   - cleanup
+
+ALL CHECKS PASSED
+```
+
+If any check fails, the script prints `FAIL - <name>: <error>` and exits with code 1. Checks after a failed `dataset create` may also fail because subsequent steps depend on the dataset ID being set.
+
+## Orphan Storage Objects
+
+The cleanup step deletes registry records (dataset and distribution) but does **not** directly delete the underlying storage objects in the object store. MAGDA's storage lifecycle is registry-driven, so orphan objects in the bucket are acceptable for a dedicated e2e verification account and will not interfere with production data. If running against a shared environment, arrange a separate storage cleanup or use a purpose-built test tenant.

--- a/docs/docs/e2e-test-cases/mgd-skill-auto-use.md
+++ b/docs/docs/e2e-test-cases/mgd-skill-auto-use.md
@@ -1,0 +1,191 @@
+# E2E test case: `mgd` coding-agent skill global auto-use
+
+**Purpose:** Verify that, after installing the locally built `mgd` CLI and running
+`mgd skills install` (which installs the skill **globally** for all agents), each
+supported coding agent (**Claude Code**, **Codex**, **opencode**) **auto-uses** the
+skill — discovers and runs `mgd` on its own — when asked a natural dataset question
+**from an unrelated working directory** that contains no project-level skill and never
+mentions "mgd" or "skill".
+
+The "from an unrelated working directory" part is the point: the skill is installed
+into each agent's global skills directory, so it must be discovered regardless of cwd.
+
+Related: `mgd-cli.md` (CLI e2e), issue #3682, PR #3683.
+
+## What "auto-use" means here
+
+The prompt says nothing about `mgd`, the skill, or the site URL, and the agent is
+launched from a clean directory with no local skill. A PATH **logging shim** records
+every `mgd` invocation. Any `mgd` call during such a run means the agent discovered the
+globally installed `SKILL.md` on its own — that is the signal we assert. All three
+agents natively auto-discover `SKILL.md` skills; there is no per-tool wrapper.
+
+## Prerequisites
+
+- Node ≥ 22, `npm`, `yarn`.
+- `claude`, `codex` on `PATH`; `opencode` at `~/.opencode/bin/opencode`.
+- Each agent already authenticated to its own model provider (this test does not set
+  that up). Codex sandboxes network by default, so its run uses
+  `--sandbox danger-full-access`.
+- Repo `.env` at the worktree root containing `API_KEY_ID` and `API_KEY` for
+  `https://dev.magda.io`.
+- **Read-only:** every prompt triggers search/get only — no create/update/publish.
+
+## Isolation & safety
+
+- `mgd` credentials are supplied via `MGD_*` environment variables, so **no mgd config
+  file is read or written** — nothing to clean up in `~/.config/mgd`.
+- The global skill install writes into each agent's real skills dir
+  (`~/.claude/skills`, `~/.codex/skills`, `~/.config/opencode/skills`); these cannot be
+  sandboxed the way a project install can, because each agent also reads its own auth
+  from its real home. Teardown removes them with `mgd skills uninstall`.
+- The only other global change is `npm link` of `@magda/mgd`, undone in teardown.
+- All scratch files (shim, logs, the unrelated cwd) live under one `WORK` temp dir.
+
+---
+
+## Procedure
+
+Shared variables (run from the repo/worktree root):
+
+```sh
+ROOT="$(git rev-parse --show-toplevel)"
+WORK="$(mktemp -d /tmp/mgd-skill-test.XXXX)"
+mkdir -p "$WORK/shim" "$WORK/cwd"          # cwd = clean, unrelated launch dir
+OPENCODE_BIN="$HOME/.opencode/bin/opencode"
+```
+
+### Step 1 — Build and install `mgd` on PATH
+
+```sh
+( cd "$ROOT/packages/mgd" && yarn build && npm link )
+REAL_MGD="$(command -v mgd)"
+# Fallback: some non-interactive shells don't put the fnm global bin on PATH.
+[ -n "$REAL_MGD" ] || REAL_MGD="$(npm prefix -g)/bin/mgd"
+"$REAL_MGD" --version                      # expect a version line
+echo "REAL_MGD=$REAL_MGD"
+```
+
+Expected: `mgd --version` prints a version. (The build now `chmod +x`es `bin/mgd.js`,
+so the linked binary is executable.)
+
+### Step 2 — Supply credentials via environment (no profile file)
+
+```sh
+set -a; . "$ROOT/.env"; set +a             # loads API_KEY_ID / API_KEY
+export MGD_BASE_URL="https://dev.magda.io/api"
+export MGD_API_KEY_ID="$API_KEY_ID"
+export MGD_API_KEY="$API_KEY"
+"$REAL_MGD" auth status --json             # expect authenticated:true
+```
+
+Expected: `auth status` shows the identity for the API key; with all three `MGD_*` set,
+mgd reads/writes no config file.
+
+### Step 3 — Install the skill globally (all agents)
+
+```sh
+"$REAL_MGD" skills install                 # all agents, global, by default
+ls ~/.claude/skills/magda-mgd/SKILL.md \
+   ~/.codex/skills/magda-mgd/SKILL.md \
+   ~/.config/opencode/skills/magda-mgd/SKILL.md
+```
+
+Expected: `skills install` reports `created` for claude/codex/opencode (global); a
+`SKILL.md` exists in each global dir.
+
+### Step 4 — Install the logging shim ahead of the real `mgd`
+
+```sh
+cat > "$WORK/shim/mgd" <<EOF
+#!/bin/sh
+echo "\$(date -u +%FT%TZ) \$*" >> "$WORK/mgd-invocations.log"
+exec "$REAL_MGD" "\$@"
+EOF
+chmod +x "$WORK/shim/mgd"
+export PATH="$WORK/shim:$(dirname "$REAL_MGD"):$HOME/.opencode/bin:$PATH"
+command -v mgd                             # expect $WORK/shim/mgd
+```
+
+Expected: `command -v mgd` resolves to the shim (which execs the real binary and logs).
+
+### Step 5 — Drive each agent headless from the **unrelated** cwd
+
+Prompt (identical for all three, mentions neither `mgd` nor the skill):
+
+> Using the data catalogue, find a few datasets about rainfall and list their titles.
+
+Reset the log before each run so calls are attributed per agent:
+
+```sh
+PROMPT="Using the data catalogue, find a few datasets about rainfall and list their titles."
+
+: > "$WORK/mgd-invocations.log"
+( cd "$WORK/cwd" && claude -p "$PROMPT" --allowedTools Bash ) \
+  > "$WORK/out.claude.txt" 2>&1
+cp "$WORK/mgd-invocations.log" "$WORK/log.claude.txt"
+
+: > "$WORK/mgd-invocations.log"
+( cd "$WORK/cwd" && codex exec --sandbox danger-full-access \
+    --skip-git-repo-check "$PROMPT" < /dev/null ) \
+  > "$WORK/out.codex.txt" 2>&1
+cp "$WORK/mgd-invocations.log" "$WORK/log.codex.txt"
+
+: > "$WORK/mgd-invocations.log"
+( cd "$WORK/cwd" && "$OPENCODE_BIN" run "$PROMPT" < /dev/null ) \
+  > "$WORK/out.opencode.txt" 2>&1
+cp "$WORK/mgd-invocations.log" "$WORK/log.opencode.txt"
+```
+
+(The sandbox/permission flags are test-harness concessions so each agent may run `mgd`
+non-interactively; adjust per agent if a run reports a blocked command. macOS has no
+`timeout` — use `gtimeout` from coreutils, or rely on the agents terminating on their
+own.)
+
+### Step 6 — Assert auto-use
+
+```sh
+for a in claude codex opencode; do
+  echo "=== $a ==="; cat "$WORK/log.$a.txt"; tail -6 "$WORK/out.$a.txt"
+done
+```
+
+**PASS (per agent):** its log gained a `search`/`dataset` `mgd` call **and** its output
+lists real dataset titles from dev.magda.io — proving it discovered the _global_ skill
+from a directory with no local skill.
+**FAIL / inconclusive:** no `mgd` call logged, or the agent answered without touching
+the catalogue (e.g. fell back to web search) — capture transcript + log for diagnosis.
+
+---
+
+## Teardown / recovery
+
+```sh
+"$REAL_MGD" skills uninstall               # removes the 3 global skill dirs
+( cd "$ROOT/packages/mgd" && npm unlink ) 2>/dev/null || true
+npm rm -g @magda/mgd 2>/dev/null || true
+command -v mgd || echo "mgd removed from PATH (expected)"
+unset MGD_BASE_URL MGD_API_KEY_ID MGD_API_KEY
+rm -rf "$WORK"
+```
+
+Expected end state: the three `magda-mgd/` global skill dirs removed; `mgd` no longer on
+PATH; no mgd config written; temp dir gone.
+
+## Results
+
+Executed 2026-07-10 against `dev.magda.io` (mgd built from this branch;
+`claude` 2.1.170, `codex` 0.144.1, `opencode` 1.17.18). Each agent was launched from a
+clean unrelated directory (`$WORK/cwd`) with the verbatim prompt above — no mention of
+`mgd`, the skill, or the site URL, and no local skill in cwd.
+
+| Agent       | mgd auto-invoked (from unrelated cwd)?                                                       | Real titles? | Verdict  | Notes                                                                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code | Yes — explored `mgd --help`, then `search datasets rainfall`                                 | Yes          | **PASS** | Discovered the global skill in `~/.claude/skills/magda-mgd`.                                                                                |
+| Codex       | Yes — `auth status`, `search datasets`, `search semantic`, then a narrower `search datasets` | Yes          | **PASS** | This is the case that failed under the old project-scoped install; global install fixes it. Correctly reported semantic search unavailable. |
+| opencode    | Yes — `auth status`, `search datasets`, `search semantic`                                    | Yes          | **PASS** | Discovered the global skill in `~/.config/opencode/skills/magda-mgd`.                                                                       |
+
+**Outcome: all three agents auto-used the skill from an unrelated working directory** —
+each discovered and ran `mgd` against dev.magda.io from a natural dataset question,
+driven solely by the globally installed `SKILL.md`. Teardown removed the global skill
+dirs, unlinked `mgd`, and left no mgd config behind (`MGD_*` env credentials).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -13,6 +13,7 @@
 - [How to deploy Magda on Amazon AWS EKS](./deploy-to-aws.md)
 - [How to deploy Magda on Microsoft Azure Cloud AKS](./deploy-to-azure.md)
 - [How to use APIs](./using-api.md)
+- [`mgd` CLI — terminal & coding-agent access to a catalog (search, download, create/edit datasets; Claude Code / Codex / opencode skills)](https://github.com/magda-io/magda/tree/main/packages/mgd)
 - [How to document APIs](./api-documentation-howto.md)
 - [How to create API key](./how-to-create-api-key.md)
 - [How to set/unset admin users](./how-to-set-user-as-admin-user.md)

--- a/docs/docs/installing-minikube.md
+++ b/docs/docs/installing-minikube.md
@@ -2,10 +2,17 @@
 
 Minikube is a local Virtual Machine with Kubernetes that runs locally, and you can use it just like you'd use a remote Kubernetes cluster.
 
+> **Just want to deploy Magda to minikube and use it?** This page covers setting
+> up minikube for **building and running Magda from source**. If instead you want
+> to install the **published Helm chart** on minikube, wait for it to come up,
+> expose the gateway, and access it with an API key, follow
+> [End-to-End Full Cluster Deployment Test](./e2e-cluster-deployment-test.md) —
+> it is the canonical deploy + admin-API-key runbook.
+
 You'll need to download and install:
 
--   [VirtualBox](https://www.virtualbox.org/wiki/Downloads) We find this is the best virtual machine to use with minikube.
--   [Minikube](https://github.com/kubernetes/minikube)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads) We find this is the best virtual machine to use with minikube.
+- [Minikube](https://github.com/kubernetes/minikube)
 
 ## Setup
 
@@ -34,18 +41,18 @@ You'll need to run this in each new shell.
 
 A few notes for setting up Minikube in a WSL environment:
 
--   Install `minikube` for _Windows_ (not the Linux version in WSL, it won't work).
--   Install `docker` and `kubectl` in _WSL_.
--   Create a simple bash script named `minikube` to run the Windows version of minikube and put it in your path in your WSL environment:
+- Install `minikube` for _Windows_ (not the Linux version in WSL, it won't work).
+- Install `docker` and `kubectl` in _WSL_.
+- Create a simple bash script named `minikube` to run the Windows version of minikube and put it in your path in your WSL environment:
 
 ```bash
 #!/bin/sh
 /mnt/c/Program\ Files/Kubernetes/Minikube/minikube.exe $@
 ```
 
--   Start `minikube` (from Windows or WSL is fine) by running `minikube start`
--   The above will configure _Windows_ `kubectl` to be able to talk to Kubernetes in minikube, but the `kubectl` in WSL won't work. To fix that, open `%userprofile%\.kube\config` in a text editor and copy all the minikube context, cluster, and user from there into `~/.kube/config` in your WSL environment.
--   Create another bash script named `minikube-go` in your WSL path to configure WSL Docker to talk to minikube:
+- Start `minikube` (from Windows or WSL is fine) by running `minikube start`
+- The above will configure _Windows_ `kubectl` to be able to talk to Kubernetes in minikube, but the `kubectl` in WSL won't work. To fix that, open `%userprofile%\.kube\config` in a text editor and copy all the minikube context, cluster, and user from there into `~/.kube/config` in your WSL environment.
+- Create another bash script named `minikube-go` in your WSL path to configure WSL Docker to talk to minikube:
 
 ```bash
 #!/bin/sh
@@ -53,4 +60,4 @@ eval $(minikube docker-env --shell=bash)
 export DOCKER_CERT_PATH=$(wslpath -u "${DOCKER_CERT_PATH}")
 ```
 
--   Run the `minikube-go` in each new WSL terminal, instead of the `eval $(minikube docker-env)` in the instructions above: `source minikube-go`.
+- Run the `minikube-go` in each new WSL terminal, instead of the `eval $(minikube docker-env)` in the instructions above: `source minikube-go`.

--- a/packages/mgd/.gitignore
+++ b/packages/mgd/.gitignore
@@ -1,0 +1,2 @@
+bin/
+coverage/

--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -1,0 +1,393 @@
+# @magda/mgd — MAGDA Command-Line Interface
+
+`mgd` is the local command-line interface for the
+[MAGDA](https://github.com/magda-io/magda) data catalog platform, developed as
+part of [epic #3648](https://github.com/magda-io/magda/issues/3648). It lets you
+work with a MAGDA catalog from your terminal — or from an AI coding assistant —
+without cloning the repository or running anything inside the cluster. With it
+you can:
+
+- authenticate with an API key and manage multiple site profiles;
+- search the catalog by keyword or semantic similarity;
+- inspect and download datasets, distributions and files (including large ones);
+- create and edit dataset records, upload files, and manage custom aspects;
+- call any MAGDA REST endpoint directly.
+
+`mgd` is designed to be **script- and agent-friendly**: results go to stdout,
+progress/diagnostics go to stderr, machine output is available via `--json` /
+`--jsonl`, and it uses stable exit codes. It ships with an assistant "skill" so
+coding agents such as Claude Code can drive it — see
+[Using `mgd` with a coding agent](#using-mgd-with-a-coding-agent).
+
+> See also: [How to create an API key](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-create-api-key.md).
+
+## Installation
+
+`mgd` requires **Node.js ≥ 22**. Install it globally so the `mgd` command is on
+your `PATH`:
+
+```sh
+npm install -g @magda/mgd
+mgd --version
+```
+
+Or run it without installing:
+
+```sh
+npx @magda/mgd <command>
+```
+
+The package is self-contained (one runtime dependency) and ships the assistant
+skill files under [`skills/`](./skills/).
+
+## Quick start
+
+```sh
+# 1. Log in (prompts for site URL, API key ID and key; or pass them as flags)
+mgd auth login
+
+# 2. Confirm who you are and where
+mgd auth status
+
+# 3. Search
+mgd search datasets "climate temperature"
+mgd search semantic "rainfall impact on crop yield"    # if semantic search is available
+
+# 4. Inspect and download
+mgd dataset get magda-ds-<uuid>
+mgd dataset distributions magda-ds-<uuid> --jsonl
+mgd dist download magda-dist-<uuid> -o data.csv
+```
+
+## Authentication and profiles
+
+### Logging in
+
+Create an API key in the MAGDA web UI first
+([**Settings → API Keys**](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-create-api-key.md)),
+then:
+
+```sh
+mgd auth login
+# or non-interactively:
+mgd auth login --url https://dev.magda.io --key-id <id> --key <key> --profile default
+```
+
+- `--url` accepts either a **site URL** (`https://dev.magda.io`) or a full **API
+  base URL** — `mgd` normalises it by probing `<url>/api/v0` then `<url>/v0`, so
+  non-standard gateway mounts work.
+- Credentials are verified against the API before being saved.
+- Leave the API key ID empty to configure **anonymous** access (MAGDA supports
+  anonymous read access to public data).
+
+### Profiles
+
+Credentials are stored per named profile in `~/.config/mgd/config.json`
+(respecting `$XDG_CONFIG_HOME`), with restrictive permissions (`0600` file,
+`0700` directory). The default profile is named `default`.
+
+```sh
+mgd auth login --profile prod --url https://prod.example.com   # add a profile
+mgd profile list                                               # list profiles
+mgd profile use prod                                           # switch active profile
+mgd auth status                                                # who am I, where
+mgd auth logout                                                # clear active profile creds
+```
+
+`mgd auth status` reports the active profile, base URL and the identity returned
+by the server; it shows `anonymous` when no credentials are configured.
+
+### Environment variables (CI / agents)
+
+Environment variables override the stored profile and are ideal for CI or
+ephemeral containers. When all three of `MGD_BASE_URL`, `MGD_API_KEY_ID` and
+`MGD_API_KEY` are set, **no config file is read or written**:
+
+| Variable         | Purpose                                     |
+| ---------------- | ------------------------------------------- |
+| `MGD_BASE_URL`   | Site or API base URL                        |
+| `MGD_API_KEY_ID` | API key ID                                  |
+| `MGD_API_KEY`    | API key value                               |
+| `MGD_PROFILE`    | Select a stored profile by name             |
+| `NO_COLOR`       | Disable ANSI colour (also via `--no-color`) |
+
+```sh
+export MGD_BASE_URL="https://dev.magda.io/api"
+export MGD_API_KEY_ID="…"
+export MGD_API_KEY="…"
+mgd auth status
+```
+
+## Output modes, scripting and exit codes
+
+- **stdout** carries the result; **stderr** carries progress, warnings and error
+  details. Suppress diagnostics with `2>/dev/null`.
+- `--json` prints one pretty JSON document. `--jsonl` prints one JSON object per
+  line for list results — ideal for streaming into `jq`, `grep`, `xargs`, etc.
+- In `--json`/`--jsonl` mode, errors are emitted to stderr as a structured object
+  `{"error":{"code","message","status","hint"}}` so agents can parse failures.
+
+```sh
+# titles of the first 20 datasets matching a query
+mgd search datasets "water quality" --limit 20 --jsonl | jq -r '.title'
+```
+
+### Exit codes
+
+| Code | Meaning                                            |
+| ---- | -------------------------------------------------- |
+| `0`  | Success                                            |
+| `1`  | General runtime / API error                        |
+| `2`  | Usage error (bad argument, flag or env var)        |
+| `3`  | Authentication error (missing/invalid credentials) |
+| `4`  | Not found (record or object does not exist)        |
+
+## Searching the catalog
+
+MAGDA offers two complementary search modes:
+
+```sh
+# Keyword / faceted search — best for known terms, filters, pagination
+mgd search datasets "rainfall" --limit 10 --offset 0
+
+# Semantic (embedding) search — best for conceptual, natural-language queries
+mgd search semantic "impact of drought on crop yield"
+```
+
+Use keyword search when you know the vocabulary; use semantic search when the
+wording differs from the dataset's metadata. Semantic search requires a
+deployment with the semantic-search components installed — on sites without it,
+`mgd search semantic` returns a clear `semantic-search-unavailable` error (a
+non-zero exit) rather than failing silently, so you can fall back to keyword
+search. A useful recipe is to run both with `--jsonl` and merge/de-duplicate by
+dataset ID.
+
+## Inspecting datasets and distributions
+
+```sh
+mgd dataset get magda-ds-<uuid>                       # dataset record
+mgd dataset get magda-ds-<uuid> --json                # full record as JSON
+mgd dataset distributions magda-ds-<uuid> --jsonl     # its distributions
+mgd dist get magda-dist-<uuid> --json                 # a single distribution
+```
+
+Distribution records carry metadata under aspects such as
+`dcat-distribution-strings` (title, format, `downloadURL`/`accessURL`). Use
+`--jsonl` + `jq` to pull out just the fields you need.
+
+## Downloading data
+
+```sh
+mgd dist download magda-dist-<uuid> -o data.csv         # to a file
+mgd dist download magda-dist-<uuid> -o - | head         # stream to stdout
+mgd file download magda-datasets/<datasetId>/<distId>/<fileName> -o data.csv   # by bucket/key
+```
+
+`mgd dist download` resolves the distribution's `downloadURL`: MAGDA-hosted
+`magda://storage-api/…` URLs are fetched through the gateway (with your
+credentials); plain `http(s)://` URLs are fetched directly (no MAGDA auth headers
+sent to third-party hosts). For large files, downloads use HTTP **Range**
+requests and support `--resume` to continue an interrupted transfer:
+
+```sh
+mgd dist download magda-dist-<uuid> -o big.tif --resume
+```
+
+## Creating and editing datasets
+
+`mgd` reproduces the same end-state record operations as the web "Add Dataset"
+wizard, so datasets you create or edit with the CLI remain fully editable in the
+web UI. New datasets are created as **drafts** unless you pass `--publish`.
+
+```sh
+# 1. Create a draft dataset
+mgd dataset create \
+  --title "River gauge readings 2025" \
+  --desc "Daily river height and flow measurements." \
+  --json                                              # -> magda-ds-<uuid>
+
+# 2. Upload a file and attach it as a distribution
+mgd dataset add-file magda-ds-<uuid> ./readings.csv --title "2025 readings" --format csv
+
+# 3. Register a link-only distribution (no upload)
+mgd dataset add-file magda-ds-<uuid> --access-url https://example.org/data.csv --title "Source data"
+
+# 4. Update metadata
+mgd dataset update magda-ds-<uuid> --title "River gauge readings (2025, v2)"
+
+# 5. Replace the file behind a distribution (adds a new version entry)
+mgd dist replace-file magda-dist-<uuid> ./readings-corrected.csv
+```
+
+Datasets created by the CLI are stamped with a `source` aspect
+(`{"id":"magda","name":"Magda CLI (mgd)","type":"internal","url":<site>}`) — the
+same `id` the web client uses, so they show up as editable records in the web
+metadata tools, with a distinct `name` marking their CLI provenance.
+
+> **Publishing is a deliberate step.** Create as a draft, review, then publish
+> explicitly. `add-file` / `replace-file` are multi-step operations; if a step
+> fails after the upload, `mgd` rolls back the uploaded object where it can and
+> prints the exact commands to finish or undo — it never leaves silent partial
+> state.
+
+### Custom aspects
+
+The registry supports user-defined aspects with JSON-schema validation. `mgd`
+exposes them (the web UI does not):
+
+```sh
+# aspect definitions
+mgd aspect list
+mgd aspect get <aspectId>
+mgd aspect create <aspectId> --name "My Aspect" --schema @schema.json
+
+# aspect data on any record (dataset or distribution)
+mgd dataset aspect get    magda-ds-<uuid> <aspectId>
+mgd dataset aspect set    magda-ds-<uuid> <aspectId> @data.json    # inline JSON, @file, or - for stdin
+mgd dataset aspect delete magda-ds-<uuid> <aspectId>
+```
+
+Every mutation command also accepts repeatable `--aspect <id>=<json|@file|->` to
+attach custom aspect data at create/update time.
+
+## Uploading files directly to storage
+
+```sh
+mgd file upload ./big.tif --bucket magda-datasets --key path/to/big.tif --record-id magda-ds-<uuid>
+```
+
+Files **at or above 16 MB** automatically use resumable **multipart** upload (one
+bounded part at a time, constant memory); smaller files use a single request.
+Multipart needs a deployment that exposes the multipart storage endpoints
+(`/v0/storage/multipart/{initiate,part,complete,abort}`); older deployments fall
+back to single-shot upload automatically (`--single-shot` forces it). Pass
+`--record-id <datasetId>` so record-linked storage authorization applies.
+
+## Raw API access
+
+For endpoints without a curated command, call the REST API directly — with your
+credentials and structured error handling:
+
+```sh
+mgd api request GET /v0/registry/records/<id> --query aspect=dcat-dataset-strings --json
+mgd api request POST /v0/registry/records --body-file record.json
+echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
+```
+
+## Command reference
+
+| Command                                               | Description                                      |
+| ----------------------------------------------------- | ------------------------------------------------ |
+| `auth login` / `auth status` / `auth logout`          | Manage credentials for a site profile            |
+| `profile list` / `profile use <name>`                 | List / switch profiles                           |
+| `search datasets <query>`                             | Keyword dataset search                           |
+| `search semantic <query>`                             | Semantic (embedding) search                      |
+| `dataset get <id>`                                    | Fetch a dataset record                           |
+| `dataset distributions <id>`                          | List a dataset's distributions                   |
+| `dataset create`                                      | Create a dataset (draft by default)              |
+| `dataset update <id>`                                 | Update dataset metadata                          |
+| `dataset add-file <id> [file]`                        | Upload/attach a distribution (or `--access-url`) |
+| `dataset aspect get/set/delete <recordId> <aspectId>` | Read/write custom aspect data on any record      |
+| `dist get <id>` / `dist update <id>`                  | Inspect / edit a distribution                    |
+| `dist download <id>`                                  | Download a distribution's file (`--resume`)      |
+| `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version      |
+| `file upload <file>` / `file download <bucket/key>`   | Direct storage transfer                          |
+| `aspect list` / `get <id>` / `create <id>`            | Manage aspect definitions                        |
+| `api request <method> <path>`                         | Call any MAGDA API endpoint                      |
+
+Run `mgd --help` or `mgd <command> --help` for full option documentation.
+
+## Using `mgd` with a coding agent
+
+`mgd` ships with a tool-agnostic assistant **skill** so an LLM coding agent can
+drive the catalog safely. The [`skills/`](./skills/) folder contains:
+
+- **`mgd-workflows.md`** — command usage, output modes, search strategy, recipes,
+  safety rules and error triage;
+- **`dataset-elicitation.md`** — "metadata consultant" behaviour for guided
+  dataset creation (infer before asking, quick vs guided path, confirm-then-write);
+- **`SKILL.md`** — the entry point declaring the `magda-mgd` skill (name +
+  description frontmatter that points at the two files above).
+
+For a globally installed CLI the files live at
+`$(npm root -g)/@magda/mgd/skills/`. In every case, make sure `mgd` is on the
+agent's `PATH` and that credentials are configured (a saved profile, or the
+`MGD_*` environment variables) before starting the agent.
+
+### Claude Code
+
+Claude Code auto-discovers skills under a project's `.claude/skills/` directory.
+Copy the skill in:
+
+```sh
+mkdir -p .claude/skills/magda-mgd
+cp "$(npm root -g)/@magda/mgd/skills/"*.md .claude/skills/magda-mgd/
+```
+
+Start `claude` in that project and it can invoke the `magda-mgd` skill on demand.
+(For a personal, all-projects install, use `~/.claude/skills/magda-mgd/` instead.)
+
+### Codex
+
+Codex reads project instructions from an `AGENTS.md` file. Vendor the skill into
+your repo and point `AGENTS.md` at it so Codex loads the workflow rules as
+context:
+
+```sh
+mkdir -p .agent/magda-mgd
+cp "$(npm root -g)/@magda/mgd/skills/"{mgd-workflows.md,dataset-elicitation.md} .agent/magda-mgd/
+```
+
+```markdown
+<!-- AGENTS.md -->
+
+## MAGDA `mgd` CLI
+
+When working with a MAGDA catalog, use the `mgd` CLI and follow
+`.agent/magda-mgd/mgd-workflows.md`. When creating or editing datasets, also
+follow `.agent/magda-mgd/dataset-elicitation.md`. Always use `--json`/`--jsonl`
+when parsing output and rely on the documented exit codes.
+```
+
+### opencode
+
+opencode also reads an `AGENTS.md` rules file (and honours nested ones). Use the
+same vendoring approach as Codex above — copy `mgd-workflows.md` and
+`dataset-elicitation.md` into the repo and reference them from `AGENTS.md`.
+opencode will pick up the instructions and, with `mgd` on `PATH` and credentials
+set, can run the same discovery → analyse → publish workflows.
+
+> The canonical instructions are deliberately tool-agnostic, so any assistant
+> that loads a Markdown instructions/rules file can use them — the sections above
+> just show the idiomatic place to point each tool.
+
+## Troubleshooting
+
+- **`Authentication error` (exit 3)** — no or invalid credentials. Re-run
+  `mgd auth login`, or check `MGD_API_KEY_ID` / `MGD_API_KEY`.
+- **`semantic-search-unavailable` (exit 1)** — the target site doesn't have the
+  semantic-search components installed; use `mgd search datasets` instead.
+- **`Not found` (exit 4)** — the record or storage object doesn't exist (or your
+  key can't see it).
+- **A large upload is rejected** — the deployment may lack the multipart storage
+  endpoints and hit an ingress body-size limit on single-shot upload; upload
+  against a deployment with multipart support.
+- **Parsing output in scripts** — always pass `--json` / `--jsonl` and rely on
+  the documented exit codes rather than scraping human-readable text.
+
+## Development
+
+This package lives in the `packages/mgd/` subdirectory of the Magda monorepo.
+
+```sh
+yarn build       # TypeScript → ESM via esbuild, output to bin/
+yarn test        # unit tests (Mocha + tsx)
+yarn typecheck   # type-check without emitting
+```
+
+Node.js ≥ 22 is required (set in `engines` in `package.json`).
+
+## License
+
+Apache 2.0
+</content>

--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -276,24 +276,26 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 
 ## Command reference
 
-| Command                                               | Description                                      |
-| ----------------------------------------------------- | ------------------------------------------------ |
-| `auth login` / `auth status` / `auth logout`          | Manage credentials for a site profile            |
-| `profile list` / `profile use <name>`                 | List / switch profiles                           |
-| `search datasets <query>`                             | Keyword dataset search                           |
-| `search semantic <query>`                             | Semantic (embedding) search                      |
-| `dataset get <id>`                                    | Fetch a dataset record                           |
-| `dataset distributions <id>`                          | List a dataset's distributions                   |
-| `dataset create`                                      | Create a dataset (draft by default)              |
-| `dataset update <id>`                                 | Update dataset metadata                          |
-| `dataset add-file <id> [file]`                        | Upload/attach a distribution (or `--access-url`) |
-| `dataset aspect get/set/delete <recordId> <aspectId>` | Read/write custom aspect data on any record      |
-| `dist get <id>` / `dist update <id>`                  | Inspect / edit a distribution                    |
-| `dist download <id>`                                  | Download a distribution's file (`--resume`)      |
-| `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version      |
-| `file upload <file>` / `file download <bucket/key>`   | Direct storage transfer                          |
-| `aspect list` / `get <id>` / `create <id>`            | Manage aspect definitions                        |
-| `api request <method> <path>`                         | Call any MAGDA API endpoint                      |
+| Command                                               | Description                                             |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| `auth login` / `auth status` / `auth logout`          | Manage credentials for a site profile                   |
+| `profile list` / `profile use <name>`                 | List / switch profiles                                  |
+| `search datasets <query>`                             | Keyword dataset search                                  |
+| `search semantic <query>`                             | Semantic (embedding) search                             |
+| `dataset get <id>`                                    | Fetch a dataset record                                  |
+| `dataset distributions <id>`                          | List a dataset's distributions                          |
+| `dataset create`                                      | Create a dataset (draft by default)                     |
+| `dataset update <id>`                                 | Update dataset metadata                                 |
+| `dataset add-file <id> [file]`                        | Upload/attach a distribution (or `--access-url`)        |
+| `dataset aspect get/set/delete <recordId> <aspectId>` | Read/write custom aspect data on any record             |
+| `dist get <id>` / `dist update <id>`                  | Inspect / edit a distribution                           |
+| `dist download <id>`                                  | Download a distribution's file (`--resume`)             |
+| `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version             |
+| `file upload <file>` / `file download <bucket/key>`   | Direct storage transfer                                 |
+| `aspect list` / `get <id>` / `create <id>`            | Manage aspect definitions                               |
+| `api request <method> <path>`                         | Call any MAGDA API endpoint                             |
+| `skills install [--agent <name>]`                     | Install the agent skill (all agents, global by default) |
+| `skills uninstall [--agent <name>]`                   | Remove the agent skill                                  |
 
 Run `mgd --help` or `mgd <command> --help` for full option documentation.
 
@@ -306,60 +308,40 @@ drive the catalog safely. The [`skills/`](./skills/) folder contains:
   safety rules and error triage;
 - **`dataset-elicitation.md`** — "metadata consultant" behaviour for guided
   dataset creation (infer before asking, quick vs guided path, confirm-then-write);
-- **`SKILL.md`** — the entry point declaring the `magda-mgd` skill (name +
-  description frontmatter that points at the two files above).
+- **`SKILL.md`** — the standard Agent-Skill wrapper (`name` + `description`
+  frontmatter pointing at the two files above); auto-discovered by Claude Code,
+  Codex and opencode.
 
-For a globally installed CLI the files live at
-`$(npm root -g)/@magda/mgd/skills/`. In every case, make sure `mgd` is on the
-agent's `PATH` and that credentials are configured (a saved profile, or the
-`MGD_*` environment variables) before starting the agent.
+### Installing the skill
 
-### Claude Code
-
-Claude Code auto-discovers skills under a project's `.claude/skills/` directory.
-Copy the skill in:
+Install it with the built-in installer. By default it installs for **all three
+agents, globally**, so the skill is available from any working directory:
 
 ```sh
-mkdir -p .claude/skills/magda-mgd
-cp "$(npm root -g)/@magda/mgd/skills/"*.md .claude/skills/magda-mgd/
+mgd skills install
 ```
 
-Start `claude` in that project and it can invoke the `magda-mgd` skill on demand.
-(For a personal, all-projects install, use `~/.claude/skills/magda-mgd/` instead.)
+This drops the skill into each agent's native skills directory:
 
-### Codex
+| Agent       | Global (default)                       | With `--project [dir]`              |
+| ----------- | -------------------------------------- | ----------------------------------- |
+| Claude Code | `~/.claude/skills/magda-mgd/`          | `<dir>/.claude/skills/magda-mgd/`   |
+| Codex       | `~/.codex/skills/magda-mgd/`           | `<dir>/.agents/skills/magda-mgd/`   |
+| opencode    | `~/.config/opencode/skills/magda-mgd/` | `<dir>/.opencode/skills/magda-mgd/` |
 
-Codex reads project instructions from an `AGENTS.md` file. Vendor the skill into
-your repo and point `AGENTS.md` at it so Codex loads the workflow rules as
-context:
+All three natively auto-discover `SKILL.md` skills and load the instructions on
+demand when a task matches the skill's description.
 
 ```sh
-mkdir -p .agent/magda-mgd
-cp "$(npm root -g)/@magda/mgd/skills/"{mgd-workflows.md,dataset-elicitation.md} .agent/magda-mgd/
+mgd skills install --agent codex        # just one agent
+mgd skills install --project            # into ./ (current repo) instead of globally
+mgd skills install --project ../app     # into a specific project directory
+mgd skills uninstall                    # remove (all agents, global) — --agent/--project mirror install
 ```
 
-```markdown
-<!-- AGENTS.md -->
-
-## MAGDA `mgd` CLI
-
-When working with a MAGDA catalog, use the `mgd` CLI and follow
-`.agent/magda-mgd/mgd-workflows.md`. When creating or editing datasets, also
-follow `.agent/magda-mgd/dataset-elicitation.md`. Always use `--json`/`--jsonl`
-when parsing output and rely on the documented exit codes.
-```
-
-### opencode
-
-opencode also reads an `AGENTS.md` rules file (and honours nested ones). Use the
-same vendoring approach as Codex above — copy `mgd-workflows.md` and
-`dataset-elicitation.md` into the repo and reference them from `AGENTS.md`.
-opencode will pick up the instructions and, with `mgd` on `PATH` and credentials
-set, can run the same discovery → analyse → publish workflows.
-
-> The canonical instructions are deliberately tool-agnostic, so any assistant
-> that loads a Markdown instructions/rules file can use them — the sections above
-> just show the idiomatic place to point each tool.
+Installs are idempotent — re-running refreshes the managed `magda-mgd/` folder.
+Make sure `mgd` is on the agent's `PATH` and that credentials are configured (a
+saved profile, or the `MGD_*` environment variables; check with `mgd auth status`) before starting the agent.
 
 ## Troubleshooting
 

--- a/packages/mgd/esbuild.js
+++ b/packages/mgd/esbuild.js
@@ -1,4 +1,7 @@
+import { chmodSync } from "node:fs";
 import * as esbuild from "esbuild";
+
+const outfile = "bin/mgd.js";
 
 await esbuild.build({
     entryPoints: ["src/index.ts"],
@@ -6,7 +9,12 @@ await esbuild.build({
     platform: "node",
     target: ["es2022"],
     format: "esm",
-    outfile: "bin/mgd.js",
+    outfile,
     banner: { js: "#!/usr/bin/env node" },
     external: ["commander"]
 });
+
+// Make the bundle executable so `npm link` / direct execution works locally.
+// (npm sets the bit on publish/install from the "bin" field, but a bare
+// `yarn build` would otherwise leave it 0644.)
+chmodSync(outfile, 0o755);

--- a/packages/mgd/esbuild.js
+++ b/packages/mgd/esbuild.js
@@ -1,0 +1,12 @@
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+    entryPoints: ["src/index.ts"],
+    bundle: true,
+    platform: "node",
+    target: ["es2022"],
+    format: "esm",
+    outfile: "bin/mgd.js",
+    banner: { js: "#!/usr/bin/env node" },
+    external: ["commander"]
+});

--- a/packages/mgd/package.json
+++ b/packages/mgd/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@magda/mgd",
+  "description": "MAGDA local command-line interface",
+  "version": "6.0.0",
+  "type": "module",
+  "bin": {
+    "mgd": "./bin/mgd.js"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "prebuild": "rimraf bin",
+    "build": "node esbuild.js",
+    "typecheck": "tsc --noEmit",
+    "test": "c8 mocha",
+    "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "commander": "^11.1.0"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.3.11",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^22.0.0",
+    "c8": "^9.0.0",
+    "chai": "^5.0.0",
+    "esbuild": "^0.19.10",
+    "mocha": "^10.2.0",
+    "rimraf": "^3.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "~5.3.3"
+  },
+  "mocha": {
+    "import": "tsx/esm",
+    "spec": [
+      "src/test/**/*.spec.ts"
+    ]
+  },
+  "c8": {
+    "all": true,
+    "clean": true,
+    "src": [
+      "./src"
+    ],
+    "exclude": [
+      "src/test/**"
+    ]
+  },
+  "magda": {
+    "language": "typescript",
+    "categories": {
+      "npmPackage": true
+    }
+  },
+  "keywords": [
+    "Magda",
+    "CLI",
+    "mgd"
+  ],
+  "files": [
+    "bin",
+    "skills"
+  ]
+}

--- a/packages/mgd/scripts/verify-mgd.mjs
+++ b/packages/mgd/scripts/verify-mgd.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * End-to-end verification of the mgd CLI against a real MAGDA deployment.
+ * Usage:
+ *   MGD_E2E_BASE_URL=https://... MGD_E2E_API_KEY_ID=... MGD_E2E_API_KEY=... \
+ *     node scripts/verify-mgd.mjs
+ * Creates a throwaway dataset, exercises upload/download/replace/update,
+ * then deletes what it created via raw API calls.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const required = ["MGD_E2E_BASE_URL", "MGD_E2E_API_KEY_ID", "MGD_E2E_API_KEY"];
+for (const k of required) {
+    if (!process.env[k]) {
+        console.error(`Missing env var ${k}`);
+        process.exit(2);
+    }
+}
+
+const env = {
+    ...process.env,
+    MGD_BASE_URL: process.env.MGD_E2E_BASE_URL,
+    MGD_API_KEY_ID: process.env.MGD_E2E_API_KEY_ID,
+    MGD_API_KEY: process.env.MGD_E2E_API_KEY
+};
+const BIN = path.resolve(import.meta.dirname, "../bin/mgd.js");
+
+function mgd(...args) {
+    return execFileSync("node", [BIN, ...args], {
+        env,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 64
+    });
+}
+
+const failures = [];
+function check(name, fn) {
+    try {
+        fn();
+        console.log(`ok   - ${name}`);
+    } catch (e) {
+        failures.push(name);
+        console.error(`FAIL - ${name}: ${e.message}`);
+    }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mgd-e2e-"));
+let datasetId = "";
+let distId = "";
+
+check("auth status", () => {
+    const s = JSON.parse(mgd("auth", "status", "--json"));
+    if (!s.authenticated) throw new Error("not authenticated");
+});
+
+check("search datasets", () => {
+    mgd("search", "datasets", "data", "--limit", "1", "--jsonl");
+});
+
+check("dataset create", () => {
+    datasetId = mgd(
+        "dataset",
+        "create",
+        "--title",
+        `mgd e2e ${new Date().toISOString()}`,
+        "--desc",
+        "temporary e2e verification dataset"
+    ).trim();
+    if (!/^magda-ds-/.test(datasetId)) throw new Error(`bad id: ${datasetId}`);
+});
+
+check("add-file small", () => {
+    const f = path.join(tmp, "small.csv");
+    fs.writeFileSync(f, "a,b\n1,2\n");
+    distId = mgd("dataset", "add-file", datasetId, f).trim();
+    if (!/^magda-dist-/.test(distId)) throw new Error(`bad id: ${distId}`);
+});
+
+check("add-file large (multipart)", () => {
+    const f = path.join(tmp, "large.bin");
+    fs.writeFileSync(f, crypto.randomBytes(20 * 1024 * 1024)); // 20MB > 16MB
+    const out = JSON.parse(mgd("dataset", "add-file", datasetId, f, "--json"));
+    const dl = path.join(tmp, "large-out.bin");
+    mgd("dist", "download", out.distributionId, "-o", dl);
+    const a = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(f))
+        .digest("hex");
+    const b = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(dl))
+        .digest("hex");
+    if (a !== b) throw new Error("checksum mismatch after round-trip");
+});
+
+check("replace-file bumps version", () => {
+    const f = path.join(tmp, "replacement.csv");
+    fs.writeFileSync(f, "x,y\n3,4\n");
+    const out = JSON.parse(mgd("dist", "replace-file", distId, f, "--json"));
+    if (out.versionNumber < 1) throw new Error("version not bumped");
+});
+
+check("dataset update + custom aspect", () => {
+    mgd("dataset", "update", datasetId, "--desc", "updated by e2e");
+    mgd(
+        "aspect",
+        "create",
+        "mgd-e2e-aspect",
+        "--name",
+        "mgd e2e",
+        "--schema",
+        '{"type":"object"}'
+    );
+    mgd("dataset", "aspect", "set", datasetId, "mgd-e2e-aspect", '{"ok":true}');
+});
+
+check("cleanup", () => {
+    const record = JSON.parse(mgd("dataset", "get", datasetId, "--json"));
+    const dists =
+        record.aspects?.["dataset-distributions"]?.distributions ?? [];
+    for (const d of dists) {
+        const id = typeof d === "string" ? d : d.id;
+        mgd("api", "request", "DELETE", `/v0/registry/records/${id}`);
+    }
+    mgd("api", "request", "DELETE", `/v0/registry/records/${datasetId}`);
+});
+
+fs.rmSync(tmp, { recursive: true, force: true });
+if (failures.length) {
+    console.error(`\n${failures.length} FAILURES: ${failures.join(", ")}`);
+    process.exit(1);
+}
+console.log("\nALL CHECKS PASSED");

--- a/packages/mgd/skills/SKILL.md
+++ b/packages/mgd/skills/SKILL.md
@@ -13,7 +13,3 @@ When creating or editing datasets (metadata conversations), additionally
 follow `dataset-elicitation.md` — it defines the consultant behavior: infer
 before asking, quick path vs guided path, purpose-driven field suggestions,
 and the confirm-then-write discipline.
-
-Locate the skill files via the installed package: `npx @magda/mgd --version`
-confirms the CLI; the Markdown files ship in the package's `skills/` folder
-(e.g. `$(npm root -g)/@magda/mgd/skills/` for global installs).

--- a/packages/mgd/skills/SKILL.md
+++ b/packages/mgd/skills/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: magda-mgd
+description: Use when accessing a MAGDA data catalog from the command line — searching/downloading datasets, analysing them locally, or creating/editing dataset records and uploading files via the mgd CLI.
+---
+
+# MAGDA `mgd` CLI skill
+
+Read `mgd-workflows.md` (same directory) for command usage, output modes,
+search strategy, recipes, safety rules, and error triage. Follow its ground
+rules for every MAGDA interaction.
+
+When creating or editing datasets (metadata conversations), additionally
+follow `dataset-elicitation.md` — it defines the consultant behavior: infer
+before asking, quick path vs guided path, purpose-driven field suggestions,
+and the confirm-then-write discipline.
+
+Locate the skill files via the installed package: `npx @magda/mgd --version`
+confirms the CLI; the Markdown files ship in the package's `skills/` folder
+(e.g. `$(npm root -g)/@magda/mgd/skills/` for global installs).

--- a/packages/mgd/skills/dataset-elicitation.md
+++ b/packages/mgd/skills/dataset-elicitation.md
@@ -1,0 +1,90 @@
+# Dataset metadata elicitation — consultant behavior
+
+How an assistant should behave when using `mgd` to create or edit datasets.
+Act like a professional data-catalog consultant: minimise questions, maximise
+metadata quality, and never waste the user's time.
+
+## The prime directive: context before questions
+
+Before asking the user anything, gather what you can:
+
+1. **The conversation.** Purpose, project, and audience are usually already
+   mentioned. Re-read before asking.
+2. **The data file itself.** Inspect it locally (headers, column names, row
+   count, date columns, coordinate columns, file size/format). Draft a
+   description from what you see.
+3. **The catalog's conventions.** Search for similar datasets first:
+   `mgd search datasets "<topic>" --limit 5 --jsonl`, then
+   `mgd dataset get <id> --json` on one or two. Note the org's typical
+   keywords, themes, license wording, and any custom aspects in use.
+4. **The user's identity.** `mgd auth status --json` gives the user and org
+   unit; ownership fields come from there automatically.
+
+Only ask questions whose answers you genuinely cannot infer. Batch them —
+prefer ONE round of at most 3–4 high-value questions. For everything else,
+propose drafted values and ask for confirmation, which is faster to answer
+than an open question.
+
+## Two paths — offer the choice when unclear
+
+**Quick path** (user signals urgency, or says "placeholder", "quick", "just
+get it in"): create a draft record with the minimum — title and a short
+description — attach the file, and stop:
+
+```sh
+mgd dataset create --title "Site sensor readings 2026" --desc "Raw CSV export; metadata to be enriched."
+mgd dataset add-file <datasetId> ./readings.csv
+```
+
+Tell the user what was created (IDs) and offer to enrich the metadata later.
+Do not interrogate them first.
+
+**Guided path** (user is publishing something that matters): elicit purpose,
+then fill the field tiers below, proposing inferred values.
+
+## Purpose-driven field selection
+
+Ask (or infer): _who will use this dataset, and for what?_ Then derive:
+
+| Signal                     | Fields to raise                                    |
+| -------------------------- | -------------------------------------------------- |
+| Shared beyond the team     | access level / org unit, license                   |
+| Recurring/periodic data    | update frequency (`accrualPeriodicity`), currency  |
+| Derived/processed data     | provenance (source datasets, method)               |
+| Geospatial columns         | spatial coverage                                   |
+| Time-series columns        | temporal coverage                                  |
+| Sensitive/regulated domain | information security classification, access notes  |
+| Domain-specific attributes | a custom aspect (`mgd aspect create` + `--aspect`) |
+
+## Field tiers
+
+- **Minimum (always):** title, short description. `mgd dataset create` enforces
+  title; never create a record with an empty description — one sentence is fine.
+- **Recommended (raise before publishing):** keywords/themes, license, format
+  (auto-detected from files), publisher, access level, update frequency.
+- **Purpose-driven (from the table above):** raise only the relevant ones.
+
+Never silently omit a field the inferred purpose calls for — suggest it and
+let the user decide. Phrase suggestions concretely: "This looks like quarterly
+data — set update frequency to quarterly?" beats "Do you want to add more
+metadata?".
+
+## Enrichment loop for existing datasets
+
+When asked to improve an existing dataset (or after a quick-path creation):
+
+1. `mgd dataset get <id> --json`
+2. Produce a **gap report**: which minimum/recommended/purpose-driven fields
+   are empty or defaulted, in one compact list.
+3. Propose values for each gap (inferred where possible), get one confirmation,
+   then apply with `mgd dataset update` / `mgd dataset aspect set`.
+
+## Write discipline
+
+- Datasets are created as **drafts**. `--publish` (or publishing-state changes)
+  only after explicit user confirmation.
+- Before any mutation, show a compact summary of exactly what will be written,
+  marking which values were inferred vs provided.
+- After mutations, report the record IDs and what changed.
+- Replacing a file (`mgd dist replace-file`) preserves version history; tell
+  the user the new version number.

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -1,0 +1,108 @@
+# Using the `mgd` CLI for MAGDA workflows
+
+Instructions for assistant tools (and humans) driving a MAGDA data catalog
+through the `mgd` command-line interface. Tool-agnostic: adapt the framing to
+your assistant environment, keep the rules.
+
+## Ground rules
+
+1. **Check auth first.** Before any MAGDA access, run `mgd auth status --json`.
+   If it fails with exit code 2, ask the user to run `mgd auth login`. If
+   `authenticated` is `false`, read-only public commands may still work, but
+   mutations will fail — say so up front.
+2. **Prefer curated commands** (`search`, `dataset`, `dist`, `file`, `aspect`)
+   over `mgd api request`. Use the raw command only when no curated command
+   covers the endpoint, and mention that you did.
+3. **Always parse machine output.** Use `--json` (single document) or `--jsonl`
+   (one JSON object per line) on every command whose output you consume.
+   Never scrape human-mode output.
+4. **Respect exit codes.** `0` ok; `2` usage error (your command line is wrong);
+   `3` auth error (key missing/invalid or no permission); `4` not found;
+   `1` anything else. In `--json` mode a failing command prints
+   `{"error": {"code", "message", "status", "hint"}}` on stderr.
+5. **Confirm before mutating or publishing.** Never run `dataset create --publish`, `add-file`, `replace-file`, `update`, `aspect create/set/delete`,
+   or any `api request` with POST/PUT/PATCH/DELETE without the user's explicit
+   go-ahead in this conversation. Uploading or attaching generated artifacts
+   happens only when the user asked for it.
+6. **Report identifiers.** Every user-facing summary must include the dataset
+   IDs, distribution IDs, local file paths, and upload targets you touched.
+
+## Keyword vs semantic search — use both
+
+`mgd search datasets <query>` — keyword/faceted search over the index.
+Strengths: exact terms, org vocabulary, filters, pagination, fast. Weakness:
+misses conceptual matches phrased differently from the metadata.
+
+`mgd search semantic <query>` — embedding similarity over indexed content.
+Strengths: natural-language and conceptual queries ("rainfall trends near
+brisbane"), matching document content rather than titles. Weakness: not
+available on every site — it fails with code `semantic-search-unavailable`;
+fall back to keyword-only silently.
+
+Recipe — combined search:
+
+```sh
+mgd search datasets "water quality" --limit 20 --jsonl > kw.jsonl
+mgd search semantic "water quality" --limit 20 --jsonl > sem.jsonl || true
+# merge: keep keyword rank first, append semantic-only recordIds
+jq -r '.identifier' kw.jsonl > ids.txt
+jq -r '.recordId' sem.jsonl | grep -v -x -F -f ids.txt >> ids.txt
+```
+
+Then inspect the top candidates with `mgd dataset get <id> --json`.
+
+## Common recipes
+
+Search → inspect → download → analyse locally:
+
+```sh
+mgd search datasets "air quality" --limit 10 --jsonl | jq -r '.identifier'
+mgd dataset get ds-abc --json | jq '.aspects["dcat-dataset-strings"]'
+mgd dataset distributions ds-abc --jsonl | jq -r '[.id, .aspects["dcat-distribution-strings"].format] | @tsv'
+mgd dist download dist-xyz -o ./data/raw.csv
+# analyse ./data/raw.csv locally with your usual tools
+```
+
+Download many distributions:
+
+```sh
+mgd dataset distributions ds-abc --jsonl \
+  | jq -r '.id' \
+  | xargs -I{} mgd dist download {} -o ./data/{}.bin
+```
+
+Large files: downloads resume with `--resume`; uploads switch to multipart
+automatically at 16 MB — no flags needed.
+
+Upload an artifact the user asked to publish (see dataset-elicitation.md for
+the metadata conversation first):
+
+```sh
+mgd dataset add-file ds-abc ./analysis/summary.parquet --title "2026 summary" --json
+```
+
+Custom / domain metadata:
+
+```sh
+mgd aspect list --jsonl                     # what aspect types exist here?
+mgd aspect create my-domain --name "My Domain" --schema @schema.json
+mgd dataset aspect set ds-abc my-domain @values.json
+```
+
+Raw fallback (documented REST endpoints only):
+
+```sh
+mgd api request GET /v0/registry/records --query limit=3 --query aspect=dcat-dataset-strings
+```
+
+## Error triage
+
+- exit 3 + `unauthorized` → API key invalid/expired: ask the user to re-run
+  `mgd auth login`.
+- exit 3 + `forbidden` → the key works but lacks permission: report which
+  operation was denied; do not retry.
+- exit 4 → record/object doesn't exist: re-check the ID (search again) before
+  reporting data as missing.
+- `semantic-search-unavailable` → use keyword search only.
+- Network errors mention the base URL — verify `mgd auth status` and the site
+  URL before concluding the service is down.

--- a/packages/mgd/src/client.ts
+++ b/packages/mgd/src/client.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { MgdApiError, UsageError } from "./errors.js";
+import { loadConfig, resolveProfile, Profile } from "./profile.js";
+import { VERSION } from "./version.js";
+
+export interface ClientOptions {
+    baseUrl: string;
+    apiKeyId?: string;
+    apiKey?: string;
+}
+
+export interface RequestOptions {
+    query?:
+        | Record<string, string | number | boolean | undefined>
+        | [string, string][];
+    headers?: Record<string, string>;
+    body?: BodyInit;
+    retry?: boolean;
+    retryDelayMs?: number;
+}
+
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+function codeForStatus(status: number): string {
+    if (status === 401) return "unauthorized";
+    if (status === 403) return "forbidden";
+    if (status === 404) return "not-found";
+    if (status >= 500) return "server-error";
+    return "request-failed";
+}
+
+export class MagdaClient {
+    readonly invocationId = randomUUID();
+
+    constructor(readonly opts: ClientOptions) {}
+
+    buildUrl(path: string, query?: RequestOptions["query"]): string {
+        const url = new URL(this.opts.baseUrl.replace(/\/+$/, "") + path);
+        const entries = Array.isArray(query)
+            ? query
+            : Object.entries(query ?? {}).filter(([, v]) => v !== undefined);
+        for (const [k, v] of entries) {
+            url.searchParams.append(k, String(v));
+        }
+        return url.toString();
+    }
+
+    async request(
+        method: string,
+        path: string,
+        opts: RequestOptions = {}
+    ): Promise<Response> {
+        const url = this.buildUrl(path, opts.query);
+        const headers: Record<string, string> = {
+            "user-agent": `mgd/${VERSION}`,
+            ...opts.headers
+        };
+        if (this.opts.apiKeyId && this.opts.apiKey) {
+            headers["X-Magda-API-Key-Id"] = this.opts.apiKeyId;
+            headers["X-Magda-API-Key"] = this.opts.apiKey;
+        }
+        if (MUTATING.has(method)) {
+            headers["X-Magda-Client-Id"] = "mgd";
+            headers["X-Magda-Client-Invocation-Id"] = this.invocationId;
+        }
+        const shouldRetry =
+            opts.retry ?? (method === "GET" || method === "HEAD");
+        const maxAttempts = shouldRetry && !MUTATING.has(method) ? 3 : 1;
+        const baseDelay = opts.retryDelayMs ?? 300;
+
+        let lastError: unknown;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            if (attempt > 0) await sleep(baseDelay * 2 ** (attempt - 1));
+            try {
+                const res = await fetch(url, {
+                    method,
+                    headers,
+                    body: opts.body
+                });
+                if (res.status >= 500 && attempt < maxAttempts - 1) {
+                    lastError = await toApiError(res);
+                    continue;
+                }
+                if (!res.ok) throw await toApiError(res);
+                return res;
+            } catch (e) {
+                if (e instanceof MgdApiError) throw e;
+                lastError = e;
+                if (attempt === maxAttempts - 1) break;
+            }
+        }
+        if (lastError instanceof MgdApiError) throw lastError;
+        throw new MgdApiError(
+            `Request failed: ${
+                lastError instanceof Error ? lastError.message : lastError
+            }`,
+            0,
+            "network-error",
+            "Check the site URL and your network connection."
+        );
+    }
+
+    async json<T = unknown>(
+        method: string,
+        path: string,
+        opts: RequestOptions = {}
+    ): Promise<T> {
+        const res = await this.request(method, path, opts);
+        return (await res.json()) as T;
+    }
+}
+
+async function toApiError(res: Response): Promise<MgdApiError> {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+        const text = await res.text();
+        try {
+            const parsed = JSON.parse(text);
+            message = parsed?.message || parsed?.errorMessage || message;
+        } catch {
+            if (text.trim()) message = text.trim().slice(0, 500);
+        }
+    } catch {
+        // keep default message
+    }
+    return new MgdApiError(message, res.status, codeForStatus(res.status));
+}
+
+export async function clientFromProfile(): Promise<MagdaClient> {
+    const cfg = await loadConfig();
+    const { profile } = resolveProfile(cfg);
+    if (!profile?.baseUrl) {
+        throw new UsageError(
+            "No active profile. Run `mgd auth login` or set MGD_BASE_URL."
+        );
+    }
+    return clientFor(profile);
+}
+
+export function clientFor(profile: Profile): MagdaClient {
+    return new MagdaClient({
+        baseUrl: profile.baseUrl,
+        apiKeyId: profile.apiKeyId,
+        apiKey: profile.apiKey
+    });
+}

--- a/packages/mgd/src/commands/api.ts
+++ b/packages/mgd/src/commands/api.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import { Command } from "commander";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { clientFromProfile } from "../client.js";
+import { UsageError } from "../errors.js";
+
+const METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+async function readBody(opts: {
+    body?: string;
+    bodyFile?: string;
+}): Promise<string | undefined> {
+    if (opts.bodyFile === "-") {
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+        return Buffer.concat(chunks).toString("utf8");
+    }
+    if (opts.bodyFile) return fs.readFile(opts.bodyFile, "utf8");
+    return opts.body;
+}
+
+export function registerApiCommands(program: Command): void {
+    const api = program.command("api").description("Raw API access");
+
+    api.command("request <method> <path>")
+        .description("Send an authenticated request to a documented MAGDA API")
+        .option("--query <k=v...>", "query parameter (repeatable)", collect, [])
+        .option("--body <json>", "inline request body")
+        .option(
+            "--body-file <path>",
+            "read request body from file, - for stdin"
+        )
+        .option("--content-type <ct>", "request content type")
+        .option("--json", "(default for JSON responses)")
+        .action(async (methodArg: string, path: string, opts) => {
+            const method = methodArg.toUpperCase();
+            if (!METHODS.has(method)) {
+                throw new UsageError(`Unsupported method: ${methodArg}`);
+            }
+            if (!path.startsWith("/")) {
+                throw new UsageError(
+                    `Path must start with "/" (got: ${path}). Example: /v0/registry/records`
+                );
+            }
+            const client = await clientFromProfile();
+            const body = await readBody(opts);
+            const query: [string, string][] = (opts.query as string[]).map(
+                (pair: string) => {
+                    const idx = pair.indexOf("=");
+                    if (idx < 1) {
+                        throw new UsageError(
+                            `--query must be k=v (got: ${pair})`
+                        );
+                    }
+                    return [pair.slice(0, idx), pair.slice(idx + 1)];
+                }
+            );
+            const res = await client.request(method, path, {
+                query,
+                body,
+                headers: body
+                    ? {
+                          "content-type": opts.contentType || "application/json"
+                      }
+                    : opts.contentType
+                    ? { "content-type": opts.contentType }
+                    : undefined
+            });
+            const ct = res.headers.get("content-type") || "";
+            if (ct.includes("json")) {
+                const data = await res.json();
+                process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+            } else if (res.body) {
+                await pipeline(
+                    Readable.fromWeb(res.body as any),
+                    process.stdout
+                );
+            }
+        });
+}
+
+function collect(value: string, previous: string[]): string[] {
+    return [...previous, value];
+}

--- a/packages/mgd/src/commands/aspect.ts
+++ b/packages/mgd/src/commands/aspect.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { clientFromProfile } from "../client.js";
+import { REGISTRY_ASPECTS, registryAspect } from "../endpoints.js";
+import { parseAspectValue } from "../recordBuilders.js";
+import { note, printData, resolveMode } from "../output.js";
+
+export function registerAspectCommands(program: Command): void {
+    const aspect = program
+        .command("aspect")
+        .description("Registry aspect definitions");
+
+    aspect
+        .command("list")
+        .option("--json", "output JSON")
+        .option("--jsonl", "one definition per line")
+        .action(async (opts) => {
+            const client = await clientFromProfile();
+            const defs = await client.json<any[]>("GET", REGISTRY_ASPECTS);
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                for (const d of defs) {
+                    process.stdout.write(`${d.id}\t${d.name}\n`);
+                }
+            } else {
+                printData(mode, defs);
+            }
+        });
+
+    aspect.command("get <id>").action(async (id: string) => {
+        const client = await clientFromProfile();
+        printData("json", await client.json("GET", registryAspect(id)));
+    });
+
+    aspect
+        .command("create <id>")
+        .description("Create or update an aspect definition with a JSON schema")
+        .requiredOption("--name <name>", "human-readable aspect name")
+        .requiredOption(
+            "--schema <schema>",
+            "JSON schema: inline JSON, @file.json, or -"
+        )
+        .action(async (id: string, opts) => {
+            const client = await clientFromProfile();
+            const jsonSchema = await parseAspectValue(opts.schema);
+            await client.json("PUT", registryAspect(id), {
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ id, name: opts.name, jsonSchema })
+            });
+            note(`Aspect definition "${id}" saved.`);
+        });
+}

--- a/packages/mgd/src/commands/auth.ts
+++ b/packages/mgd/src/commands/auth.ts
@@ -1,0 +1,144 @@
+import { Command } from "commander";
+import { UsageError } from "../errors.js";
+import { clientFor } from "../client.js";
+import { WHOAMI } from "../endpoints.js";
+import { loadConfig, saveConfig, resolveProfile } from "../profile.js";
+import { promptText, promptHidden } from "../prompt.js";
+import { note, colors, printData, resolveMode } from "../output.js";
+
+export async function normalizeBaseUrl(
+    input: string,
+    probe: (baseUrl: string) => Promise<boolean>
+): Promise<string> {
+    const trimmed = input.replace(/\/+$/, "");
+    const candidates = [trimmed];
+    if (!/\/api$/.test(new URL(trimmed).pathname)) {
+        candidates.push(`${trimmed}/api`);
+    }
+    for (const candidate of candidates) {
+        if (await probe(candidate)) return candidate;
+    }
+    throw new UsageError(
+        `Could not find a MAGDA API at ${input} (tried: ${candidates.join(
+            ", "
+        )}).`
+    );
+}
+
+async function probeApi(baseUrl: string): Promise<boolean> {
+    try {
+        const res = await fetch(`${baseUrl}${WHOAMI}`, {
+            headers: { accept: "application/json" }
+        });
+        const contentType = res.headers.get("content-type") || "";
+        return contentType.includes("json");
+    } catch {
+        return false;
+    }
+}
+
+export function registerAuthCommands(program: Command): void {
+    const auth = program.command("auth").description("Authentication");
+
+    auth.command("login")
+        .description("Log in to a MAGDA site with an API key")
+        .option("--url <url>", "MAGDA site or API base URL")
+        .option("--key-id <id>", "API key ID")
+        .option("--key <key>", "API key")
+        .option("--profile <name>", "profile name", "default")
+        .action(async (opts) => {
+            note(
+                "Create an API key in the MAGDA web UI (Settings -> API keys),\n" +
+                    "then enter it below. Leave key fields empty for anonymous access.\n"
+            );
+            const rawUrl = opts.url || (await promptText("MAGDA site URL: "));
+            const baseUrl = await normalizeBaseUrl(rawUrl, probeApi);
+            const apiKeyId =
+                opts.keyId ??
+                (await promptText("API key ID (empty for anonymous): "));
+            const apiKey = apiKeyId
+                ? opts.key ?? (await promptHidden("API key: "))
+                : "";
+
+            const client = clientFor({
+                baseUrl,
+                apiKeyId: apiKeyId || undefined,
+                apiKey: apiKey || undefined
+            });
+            const user = await client.json<any>("GET", WHOAMI);
+
+            const cfg = await loadConfig();
+            cfg.profiles[opts.profile] = {
+                baseUrl,
+                ...(apiKeyId ? { apiKeyId, apiKey } : {})
+            };
+            cfg.activeProfile = opts.profile;
+            await saveConfig(cfg);
+
+            note(
+                colors.green(
+                    `Logged in to ${baseUrl}` +
+                        (user?.displayName
+                            ? ` as ${user.displayName}`
+                            : " (anonymous)") +
+                        ` (profile "${opts.profile}").`
+                )
+            );
+        });
+
+    auth.command("status")
+        .description("Show the active profile and authenticated user")
+        .option("--json", "output JSON")
+        .action(async (opts) => {
+            const cfg = await loadConfig();
+            const { name, profile } = resolveProfile(cfg);
+            if (!profile?.baseUrl) {
+                throw new UsageError(
+                    "No active profile. Run `mgd auth login` or set MGD_BASE_URL."
+                );
+            }
+            const client = clientFor(profile);
+            const user = await client.json<any>("GET", WHOAMI);
+            const authenticated = Boolean(profile.apiKeyId && user?.id);
+            const status = {
+                profile: name,
+                baseUrl: profile.baseUrl,
+                authenticated,
+                user: authenticated
+                    ? {
+                          id: user.id,
+                          displayName: user.displayName,
+                          email: user.email,
+                          orgUnitId: user.orgUnitId
+                      }
+                    : null
+            };
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                note(`Profile:       ${status.profile}`);
+                note(`Base URL:      ${status.baseUrl}`);
+                note(`Authenticated: ${status.authenticated}`);
+                if (status.user) {
+                    note(
+                        `User:          ${status.user.displayName} (${status.user.id})`
+                    );
+                }
+            } else {
+                printData(mode, status);
+            }
+        });
+
+    auth.command("logout")
+        .description("Remove stored credentials for a profile")
+        .option("--profile <name>", "profile name")
+        .action(async (opts) => {
+            const cfg = await loadConfig();
+            const name = opts.profile || cfg.activeProfile || "default";
+            const profile = cfg.profiles[name];
+            if (!profile) throw new UsageError(`No such profile: ${name}`);
+            delete profile.apiKeyId;
+            delete profile.apiKey;
+            await saveConfig(cfg);
+            note(`Removed credentials from profile "${name}".`);
+        });
+}

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -1,0 +1,515 @@
+import path from "node:path";
+import { Command } from "commander";
+import { clientFromProfile, MagdaClient } from "../client.js";
+import {
+    registryRecord,
+    recordAspect,
+    WHOAMI,
+    REGISTRY_RECORDS,
+    storageObject
+} from "../endpoints.js";
+import { MgdApiError, UsageError } from "../errors.js";
+import { printData, resolveMode, note } from "../output.js";
+import { makeProgress } from "../progress.js";
+import {
+    buildDatasetRecord,
+    buildDistributionRecord,
+    deriveSiteUrl,
+    createId,
+    parseAspectArg,
+    parseAspectValue,
+    storageDownloadUrl,
+    getValidObjectKey,
+    detectFormat,
+    DATASETS_BUCKET_DEFAULT
+} from "../recordBuilders.js";
+import { uploadFile } from "../transfer.js";
+
+export const DATASET_OPTIONAL_ASPECTS = [
+    "dcat-dataset-strings",
+    "dataset-distributions",
+    "publishing",
+    "access-control",
+    "source",
+    "version",
+    "currency",
+    "provenance",
+    "spatial-coverage",
+    "temporal-coverage",
+    "information-security",
+    "access"
+];
+
+export async function fetchOwner(
+    client: MagdaClient
+): Promise<{ id?: string; orgUnitId?: string } | undefined> {
+    try {
+        const user = await client.json<any>("GET", WHOAMI);
+        return user?.id
+            ? { id: user.id, orgUnitId: user.orgUnitId }
+            : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export function withAspectHint(e: unknown): unknown {
+    if (
+        e instanceof MgdApiError &&
+        e.status === 400 &&
+        /aspect/i.test(e.message)
+    ) {
+        return new MgdApiError(
+            e.message,
+            e.status,
+            e.code,
+            "If the record uses a custom aspect, create its definition first: mgd aspect create <id> --name <name> --schema @schema.json"
+        );
+    }
+    return e;
+}
+
+export function collect(value: string, previous: string[]): string[] {
+    return [...previous, value];
+}
+
+export async function mergeAspect(
+    client: MagdaClient,
+    recordId: string,
+    aspectId: string,
+    patch: Record<string, unknown>
+): Promise<void> {
+    let current: Record<string, unknown> = {};
+    try {
+        current = await client.json("GET", recordAspect(recordId, aspectId));
+    } catch (e) {
+        if (!(e instanceof MgdApiError && e.status === 404)) throw e;
+    }
+    await client.json("PUT", recordAspect(recordId, aspectId), {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...current, ...patch })
+    });
+}
+
+export function registerDatasetCommands(program: Command): void {
+    const dataset = program.command("dataset").description("Dataset records");
+
+    dataset
+        .command("get <datasetId>")
+        .description("Fetch a dataset record")
+        .option("--aspect <name>", "fetch a single aspect only")
+        .option("--json", "output JSON")
+        .action(async (datasetId: string, opts) => {
+            const client = await clientFromProfile();
+            if (opts.aspect) {
+                const aspect = await client.json<any>(
+                    "GET",
+                    recordAspect(datasetId, opts.aspect)
+                );
+                printData("json", aspect);
+                return;
+            }
+            const record = await client.json<any>(
+                "GET",
+                registryRecord(datasetId),
+                {
+                    query: DATASET_OPTIONAL_ASPECTS.map((a): [
+                        string,
+                        string
+                    ] => ["optionalAspect", a])
+                }
+            );
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                const dcat = record.aspects?.["dcat-dataset-strings"] ?? {};
+                const distributions =
+                    record.aspects?.["dataset-distributions"]?.distributions ??
+                    [];
+                process.stdout.write(`id:            ${record.id}\n`);
+                process.stdout.write(
+                    `title:         ${dcat.title ?? record.name}\n`
+                );
+                process.stdout.write(
+                    `publishing:    ${
+                        record.aspects?.publishing?.state ?? "n/a"
+                    }\n`
+                );
+                process.stdout.write(
+                    `modified:      ${dcat.modified ?? "n/a"}\n`
+                );
+                process.stdout.write(
+                    `distributions: ${distributions.length}\n`
+                );
+                if (dcat.description) {
+                    process.stdout.write(
+                        `description:   ${dcat.description}\n`
+                    );
+                }
+            } else {
+                printData(mode, record);
+            }
+        });
+
+    dataset
+        .command("distributions <datasetId>")
+        .description("List a dataset's distributions")
+        .option("--json", "output JSON")
+        .option("--jsonl", "one distribution per line")
+        .action(async (datasetId: string, opts) => {
+            const client = await clientFromProfile();
+            const record = await client.json<any>(
+                "GET",
+                registryRecord(datasetId),
+                {
+                    query: [
+                        ["aspect", "dataset-distributions"],
+                        ["dereference", "true"]
+                    ] as [string, string][]
+                }
+            );
+            const dists: any[] =
+                record.aspects?.["dataset-distributions"]?.distributions ?? [];
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                for (const d of dists) {
+                    const s = d.aspects?.["dcat-distribution-strings"] ?? {};
+                    process.stdout.write(
+                        `${d.id}\t${s.title ?? d.name}\t${s.format ?? ""}\t${
+                            s.downloadURL ?? s.accessURL ?? ""
+                        }\n`
+                    );
+                }
+                note(`${dists.length} distributions`);
+            } else {
+                printData(mode, dists);
+            }
+        });
+
+    dataset
+        .command("create")
+        .description("Create a new dataset record (draft by default)")
+        .requiredOption("--title <title>", "dataset title")
+        .option("--desc <description>", "dataset description")
+        .option("--publish", "create as published instead of draft")
+        .option(
+            "--aspect <id=json...>",
+            "attach custom aspect data (repeatable; value may be inline JSON, @file, or -)",
+            collect,
+            []
+        )
+        .option("--json", "output the created record as JSON")
+        .action(async (opts) => {
+            const client = await clientFromProfile();
+            const owner = await fetchOwner(client);
+            const extraAspects: Record<string, unknown> = {};
+            for (const arg of opts.aspect as string[]) {
+                const { id, data } = await parseAspectArg(arg);
+                extraAspects[id] = data;
+            }
+            const record = buildDatasetRecord({
+                id: createId("ds"),
+                title: opts.title,
+                description: opts.desc,
+                publish: Boolean(opts.publish),
+                owner,
+                now: new Date(),
+                sourceUrl: deriveSiteUrl(client.opts.baseUrl),
+                extraAspects
+            });
+            try {
+                await client.json("POST", REGISTRY_RECORDS, {
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(record)
+                });
+            } catch (e) {
+                throw withAspectHint(e);
+            }
+            if (opts.json) printData("json", record);
+            else process.stdout.write(record.id + "\n");
+        });
+
+    dataset
+        .command("update <datasetId>")
+        .description(
+            "Update dataset metadata (merges into dcat-dataset-strings; record name is unchanged)"
+        )
+        .option("--title <title>")
+        .option("--desc <description>")
+        .option("--license <license>")
+        .option(
+            "--aspect <id=json...>",
+            "replace an aspect entirely (repeatable)",
+            collect,
+            []
+        )
+        .action(async (datasetId: string, opts) => {
+            const scalarPatch: Record<string, unknown> = {};
+            if (opts.title) scalarPatch.title = opts.title;
+            if (opts.desc) scalarPatch.description = opts.desc;
+            if (opts.license) scalarPatch.defaultLicense = opts.license;
+            if (
+                Object.keys(scalarPatch).length === 0 &&
+                (opts.aspect as string[]).length === 0
+            ) {
+                throw new UsageError(
+                    "Nothing to update: pass --title/--desc/--license or --aspect."
+                );
+            }
+            const client = await clientFromProfile();
+            if (Object.keys(scalarPatch).length > 0) {
+                scalarPatch.modified = new Date().toISOString();
+                await mergeAspect(
+                    client,
+                    datasetId,
+                    "dcat-dataset-strings",
+                    scalarPatch
+                );
+            }
+            for (const arg of opts.aspect as string[]) {
+                const { id, data } = await parseAspectArg(arg);
+                try {
+                    await client.json("PUT", recordAspect(datasetId, id), {
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify(data)
+                    });
+                } catch (e) {
+                    throw withAspectHint(e);
+                }
+            }
+            note(`Dataset ${datasetId} updated.`);
+        });
+
+    const datasetAspect = dataset
+        .command("aspect")
+        .description(
+            "Read or write a record's aspect data (works for any record)"
+        );
+
+    datasetAspect
+        .command("get <recordId> <aspectId>")
+        .action(async (recordId: string, aspectId: string) => {
+            const client = await clientFromProfile();
+            const data = await client.json(
+                "GET",
+                recordAspect(recordId, aspectId)
+            );
+            printData("json", data);
+        });
+
+    datasetAspect
+        .command("set <recordId> <aspectId> <value>")
+        .description("value: inline JSON, @file.json, or - for stdin")
+        .action(async (recordId: string, aspectId: string, value: string) => {
+            const client = await clientFromProfile();
+            const data = await parseAspectValue(value);
+            try {
+                await client.json("PUT", recordAspect(recordId, aspectId), {
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(data)
+                });
+            } catch (e) {
+                throw withAspectHint(e);
+            }
+            note(`Aspect "${aspectId}" set on ${recordId}.`);
+        });
+
+    datasetAspect
+        .command("delete <recordId> <aspectId>")
+        .action(async (recordId: string, aspectId: string) => {
+            const client = await clientFromProfile();
+            await client.json("DELETE", recordAspect(recordId, aspectId));
+            note(`Aspect "${aspectId}" deleted from ${recordId}.`);
+        });
+
+    dataset
+        .command("add-file <datasetId> [localFile]")
+        .description(
+            "Upload a file and attach it to a dataset as a new distribution " +
+                "(or register a link-only distribution with --access-url)"
+        )
+        .option("--access-url <url>", "register a link instead of uploading")
+        .option("--title <title>", "distribution title (default: file name)")
+        .option("--desc <description>", "distribution description")
+        .option(
+            "--format <format>",
+            "data format (default: from file extension)"
+        )
+        .option("--bucket <bucket>", "storage bucket", DATASETS_BUCKET_DEFAULT)
+        .option(
+            "--aspect <id=json...>",
+            "attach custom aspect data to the distribution (repeatable)",
+            collect,
+            []
+        )
+        .option("--json", "output JSON result")
+        .action(
+            async (datasetId: string, localFile: string | undefined, opts) => {
+                if (Boolean(localFile) === Boolean(opts.accessUrl)) {
+                    throw new UsageError(
+                        "Provide exactly one of <localFile> or --access-url."
+                    );
+                }
+                const client = await clientFromProfile();
+                const dataset = await client.json<any>(
+                    "GET",
+                    registryRecord(datasetId),
+                    {
+                        query: [
+                            ["optionalAspect", "publishing"],
+                            ["optionalAspect", "dataset-distributions"]
+                        ]
+                    }
+                );
+                const publishingState: string =
+                    dataset.aspects?.publishing?.state ?? "draft";
+                const owner = await fetchOwner(client);
+                const distId = createId("dist");
+                const now = new Date();
+
+                const extraAspects: Record<string, unknown> = {};
+                for (const arg of opts.aspect as string[]) {
+                    const { id, data } = await parseAspectArg(arg);
+                    extraAspects[id] = data;
+                }
+
+                let downloadURL: string | undefined;
+                let byteSize: number | undefined;
+                let uploadedKey: string | undefined;
+                let fileName: string | undefined;
+
+                if (localFile) {
+                    fileName = path.basename(localFile);
+                    uploadedKey = getValidObjectKey(
+                        datasetId,
+                        distId,
+                        fileName
+                    );
+                    const progress = makeProgress(`upload ${fileName}`);
+                    const uploaded = await uploadFile(client, {
+                        localPath: localFile,
+                        bucket: opts.bucket,
+                        key: uploadedKey,
+                        recordId: datasetId,
+                        onProgress: progress.update
+                    });
+                    progress.done();
+                    byteSize = uploaded.size;
+                    downloadURL = storageDownloadUrl(
+                        datasetId,
+                        distId,
+                        fileName
+                    );
+                }
+
+                const title: string =
+                    opts.title ?? fileName ?? opts.accessUrl ?? distId;
+                const record = buildDistributionRecord({
+                    id: distId,
+                    title,
+                    description: opts.desc,
+                    downloadURL,
+                    accessURL: opts.accessUrl,
+                    format:
+                        opts.format ??
+                        (fileName ? detectFormat(fileName) : undefined),
+                    byteSize,
+                    owner,
+                    publishingState,
+                    now,
+                    internalDataFileUrl: downloadURL,
+                    sourceUrl: deriveSiteUrl(client.opts.baseUrl),
+                    extraAspects
+                });
+
+                let recordCreated = false;
+                try {
+                    await client.json("POST", REGISTRY_RECORDS, {
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify(record)
+                    });
+                    recordCreated = true;
+                    const current: string[] = (
+                        dataset.aspects?.["dataset-distributions"]
+                            ?.distributions ?? []
+                    ).map((d: any) => (typeof d === "string" ? d : d.id));
+                    await mergeAspect(
+                        client,
+                        datasetId,
+                        "dataset-distributions",
+                        {
+                            distributions: [...current, distId]
+                        }
+                    );
+                    await mergeAspect(
+                        client,
+                        datasetId,
+                        "dcat-dataset-strings",
+                        {
+                            modified: now.toISOString()
+                        }
+                    );
+                } catch (e) {
+                    if (recordCreated) {
+                        try {
+                            await client.request(
+                                "DELETE",
+                                registryRecord(distId)
+                            );
+                        } catch {
+                            // best-effort cleanup
+                        }
+                    }
+                    if (uploadedKey) {
+                        try {
+                            await client.request(
+                                "DELETE",
+                                storageObject(opts.bucket, uploadedKey)
+                            );
+                        } catch {
+                            // best-effort cleanup
+                        }
+                    }
+                    const wrapped = withAspectHint(e);
+                    if (wrapped instanceof MgdApiError && uploadedKey) {
+                        const cleanupMsg = recordCreated
+                            ? `The uploaded object and the orphan distribution record were deleted (best effort).`
+                            : `The uploaded object was deleted (best effort). No distribution record was created.`;
+                        const recoveryHint =
+                            `If cleanup failed, remove leftovers with: ` +
+                            `mgd api request DELETE /v0/storage/${opts.bucket}/${uploadedKey} ` +
+                            (recordCreated
+                                ? `and: mgd api request DELETE /v0/registry/records/${distId}`
+                                : ``);
+                        throw new MgdApiError(
+                            `add-file failed after upload: ${wrapped.message}. ` +
+                                cleanupMsg,
+                            wrapped.status,
+                            wrapped.code,
+                            recoveryHint
+                        );
+                    }
+                    throw wrapped;
+                }
+
+                if (opts.json) {
+                    printData("json", {
+                        datasetId,
+                        distributionId: distId,
+                        ...(downloadURL
+                            ? { downloadURL, bytes: byteSize }
+                            : {}),
+                        ...(opts.accessUrl ? { accessURL: opts.accessUrl } : {})
+                    });
+                } else {
+                    process.stdout.write(distId + "\n");
+                    note(
+                        `Attached ${
+                            localFile
+                                ? `file "${fileName}"`
+                                : `link ${opts.accessUrl}`
+                        } to dataset ${datasetId} as distribution ${distId}.`
+                    );
+                }
+            }
+        );
+}

--- a/packages/mgd/src/commands/dist.ts
+++ b/packages/mgd/src/commands/dist.ts
@@ -1,0 +1,354 @@
+import path from "node:path";
+import { Command } from "commander";
+import { clientFromProfile } from "../client.js";
+import {
+    registryRecord,
+    recordAspect,
+    REGISTRY_RECORDS,
+    storageObject
+} from "../endpoints.js";
+import { MgdApiError, UsageError } from "../errors.js";
+import { printData, resolveMode, note } from "../output.js";
+import { resolveDownloadUrl, downloadToFile, uploadFile } from "../transfer.js";
+import { makeProgress } from "../progress.js";
+import { mergeAspect, collect, withAspectHint, fetchOwner } from "./dataset.js";
+import {
+    parseAspectArg,
+    appendVersion,
+    storageDownloadUrl,
+    getValidObjectKey,
+    detectFormat,
+    DATASETS_BUCKET_DEFAULT
+} from "../recordBuilders.js";
+
+export const DIST_OPTIONAL_ASPECTS = [
+    "dcat-distribution-strings",
+    "version",
+    "publishing",
+    "access-control",
+    "source"
+];
+
+export function registerDistCommands(program: Command): void {
+    const dist = program.command("dist").description("Distribution records");
+
+    dist.command("get <distributionId>")
+        .description("Fetch a distribution record")
+        .option("--json", "output JSON")
+        .action(async (distributionId: string, opts) => {
+            const client = await clientFromProfile();
+            const record = await client.json<any>(
+                "GET",
+                registryRecord(distributionId),
+                {
+                    query: DIST_OPTIONAL_ASPECTS.map((a): [string, string] => [
+                        "optionalAspect",
+                        a
+                    ])
+                }
+            );
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                const s = record.aspects?.["dcat-distribution-strings"] ?? {};
+                process.stdout.write(`id:          ${record.id}\n`);
+                process.stdout.write(
+                    `title:       ${s.title ?? record.name}\n`
+                );
+                process.stdout.write(`format:      ${s.format ?? "n/a"}\n`);
+                process.stdout.write(`byteSize:    ${s.byteSize ?? "n/a"}\n`);
+                process.stdout.write(
+                    `downloadURL: ${s.downloadURL ?? s.accessURL ?? "n/a"}\n`
+                );
+                process.stdout.write(`modified:    ${s.modified ?? "n/a"}\n`);
+            } else {
+                printData(mode, record);
+            }
+        });
+
+    dist.command("update <distributionId>")
+        .description(
+            "Update distribution metadata (merges into dcat-distribution-strings)"
+        )
+        .option("--title <title>")
+        .option("--desc <description>")
+        .option("--format <format>")
+        .option("--license <license>")
+        .option(
+            "--aspect <id=json...>",
+            "replace an aspect entirely (repeatable)",
+            collect,
+            []
+        )
+        .action(async (distributionId: string, opts) => {
+            const scalarPatch: Record<string, unknown> = {};
+            if (opts.title) scalarPatch.title = opts.title;
+            if (opts.desc) scalarPatch.description = opts.desc;
+            if (opts.format) scalarPatch.format = opts.format;
+            if (opts.license) scalarPatch.license = opts.license;
+            if (
+                Object.keys(scalarPatch).length === 0 &&
+                (opts.aspect as string[]).length === 0
+            ) {
+                throw new UsageError(
+                    "Nothing to update: pass --title/--desc/--format/--license or --aspect."
+                );
+            }
+            const client = await clientFromProfile();
+            if (Object.keys(scalarPatch).length > 0) {
+                scalarPatch.modified = new Date().toISOString();
+                await mergeAspect(
+                    client,
+                    distributionId,
+                    "dcat-distribution-strings",
+                    scalarPatch
+                );
+            }
+            for (const arg of opts.aspect as string[]) {
+                const { id, data } = await parseAspectArg(arg);
+                try {
+                    await client.json("PUT", recordAspect(distributionId, id), {
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify(data)
+                    });
+                } catch (e) {
+                    throw withAspectHint(e);
+                }
+            }
+            note(`Distribution ${distributionId} updated.`);
+        });
+
+    dist.command("replace-file <distributionId> <localFile>")
+        .description(
+            "Replace a distribution's data file (bumps the version aspect)"
+        )
+        .option(
+            "--title <title>",
+            "new distribution title (default: file name)"
+        )
+        .option("--bucket <bucket>", "storage bucket", DATASETS_BUCKET_DEFAULT)
+        .option("--keep-old", "never delete the superseded storage object")
+        .option("--json", "output JSON result")
+        .action(async (distributionId: string, localFile: string, opts) => {
+            const client = await clientFromProfile();
+            const dist = await client.json<any>(
+                "GET",
+                registryRecord(distributionId),
+                {
+                    query: [
+                        ["optionalAspect", "dcat-distribution-strings"],
+                        ["optionalAspect", "version"]
+                    ]
+                }
+            );
+            const oldStrings =
+                dist.aspects?.["dcat-distribution-strings"] ?? {};
+            const oldVersionAspect = dist.aspects?.version;
+            const oldDownloadURL: string | undefined = oldStrings.downloadURL;
+
+            const parents = await client.json<any>("GET", REGISTRY_RECORDS, {
+                query: [
+                    ["aspect", "dataset-distributions"],
+                    [
+                        "aspectQuery",
+                        `dataset-distributions.distributions:<|${distributionId}`
+                    ],
+                    ["limit", "1"]
+                ]
+            });
+            const datasetId: string | undefined = parents?.records?.[0]?.id;
+            if (!datasetId) {
+                throw new MgdApiError(
+                    `Could not find the parent dataset of ${distributionId}.`,
+                    404,
+                    "parent-dataset-not-found",
+                    "If the distribution is unlinked, manage it via `mgd api request`."
+                );
+            }
+
+            const owner = await fetchOwner(client);
+            const now = new Date();
+            const fileName = path.basename(localFile);
+            const newKey = getValidObjectKey(
+                datasetId,
+                distributionId,
+                fileName
+            );
+            const newDownloadURL = storageDownloadUrl(
+                datasetId,
+                distributionId,
+                fileName
+            );
+
+            const progress = makeProgress(`upload ${fileName}`);
+            const uploaded = await uploadFile(client, {
+                localPath: localFile,
+                bucket: opts.bucket,
+                key: newKey,
+                recordId: datasetId,
+                onProgress: progress.update
+            });
+            progress.done();
+
+            const title = opts.title ?? fileName;
+            const newVersionAspect = appendVersion(oldVersionAspect, {
+                title,
+                creatorId: owner?.id,
+                now,
+                internalDataFileUrl: newDownloadURL,
+                description: "Replaced superseded by a new distribution"
+            });
+
+            const detectedFormat = detectFormat(fileName);
+            try {
+                await mergeAspect(
+                    client,
+                    distributionId,
+                    "dcat-distribution-strings",
+                    {
+                        title,
+                        downloadURL: newDownloadURL,
+                        byteSize: uploaded.size,
+                        modified: now.toISOString(),
+                        useStorageApi: true,
+                        ...(detectedFormat ? { format: detectedFormat } : {})
+                    }
+                );
+                try {
+                    await client.json(
+                        "PUT",
+                        recordAspect(distributionId, "version"),
+                        {
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify(newVersionAspect)
+                        }
+                    );
+                } catch (e) {
+                    throw withAspectHint(e);
+                }
+            } catch (e) {
+                try {
+                    await client.request(
+                        "DELETE",
+                        storageObject(opts.bucket, newKey)
+                    );
+                } catch {
+                    // best-effort cleanup
+                }
+                if (e instanceof MgdApiError) {
+                    throw new MgdApiError(
+                        `replace-file failed after upload: ${e.message}. ` +
+                            `The new object was deleted (best effort); the distribution record is unchanged.`,
+                        e.status,
+                        e.code,
+                        e.hint
+                    );
+                }
+                throw e;
+            }
+
+            let oldFileDeleted = false;
+            if (
+                !opts.keepOld &&
+                oldDownloadURL?.startsWith("magda://storage-api/") &&
+                oldDownloadURL !== newDownloadURL &&
+                !newVersionAspect.versions.some(
+                    (v: any) => v.internalDataFileUrl === oldDownloadURL
+                )
+            ) {
+                const resolved = resolveDownloadUrl(oldDownloadURL);
+                if (resolved.kind === "storage") {
+                    try {
+                        await client.request("DELETE", resolved.path);
+                        oldFileDeleted = true;
+                    } catch {
+                        note(
+                            `Warning: could not delete superseded object ${oldDownloadURL}.`
+                        );
+                    }
+                }
+            }
+
+            if (opts.json) {
+                printData("json", {
+                    distributionId,
+                    datasetId,
+                    downloadURL: newDownloadURL,
+                    versionNumber: newVersionAspect.currentVersionNumber,
+                    oldFileDeleted
+                });
+            } else {
+                note(
+                    `Replaced file of ${distributionId} (version ${newVersionAspect.currentVersionNumber}, ${uploaded.size} bytes).` +
+                        (oldFileDeleted ? " Superseded object deleted." : "")
+                );
+            }
+        });
+
+    dist.command("download <distributionId>")
+        .description("Download a distribution's data file")
+        .option("-o, --output <path>", "output file path, - for stdout")
+        .option("--resume", "resume an interrupted download")
+        .action(async (distributionId: string, opts) => {
+            const client = await clientFromProfile();
+            const aspect = await client.json<any>(
+                "GET",
+                recordAspect(distributionId, "dcat-distribution-strings")
+            );
+            const url: string | undefined =
+                aspect.downloadURL || aspect.accessURL;
+            if (!url) {
+                throw new MgdApiError(
+                    `Distribution ${distributionId} has no downloadURL or accessURL.`,
+                    404,
+                    "no-download-url"
+                );
+            }
+            const resolved = resolveDownloadUrl(url);
+            const fetcher =
+                resolved.kind === "storage"
+                    ? (rangeStart?: number) =>
+                          client.request("GET", resolved.path, {
+                              headers:
+                                  rangeStart !== undefined
+                                      ? { Range: `bytes=${rangeStart}-` }
+                                      : undefined
+                          })
+                    : async (rangeStart?: number) => {
+                          const res = await fetch(resolved.url, {
+                              headers:
+                                  rangeStart !== undefined
+                                      ? { Range: `bytes=${rangeStart}-` }
+                                      : undefined
+                          });
+                          if (!res.ok && res.status !== 206) {
+                              throw new MgdApiError(
+                                  `Download failed: ${res.status} ${res.statusText}`,
+                                  res.status,
+                                  "download-failed"
+                              );
+                          }
+                          return res;
+                      };
+            const defaultName = decodeURIComponent(
+                (resolved.kind === "storage"
+                    ? resolved.path
+                    : new URL(resolved.url).pathname
+                )
+                    .split("/")
+                    .filter(Boolean)
+                    .pop() || "download"
+            );
+            const output = opts.output ?? defaultName;
+            const progress = makeProgress(`download ${defaultName}`);
+            const result = await downloadToFile(fetcher, output, {
+                resume: Boolean(opts.resume),
+                onProgress: progress.update
+            });
+            progress.done();
+            note(
+                `Downloaded ${result.bytes} bytes to ${
+                    output === "-" ? "stdout" : output
+                }`
+            );
+        });
+}

--- a/packages/mgd/src/commands/file.ts
+++ b/packages/mgd/src/commands/file.ts
@@ -1,0 +1,88 @@
+import path from "node:path";
+import { Command } from "commander";
+import { clientFromProfile } from "../client.js";
+import { storageObject } from "../endpoints.js";
+import { UsageError } from "../errors.js";
+import { downloadToFile, uploadFile } from "../transfer.js";
+import { note, printData } from "../output.js";
+import { makeProgress } from "../progress.js";
+
+export function parseBucketKey(arg: string): { bucket: string; key: string } {
+    const idx = arg.indexOf("/");
+    if (idx < 1 || idx === arg.length - 1) {
+        throw new UsageError(
+            `Expected <bucket>/<key...> (got: ${arg}). Example: magda-datasets/ds-1/dist-1/data.csv`
+        );
+    }
+    return { bucket: arg.slice(0, idx), key: arg.slice(idx + 1) };
+}
+
+export function registerFileCommands(program: Command): void {
+    const file = program.command("file").description("Storage objects");
+
+    file.command("download <bucketAndKey>")
+        .description("Download a storage object")
+        .option("-o, --output <path>", "output file path, - for stdout")
+        .option("--resume", "resume an interrupted download")
+        .action(async (bucketAndKey: string, opts) => {
+            const { bucket, key } = parseBucketKey(bucketAndKey);
+            const client = await clientFromProfile();
+            const output =
+                opts.output ?? path.basename(decodeURIComponent(key));
+            const progress = makeProgress(`download ${key}`);
+            const result = await downloadToFile(
+                (rangeStart) =>
+                    client.request("GET", storageObject(bucket, key), {
+                        headers:
+                            rangeStart !== undefined
+                                ? { Range: `bytes=${rangeStart}-` }
+                                : undefined
+                    }),
+                output,
+                { resume: Boolean(opts.resume), onProgress: progress.update }
+            );
+            progress.done();
+            note(
+                `Downloaded ${result.bytes} bytes to ${
+                    output === "-" ? "stdout" : output
+                }` +
+                    (result.resumedFrom
+                        ? ` (resumed from byte ${result.resumedFrom})`
+                        : "")
+            );
+        });
+
+    file.command("upload <localFile>")
+        .description("Upload a file to storage (multipart for large files)")
+        .requiredOption("--bucket <bucket>", "target bucket")
+        .option("--key <key>", "object key (defaults to the file name)")
+        .option("--record-id <id>", "record to associate for authorization")
+        .option("--content-type <ct>", "content type")
+        .option("--part-size <bytes>", "override multipart part size")
+        .option("--single-shot", "force legacy single-request upload")
+        .option("--json", "output JSON result")
+        .action(async (localFile: string, opts) => {
+            const client = await clientFromProfile();
+            const key = opts.key ?? path.basename(localFile);
+            const progress = makeProgress(`upload ${key}`);
+            const result = await uploadFile(client, {
+                localPath: localFile,
+                bucket: opts.bucket,
+                key,
+                recordId: opts.recordId,
+                contentType: opts.contentType,
+                partSize: opts.partSize ? Number(opts.partSize) : undefined,
+                singleShot: Boolean(opts.singleShot),
+                onProgress: progress.update
+            });
+            progress.done();
+            if (opts.json) {
+                printData("json", result);
+            } else {
+                note(
+                    `Uploaded ${result.size} bytes to ${result.bucket}/${result.key}` +
+                        (result.multipart ? " (multipart)" : "")
+                );
+            }
+        });
+}

--- a/packages/mgd/src/commands/profileCmd.ts
+++ b/packages/mgd/src/commands/profileCmd.ts
@@ -1,0 +1,46 @@
+import { Command } from "commander";
+import { UsageError } from "../errors.js";
+import { loadConfig, saveConfig } from "../profile.js";
+import { note, printData, resolveMode } from "../output.js";
+
+export function registerProfileCommands(program: Command): void {
+    const profile = program.command("profile").description("Manage profiles");
+
+    profile
+        .command("list")
+        .description("List profiles")
+        .option("--json", "output JSON")
+        .action(async (opts) => {
+            const cfg = await loadConfig();
+            const rows = Object.entries(cfg.profiles).map(([name, p]) => ({
+                name,
+                baseUrl: p.baseUrl,
+                hasCredentials: Boolean(p.apiKeyId),
+                active: name === (cfg.activeProfile || "default")
+            }));
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                for (const r of rows) {
+                    process.stdout.write(
+                        `${r.active ? "*" : " "} ${r.name}\t${r.baseUrl}\t${
+                            r.hasCredentials ? "api-key" : "anonymous"
+                        }\n`
+                    );
+                }
+            } else {
+                printData(mode, rows);
+            }
+        });
+
+    profile
+        .command("use <name>")
+        .description("Set the active profile")
+        .action(async (name: string) => {
+            const cfg = await loadConfig();
+            if (!cfg.profiles[name])
+                throw new UsageError(`No such profile: ${name}`);
+            cfg.activeProfile = name;
+            await saveConfig(cfg);
+            note(`Active profile set to "${name}".`);
+        });
+}

--- a/packages/mgd/src/commands/search.ts
+++ b/packages/mgd/src/commands/search.ts
@@ -1,0 +1,92 @@
+import { Command } from "commander";
+import { clientFromProfile } from "../client.js";
+import { SEARCH_DATASETS, SEMANTIC_SEARCH } from "../endpoints.js";
+import { MgdApiError } from "../errors.js";
+import { note, printData, resolveMode } from "../output.js";
+
+// The semantic search API is absent (404) on sites without the feature, but a
+// deployed-yet-unindexed site instead 500s with an OpenSearch "no such index
+// [semantic-index-v1]" message until a semantic indexer runs. Treat both as
+// "unavailable" so agents get the documented structured error either way.
+function isSemanticUnavailable(e: MgdApiError): boolean {
+    if (e.status === 404) return true;
+    return (
+        e.status >= 500 &&
+        /no such index|index not found|semantic-index/i.test(e.message)
+    );
+}
+
+export function registerSearchCommands(program: Command): void {
+    const search = program.command("search").description("Search the catalog");
+
+    search
+        .command("datasets <query>")
+        .description("Keyword dataset search")
+        .option("--limit <n>", "max results", "10")
+        .option("--offset <n>", "result offset", "0")
+        .option("--json", "output full response as JSON")
+        .option("--jsonl", "output one dataset per line")
+        .action(async (query: string, opts) => {
+            const client = await clientFromProfile();
+            const result = await client.json<any>("GET", SEARCH_DATASETS, {
+                query: {
+                    query,
+                    start: Number(opts.offset),
+                    limit: Number(opts.limit)
+                }
+            });
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                for (const ds of result.dataSets ?? []) {
+                    process.stdout.write(`${ds.identifier}\t${ds.title}\n`);
+                }
+                note(
+                    `${result.dataSets?.length ?? 0} of ${
+                        result.hitCount
+                    } results`
+                );
+            } else {
+                printData(mode, result, result.dataSets ?? []);
+            }
+        });
+
+    search
+        .command("semantic <query>")
+        .description("Semantic (embedding) dataset/content search")
+        .option("--limit <n>", "max results", "10")
+        .option("--json", "output full response as JSON")
+        .option("--jsonl", "output one result per line")
+        .action(async (query: string, opts) => {
+            const client = await clientFromProfile();
+            let results: any[];
+            try {
+                results = await client.json<any[]>("GET", SEMANTIC_SEARCH, {
+                    query: { query, max_num_results: Number(opts.limit) }
+                });
+            } catch (e) {
+                if (e instanceof MgdApiError && isSemanticUnavailable(e)) {
+                    throw new MgdApiError(
+                        "Semantic search is not available on this MAGDA site.",
+                        501,
+                        "semantic-search-unavailable",
+                        "Use `mgd search datasets` instead."
+                    );
+                }
+                throw e;
+            }
+            const mode = resolveMode(opts);
+            if (mode === "human") {
+                for (const r of results) {
+                    const text = String(r.text ?? "").replace(/\s+/g, " ");
+                    process.stdout.write(
+                        `${r.recordId}\t${
+                            r.score?.toFixed?.(3) ?? r.score
+                        }\t${text.slice(0, 80)}\n`
+                    );
+                }
+                note(`${results.length} results`);
+            } else {
+                printData(mode, results);
+            }
+        });
+}

--- a/packages/mgd/src/commands/skills.ts
+++ b/packages/mgd/src/commands/skills.ts
@@ -1,0 +1,104 @@
+import { Command } from "commander";
+import {
+    installSkill,
+    uninstallSkill,
+    packageSkillsDir,
+    parseAgents,
+    AGENT_NAMES,
+    InstallResult,
+    Scope
+} from "../skills.js";
+import { note, printData, resolveMode } from "../output.js";
+
+// --project absent => global; --project (bare) => cwd; --project <dir> => <dir>.
+function scopeAndDir(opts: {
+    project?: string | boolean;
+}): {
+    scope: Scope;
+    projectDir: string;
+} {
+    if (opts.project === undefined) {
+        return { scope: "global", projectDir: process.cwd() };
+    }
+    const projectDir =
+        typeof opts.project === "string" ? opts.project : process.cwd();
+    return { scope: "project", projectDir };
+}
+
+function reportHuman(results: InstallResult[], verb: string): void {
+    for (const r of results) {
+        note(`${verb} ${r.agent} (${r.scope}): ${r.action} ${r.dir}`);
+    }
+}
+
+export function registerSkillsCommands(program: Command): void {
+    const skills = program
+        .command("skills")
+        .description("Manage the mgd coding-agent skill");
+
+    skills
+        .command("install")
+        .description(
+            "Install the mgd skill for coding agents (all agents, global, by default)"
+        )
+        .option(
+            "--agent <name>",
+            `coding agent: ${AGENT_NAMES.join(" | ")} (default: all)`
+        )
+        .option(
+            "--project [dir]",
+            "install into a project directory instead of globally"
+        )
+        .option("--json", "output JSON")
+        .action(async (opts) => {
+            const agents = parseAgents(opts.agent);
+            const { scope, projectDir } = scopeAndDir(opts);
+            const skillsDir = packageSkillsDir();
+            const results: InstallResult[] = [];
+            for (const agent of agents) {
+                results.push(
+                    await installSkill({
+                        agent,
+                        scope,
+                        projectDir,
+                        skillsDir,
+                        env: process.env
+                    })
+                );
+            }
+            const mode = resolveMode(opts);
+            if (mode === "human") reportHuman(results, "installed");
+            else printData(mode, results);
+        });
+
+    skills
+        .command("uninstall")
+        .description("Remove the mgd skill for coding agents")
+        .option(
+            "--agent <name>",
+            `coding agent: ${AGENT_NAMES.join(" | ")} (default: all)`
+        )
+        .option(
+            "--project [dir]",
+            "uninstall from a project directory instead of globally"
+        )
+        .option("--json", "output JSON")
+        .action(async (opts) => {
+            const agents = parseAgents(opts.agent);
+            const { scope, projectDir } = scopeAndDir(opts);
+            const results: InstallResult[] = [];
+            for (const agent of agents) {
+                results.push(
+                    await uninstallSkill({
+                        agent,
+                        scope,
+                        projectDir,
+                        env: process.env
+                    })
+                );
+            }
+            const mode = resolveMode(opts);
+            if (mode === "human") reportHuman(results, "uninstalled");
+            else printData(mode, results);
+        });
+}

--- a/packages/mgd/src/endpoints.ts
+++ b/packages/mgd/src/endpoints.ts
@@ -1,0 +1,39 @@
+export function encodeKey(key: string): string {
+    return key
+        .split("/")
+        .map((seg) => encodeURIComponent(seg))
+        .join("/");
+}
+
+export const WHOAMI = "/v0/auth/users/whoami";
+export const SEARCH_DATASETS = "/v0/search/datasets";
+export const SEMANTIC_SEARCH = "/v0/semantic-search/search";
+export const REGISTRY_RECORDS = "/v0/registry/records";
+export const REGISTRY_ASPECTS = "/v0/registry/aspects";
+
+export const registryRecord = (id: string) =>
+    `${REGISTRY_RECORDS}/${encodeURIComponent(id)}`;
+
+export const recordAspect = (recordId: string, aspectId: string) =>
+    `${registryRecord(recordId)}/aspects/${encodeURIComponent(aspectId)}`;
+
+export const registryAspect = (id: string) =>
+    `${REGISTRY_ASPECTS}/${encodeURIComponent(id)}`;
+
+export const storageObject = (bucket: string, key: string) =>
+    `/v0/storage/${encodeURIComponent(bucket)}/${encodeKey(key)}`;
+
+export const storageUpload = (bucket: string, keyPrefix: string) =>
+    `/v0/storage/upload/${encodeURIComponent(bucket)}` +
+    (keyPrefix ? `/${encodeKey(keyPrefix)}` : "");
+
+const multipart = (op: string) => (bucket: string, key: string) =>
+    `/v0/storage/multipart/${op}/${encodeURIComponent(bucket)}/${encodeKey(
+        key
+    )}`;
+
+export const multipartInitiate = multipart("initiate");
+export const multipartPart = multipart("part");
+export const multipartParts = multipart("parts");
+export const multipartComplete = multipart("complete");
+export const multipartAbort = multipart("abort");

--- a/packages/mgd/src/errors.ts
+++ b/packages/mgd/src/errors.ts
@@ -1,0 +1,27 @@
+export class MgdApiError extends Error {
+    constructor(
+        message: string,
+        readonly status: number,
+        readonly code: string,
+        readonly hint?: string
+    ) {
+        super(message);
+        this.name = "MgdApiError";
+    }
+}
+
+export class UsageError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UsageError";
+    }
+}
+
+export function exitCodeFor(e: unknown): number {
+    if (e instanceof UsageError) return 2;
+    if (e instanceof MgdApiError) {
+        if (e.status === 401 || e.status === 403) return 3;
+        if (e.status === 404) return 4;
+    }
+    return 1;
+}

--- a/packages/mgd/src/index.ts
+++ b/packages/mgd/src/index.ts
@@ -10,6 +10,7 @@ import { registerDistCommands } from "./commands/dist.js";
 import { registerApiCommands } from "./commands/api.js";
 import { registerFileCommands } from "./commands/file.js";
 import { registerAspectCommands } from "./commands/aspect.js";
+import { registerSkillsCommands } from "./commands/skills.js";
 
 const program = new Command();
 
@@ -26,6 +27,7 @@ registerDistCommands(program);
 registerApiCommands(program);
 registerFileCommands(program);
 registerAspectCommands(program);
+registerSkillsCommands(program);
 
 try {
     await program.parseAsync(process.argv);

--- a/packages/mgd/src/index.ts
+++ b/packages/mgd/src/index.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import { VERSION } from "./version.js";
+import { printError, resolveModeFromArgv } from "./output.js";
+import { exitCodeFor } from "./errors.js";
+import { registerAuthCommands } from "./commands/auth.js";
+import { registerProfileCommands } from "./commands/profileCmd.js";
+import { registerSearchCommands } from "./commands/search.js";
+import { registerDatasetCommands } from "./commands/dataset.js";
+import { registerDistCommands } from "./commands/dist.js";
+import { registerApiCommands } from "./commands/api.js";
+import { registerFileCommands } from "./commands/file.js";
+import { registerAspectCommands } from "./commands/aspect.js";
+
+const program = new Command();
+
+program
+    .name("mgd")
+    .description("MAGDA local command-line interface")
+    .version(VERSION);
+
+registerAuthCommands(program);
+registerProfileCommands(program);
+registerSearchCommands(program);
+registerDatasetCommands(program);
+registerDistCommands(program);
+registerApiCommands(program);
+registerFileCommands(program);
+registerAspectCommands(program);
+
+try {
+    await program.parseAsync(process.argv);
+} catch (e) {
+    printError(e, resolveModeFromArgv(process.argv));
+    process.exit(exitCodeFor(e));
+}

--- a/packages/mgd/src/output.ts
+++ b/packages/mgd/src/output.ts
@@ -1,0 +1,79 @@
+import { MgdApiError } from "./errors.js";
+
+export type OutputMode = "human" | "json" | "jsonl";
+
+export function resolveMode(opts: {
+    json?: boolean;
+    jsonl?: boolean;
+}): OutputMode {
+    if (opts?.jsonl) return "jsonl";
+    if (opts?.json) return "json";
+    return "human";
+}
+
+// The --json/--jsonl flags live on subcommands, so the top-level error
+// handler cannot read them from the root program's opts. Derive the mode
+// straight from argv so errors honor the same output contract as data.
+export function resolveModeFromArgv(argv: readonly string[]): OutputMode {
+    if (argv.includes("--jsonl")) return "jsonl";
+    if (argv.includes("--json")) return "json";
+    return "human";
+}
+
+export function printData(
+    mode: OutputMode,
+    data: unknown,
+    items?: unknown[]
+): void {
+    if (mode === "json") {
+        process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+    } else if (mode === "jsonl") {
+        const list = items ?? (Array.isArray(data) ? data : [data]);
+        for (const item of list) {
+            process.stdout.write(JSON.stringify(item) + "\n");
+        }
+    }
+    // human mode: commands print their own layout
+}
+
+export function printError(e: unknown, mode: OutputMode): void {
+    if (mode === "json" || mode === "jsonl") {
+        const error =
+            e instanceof MgdApiError
+                ? {
+                      code: e.code,
+                      message: e.message,
+                      status: e.status,
+                      ...(e.hint ? { hint: e.hint } : {})
+                  }
+                : {
+                      code: "error",
+                      message: e instanceof Error ? e.message : String(e)
+                  };
+        process.stderr.write(JSON.stringify({ error }) + "\n");
+    } else {
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(colors.red(`Error: ${msg}`) + "\n");
+        if (e instanceof MgdApiError && e.hint) {
+            process.stderr.write(colors.dim(`Hint: ${e.hint}`) + "\n");
+        }
+    }
+}
+
+export function note(msg: string): void {
+    process.stderr.write(msg + "\n");
+}
+
+const useColor = !process.env.NO_COLOR && process.stderr.isTTY;
+
+function wrap(open: number, close: number) {
+    return (s: string) => (useColor ? `[${open}m${s}[${close}m` : s);
+}
+
+export const colors = {
+    bold: wrap(1, 22),
+    dim: wrap(2, 22),
+    red: wrap(31, 39),
+    green: wrap(32, 39),
+    yellow: wrap(33, 39)
+};

--- a/packages/mgd/src/profile.ts
+++ b/packages/mgd/src/profile.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface Profile {
+    baseUrl: string;
+    apiKeyId?: string;
+    apiKey?: string;
+}
+
+export interface ConfigFile {
+    activeProfile?: string;
+    profiles: Record<string, Profile>;
+}
+
+export function configPath(env: NodeJS.ProcessEnv = process.env): string {
+    const base =
+        env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.trim() !== ""
+            ? env.XDG_CONFIG_HOME
+            : path.join(os.homedir(), ".config");
+    return path.join(base, "mgd", "config.json");
+}
+
+export async function loadConfig(
+    env: NodeJS.ProcessEnv = process.env
+): Promise<ConfigFile> {
+    try {
+        const raw = await fs.readFile(configPath(env), "utf8");
+        const parsed = JSON.parse(raw);
+        return { profiles: {}, ...parsed };
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException)?.code === "ENOENT")
+            return { profiles: {} };
+        throw e;
+    }
+}
+
+export async function saveConfig(
+    cfg: ConfigFile,
+    env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+    const file = configPath(env);
+    await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    await fs.writeFile(file, JSON.stringify(cfg, null, 2) + "\n", {
+        mode: 0o600
+    });
+    // mkdir/writeFile modes don't apply if dir/file pre-existed — enforce:
+    await fs.chmod(path.dirname(file), 0o700);
+    await fs.chmod(file, 0o600);
+}
+
+export function resolveProfile(
+    cfg: ConfigFile,
+    env: NodeJS.ProcessEnv = process.env
+): { name: string; profile?: Profile } {
+    const name = env.MGD_PROFILE || cfg.activeProfile || "default";
+    const fromFile = cfg.profiles[name];
+    const overridden: Profile | undefined =
+        env.MGD_BASE_URL || fromFile
+            ? {
+                  baseUrl: env.MGD_BASE_URL || fromFile?.baseUrl || "",
+                  apiKeyId: env.MGD_API_KEY_ID || fromFile?.apiKeyId,
+                  apiKey: env.MGD_API_KEY || fromFile?.apiKey
+              }
+            : undefined;
+    if (overridden && !overridden.apiKeyId) delete overridden.apiKeyId;
+    if (overridden && !overridden.apiKey) delete overridden.apiKey;
+    return {
+        name: env.MGD_BASE_URL && !fromFile ? "env" : name,
+        profile: overridden
+    };
+}

--- a/packages/mgd/src/progress.ts
+++ b/packages/mgd/src/progress.ts
@@ -1,0 +1,32 @@
+export interface Progress {
+    update: (done: number, total?: number) => void;
+    done: () => void;
+}
+
+export function makeProgress(label: string): Progress {
+    if (!process.stderr.isTTY || process.env.NO_COLOR) {
+        return { update: () => {}, done: () => {} };
+    }
+    let lastRender = 0;
+    return {
+        update(done, total) {
+            const now = Date.now();
+            if (now - lastRender < 100) return;
+            lastRender = now;
+            const totalStr = total ? `/${formatBytes(total)}` : "";
+            process.stderr.write(
+                `\r${label}: ${formatBytes(done)}${totalStr}   `
+            );
+        },
+        done() {
+            process.stderr.write("\r\x1b[2K");
+        }
+    };
+}
+
+export function formatBytes(n: number): string {
+    if (n < 1024) return `${n}B`;
+    if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)}MB`;
+    return `${(n / 1024 ** 3).toFixed(2)}GB`;
+}

--- a/packages/mgd/src/prompt.ts
+++ b/packages/mgd/src/prompt.ts
@@ -1,0 +1,50 @@
+import readline from "node:readline/promises";
+
+export async function promptText(question: string): Promise<string> {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stderr
+    });
+    try {
+        return (await rl.question(question)).trim();
+    } finally {
+        rl.close();
+    }
+}
+
+export async function promptHidden(question: string): Promise<string> {
+    if (!process.stdin.isTTY) {
+        process.stderr.write(
+            "Warning: stdin is not a TTY; input will be visible.\n"
+        );
+        return promptText(question);
+    }
+    process.stderr.write(question);
+    return new Promise((resolve, reject) => {
+        const chars: string[] = [];
+        const stdin = process.stdin;
+        stdin.setRawMode(true);
+        stdin.resume();
+        const onData = (buf: Buffer) => {
+            const c = buf.toString("utf8");
+            if (c === "\r" || c === "\n" || c === "") {
+                stdin.setRawMode(false);
+                stdin.pause();
+                stdin.off("data", onData);
+                process.stderr.write("\n");
+                resolve(chars.join("").trim());
+            } else if (c === "") {
+                stdin.setRawMode(false);
+                stdin.pause();
+                stdin.off("data", onData);
+                process.stderr.write("\n");
+                reject(new Error("Input cancelled."));
+            } else if (c === "" || c === "\b") {
+                chars.pop();
+            } else {
+                chars.push(c);
+            }
+        };
+        stdin.on("data", onData);
+    });
+}

--- a/packages/mgd/src/recordBuilders.ts
+++ b/packages/mgd/src/recordBuilders.ts
@@ -1,0 +1,331 @@
+import fs from "node:fs/promises";
+import { randomUUID, createHash } from "node:crypto";
+import { UsageError } from "./errors.js";
+
+export const DATASETS_BUCKET_DEFAULT = "magda-datasets";
+
+export function createId(type: "ds" | "dist"): string {
+    return `magda-${type}-${randomUUID()}`;
+}
+
+// max allowed S3/MinIO object key length
+const MAX_KEY_LENGTH = 1024;
+
+/**
+ * Strip characters that are invalid in S3 object key segments.
+ * Mirrors the algorithm in magda-typescript-common/src/getStorageUrl.ts.
+ */
+export function removeInvalidChars(input: string): string {
+    if (!input || typeof input !== "string") {
+        return "";
+    }
+    return input.replace(/[^a-zA-Z0-9\-_.]/g, "").replace(/\.+$/, "");
+}
+
+/**
+ * Build a sanitized S3-safe object key in the `datasetId/distId/fileName`
+ * pattern.  Faithfully ports getValidS3ObjectKey from magda-typescript-common
+ * using Node built-ins only (no workspace imports).
+ */
+export function getValidObjectKey(
+    datasetId: string,
+    distId: string,
+    fileName: string
+): string {
+    let processedDatasetId = removeInvalidChars(datasetId);
+    let processedDistId = removeInvalidChars(distId);
+    let processedFileName = removeInvalidChars(fileName);
+
+    if (!processedDatasetId.length) {
+        throw new UsageError(
+            "Failed to create object key: DatasetId after processing is an empty string."
+        );
+    }
+    if (!processedDistId.length) {
+        throw new UsageError(
+            "Failed to create object key: DistId after processing is an empty string."
+        );
+    }
+    if (!processedFileName.length) {
+        processedFileName = `untitled_file_${randomUUID()}.dat`;
+    }
+
+    if (processedDatasetId.length > 72) {
+        processedDatasetId = createHash("md5").update(datasetId).digest("hex");
+    }
+    if (processedDistId.length > 72) {
+        processedDistId = createHash("md5").update(distId).digest("hex");
+    }
+
+    const totalLength =
+        processedDatasetId.length +
+        processedDistId.length +
+        processedFileName.length +
+        2;
+
+    if (totalLength < MAX_KEY_LENGTH) {
+        return `${processedDatasetId}/${processedDistId}/${processedFileName}`;
+    }
+
+    // Key is too long — shorten the fileName part.
+    const extNameIdx = processedFileName.lastIndexOf(".");
+    if (extNameIdx === -1) {
+        return `${processedDatasetId}/${processedDistId}/${processedFileName}`.substring(
+            0,
+            MAX_KEY_LENGTH
+        );
+    }
+
+    const extNameLength = processedFileName.length - extNameIdx;
+    const extNameLengthDiff = extNameLength - 32;
+    if (extNameLengthDiff > 0) {
+        processedFileName = processedFileName.substring(
+            0,
+            processedFileName.length - extNameLengthDiff
+        );
+        const newTotal =
+            processedDatasetId.length +
+            processedDistId.length +
+            processedFileName.length +
+            2;
+        if (newTotal < MAX_KEY_LENGTH) {
+            return `${processedDatasetId}/${processedDistId}/${processedFileName}`;
+        }
+    }
+
+    const newExtNameIdx = processedFileName.lastIndexOf(".");
+    const newExtName = processedFileName.substring(newExtNameIdx);
+    const newFileNameNoExtName = processedFileName.substring(0, newExtNameIdx);
+    const excessLength =
+        processedDatasetId.length +
+        processedDistId.length +
+        processedFileName.length +
+        2 -
+        MAX_KEY_LENGTH;
+    return `${processedDatasetId}/${processedDistId}/${newFileNameNoExtName.substring(
+        0,
+        newFileNameNoExtName.length - excessLength
+    )}${newExtName}`;
+}
+
+export function storageDownloadUrl(
+    datasetId: string,
+    distId: string,
+    fileName: string
+): string {
+    const key = getValidObjectKey(datasetId, distId, fileName);
+    const parts = key.split("/");
+    return "magda://storage-api/" + parts.map(encodeURIComponent).join("/");
+}
+
+export function detectFormat(fileName: string): string | undefined {
+    const m = /\.([A-Za-z0-9]+)$/.exec(fileName);
+    return m ? m[1].toUpperCase() : undefined;
+}
+
+export async function parseAspectValue(v: string): Promise<unknown> {
+    let raw: string;
+    if (v === "-") {
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+        raw = Buffer.concat(chunks).toString("utf8");
+    } else if (v.startsWith("@")) {
+        raw = await fs.readFile(v.slice(1), "utf8");
+    } else {
+        raw = v;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch {
+        throw new UsageError(
+            `Invalid JSON for aspect value: ${v.slice(0, 80)}`
+        );
+    }
+}
+
+export async function parseAspectArg(
+    v: string
+): Promise<{ id: string; data: unknown }> {
+    const idx = v.indexOf("=");
+    if (idx < 1) {
+        throw new UsageError(
+            `--aspect must be <id>=<json|@file|-> (got: ${v})`
+        );
+    }
+    return {
+        id: v.slice(0, idx),
+        data: await parseAspectValue(v.slice(idx + 1))
+    };
+}
+
+// Match the web client's internal source aspect (id "magda") so datasets
+// created by the CLI are picked up by the web dataset-editing UI, but keep a
+// distinct `name` so their provenance as CLI-created records stays clear. See
+// getInternalDatasetSourceAspectData in the web client's DatasetAddCommon.ts.
+function sourceAspect(siteUrl?: string) {
+    return {
+        id: "magda",
+        name: "Magda CLI (mgd)",
+        type: "internal",
+        ...(siteUrl ? { url: siteUrl } : {})
+    };
+}
+
+// Derive the site's external URL (as the web client stores in source.url) from
+// the profile's API base URL, e.g. "https://x.magda.io/api" -> "https://x.magda.io/".
+export function deriveSiteUrl(baseUrl: string): string {
+    const trimmed = baseUrl
+        .replace(/\/+$/, "")
+        .replace(/\/(api\/v0|api|v0)$/i, "");
+    return trimmed + "/";
+}
+
+function accessControlAspect(owner?: { id?: string; orgUnitId?: string }) {
+    if (!owner?.id) return {};
+    return {
+        "access-control": {
+            ownerId: owner.id,
+            ...(owner.orgUnitId ? { orgUnitId: owner.orgUnitId } : {}),
+            constraintExemption: false
+        }
+    };
+}
+
+export function buildInitialVersionAspect(args: {
+    title: string;
+    creatorId?: string;
+    now: Date;
+    internalDataFileUrl?: string;
+}) {
+    return {
+        currentVersionNumber: 0,
+        versions: [
+            {
+                versionNumber: 0,
+                createTime: args.now.toISOString(),
+                ...(args.creatorId ? { creatorId: args.creatorId } : {}),
+                description: "initial version",
+                title: args.title,
+                ...(args.internalDataFileUrl
+                    ? { internalDataFileUrl: args.internalDataFileUrl }
+                    : {})
+            }
+        ]
+    };
+}
+
+export function appendVersion(
+    existing: { currentVersionNumber: number; versions: any[] } | undefined,
+    args: {
+        title: string;
+        creatorId?: string;
+        now: Date;
+        internalDataFileUrl?: string;
+        description: string;
+    }
+) {
+    const base = existing ?? { currentVersionNumber: -1, versions: [] };
+    const versionNumber = base.currentVersionNumber + 1;
+    return {
+        currentVersionNumber: versionNumber,
+        versions: [
+            ...base.versions,
+            {
+                versionNumber,
+                createTime: args.now.toISOString(),
+                ...(args.creatorId ? { creatorId: args.creatorId } : {}),
+                description: args.description,
+                title: args.title,
+                ...(args.internalDataFileUrl
+                    ? { internalDataFileUrl: args.internalDataFileUrl }
+                    : {})
+            }
+        ]
+    };
+}
+
+export function buildDatasetRecord(args: {
+    id: string;
+    title: string;
+    description?: string;
+    publish?: boolean;
+    owner?: { id?: string; orgUnitId?: string };
+    now: Date;
+    sourceUrl?: string;
+    extraAspects?: Record<string, unknown>;
+}) {
+    const iso = args.now.toISOString();
+    return {
+        id: args.id,
+        name: args.title,
+        aspects: {
+            "dcat-dataset-strings": {
+                title: args.title,
+                description: args.description ?? "",
+                issued: iso,
+                modified: iso,
+                languages: ["eng"]
+            },
+            publishing: { state: args.publish ? "published" : "draft" },
+            ...accessControlAspect(args.owner),
+            source: sourceAspect(args.sourceUrl),
+            version: buildInitialVersionAspect({
+                title: args.title,
+                creatorId: args.owner?.id,
+                now: args.now
+            }),
+            "dataset-distributions": { distributions: [] },
+            ...args.extraAspects
+        } as Record<string, any>
+    };
+}
+
+export function buildDistributionRecord(args: {
+    id: string;
+    title: string;
+    downloadURL?: string;
+    accessURL?: string;
+    format?: string;
+    byteSize?: number;
+    description?: string;
+    owner?: { id?: string; orgUnitId?: string };
+    publishingState: string;
+    now: Date;
+    internalDataFileUrl?: string;
+    sourceUrl?: string;
+    extraAspects?: Record<string, unknown>;
+}) {
+    const iso = args.now.toISOString();
+    const useStorageApi = Boolean(
+        args.downloadURL?.startsWith("magda://storage-api/")
+    );
+    return {
+        id: args.id,
+        name: args.title,
+        aspects: {
+            "dcat-distribution-strings": {
+                title: args.title,
+                ...(args.description ? { description: args.description } : {}),
+                issued: iso,
+                modified: iso,
+                ...(args.downloadURL ? { downloadURL: args.downloadURL } : {}),
+                ...(args.accessURL ? { accessURL: args.accessURL } : {}),
+                ...(args.format ? { format: args.format } : {}),
+                ...(args.byteSize !== undefined
+                    ? { byteSize: args.byteSize }
+                    : {}),
+                ...(useStorageApi ? { useStorageApi: true } : {})
+            },
+            publishing: { state: args.publishingState },
+            ...accessControlAspect(args.owner),
+            source: sourceAspect(args.sourceUrl),
+            version: buildInitialVersionAspect({
+                title: args.title,
+                creatorId: args.owner?.id,
+                now: args.now,
+                internalDataFileUrl: args.internalDataFileUrl
+            }),
+            ...args.extraAspects
+        } as Record<string, any>
+    };
+}

--- a/packages/mgd/src/skills.ts
+++ b/packages/mgd/src/skills.ts
@@ -1,0 +1,145 @@
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { UsageError } from "./errors.js";
+
+export type AgentName = "claude" | "codex" | "opencode";
+export const AGENT_NAMES: readonly AgentName[] = [
+    "claude",
+    "codex",
+    "opencode"
+];
+
+export type Scope = "global" | "project";
+
+export interface InstallResult {
+    agent: AgentName;
+    scope: Scope;
+    dir: string;
+    files: string[];
+    action: "created" | "updated" | "removed" | "absent";
+}
+
+// The whole magda-mgd/ folder is a managed unit: install overwrites it, uninstall
+// removes it. SKILL.md references the other two files "in the same directory", so
+// the three ship and install together.
+const SKILL_SUBDIR = "magda-mgd";
+const BUNDLE = ["SKILL.md", "mgd-workflows.md", "dataset-elicitation.md"];
+
+function homeDir(env: NodeJS.ProcessEnv): string {
+    const home = env.HOME;
+    if (!home) throw new Error("mgd: HOME is not set");
+    return home;
+}
+
+// Per-agent GLOBAL skills dir (cwd-independent). Honour each tool's env override
+// so non-default homes/config roots work and tests can redirect into a temp dir.
+function globalBase(agent: AgentName, env: NodeJS.ProcessEnv): string {
+    switch (agent) {
+        case "claude":
+            return path.join(homeDir(env), ".claude", "skills");
+        case "codex":
+            return path.join(
+                env.CODEX_HOME || path.join(homeDir(env), ".codex"),
+                "skills"
+            );
+        case "opencode":
+            return path.join(
+                env.XDG_CONFIG_HOME || path.join(homeDir(env), ".config"),
+                "opencode",
+                "skills"
+            );
+    }
+}
+
+// Per-agent PROJECT skills dir (each tool's native project location).
+function projectBase(agent: AgentName, projectDir: string): string {
+    switch (agent) {
+        case "claude":
+            return path.join(projectDir, ".claude", "skills");
+        case "codex":
+            return path.join(projectDir, ".agents", "skills");
+        case "opencode":
+            return path.join(projectDir, ".opencode", "skills");
+    }
+}
+
+export function resolveSkillDir(opts: {
+    agent: AgentName;
+    scope: Scope;
+    projectDir: string;
+    env: NodeJS.ProcessEnv;
+}): string {
+    const base =
+        opts.scope === "global"
+            ? globalBase(opts.agent, opts.env)
+            : projectBase(opts.agent, opts.projectDir);
+    return path.join(base, SKILL_SUBDIR);
+}
+
+// --agent omitted => all agents; a given value must be a known agent.
+export function parseAgents(value: string | undefined): AgentName[] {
+    if (value === undefined) return [...AGENT_NAMES];
+    if (!AGENT_NAMES.includes(value as AgentName)) {
+        throw new UsageError(
+            `Unknown agent "${value}". Expected one of: ${AGENT_NAMES.join(
+                ", "
+            )}.`
+        );
+    }
+    return [value as AgentName];
+}
+
+// Locate the shipped skills/ folder relative to this module: "../skills/" for the
+// esbuild bundle at bin/mgd.js, "../../skills/" for the TS source under tsx.
+export function packageSkillsDir(): string {
+    for (const rel of ["../skills/", "../../skills/"]) {
+        const dir = fileURLToPath(new URL(rel, import.meta.url));
+        if (existsSync(path.join(dir, "SKILL.md"))) return dir;
+    }
+    throw new Error("mgd: could not locate the package skills/ directory");
+}
+
+export async function installSkill(opts: {
+    agent: AgentName;
+    scope: Scope;
+    projectDir: string;
+    skillsDir: string;
+    env: NodeJS.ProcessEnv;
+}): Promise<InstallResult> {
+    const dir = resolveSkillDir(opts);
+    const action = existsSync(dir) ? "updated" : "created";
+    await fs.mkdir(dir, { recursive: true });
+    for (const name of BUNDLE) {
+        await fs.copyFile(
+            path.join(opts.skillsDir, name),
+            path.join(dir, name)
+        );
+    }
+    return {
+        agent: opts.agent,
+        scope: opts.scope,
+        dir,
+        files: [...BUNDLE],
+        action
+    };
+}
+
+export async function uninstallSkill(opts: {
+    agent: AgentName;
+    scope: Scope;
+    projectDir: string;
+    env: NodeJS.ProcessEnv;
+}): Promise<InstallResult> {
+    const dir = resolveSkillDir(opts);
+    const existed = existsSync(dir);
+    if (existed) await fs.rm(dir, { recursive: true, force: true });
+    return {
+        agent: opts.agent,
+        scope: opts.scope,
+        dir,
+        files: [],
+        action: existed ? "removed" : "absent"
+    };
+}

--- a/packages/mgd/src/test/addFile.spec.ts
+++ b/packages/mgd/src/test/addFile.spec.ts
@@ -1,0 +1,266 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dataset add-file", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    let tmp: string;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-af-"));
+    });
+    afterEach(async () => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    function routes(overrides: any = {}) {
+        return [
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    aspects: {
+                        publishing: { state: "draft" },
+                        "dataset-distributions": { distributions: ["dist-old"] }
+                    }
+                }
+            },
+            {
+                method: "POST",
+                path: /^\/v0\/storage\/upload\//,
+                body: { message: "ok" },
+                ...overrides.upload
+            },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                body: {},
+                ...overrides.createRecord
+            },
+            {
+                method: "GET",
+                path: /aspects\/dataset-distributions$/,
+                body: { distributions: ["dist-old"] }
+            },
+            {
+                method: "GET",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: { title: "t" }
+            },
+            { method: "PUT", path: /aspects\//, body: {} },
+            { method: "DELETE", path: /^\/v0\/storage\//, body: {} }
+        ];
+    }
+
+    it("uploads, creates the distribution and links it to the dataset", async () => {
+        const local = path.join(tmp, "data.csv");
+        await fs.writeFile(local, "a,b\n");
+        const server = await startMockServer(routes());
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program.parseAsync(["dataset", "add-file", "ds-1", local], {
+                    from: "user"
+                })
+            );
+            const distId = out.trim();
+            expect(distId).to.match(/^magda-dist-/);
+
+            const posted = JSON.parse(
+                server.requests
+                    .find(
+                        (r) =>
+                            r.method === "POST" &&
+                            r.url.startsWith("/v0/registry/records")
+                    )!
+                    .body.toString()
+            );
+            const s = posted.aspects["dcat-distribution-strings"];
+            expect(s.useStorageApi).to.equal(true);
+            expect(s.downloadURL).to.equal(
+                `magda://storage-api/ds-1/${distId}/data.csv`
+            );
+            expect(posted.aspects.publishing.state).to.equal("draft");
+
+            const distPut = server.requests.find(
+                (r) =>
+                    r.method === "PUT" &&
+                    r.url.includes("aspects/dataset-distributions")
+            )!;
+            expect(
+                JSON.parse(distPut.body.toString()).distributions
+            ).to.deep.equal(["dist-old", distId]);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("cleans up the uploaded object when record creation fails", async () => {
+        const local = path.join(tmp, "data.csv");
+        await fs.writeFile(local, "a,b\n");
+        const server = await startMockServer(
+            routes({
+                createRecord: { status: 500, body: { message: "boom" } }
+            })
+        );
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            let err: unknown;
+            try {
+                await captureStdout(() =>
+                    program.parseAsync(["dataset", "add-file", "ds-1", local], {
+                        from: "user"
+                    })
+                );
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(Error);
+            const deletes = server.requests.filter(
+                (r) => r.method === "DELETE" && r.url.startsWith("/v0/storage/")
+            );
+            expect(deletes).to.have.length(1);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("cleans up both the uploaded object and the distribution record when mergeAspect fails (recordCreated=true)", async () => {
+        const local = path.join(tmp, "data.csv");
+        await fs.writeFile(local, "a,b\n");
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    aspects: {
+                        publishing: { state: "draft" },
+                        "dataset-distributions": { distributions: ["dist-old"] }
+                    }
+                }
+            },
+            {
+                method: "POST",
+                path: /^\/v0\/storage\/upload\//,
+                body: { message: "ok" }
+            },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                body: {}
+            },
+            {
+                method: "GET",
+                path: /aspects\/dataset-distributions$/,
+                body: { distributions: ["dist-old"] }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dataset-distributions$/,
+                status: 500,
+                body: { message: "registry error" }
+            },
+            {
+                method: "DELETE",
+                path: /^\/v0\/registry\/records\//,
+                body: {}
+            },
+            {
+                method: "DELETE",
+                path: /^\/v0\/storage\//,
+                body: {}
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            let err: unknown;
+            try {
+                await captureStdout(() =>
+                    program.parseAsync(["dataset", "add-file", "ds-1", local], {
+                        from: "user"
+                    })
+                );
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(Error);
+            const distDeletes = server.requests.filter(
+                (r) =>
+                    r.method === "DELETE" &&
+                    r.url.startsWith("/v0/registry/records/")
+            );
+            expect(distDeletes).to.have.length(1);
+            const storageDeletes = server.requests.filter(
+                (r) => r.method === "DELETE" && r.url.startsWith("/v0/storage/")
+            );
+            expect(storageDeletes).to.have.length(1);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("registers a link-only distribution with --access-url", async () => {
+        const server = await startMockServer(routes());
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "add-file",
+                        "ds-1",
+                        "--access-url",
+                        "https://example.com/api",
+                        "--title",
+                        "API endpoint"
+                    ],
+                    { from: "user" }
+                )
+            );
+            const uploads = server.requests.filter((r) =>
+                r.url.startsWith("/v0/storage/upload")
+            );
+            expect(uploads).to.have.length(0);
+            const posted = JSON.parse(
+                server.requests
+                    .find(
+                        (r) =>
+                            r.method === "POST" &&
+                            r.url.startsWith("/v0/registry/records")
+                    )!
+                    .body.toString()
+            );
+            const s = posted.aspects["dcat-distribution-strings"];
+            expect(s.accessURL).to.equal("https://example.com/api");
+            expect(s.useStorageApi).to.equal(undefined);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/api.spec.ts
+++ b/packages/mgd/src/test/api.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerApiCommands } from "../commands/api.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("api request", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("performs GET with query params and pretty-prints JSON", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { records: [] }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerApiCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(
+                        [
+                            "api",
+                            "request",
+                            "get",
+                            "/v0/registry/records",
+                            "--query",
+                            "limit=5",
+                            "--query",
+                            "aspect=dcat-dataset-strings"
+                        ],
+                        { from: "user" }
+                    )
+                    .then(() => {})
+            );
+            expect(JSON.parse(out)).to.deep.equal({ records: [] });
+            expect(server.requests[0].url).to.contain("limit=5");
+            expect(server.requests[0].url).to.contain(
+                "aspect=dcat-dataset-strings"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("sends an inline JSON body on POST", async () => {
+        const server = await startMockServer([
+            { method: "POST", path: "/v0/registry/records", body: { id: "x" } }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerApiCommands(program);
+            await captureStdout(() =>
+                program
+                    .parseAsync(
+                        [
+                            "api",
+                            "request",
+                            "POST",
+                            "/v0/registry/records",
+                            "--body",
+                            '{"id":"x","name":"X","aspects":{}}'
+                        ],
+                        { from: "user" }
+                    )
+                    .then(() => {})
+            );
+            const req = server.requests[0];
+            expect(req.headers["content-type"]).to.contain("application/json");
+            expect(JSON.parse(req.body.toString()).id).to.equal("x");
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/auth.spec.ts
+++ b/packages/mgd/src/test/auth.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { normalizeBaseUrl, registerAuthCommands } from "../commands/auth.js";
+import { loadConfig } from "../profile.js";
+import { startMockServer } from "./mockServer.js";
+
+describe("normalizeBaseUrl", () => {
+    it("prefers the input as-is when it probes OK", async () => {
+        const url = await normalizeBaseUrl("https://x/api/", async (u) =>
+            u === "https://x/api" ? true : false
+        );
+        expect(url).to.equal("https://x/api");
+    });
+    it("falls back to <input>/api", async () => {
+        const url = await normalizeBaseUrl("https://x", async (u) =>
+            u === "https://x/api" ? true : false
+        );
+        expect(url).to.equal("https://x/api");
+    });
+    it("throws when nothing probes OK", async () => {
+        let err: unknown;
+        try {
+            await normalizeBaseUrl("https://x", async () => false);
+        } catch (e) {
+            err = e;
+        }
+        expect(err).to.be.instanceOf(Error);
+    });
+});
+
+describe("auth login/status", () => {
+    let tmp: string;
+    const origEnv: Record<string, string | undefined> = {};
+
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-auth-"));
+        for (const k of [
+            "XDG_CONFIG_HOME",
+            "MGD_BASE_URL",
+            "MGD_API_KEY_ID",
+            "MGD_API_KEY",
+            "MGD_PROFILE"
+        ]) {
+            origEnv[k] = process.env[k];
+            delete process.env[k];
+        }
+        process.env.XDG_CONFIG_HOME = tmp;
+    });
+    afterEach(async () => {
+        for (const [k, v] of Object.entries(origEnv)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("logs in non-interactively, verifies whoami and saves the profile", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1", displayName: "Test User" }
+            }
+        ]);
+        try {
+            const program = new Command();
+            registerAuthCommands(program);
+            await program.parseAsync(
+                [
+                    "auth",
+                    "login",
+                    "--url",
+                    server.url,
+                    "--key-id",
+                    "kid",
+                    "--key",
+                    "kv"
+                ],
+                { from: "user" }
+            );
+            const cfg = await loadConfig();
+            expect(cfg.activeProfile).to.equal("default");
+            expect(cfg.profiles.default.baseUrl).to.equal(server.url);
+            expect(cfg.profiles.default.apiKeyId).to.equal("kid");
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("fails login when whoami rejects the key", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                handler: (req, res) => {
+                    // probe (no key headers) succeeds; keyed request fails
+                    if (req.headers["x-magda-api-key"]) {
+                        res.writeHead(401, {
+                            "content-type": "application/json"
+                        }).end(JSON.stringify({ errorMessage: "bad key" }));
+                    } else {
+                        res.writeHead(200, {
+                            "content-type": "application/json"
+                        }).end(JSON.stringify({}));
+                    }
+                }
+            }
+        ]);
+        try {
+            const program = new Command();
+            registerAuthCommands(program);
+            let err: unknown;
+            try {
+                await program.parseAsync(
+                    [
+                        "auth",
+                        "login",
+                        "--url",
+                        server.url,
+                        "--key-id",
+                        "kid",
+                        "--key",
+                        "bad"
+                    ],
+                    { from: "user" }
+                );
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(Error);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/captureStdout.ts
+++ b/packages/mgd/src/test/captureStdout.ts
@@ -1,0 +1,18 @@
+export function captureStdout(fn: () => Promise<unknown>): Promise<string> {
+    const orig = process.stdout.write;
+    let out = "";
+    (process.stdout as any).write = (chunk: any) => {
+        out += String(chunk);
+        return true;
+    };
+    return fn().then(
+        () => {
+            process.stdout.write = orig;
+            return out;
+        },
+        (e) => {
+            process.stdout.write = orig;
+            throw e;
+        }
+    );
+}

--- a/packages/mgd/src/test/client.spec.ts
+++ b/packages/mgd/src/test/client.spec.ts
@@ -1,0 +1,141 @@
+import { expect } from "chai";
+import { MagdaClient } from "../client.js";
+import { MgdApiError } from "../errors.js";
+import { encodeKey, storageObject } from "../endpoints.js";
+import { startMockServer } from "./mockServer.js";
+
+describe("endpoints", () => {
+    it("encodes key segments but keeps separators", () => {
+        expect(encodeKey("a b/c#d/e")).to.equal("a%20b/c%23d/e");
+        expect(storageObject("magda-datasets", "ds1/dist1/f.csv")).to.equal(
+            "/v0/storage/magda-datasets/ds1/dist1/f.csv"
+        );
+    });
+});
+
+describe("MagdaClient", () => {
+    it("attaches API key headers and user agent", async () => {
+        const server = await startMockServer([
+            { method: "GET", path: "/v0/auth/users/whoami", body: { id: "u1" } }
+        ]);
+        try {
+            const client = new MagdaClient({
+                baseUrl: server.url,
+                apiKeyId: "kid",
+                apiKey: "kv"
+            });
+            const user = await client.json<any>("GET", "/v0/auth/users/whoami");
+            expect(user.id).to.equal("u1");
+            const req = server.requests[0];
+            expect(req.headers["x-magda-api-key-id"]).to.equal("kid");
+            expect(req.headers["x-magda-api-key"]).to.equal("kv");
+            expect(req.headers["user-agent"]).to.match(/^mgd\//);
+            expect(req.headers["x-magda-client-id"]).to.equal(undefined);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("adds client metadata headers on mutating requests", async () => {
+        const server = await startMockServer([
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            await client.json("POST", "/v0/registry/records", {
+                body: JSON.stringify({ id: "x" }),
+                headers: { "content-type": "application/json" }
+            });
+            const req = server.requests[0];
+            expect(req.headers["x-magda-client-id"]).to.equal("mgd");
+            expect(req.headers["x-magda-client-invocation-id"]).to.match(
+                /^[0-9a-f-]{36}$/
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("throws MgdApiError with server message on non-2xx", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records/nope",
+                status: 404,
+                body: { message: "no record" }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            let err: unknown;
+            try {
+                await client.json("GET", "/v0/registry/records/nope");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(MgdApiError);
+            expect((err as MgdApiError).status).to.equal(404);
+            expect((err as MgdApiError).message).to.equal("no record");
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("retries GETs on 5xx up to 3 attempts", async () => {
+        let calls = 0;
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/flaky",
+                handler: (_req, res) => {
+                    calls++;
+                    if (calls < 3) {
+                        res.writeHead(500).end("boom");
+                    } else {
+                        res.writeHead(200, {
+                            "content-type": "application/json"
+                        }).end(JSON.stringify({ ok: true }));
+                    }
+                }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            // retryDelayMs keeps the test fast
+            const out = await client.json<any>("GET", "/v0/flaky", {
+                retryDelayMs: 1
+            });
+            expect(out.ok).to.equal(true);
+            expect(calls).to.equal(3);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("never retries mutating requests", async () => {
+        let calls = 0;
+        const server = await startMockServer([
+            {
+                method: "POST",
+                path: "/v0/thing",
+                handler: (_req, res) => {
+                    calls++;
+                    res.writeHead(500).end("boom");
+                }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            let err: unknown;
+            try {
+                await client.json("POST", "/v0/thing", { retryDelayMs: 1 });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(MgdApiError);
+            expect(calls).to.equal(1);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/datasetCreate.spec.ts
+++ b/packages/mgd/src/test/datasetCreate.spec.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dataset create", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("creates a draft dataset with owner from whoami", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1", orgUnitId: "o1" }
+            },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                handler: (_req, res, recorded) => {
+                    const record = JSON.parse(recorded.body.toString());
+                    res.writeHead(200, {
+                        "content-type": "application/json"
+                    }).end(JSON.stringify(record));
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "create", "--title", "My Data", "--desc", "d"],
+                    { from: "user" }
+                )
+            );
+            expect(out.trim()).to.match(/^magda-ds-[0-9a-f-]{36}$/);
+            const posted = JSON.parse(
+                server.requests
+                    .find((r) => r.method === "POST")!
+                    .body.toString()
+            );
+            expect(posted.aspects.publishing.state).to.equal("draft");
+            expect(posted.aspects["access-control"].ownerId).to.equal("u1");
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("attaches custom aspects from --aspect", async () => {
+        const server = await startMockServer([
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "create",
+                        "--title",
+                        "T",
+                        "--aspect",
+                        'my-aspect={"a":1}'
+                    ],
+                    { from: "user" }
+                )
+            );
+            const posted = JSON.parse(
+                server.requests
+                    .find((r) => r.method === "POST")!
+                    .body.toString()
+            );
+            expect(posted.aspects["my-aspect"]).to.deep.equal({ a: 1 });
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/datasetRead.spec.ts
+++ b/packages/mgd/src/test/datasetRead.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dataset read commands", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("gets a dataset record with optional aspects", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    name: "Water Data",
+                    aspects: {
+                        "dcat-dataset-strings": { title: "Water Data" },
+                        "dataset-distributions": { distributions: ["d1"] }
+                    }
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(["dataset", "get", "ds-1", "--json"], {
+                        from: "user"
+                    })
+                    .then(() => {})
+            );
+            expect(JSON.parse(out).id).to.equal("ds-1");
+            expect(server.requests[0].url).to.contain(
+                "optionalAspect=dcat-dataset-strings"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("lists distributions dereferenced", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    aspects: {
+                        "dataset-distributions": {
+                            distributions: [
+                                {
+                                    id: "dist-1",
+                                    name: "file.csv",
+                                    aspects: {
+                                        "dcat-distribution-strings": {
+                                            title: "file.csv",
+                                            format: "CSV"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(
+                        ["dataset", "distributions", "ds-1", "--jsonl"],
+                        { from: "user" }
+                    )
+                    .then(() => {})
+            );
+            const item = JSON.parse(out.trim());
+            expect(item.id).to.equal("dist-1");
+            expect(server.requests[0].url).to.contain("dereference=true");
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/download.spec.ts
+++ b/packages/mgd/src/test/download.spec.ts
@@ -72,13 +72,20 @@ describe("downloadToFile", () => {
 
 describe("file download command", () => {
     const origBaseUrl = process.env.MGD_BASE_URL;
+    const origXdg = process.env.XDG_CONFIG_HOME;
     let tmp: string;
     beforeEach(async () => {
         tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-dlc-"));
+        // Isolate the profile store: point config at an empty temp dir so the
+        // test runs against an anonymous profile regardless of the developer's
+        // real ~/.config/mgd (otherwise stored credentials leak into requests).
+        process.env.XDG_CONFIG_HOME = tmp;
     });
     afterEach(async () => {
         if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
         else process.env.MGD_BASE_URL = origBaseUrl;
+        if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+        else process.env.XDG_CONFIG_HOME = origXdg;
         await fs.rm(tmp, { recursive: true, force: true });
     });
 

--- a/packages/mgd/src/test/download.spec.ts
+++ b/packages/mgd/src/test/download.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { resolveDownloadUrl, downloadToFile } from "../transfer.js";
+import { registerFileCommands } from "../commands/file.js";
+import { startMockServer } from "./mockServer.js";
+
+describe("resolveDownloadUrl", () => {
+    it("maps magda:// URLs to gateway storage paths", () => {
+        const r = resolveDownloadUrl(
+            "magda://storage-api/ds%201/dist-1/file.csv"
+        );
+        expect(r).to.deep.equal({
+            kind: "storage",
+            path: "/v0/storage/magda-datasets/ds%201/dist-1/file.csv"
+        });
+    });
+    it("passes through external http URLs", () => {
+        const r = resolveDownloadUrl("https://example.com/data.csv");
+        expect(r).to.deep.equal({
+            kind: "external",
+            url: "https://example.com/data.csv"
+        });
+    });
+});
+
+describe("downloadToFile", () => {
+    let tmp: string;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-dl-"));
+    });
+    afterEach(async () => {
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("streams a full download to disk", async () => {
+        const target = path.join(tmp, "out.bin");
+        const fetcher = async () =>
+            new Response("hello world", { status: 200 });
+        const result = await downloadToFile(fetcher, target);
+        expect(result.bytes).to.equal(11);
+        expect(await fs.readFile(target, "utf8")).to.equal("hello world");
+    });
+
+    it("resumes from an existing .part file when server honors Range", async () => {
+        const target = path.join(tmp, "out.bin");
+        await fs.writeFile(target + ".part", "hello ");
+        const fetcher = async (rangeStart?: number) => {
+            expect(rangeStart).to.equal(6);
+            return new Response("world", {
+                status: 206,
+                headers: { "content-range": "bytes 6-10/11" }
+            });
+        };
+        const result = await downloadToFile(fetcher, target, { resume: true });
+        expect(result.resumedFrom).to.equal(6);
+        expect(await fs.readFile(target, "utf8")).to.equal("hello world");
+    });
+
+    it("restarts when server ignores Range", async () => {
+        const target = path.join(tmp, "out.bin");
+        await fs.writeFile(target + ".part", "garbage");
+        const fetcher = async () =>
+            new Response("hello world", { status: 200 });
+        const result = await downloadToFile(fetcher, target, { resume: true });
+        expect(result.resumedFrom).to.equal(0);
+        expect(await fs.readFile(target, "utf8")).to.equal("hello world");
+    });
+});
+
+describe("file download command", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    let tmp: string;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-dlc-"));
+    });
+    afterEach(async () => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("downloads a storage object through the gateway", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/storage/magda-datasets/ds1/d1/f.csv",
+                handler: (_req, res) => {
+                    res.writeHead(200, {
+                        "content-type": "text/csv",
+                        "content-length": "3"
+                    }).end("a,b");
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerFileCommands(program);
+            const out = path.join(tmp, "f.csv");
+            await program.parseAsync(
+                ["file", "download", "magda-datasets/ds1/d1/f.csv", "-o", out],
+                { from: "user" }
+            );
+            expect(await fs.readFile(out, "utf8")).to.equal("a,b");
+            expect(server.requests[0].headers["x-magda-api-key"]).to.equal(
+                undefined
+            ); // anonymous profile — header only set when key present
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/errors.spec.ts
+++ b/packages/mgd/src/test/errors.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { MgdApiError, UsageError, exitCodeFor } from "../errors.js";
+
+describe("exitCodeFor", () => {
+    it("maps auth failures to 3", () => {
+        expect(
+            exitCodeFor(new MgdApiError("nope", 401, "unauthorized"))
+        ).to.equal(3);
+        expect(exitCodeFor(new MgdApiError("nope", 403, "forbidden"))).to.equal(
+            3
+        );
+    });
+    it("maps 404 to 4", () => {
+        expect(exitCodeFor(new MgdApiError("gone", 404, "not-found"))).to.equal(
+            4
+        );
+    });
+    it("maps usage errors to 2", () => {
+        expect(exitCodeFor(new UsageError("bad flag"))).to.equal(2);
+    });
+    it("maps everything else to 1", () => {
+        expect(exitCodeFor(new Error("boom"))).to.equal(1);
+        expect(
+            exitCodeFor(new MgdApiError("server", 500, "server-error"))
+        ).to.equal(1);
+    });
+});

--- a/packages/mgd/src/test/mockServer.ts
+++ b/packages/mgd/src/test/mockServer.ts
@@ -1,0 +1,80 @@
+import http from "node:http";
+import { AddressInfo } from "node:net";
+
+export interface RecordedRequest {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: Buffer;
+}
+
+export interface MockRoute {
+    method: string;
+    path: RegExp | string;
+    status?: number;
+    body?: unknown;
+    headers?: Record<string, string>;
+    handler?: (
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        recorded: RecordedRequest
+    ) => void;
+}
+
+export async function startMockServer(routes: MockRoute[]) {
+    const requests: RecordedRequest[] = [];
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c) => chunks.push(c));
+        req.on("end", () => {
+            const recorded: RecordedRequest = {
+                method: req.method || "",
+                url: req.url || "",
+                headers: Object.fromEntries(
+                    Object.entries(req.headers).map(([k, v]) => [
+                        k,
+                        Array.isArray(v) ? v.join(",") : v || ""
+                    ])
+                ),
+                body: Buffer.concat(chunks)
+            };
+            requests.push(recorded);
+            const urlPath = (req.url || "").split("?")[0];
+            const route = routes.find(
+                (r) =>
+                    r.method === req.method &&
+                    (typeof r.path === "string"
+                        ? r.path === urlPath
+                        : r.path.test(urlPath))
+            );
+            if (!route) {
+                res.writeHead(404, { "content-type": "application/json" });
+                res.end(JSON.stringify({ message: "no such route" }));
+                return;
+            }
+            if (route.handler) {
+                route.handler(req, res, recorded);
+                return;
+            }
+            res.writeHead(route.status ?? 200, {
+                "content-type": "application/json",
+                ...route.headers
+            });
+            res.end(
+                typeof route.body === "string"
+                    ? route.body
+                    : JSON.stringify(route.body ?? {})
+            );
+        });
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const { port } = server.address() as AddressInfo;
+    return {
+        url: `http://127.0.0.1:${port}`,
+        requests,
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((e) => (e ? reject(e) : resolve()))
+            )
+    };
+}

--- a/packages/mgd/src/test/output.spec.ts
+++ b/packages/mgd/src/test/output.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import {
+    resolveMode,
+    resolveModeFromArgv,
+    printData,
+    printError
+} from "../output.js";
+import { MgdApiError } from "../errors.js";
+
+function captureStream(stream: NodeJS.WriteStream, fn: () => void): string {
+    const orig = stream.write;
+    let out = "";
+    (stream as any).write = (chunk: any) => {
+        out += String(chunk);
+        return true;
+    };
+    try {
+        fn();
+    } finally {
+        stream.write = orig;
+    }
+    return out;
+}
+
+describe("output", () => {
+    it("resolves mode from flags", () => {
+        expect(resolveMode({})).to.equal("human");
+        expect(resolveMode({ json: true })).to.equal("json");
+        expect(resolveMode({ jsonl: true })).to.equal("jsonl");
+    });
+
+    it("resolves mode from argv (subcommand flags)", () => {
+        expect(resolveModeFromArgv(["search", "datasets", "water"])).to.equal(
+            "human"
+        );
+        expect(
+            resolveModeFromArgv(["search", "datasets", "water", "--json"])
+        ).to.equal("json");
+        expect(
+            resolveModeFromArgv(["dataset", "get", "id", "--jsonl"])
+        ).to.equal("jsonl");
+    });
+
+    it("prints a single pretty JSON document in json mode", () => {
+        const out = captureStream(process.stdout, () =>
+            printData("json", { a: 1 })
+        );
+        expect(JSON.parse(out)).to.deep.equal({ a: 1 });
+    });
+
+    it("prints one object per line in jsonl mode", () => {
+        const out = captureStream(process.stdout, () =>
+            printData("jsonl", { ignored: true }, [{ a: 1 }, { a: 2 }])
+        );
+        const lines = out.trim().split("\n");
+        expect(lines).to.have.length(2);
+        expect(JSON.parse(lines[0])).to.deep.equal({ a: 1 });
+    });
+
+    it("prints structured error JSON to stderr in json mode", () => {
+        const err = new MgdApiError(
+            "no perm",
+            403,
+            "forbidden",
+            "check API key"
+        );
+        const out = captureStream(process.stderr, () =>
+            printError(err, "json")
+        );
+        const parsed = JSON.parse(out);
+        expect(parsed.error.code).to.equal("forbidden");
+        expect(parsed.error.status).to.equal(403);
+        expect(parsed.error.hint).to.equal("check API key");
+    });
+
+    it("prints human-readable error to stderr in human mode", () => {
+        const out = captureStream(process.stderr, () =>
+            printError(new Error("boom"), "human")
+        );
+        expect(out).to.contain("Error: boom");
+    });
+});

--- a/packages/mgd/src/test/profile.spec.ts
+++ b/packages/mgd/src/test/profile.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+    configPath,
+    loadConfig,
+    saveConfig,
+    resolveProfile,
+    ConfigFile
+} from "../profile.js";
+
+describe("profile store", () => {
+    let tmp: string;
+    let env: NodeJS.ProcessEnv;
+
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-test-"));
+        env = { XDG_CONFIG_HOME: tmp };
+    });
+    afterEach(async () => {
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("computes config path under XDG_CONFIG_HOME", () => {
+        expect(configPath(env)).to.equal(path.join(tmp, "mgd", "config.json"));
+    });
+
+    it("returns empty config when file missing", async () => {
+        const cfg = await loadConfig(env);
+        expect(cfg.profiles).to.deep.equal({});
+    });
+
+    it("round-trips config with strict permissions", async () => {
+        const cfg: ConfigFile = {
+            activeProfile: "default",
+            profiles: {
+                default: {
+                    baseUrl: "https://x/api",
+                    apiKeyId: "id",
+                    apiKey: "k"
+                }
+            }
+        };
+        await saveConfig(cfg, env);
+        const stat = await fs.stat(configPath(env));
+        expect(stat.mode & 0o777).to.equal(0o600);
+        const dirStat = await fs.stat(path.dirname(configPath(env)));
+        expect(dirStat.mode & 0o777).to.equal(0o700);
+        expect(await loadConfig(env)).to.deep.equal(cfg);
+    });
+
+    it("resolves active profile from file", () => {
+        const cfg: ConfigFile = {
+            activeProfile: "p1",
+            profiles: { p1: { baseUrl: "https://a/api" } }
+        };
+        const { name, profile } = resolveProfile(cfg, env);
+        expect(name).to.equal("p1");
+        expect(profile?.baseUrl).to.equal("https://a/api");
+    });
+
+    it("env vars override file profile", () => {
+        const cfg: ConfigFile = {
+            activeProfile: "p1",
+            profiles: {
+                p1: { baseUrl: "https://a/api", apiKeyId: "x", apiKey: "y" }
+            }
+        };
+        const { profile } = resolveProfile(cfg, {
+            ...env,
+            MGD_BASE_URL: "https://b/api",
+            MGD_API_KEY_ID: "id2",
+            MGD_API_KEY: "key2"
+        });
+        expect(profile).to.deep.equal({
+            baseUrl: "https://b/api",
+            apiKeyId: "id2",
+            apiKey: "key2"
+        });
+    });
+
+    it("MGD_PROFILE selects a named profile", () => {
+        const cfg: ConfigFile = {
+            activeProfile: "p1",
+            profiles: {
+                p1: { baseUrl: "https://a/api" },
+                p2: { baseUrl: "https://b/api" }
+            }
+        };
+        const { name, profile } = resolveProfile(cfg, {
+            ...env,
+            MGD_PROFILE: "p2"
+        });
+        expect(name).to.equal("p2");
+        expect(profile?.baseUrl).to.equal("https://b/api");
+    });
+});

--- a/packages/mgd/src/test/recordBuilders.spec.ts
+++ b/packages/mgd/src/test/recordBuilders.spec.ts
@@ -1,0 +1,194 @@
+import { expect } from "chai";
+import {
+    createId,
+    storageDownloadUrl,
+    detectFormat,
+    buildDatasetRecord,
+    buildDistributionRecord,
+    buildInitialVersionAspect,
+    appendVersion,
+    removeInvalidChars,
+    getValidObjectKey,
+    deriveSiteUrl
+} from "../recordBuilders.js";
+
+const NOW = new Date("2026-07-05T00:00:00.000Z");
+
+describe("recordBuilders", () => {
+    it("creates web-client-compatible ids", () => {
+        expect(createId("ds")).to.match(/^magda-ds-[0-9a-f-]{36}$/);
+        expect(createId("dist")).to.match(/^magda-dist-[0-9a-f-]{36}$/);
+    });
+
+    it("builds magda:// download URLs with sanitized + encoded segments", () => {
+        // spaces and invalid chars are stripped before encoding
+        expect(
+            storageDownloadUrl("magda-ds-x", "magda-dist-y", "my file.csv")
+        ).to.equal("magda://storage-api/magda-ds-x/magda-dist-y/myfile.csv");
+    });
+
+    describe("removeInvalidChars", () => {
+        it("strips spaces and non-S3-safe chars", () => {
+            expect(removeInvalidChars("my file.csv")).to.equal("myfile.csv");
+            expect(removeInvalidChars("report (v2).csv")).to.equal(
+                "reportv2.csv"
+            );
+            expect(removeInvalidChars("")).to.equal("");
+            // trailing dots stripped
+            expect(removeInvalidChars("file..")).to.equal("file");
+        });
+    });
+
+    describe("getValidObjectKey", () => {
+        it("sanitizes all three key segments for a typical filename with spaces and parens", () => {
+            const key = getValidObjectKey(
+                "magda-ds-x",
+                "magda-dist-y",
+                "my report (v2).csv"
+            );
+            const [dsSegment, distSegment, fileSegment] = key.split("/");
+            // no invalid chars in any segment
+            const validPattern = /^[a-zA-Z0-9\-_.]+$/;
+            expect(validPattern.test(dsSegment)).to.equal(true);
+            expect(validPattern.test(distSegment)).to.equal(true);
+            expect(validPattern.test(fileSegment)).to.equal(true);
+            // no empty segments (no double slashes)
+            expect(key).to.not.include("//");
+            // known sanitized output
+            expect(key).to.equal("magda-ds-x/magda-dist-y/myreportv2.csv");
+        });
+
+        it("replaces empty-after-strip filename with untitled_file_*.dat", () => {
+            const key = getValidObjectKey("magda-ds-x", "magda-dist-y", "!!!");
+            expect(key).to.match(
+                /^magda-ds-x\/magda-dist-y\/untitled_file_[0-9a-f-]{36}\.dat$/
+            );
+        });
+
+        it("storageDownloadUrl sanitizes the key before encoding", () => {
+            const url = storageDownloadUrl(
+                "magda-ds-x",
+                "magda-dist-y",
+                "my file.csv"
+            );
+            expect(url).to.equal(
+                "magda://storage-api/magda-ds-x/magda-dist-y/myfile.csv"
+            );
+        });
+    });
+
+    it("detects formats from extensions", () => {
+        expect(detectFormat("a.csv")).to.equal("CSV");
+        expect(detectFormat("a.GeoJSON")).to.equal("GEOJSON");
+        expect(detectFormat("noext")).to.equal(undefined);
+    });
+
+    it("builds a draft dataset record with the web-client aspect set", () => {
+        const record = buildDatasetRecord({
+            id: "magda-ds-x",
+            title: "My Data",
+            description: "desc",
+            owner: { id: "u1", orgUnitId: "o1" },
+            now: NOW,
+            sourceUrl: "https://x.magda.io/"
+        });
+        expect(record.id).to.equal("magda-ds-x");
+        expect(record.name).to.equal("My Data");
+        expect(record.aspects["dcat-dataset-strings"]).to.deep.equal({
+            title: "My Data",
+            description: "desc",
+            issued: NOW.toISOString(),
+            modified: NOW.toISOString(),
+            languages: ["eng"]
+        });
+        expect(record.aspects.publishing).to.deep.equal({ state: "draft" });
+        expect(record.aspects["access-control"]).to.deep.equal({
+            ownerId: "u1",
+            orgUnitId: "o1",
+            constraintExemption: false
+        });
+        expect(record.aspects.source).to.deep.equal({
+            id: "magda",
+            name: "Magda CLI (mgd)",
+            type: "internal",
+            url: "https://x.magda.io/"
+        });
+        expect(record.aspects["dataset-distributions"]).to.deep.equal({
+            distributions: []
+        });
+        expect(record.aspects.version.currentVersionNumber).to.equal(0);
+    });
+
+    it("omits source.url when no sourceUrl is given", () => {
+        const record = buildDatasetRecord({ id: "x", title: "t", now: NOW });
+        expect(record.aspects.source).to.deep.equal({
+            id: "magda",
+            name: "Magda CLI (mgd)",
+            type: "internal"
+        });
+    });
+
+    it("derives the site URL from the API base URL", () => {
+        expect(deriveSiteUrl("https://x.magda.io/api")).to.equal(
+            "https://x.magda.io/"
+        );
+        expect(deriveSiteUrl("https://x.magda.io/api/v0")).to.equal(
+            "https://x.magda.io/"
+        );
+        expect(deriveSiteUrl("https://x.magda.io/v0/")).to.equal(
+            "https://x.magda.io/"
+        );
+        expect(deriveSiteUrl("https://x.magda.io/custom/gw")).to.equal(
+            "https://x.magda.io/custom/gw/"
+        );
+    });
+
+    it("merges custom aspects last", () => {
+        const record = buildDatasetRecord({
+            id: "x",
+            title: "t",
+            now: NOW,
+            extraAspects: {
+                "my-aspect": { a: 1 },
+                publishing: { state: "published" }
+            }
+        });
+        expect(record.aspects["my-aspect"]).to.deep.equal({ a: 1 });
+        expect(record.aspects.publishing).to.deep.equal({ state: "published" });
+    });
+
+    it("builds a storage-backed distribution record", () => {
+        const record = buildDistributionRecord({
+            id: "magda-dist-y",
+            title: "data.csv",
+            downloadURL: "magda://storage-api/ds/dist/data.csv",
+            format: "CSV",
+            byteSize: 42,
+            publishingState: "draft",
+            owner: { id: "u1" },
+            internalDataFileUrl: "magda://storage-api/ds/dist/data.csv",
+            now: NOW
+        });
+        const s = record.aspects["dcat-distribution-strings"];
+        expect(s.useStorageApi).to.equal(true);
+        expect(s.downloadURL).to.equal("magda://storage-api/ds/dist/data.csv");
+        expect(s.byteSize).to.equal(42);
+        expect(record.aspects.version.versions[0].internalDataFileUrl).to.equal(
+            "magda://storage-api/ds/dist/data.csv"
+        );
+    });
+
+    it("appends versions with an incremented number", () => {
+        const v0 = buildInitialVersionAspect({ title: "t", now: NOW });
+        const v1 = appendVersion(v0, {
+            title: "t2",
+            now: NOW,
+            internalDataFileUrl: "magda://storage-api/a/b/c",
+            description: "Replaced superseded by a new distribution"
+        });
+        expect(v1.currentVersionNumber).to.equal(1);
+        expect(v1.versions).to.have.length(2);
+        expect(v1.versions[1].versionNumber).to.equal(1);
+        expect(v0.versions).to.have.length(1); // input not mutated
+    });
+});

--- a/packages/mgd/src/test/recordUpdate.spec.ts
+++ b/packages/mgd/src/test/recordUpdate.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dataset update", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("merges scalar fields into dcat-dataset-strings", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: { title: "Old", description: "keep me" }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: {}
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "update", "ds-1", "--title", "New"],
+                    { from: "user" }
+                )
+            );
+            const put = server.requests.find((r) => r.method === "PUT")!;
+            const body = JSON.parse(put.body.toString());
+            expect(body.title).to.equal("New");
+            expect(body.description).to.equal("keep me");
+            expect(body.modified).to.be.a("string");
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/replaceFile.spec.ts
+++ b/packages/mgd/src/test/replaceFile.spec.ts
@@ -1,0 +1,153 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { registerDistCommands } from "../commands/dist.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dist replace-file", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    let tmp: string;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-rf-"));
+    });
+    afterEach(async () => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("uploads, merges metadata, bumps version and keeps history-referenced old file", async () => {
+        const local = path.join(tmp, "new.csv");
+        await fs.writeFile(local, "x,y\n1,2\n");
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/dist-1$/,
+                body: {
+                    id: "dist-1",
+                    aspects: {
+                        "dcat-distribution-strings": {
+                            title: "old.csv",
+                            downloadURL:
+                                "magda://storage-api/ds-1/dist-1/old.csv"
+                        },
+                        version: {
+                            currentVersionNumber: 0,
+                            versions: [
+                                {
+                                    versionNumber: 0,
+                                    title: "old.csv",
+                                    internalDataFileUrl:
+                                        "magda://storage-api/ds-1/dist-1/old.csv"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { records: [{ id: "ds-1" }] }
+            },
+            { method: "POST", path: /^\/v0\/storage\/upload\//, body: {} },
+            {
+                method: "GET",
+                path: /aspects\/dcat-distribution-strings$/,
+                body: { title: "old.csv" }
+            },
+            { method: "PUT", path: /aspects\//, body: {} },
+            { method: "DELETE", path: /^\/v0\/storage\//, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDistCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(["dist", "replace-file", "dist-1", local], {
+                    from: "user"
+                })
+            );
+            const versionPut = server.requests.find(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            )!;
+            const version = JSON.parse(versionPut.body.toString());
+            expect(version.currentVersionNumber).to.equal(1);
+            expect(version.versions).to.have.length(2);
+            expect(version.versions[1].internalDataFileUrl).to.equal(
+                "magda://storage-api/ds-1/dist-1/new.csv"
+            );
+            // old file IS referenced by version 0 -> must NOT be deleted
+            const deletes = server.requests.filter(
+                (r) => r.method === "DELETE" && r.url.includes("old.csv")
+            );
+            expect(deletes).to.have.length(0);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("deletes the old object when it is not referenced by version history", async () => {
+        const local = path.join(tmp, "new.csv");
+        await fs.writeFile(local, "x\n");
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/dist-1$/,
+                body: {
+                    id: "dist-1",
+                    aspects: {
+                        "dcat-distribution-strings": {
+                            title: "old.csv",
+                            downloadURL:
+                                "magda://storage-api/ds-1/dist-1/old.csv"
+                        }
+                        // no version aspect at all
+                    }
+                }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { records: [{ id: "ds-1" }] }
+            },
+            { method: "POST", path: /^\/v0\/storage\/upload\//, body: {} },
+            {
+                method: "GET",
+                path: /aspects\/dcat-distribution-strings$/,
+                body: { title: "old.csv" }
+            },
+            { method: "PUT", path: /aspects\//, body: {} },
+            { method: "DELETE", path: /^\/v0\/storage\//, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDistCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(["dist", "replace-file", "dist-1", local], {
+                    from: "user"
+                })
+            );
+            const deletes = server.requests.filter(
+                (r) => r.method === "DELETE" && r.url.includes("old.csv")
+            );
+            expect(deletes).to.have.length(1);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/search.spec.ts
+++ b/packages/mgd/src/test/search.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerSearchCommands } from "../commands/search.js";
+import { MgdApiError } from "../errors.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("search commands", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("searches datasets and emits jsonl", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/search/datasets",
+                body: {
+                    hitCount: 2,
+                    dataSets: [
+                        { identifier: "ds-1", title: "Water" },
+                        { identifier: "ds-2", title: "Fire" }
+                    ]
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerSearchCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(["search", "datasets", "water", "--jsonl"], {
+                        from: "user"
+                    })
+                    .then(() => {})
+            );
+            const lines = out.trim().split("\n");
+            expect(lines).to.have.length(2);
+            expect(JSON.parse(lines[0]).identifier).to.equal("ds-1");
+            const reqUrl = server.requests[0].url;
+            expect(reqUrl).to.contain("query=water");
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("maps semantic-search 404 to semantic-search-unavailable", async () => {
+        const server = await startMockServer([]); // no routes -> 404
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerSearchCommands(program);
+            let err: unknown;
+            try {
+                await program
+                    .parseAsync(["search", "semantic", "water"], {
+                        from: "user"
+                    })
+                    .then(() => {});
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(MgdApiError);
+            expect((err as MgdApiError).code).to.equal(
+                "semantic-search-unavailable"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("maps semantic-search 500 'no such index' to semantic-search-unavailable", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/semantic-search/search",
+                status: 500,
+                body: {
+                    message:
+                        "OpenSearch index not found: no such index [semantic-index-v1]"
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerSearchCommands(program);
+            let err: unknown;
+            try {
+                await program
+                    .parseAsync(["search", "semantic", "water"], {
+                        from: "user"
+                    })
+                    .then(() => {});
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(MgdApiError);
+            expect((err as MgdApiError).code).to.equal(
+                "semantic-search-unavailable"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/skillsInstall.spec.ts
+++ b/packages/mgd/src/test/skillsInstall.spec.ts
@@ -1,0 +1,181 @@
+import { expect } from "chai";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    installSkill,
+    uninstallSkill,
+    resolveSkillDir,
+    parseAgents,
+    packageSkillsDir,
+    AGENT_NAMES
+} from "../skills.js";
+import { UsageError } from "../errors.js";
+
+const SKILLS_DIR = fileURLToPath(new URL("../../skills/", import.meta.url));
+const BUNDLE = ["SKILL.md", "mgd-workflows.md", "dataset-elicitation.md"];
+
+describe("skills install", () => {
+    let tmp: string;
+    let env: NodeJS.ProcessEnv;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-test-"));
+        env = {
+            HOME: tmp,
+            CODEX_HOME: path.join(tmp, "codexhome"),
+            XDG_CONFIG_HOME: path.join(tmp, "xdg")
+        };
+    });
+    afterEach(async () => {
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("packageSkillsDir finds the shipped skills folder", () => {
+        expect(existsSync(path.join(packageSkillsDir(), "SKILL.md"))).to.equal(
+            true
+        );
+    });
+
+    it("resolveSkillDir: global dirs honour env overrides", () => {
+        expect(
+            resolveSkillDir({
+                agent: "claude",
+                scope: "global",
+                projectDir: tmp,
+                env
+            })
+        ).to.equal(path.join(tmp, ".claude", "skills", "magda-mgd"));
+        expect(
+            resolveSkillDir({
+                agent: "codex",
+                scope: "global",
+                projectDir: tmp,
+                env
+            })
+        ).to.equal(path.join(tmp, "codexhome", "skills", "magda-mgd"));
+        expect(
+            resolveSkillDir({
+                agent: "opencode",
+                scope: "global",
+                projectDir: tmp,
+                env
+            })
+        ).to.equal(path.join(tmp, "xdg", "opencode", "skills", "magda-mgd"));
+    });
+
+    it("resolveSkillDir: project dirs are per-tool", () => {
+        const proj = path.join(tmp, "proj");
+        expect(
+            resolveSkillDir({
+                agent: "claude",
+                scope: "project",
+                projectDir: proj,
+                env
+            })
+        ).to.equal(path.join(proj, ".claude", "skills", "magda-mgd"));
+        expect(
+            resolveSkillDir({
+                agent: "codex",
+                scope: "project",
+                projectDir: proj,
+                env
+            })
+        ).to.equal(path.join(proj, ".agents", "skills", "magda-mgd"));
+        expect(
+            resolveSkillDir({
+                agent: "opencode",
+                scope: "project",
+                projectDir: proj,
+                env
+            })
+        ).to.equal(path.join(proj, ".opencode", "skills", "magda-mgd"));
+    });
+
+    it("installs the bundle globally for each agent", async () => {
+        for (const agent of AGENT_NAMES) {
+            const res = await installSkill({
+                agent,
+                scope: "global",
+                projectDir: tmp,
+                skillsDir: SKILLS_DIR,
+                env
+            });
+            expect(res.action).to.equal("created");
+            expect(res.scope).to.equal("global");
+            expect(res.files).to.deep.equal(BUNDLE);
+            for (const f of BUNDLE) {
+                expect(existsSync(path.join(res.dir, f))).to.equal(true);
+            }
+        }
+    });
+
+    it("installs the bundle into a project dir", async () => {
+        const proj = path.join(tmp, "proj");
+        const res = await installSkill({
+            agent: "codex",
+            scope: "project",
+            projectDir: proj,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+        expect(res.dir).to.equal(
+            path.join(proj, ".agents", "skills", "magda-mgd")
+        );
+        expect(existsSync(path.join(res.dir, "SKILL.md"))).to.equal(true);
+    });
+
+    it("is idempotent: second install reports updated, files intact", async () => {
+        const first = await installSkill({
+            agent: "claude",
+            scope: "global",
+            projectDir: tmp,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+        expect(first.action).to.equal("created");
+        const second = await installSkill({
+            agent: "claude",
+            scope: "global",
+            projectDir: tmp,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+        expect(second.action).to.equal("updated");
+        for (const f of BUNDLE) {
+            expect(existsSync(path.join(second.dir, f))).to.equal(true);
+        }
+    });
+
+    it("uninstall removes the folder, then is a no-op", async () => {
+        await installSkill({
+            agent: "opencode",
+            scope: "global",
+            projectDir: tmp,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+        const first = await uninstallSkill({
+            agent: "opencode",
+            scope: "global",
+            projectDir: tmp,
+            env
+        });
+        expect(first.action).to.equal("removed");
+        expect(existsSync(first.dir)).to.equal(false);
+        const second = await uninstallSkill({
+            agent: "opencode",
+            scope: "global",
+            projectDir: tmp,
+            env
+        });
+        expect(second.action).to.equal("absent");
+    });
+
+    it("parseAgents: default all, single, and bad value", () => {
+        expect(parseAgents(undefined)).to.deep.equal([...AGENT_NAMES]);
+        expect(parseAgents("codex")).to.deep.equal(["codex"]);
+        expect(() => parseAgents("cursor")).to.throw(UsageError);
+    });
+});

--- a/packages/mgd/src/test/upload.spec.ts
+++ b/packages/mgd/src/test/upload.spec.ts
@@ -1,0 +1,207 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { MagdaClient } from "../client.js";
+import { planParts, uploadFile, SINGLE_SHOT_MAX } from "../transfer.js";
+import { startMockServer } from "./mockServer.js";
+
+describe("planParts", () => {
+    it("splits a file into fixed-size parts with a short tail", () => {
+        expect(planParts(25, 10)).to.deep.equal([
+            { partNumber: 1, start: 0, end: 10 },
+            { partNumber: 2, start: 10, end: 20 },
+            { partNumber: 3, start: 20, end: 25 }
+        ]);
+    });
+    it("handles empty files as one empty part", () => {
+        expect(planParts(0, 10)).to.deep.equal([
+            { partNumber: 1, start: 0, end: 0 }
+        ]);
+    });
+});
+
+describe("uploadFile", () => {
+    let tmp: string;
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-ul-"));
+    });
+    afterEach(async () => {
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("uses single-shot for small files", async () => {
+        const local = path.join(tmp, "small.csv");
+        await fs.writeFile(local, "a,b\n1,2\n");
+        const server = await startMockServer([
+            {
+                method: "POST",
+                path: /^\/v0\/storage\/upload\//,
+                body: { message: "ok" }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            const result = await uploadFile(client, {
+                localPath: local,
+                bucket: "magda-datasets",
+                key: "ds1/d1/small.csv",
+                recordId: "ds1"
+            });
+            expect(result.multipart).to.equal(false);
+            const req = server.requests[0];
+            expect(req.url).to.contain(
+                "/v0/storage/upload/magda-datasets/ds1/d1"
+            );
+            expect(req.url).to.contain("recordId=ds1");
+            expect(req.headers["content-type"]).to.contain(
+                "multipart/form-data"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("uses multipart for large files and completes with collected etags", async function () {
+        this.timeout(10000);
+        const local = path.join(tmp, "big.bin");
+        // 2.5 "parts" of 8 bytes with a forced tiny part size for the test
+        await fs.writeFile(local, Buffer.alloc(20, 1));
+        const parts: any[] = [];
+        const server = await startMockServer([
+            {
+                method: "POST",
+                path: /multipart\/initiate/,
+                body: {
+                    uploadId: "tok",
+                    recommendedPartSizeBytes: 8,
+                    maxPartSizeBytes: 64,
+                    minPartSize: 1
+                }
+            },
+            {
+                method: "PUT",
+                path: /multipart\/part/,
+                handler: (req, res, recorded) => {
+                    const url = new URL(recorded.url, "http://x");
+                    const partNumber = Number(
+                        url.searchParams.get("partNumber")
+                    );
+                    parts.push({ partNumber, size: recorded.body.length });
+                    res.writeHead(200, {
+                        "content-type": "application/json"
+                    }).end(
+                        JSON.stringify({
+                            partNumber,
+                            etag: `etag-${partNumber}`
+                        })
+                    );
+                }
+            },
+            {
+                method: "POST",
+                path: /multipart\/complete/,
+                body: { message: "done" }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            const result = await uploadFile(client, {
+                localPath: local,
+                bucket: "magda-datasets",
+                key: "ds1/d1/big.bin",
+                // force the multipart path without a 16MB fixture:
+                singleShot: false,
+                forceMultipart: true
+            });
+            expect(result.multipart).to.equal(true);
+            expect(parts.map((p) => p.size)).to.deep.equal([8, 8, 4]);
+            const completeReq = server.requests.at(-1)!;
+            const body = JSON.parse(completeReq.body.toString());
+            expect(body.parts).to.deep.equal([
+                { partNumber: 1, etag: "etag-1" },
+                { partNumber: 2, etag: "etag-2" },
+                { partNumber: 3, etag: "etag-3" }
+            ]);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("aborts the multipart session when a part fails", async () => {
+        const local = path.join(tmp, "big.bin");
+        await fs.writeFile(local, Buffer.alloc(20, 1));
+        let aborted = false;
+        const server = await startMockServer([
+            {
+                method: "POST",
+                path: /multipart\/initiate/,
+                body: { uploadId: "tok", recommendedPartSizeBytes: 8 }
+            },
+            {
+                method: "PUT",
+                path: /multipart\/part/,
+                status: 502,
+                body: { message: "part failed" }
+            },
+            {
+                method: "DELETE",
+                path: /multipart\/abort/,
+                handler: (_req, res) => {
+                    aborted = true;
+                    res.writeHead(200, {
+                        "content-type": "application/json"
+                    }).end("{}");
+                }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            let err: unknown;
+            try {
+                await uploadFile(client, {
+                    localPath: local,
+                    bucket: "b",
+                    key: "k/big.bin",
+                    forceMultipart: true
+                });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.instanceOf(Error);
+            expect(aborted).to.equal(true);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("falls back to single-shot when initiate 404s", async () => {
+        const local = path.join(tmp, "big.bin");
+        await fs.writeFile(local, Buffer.alloc(20, 1));
+        const server = await startMockServer([
+            {
+                method: "POST",
+                path: /multipart\/initiate/,
+                status: 404,
+                body: { message: "no route" }
+            },
+            {
+                method: "POST",
+                path: /^\/v0\/storage\/upload\//,
+                body: { message: "ok" }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: server.url });
+            const result = await uploadFile(client, {
+                localPath: local,
+                bucket: "b",
+                key: "k/big.bin",
+                forceMultipart: true
+            });
+            expect(result.multipart).to.equal(false);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/version.spec.ts
+++ b/packages/mgd/src/test/version.spec.ts
@@ -1,0 +1,8 @@
+import { expect } from "chai";
+import { VERSION } from "../version.js";
+
+describe("version", () => {
+    it("exposes the package.json version", () => {
+        expect(VERSION).to.match(/^\d+\.\d+\.\d+/);
+    });
+});

--- a/packages/mgd/src/transfer.ts
+++ b/packages/mgd/src/transfer.ts
@@ -1,0 +1,272 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { openAsBlob } from "node:fs";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { UsageError, MgdApiError } from "./errors.js";
+import { note } from "./output.js";
+import { MagdaClient } from "./client.js";
+import {
+    storageUpload,
+    multipartInitiate,
+    multipartPart,
+    multipartComplete,
+    multipartAbort
+} from "./endpoints.js";
+import { DATASETS_BUCKET_DEFAULT } from "./recordBuilders.js";
+
+export function resolveDownloadUrl(
+    downloadUrl: string,
+    datasetsBucket: string = DATASETS_BUCKET_DEFAULT
+): { kind: "storage"; path: string } | { kind: "external"; url: string } {
+    if (downloadUrl.startsWith("magda://storage-api/")) {
+        const rest = downloadUrl.slice("magda://storage-api/".length);
+        const segments = rest
+            .split("/")
+            .map((s) => encodeURIComponent(decodeURIComponent(s)));
+        return {
+            kind: "storage",
+            path: `/v0/storage/${datasetsBucket}/${segments.join("/")}`
+        };
+    }
+    if (/^https?:\/\//.test(downloadUrl)) {
+        return { kind: "external", url: downloadUrl };
+    }
+    throw new UsageError(`Unsupported download URL: ${downloadUrl}`);
+}
+
+export type RangeFetcher = (rangeStart?: number) => Promise<Response>;
+
+export interface DownloadOptions {
+    resume?: boolean;
+    onProgress?: (done: number, total?: number) => void;
+}
+
+export async function downloadToFile(
+    fetchRange: RangeFetcher,
+    outputPath: string | "-",
+    opts: DownloadOptions = {}
+): Promise<{ bytes: number; resumedFrom: number }> {
+    if (outputPath === "-") {
+        const res = await fetchRange();
+        let bytes = 0;
+        if (res.body) {
+            const counter = countBytes((n) => (bytes += n));
+            await pipeline(
+                Readable.fromWeb(res.body as any),
+                counter,
+                process.stdout
+            );
+        }
+        return { bytes, resumedFrom: 0 };
+    }
+
+    const partPath = outputPath + ".part";
+    let resumedFrom = 0;
+    if (opts.resume) {
+        try {
+            resumedFrom = (await fsp.stat(partPath)).size;
+        } catch {
+            resumedFrom = 0;
+        }
+    }
+
+    let res = await fetchRange(resumedFrom > 0 ? resumedFrom : undefined);
+    if (resumedFrom > 0 && res.status !== 206) {
+        note("Server does not support resume; restarting download.");
+        resumedFrom = 0;
+    }
+
+    const total = contentTotal(res, resumedFrom);
+    let bytes = resumedFrom;
+    const out = fs.createWriteStream(partPath, {
+        flags: resumedFrom > 0 ? "a" : "w"
+    });
+    if (res.body) {
+        const counter = countBytes((n) => {
+            bytes += n;
+            opts.onProgress?.(bytes, total);
+        });
+        await pipeline(Readable.fromWeb(res.body as any), counter, out);
+    } else {
+        out.end();
+    }
+    await fsp.rename(partPath, outputPath);
+    return { bytes, resumedFrom };
+}
+
+function contentTotal(res: Response, offset: number): number | undefined {
+    const contentRange = res.headers.get("content-range");
+    if (contentRange) {
+        const m = /\/(\d+)$/.exec(contentRange);
+        if (m) return Number(m[1]);
+    }
+    const len = res.headers.get("content-length");
+    if (len) return offset + Number(len);
+    return undefined;
+}
+
+function countBytes(onChunk: (n: number) => void): Transform {
+    return new Transform({
+        transform(chunk, _enc, cb) {
+            onChunk((chunk as Buffer).length);
+            cb(null, chunk);
+        }
+    });
+}
+
+export const SINGLE_SHOT_MAX = 16 * 1024 * 1024;
+
+export interface PartPlan {
+    partNumber: number;
+    start: number;
+    end: number;
+}
+
+export function planParts(fileSize: number, partSize: number): PartPlan[] {
+    if (fileSize === 0) return [{ partNumber: 1, start: 0, end: 0 }];
+    const parts: PartPlan[] = [];
+    let start = 0;
+    let partNumber = 1;
+    while (start < fileSize) {
+        const end = Math.min(start + partSize, fileSize);
+        parts.push({ partNumber, start, end });
+        start = end;
+        partNumber++;
+    }
+    return parts;
+}
+
+export interface UploadOptions {
+    localPath: string;
+    bucket: string;
+    key: string;
+    recordId?: string;
+    contentType?: string;
+    partSize?: number;
+    singleShot?: boolean;
+    forceMultipart?: boolean;
+    onProgress?: (done: number, total: number) => void;
+}
+
+export interface UploadResult {
+    bucket: string;
+    key: string;
+    size: number;
+    multipart: boolean;
+}
+
+export async function uploadFile(
+    client: MagdaClient,
+    opts: UploadOptions
+): Promise<UploadResult> {
+    const size = (await fsp.stat(opts.localPath)).size;
+    const wantMultipart =
+        opts.forceMultipart || (!opts.singleShot && size >= SINGLE_SHOT_MAX);
+
+    if (!wantMultipart) {
+        await singleShotUpload(client, opts, size);
+        return { bucket: opts.bucket, key: opts.key, size, multipart: false };
+    }
+
+    let init: any;
+    try {
+        init = await client.json<any>(
+            "POST",
+            multipartInitiate(opts.bucket, opts.key),
+            {
+                query: { recordId: opts.recordId },
+                headers: {
+                    "content-type":
+                        opts.contentType ?? "application/octet-stream"
+                }
+            }
+        );
+    } catch (e) {
+        if (e instanceof MgdApiError && e.status === 404) {
+            if (size >= SINGLE_SHOT_MAX) {
+                note(
+                    "Server lacks multipart upload support; attempting single-shot upload of a large file — this may exceed the server's body-size limit."
+                );
+            }
+            await singleShotUpload(client, opts, size);
+            return {
+                bucket: opts.bucket,
+                key: opts.key,
+                size,
+                multipart: false
+            };
+        }
+        throw e;
+    }
+
+    const partSize: number =
+        opts.partSize ?? init.recommendedPartSizeBytes ?? SINGLE_SHOT_MAX;
+    const uploadId: string = init.uploadId;
+    const etags: { partNumber: number; etag: string }[] = [];
+
+    const handle = await fsp.open(opts.localPath, "r");
+    try {
+        for (const part of planParts(size, partSize)) {
+            const length = part.end - part.start;
+            const buffer = Buffer.alloc(length);
+            if (length > 0) {
+                await handle.read(buffer, 0, length, part.start);
+            }
+            const res = await client.json<any>(
+                "PUT",
+                multipartPart(opts.bucket, opts.key),
+                {
+                    query: { uploadId, partNumber: part.partNumber },
+                    headers: { "content-type": "application/octet-stream" },
+                    body: new Uint8Array(buffer)
+                }
+            );
+            etags.push({ partNumber: res.partNumber, etag: res.etag });
+            opts.onProgress?.(part.end, size);
+        }
+        await client.json("POST", multipartComplete(opts.bucket, opts.key), {
+            query: { uploadId },
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ parts: etags })
+        });
+    } catch (e) {
+        try {
+            await client.request(
+                "DELETE",
+                multipartAbort(opts.bucket, opts.key),
+                { query: { uploadId } }
+            );
+        } catch {
+            // best-effort abort; the server's lifecycle rule cleans up eventually
+        }
+        throw e;
+    } finally {
+        await handle.close();
+    }
+    return { bucket: opts.bucket, key: opts.key, size, multipart: true };
+}
+
+async function singleShotUpload(
+    client: MagdaClient,
+    opts: UploadOptions,
+    size: number
+): Promise<void> {
+    const fileName = path.basename(opts.key);
+    const keyPrefix = path.dirname(opts.key);
+    const blob = await openAsBlob(opts.localPath, {
+        type: opts.contentType ?? "application/octet-stream"
+    });
+    const form = new FormData();
+    form.append(fileName, blob, fileName);
+    await client.request(
+        "POST",
+        storageUpload(opts.bucket, keyPrefix === "." ? "" : keyPrefix),
+        {
+            query: { recordId: opts.recordId },
+            body: form
+        }
+    );
+    opts.onProgress?.(size, size);
+}

--- a/packages/mgd/src/version.ts
+++ b/packages/mgd/src/version.ts
@@ -1,0 +1,5 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export const VERSION: string = require("../package.json").version;

--- a/packages/mgd/tsconfig.json
+++ b/packages/mgd/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "types": ["node", "mocha"],
+        "noEmit": true
+    },
+    "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8032,6 +8032,17 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
+chai@^5.0.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chai@^5.0.0-rc.0:
   version "5.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.0.0-rc.0.tgz#8f1af623e93737a362fd35ba387c50266c273a75"
@@ -8126,6 +8137,11 @@ check-error@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.0.0.tgz#589a4f201b6256fd93a2d165089fe43d2676d8c6"
   integrity sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 check-types@^11.1.1:
   version "11.1.2"
@@ -16033,6 +16049,11 @@ loupe@^3.0.0:
   integrity sha512-phbaE2fPsRe8cQ7Cy5Ze5p9JLmpiaqGT45RCUWYYjZgYPBoeC3vqrlYPj4BQ82ln60ZtM3Iq00PPC3FyUdS4Kw==
   dependencies:
     get-func-name "^2.0.1"
+
+loupe@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
 
 lower-case@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
## Summary

Adds **`packages/mgd`** — a self-contained, npm-installable CLI (`mgd`) for working with a MAGDA catalog from the terminal or from an AI coding assistant, without cloning the repo or running anything inside the cluster. Built on `commander` + Node built-ins (no native modules).

Implements the CLI foundation (#3649), assistant workflow skills (#3650), and the global coding-agent skill install (#3682) under epic #3648.

## What's included

- **Auth & profiles** — API-key login with multi-profile config (`~/.config/mgd/config.json`) and `MGD_*` env overrides; anonymous read supported.
- **Search** — keyword and semantic dataset search; `semantic-search-unavailable` is surfaced clearly on sites without the feature.
- **Records** — dataset/distribution inspection; dataset & distribution create/update, `add-file`, `replace-file`; custom aspect management; and a raw `api request` fallback for any REST endpoint.
- **Large-file transfer** — S3 multipart proxy upload and resumable HTTP Range download, degrading gracefully against servers without those endpoints.
- **Machine-friendly contract** — stdout/stderr separation, `--json`/`--jsonl` output, structured errors, and documented exit codes.
- **Coding-agent skills** — tool-agnostic `mgd-workflows.md` + `dataset-elicitation.md` plus a standard-format `SKILL.md` wrapper, auto-discovered by Claude Code, Codex and opencode.
- **Coding-agent skill install (#3682)** — `mgd skills install` / `mgd skills uninstall` vendor the `SKILL.md` bundle into each agent's native skills directory. Installs for **all three agents globally by default**, so the skill is available from any working directory; `--agent` targets one, `--project [dir]` installs repo-locally, and installs are idempotent. This replaces the earlier per-tool `AGENTS.md` wrapper.
- **Docs** — e2e test cases (including a coding-agent skill global auto-use case), docs index links, an `installing-minikube` pointer, and a `CHANGES.md` entry.

## Testing

- `yarn test` in `packages/mgd`: **77 unit tests passing** (mock-server auth/retry/Range/multipart, record/aspect payload builders golden-tested against the web client's shapes, output formatting/exit codes, profile store, and skill install/uninstall across global/project scopes).
- Manually verified end-to-end against `dev.magda.io` and a local minikube deployment (search, download, dataset create + file upload round-trip, semantic search behaviour).
- Verified the skill is **auto-used** by Claude Code, Codex and opencode when each is launched from an unrelated working directory after a global `mgd skills install` (see `docs/docs/e2e-test-cases/mgd-skill-auto-use.md`).

## Related

- Epic #3648 · CLI foundation #3649 · assistant skills #3650
- Closes #3682 (global coding-agent skill install).
- Builds on the storage-api large-file support in #3681.
