### PR TITLE
chore: bump ts-module-alias-transformer to ^3.0.0

### DIFF
--- a/magda-storage-api/package.json
+++ b/magda-storage-api/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "yarn run compile",
-    "compile": "tsc -b && rimraf \"dist/**/*.d.ts\" && ts-module-alias-transformer dist",
+    "compile": "tsc -b && ts-module-alias-transformer dist",
     "watch": "tsc -b --watch",
     "start": "node dist/index.js",
     "dev": "MINIO_HOST=localhost MINIO_PORT=9000 MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123  run-typescript-in-nodemon src/index.ts",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
     "rimraf": "^3.0.0",
-    "ts-module-alias-transformer": "^2.0.1",
+    "ts-module-alias-transformer": "^3.0.0",
     "typescript": "~5.3.3",
     "tsx": "^4.7.0",
     "type-fest": "~2.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23975,10 +23975,10 @@ ts-loader@^9.5.1:
     semver "^7.3.4"
     source-map "^0.7.4"
 
-ts-module-alias-transformer@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ts-module-alias-transformer/-/ts-module-alias-transformer-2.0.1.tgz#009c480e0ac9098d8863a62629327afcf1cc2c9f"
-  integrity sha512-YqTcaqGWdEmxKk6PAqUEzOJTSyUgBZdKt40o+L5c1DEnY2WEGmLAzPKvee9/obBhEb8es4B9c0QbNCMqRQ7fkA==
+ts-module-alias-transformer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ts-module-alias-transformer/-/ts-module-alias-transformer-3.0.0.tgz#14afd1c7443fb253249d67cab09cee4b93c410b4"
+  integrity sha512-ttpUapq6O4Fbz5eg/4u8CREcjdNaEhwtnm87D6QHaSKVS7QiIX5RSH2i8KDjt3BMTRlJVmpDBkH4/nGBAGZCPg==
 
 ts-node@^10.7.0:
   version "10.9.1"


### PR DESCRIPTION
## What

- Bump the `ts-module-alias-transformer` dev dependency from `^2.0.1` to `^3.0.0` (declared once, hoisted at the workspace root) and update `yarn.lock`.
- Remove the `rimraf "dist/**/*.d.ts"` workaround from `magda-storage-api`'s `compile` script.

## Why

`storage-api` added public method signatures referencing Node built-in types, so TypeScript emitted `/// <reference types="node" resolution-mode="require" />` directives and declaration-only syntax into the generated `.d.ts`. The old `ts-module-alias-transformer` (`2.0.1`) aborted on those files **and exited 0**, silently leaving `.js` files with un-rewritten import specifiers — which shipped a broken bundle that failed at runtime with `ERR_MODULE_NOT_FOUND`. The workaround was to strip `.d.ts` before running the transformer, which also disabled `.d.ts` alias rewriting.

[ts-module-alias-transformer v3.0.0](https://github.com/magda-io/ts-module-alias-transformer/releases/tag/v3.0.0) fixes this (magda-io/ts-module-alias-transformer#15):
- `.d.ts` files are parsed correctly (declaration syntax + `resolution-mode` directives).
- A parse error on any file is now a hard, non-zero-exit failure instead of a silent partial rewrite.

So the workaround is no longer needed, and `.d.ts` alias rewriting is restored for `storage-api`.

## Verification

Validated the published `3.0.0` against a real `magda-storage-api` build: `.d.ts` files (including `MagdaMinioClient.d.ts` / `ObjectFromStore.d.ts`) are rewritten correctly and `index.js` gets its `magda-typescript-common/src` → `@magda/typescript-common/dist` aliases, with exit 0.