### PR TITLE
feat(mgd): profile management commands (`profile create`/`update`/`remove`); move `auth login`→`profile create`

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -43,8 +43,8 @@ skill files under [`skills/`](./skills/).
 ## Quick start
 
 ```sh
-# 1. Log in (prompts for site URL, API key ID and key; or pass them as flags)
-mgd auth login
+# 1. Create a profile (prompts for site URL, API key ID and key; or pass them as flags)
+mgd profile create default
 
 # 2. Confirm who you are and where
 mgd auth status
@@ -61,38 +61,54 @@ mgd dist download magda-dist-<uuid> -o data.csv
 
 ## Authentication and profiles
 
-### Logging in
+### Setting up a profile
 
 Create an API key in the MAGDA web UI first
 ([**Settings → API Keys**](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-create-api-key.md)),
-then:
+then create a profile:
 
 ```sh
-mgd auth login
+mgd profile create default
 # or non-interactively:
-mgd auth login --url https://dev.magda.io --key-id <id> --key <key> --profile default
+mgd profile create default --url https://dev.magda.io --key-id <id> --key <key>
 ```
 
+- The profile `<name>` is **required** — there is no implicit target, so you
+  can't accidentally set up the wrong profile.
 - `--url` accepts either a **site URL** (`https://dev.magda.io`) or a full **API
-  base URL** — `mgd` normalises it by probing `<url>/api/v0` then `<url>/v0`, so
+  base URL** — `mgd` normalises it by probing `<url>` first, then `<url>/api`, so
   non-standard gateway mounts work.
-- Credentials are verified against the API before being saved.
+- Any of `--url` / `--key-id` / `--key` you don't pass is **prompted for** (the
+  key is entered hidden). Credentials are verified against the API before saving.
 - Leave the API key ID empty to configure **anonymous** access (MAGDA supports
   anonymous read access to public data).
+- `create` **refuses to overwrite** an existing profile — use `profile update`
+  to change one, or `profile remove` to delete it first.
 
-### Profiles
+### Managing profiles
 
 Credentials are stored per named profile in `~/.config/mgd/config.json`
 (respecting `$XDG_CONFIG_HOME`), with restrictive permissions (`0600` file,
-`0700` directory). The default profile is named `default`.
+`0700` directory). The default profile is named `default`. Every `profile`
+subcommand **except `list`** takes a required positional `<name>`.
 
 ```sh
-mgd auth login --profile prod --url https://prod.example.com   # add a profile
-mgd profile list                                               # list profiles
-mgd profile use prod                                           # switch active profile
-mgd auth status                                                # who am I, where
-mgd auth logout                                                # clear active profile creds
+mgd profile create prod --url https://prod.example.com   # create a new profile
+mgd profile update prod --key-id <id> --key <key>        # patch only the given fields
+mgd profile list                                         # list profiles
+mgd profile use prod                                     # switch the active profile
+mgd profile remove prod                                  # delete a profile
+mgd auth status                                          # who am I, where
 ```
+
+- **`profile update <name>`** changes **only** the fields you pass
+  (`--url` / `--key-id` / `--key`); it does **not** prompt, errors if you pass no
+  field, and errors if the profile doesn't exist. Handy for rotating a key.
+- **`profile remove <name>`** deletes the profile; if it was the active one, the
+  active profile resets to `default`.
+- **`mgd auth login`** is a **deprecated** alias of `profile create` (it keeps
+  its `--profile <name>` flag, defaulting to `default`) and prints a notice.
+  **`mgd auth logout` has been removed** — use `mgd profile remove <name>`.
 
 `mgd auth status` reports the active profile, base URL and the identity returned
 by the server; it shows `anonymous` when no credentials are configured.
@@ -291,8 +307,10 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 
 | Command                                               | Description                                             |
 | ----------------------------------------------------- | ------------------------------------------------------- |
-| `auth login` / `auth status` / `auth logout`          | Manage credentials for a site profile                   |
+| `profile create <name>` / `update <name>` / `remove <name>` | Create / patch / delete a site profile            |
 | `profile list` / `profile use <name>`                 | List / switch profiles                                  |
+| `auth status`                                         | Show the active profile and authenticated user          |
+| `auth login`                                          | Deprecated alias of `profile create` (`--profile`)      |
 | `search datasets <query>`                             | Keyword dataset search                                  |
 | `search semantic <query>`                             | Semantic (embedding) search                             |
 | `dataset get <id>`                                    | Fetch a dataset record                                  |
@@ -358,8 +376,10 @@ saved profile, or the `MGD_*` environment variables; check with `mgd auth status
 
 ## Troubleshooting
 
-- **`Authentication error` (exit 3)** — no or invalid credentials. Re-run
-  `mgd auth login`, or check `MGD_API_KEY_ID` / `MGD_API_KEY`.
+- **`Authentication error` (exit 3)** — no or invalid credentials. Recreate the
+  profile with `mgd profile create <name>` (or update it with
+  `mgd profile update <name> --key-id … --key …`), or check
+  `MGD_API_KEY_ID` / `MGD_API_KEY`.
 - **`semantic-search-unavailable` (exit 1)** — the target site doesn't have the
   semantic-search components installed; use `mgd search datasets` instead.
 - **`Not found` (exit 4)** — the record or storage object doesn't exist (or your

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -7,7 +7,9 @@ your assistant environment, keep the rules.
 ## Ground rules
 
 1. **Check auth first.** Before any MAGDA access, run `mgd auth status --json`.
-   If it fails with exit code 2, ask the user to run `mgd auth login`. If
+   If it fails with exit code 2, no usable profile is configured — relay the
+   error message, which says whether to run `mgd profile create <name>` (none
+   set up) or `mgd profile use <name>` (one exists but isn't active). If
    `authenticated` is `false`, read-only public commands may still work, but
    mutations will fail — say so up front.
 2. **Prefer curated commands** (`search`, `dataset`, `dist`, `file`, `aspect`)
@@ -97,8 +99,9 @@ mgd api request GET /v0/registry/records --query limit=3 --query aspect=dcat-dat
 
 ## Error triage
 
-- exit 3 + `unauthorized` → API key invalid/expired: ask the user to re-run
-  `mgd auth login`.
+- exit 3 + `unauthorized` → API key invalid/expired: ask the user to update the
+  profile (`mgd profile update <name> --key-id … --key …`) or recreate it
+  (`mgd profile create <name>`).
 - exit 3 + `forbidden` → the key works but lacks permission: report which
   operation was denied; do not retry.
 - exit 4 → record/object doesn't exist: re-check the ID (search again) before

--- a/packages/mgd/src/client.ts
+++ b/packages/mgd/src/client.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
-import { MgdApiError, UsageError } from "./errors.js";
-import { loadConfig, resolveProfile, Profile } from "./profile.js";
+import { MgdApiError } from "./errors.js";
+import {
+    loadConfig,
+    resolveProfile,
+    noProfileError,
+    Profile
+} from "./profile.js";
 import { VERSION } from "./version.js";
 
 export interface ClientOptions {
@@ -131,9 +136,7 @@ export async function clientFromProfile(): Promise<MagdaClient> {
     const cfg = await loadConfig();
     const { profile } = resolveProfile(cfg);
     if (!profile?.baseUrl) {
-        throw new UsageError(
-            "No active profile. Run `mgd auth login` or set MGD_BASE_URL."
-        );
+        throw noProfileError(cfg);
     }
     return clientFor(profile);
 }

--- a/packages/mgd/src/commands/auth.ts
+++ b/packages/mgd/src/commands/auth.ts
@@ -1,89 +1,43 @@
 import { Command } from "commander";
-import { UsageError } from "../errors.js";
 import { clientFor } from "../client.js";
 import { WHOAMI } from "../endpoints.js";
-import { loadConfig, saveConfig, resolveProfile } from "../profile.js";
-import { promptText, promptHidden } from "../prompt.js";
+import { loadConfig, resolveProfile, noProfileError } from "../profile.js";
 import { note, colors, printData, resolveMode } from "../output.js";
+import { createProfile } from "./profileSetup.js";
 
-export async function normalizeBaseUrl(
-    input: string,
-    probe: (baseUrl: string) => Promise<boolean>
-): Promise<string> {
-    const trimmed = input.replace(/\/+$/, "");
-    const candidates = [trimmed];
-    if (!/\/api$/.test(new URL(trimmed).pathname)) {
-        candidates.push(`${trimmed}/api`);
-    }
-    for (const candidate of candidates) {
-        if (await probe(candidate)) return candidate;
-    }
-    throw new UsageError(
-        `Could not find a MAGDA API at ${input} (tried: ${candidates.join(
-            ", "
-        )}).`
-    );
-}
-
-async function probeApi(baseUrl: string): Promise<boolean> {
-    try {
-        const res = await fetch(`${baseUrl}${WHOAMI}`, {
-            headers: { accept: "application/json" }
-        });
-        const contentType = res.headers.get("content-type") || "";
-        return contentType.includes("json");
-    } catch {
-        return false;
-    }
-}
+// Re-exported for back-compat with existing imports/tests; the implementation
+// now lives with the shared profile-setup helpers.
+export { normalizeBaseUrl } from "./profileSetup.js";
 
 export function registerAuthCommands(program: Command): void {
     const auth = program.command("auth").description("Authentication");
 
     auth.command("login")
-        .description("Log in to a MAGDA site with an API key")
+        .description(
+            "[deprecated] Set up a profile's credentials — use `mgd profile create <name>`"
+        )
         .option("--url <url>", "MAGDA site or API base URL")
         .option("--key-id <id>", "API key ID")
         .option("--key <key>", "API key")
         .option("--profile <name>", "profile name", "default")
+        .addHelpText(
+            "after",
+            "\nDeprecated alias of `mgd profile create <name>`. " +
+                "Prefer `mgd profile create`, which takes the profile name as a\n" +
+                "positional argument and refuses to overwrite an existing profile."
+        )
         .action(async (opts) => {
             note(
-                "Create an API key in the MAGDA web UI (Settings -> API keys),\n" +
-                    "then enter it below. Leave key fields empty for anonymous access.\n"
-            );
-            const rawUrl = opts.url || (await promptText("MAGDA site URL: "));
-            const baseUrl = await normalizeBaseUrl(rawUrl, probeApi);
-            const apiKeyId =
-                opts.keyId ??
-                (await promptText("API key ID (empty for anonymous): "));
-            const apiKey = apiKeyId
-                ? opts.key ?? (await promptHidden("API key: "))
-                : "";
-
-            const client = clientFor({
-                baseUrl,
-                apiKeyId: apiKeyId || undefined,
-                apiKey: apiKey || undefined
-            });
-            const user = await client.json<any>("GET", WHOAMI);
-
-            const cfg = await loadConfig();
-            cfg.profiles[opts.profile] = {
-                baseUrl,
-                ...(apiKeyId ? { apiKeyId, apiKey } : {})
-            };
-            cfg.activeProfile = opts.profile;
-            await saveConfig(cfg);
-
-            note(
-                colors.green(
-                    `Logged in to ${baseUrl}` +
-                        (user?.displayName
-                            ? ` as ${user.displayName}`
-                            : " (anonymous)") +
-                        ` (profile "${opts.profile}").`
+                colors.yellow(
+                    "`mgd auth login` is deprecated; use " +
+                        "`mgd profile create <name>` instead."
                 )
             );
+            await createProfile(opts.profile, {
+                url: opts.url,
+                keyId: opts.keyId,
+                key: opts.key
+            });
         });
 
     auth.command("status")
@@ -93,9 +47,7 @@ export function registerAuthCommands(program: Command): void {
             const cfg = await loadConfig();
             const { name, profile } = resolveProfile(cfg);
             if (!profile?.baseUrl) {
-                throw new UsageError(
-                    "No active profile. Run `mgd auth login` or set MGD_BASE_URL."
-                );
+                throw noProfileError(cfg);
             }
             const client = clientFor(profile);
             const user = await client.json<any>("GET", WHOAMI);
@@ -126,19 +78,5 @@ export function registerAuthCommands(program: Command): void {
             } else {
                 printData(mode, status);
             }
-        });
-
-    auth.command("logout")
-        .description("Remove stored credentials for a profile")
-        .option("--profile <name>", "profile name")
-        .action(async (opts) => {
-            const cfg = await loadConfig();
-            const name = opts.profile || cfg.activeProfile || "default";
-            const profile = cfg.profiles[name];
-            if (!profile) throw new UsageError(`No such profile: ${name}`);
-            delete profile.apiKeyId;
-            delete profile.apiKey;
-            await saveConfig(cfg);
-            note(`Removed credentials from profile "${name}".`);
         });
 }

--- a/packages/mgd/src/commands/profileCmd.ts
+++ b/packages/mgd/src/commands/profileCmd.ts
@@ -2,6 +2,14 @@ import { Command } from "commander";
 import { UsageError } from "../errors.js";
 import { loadConfig, saveConfig } from "../profile.js";
 import { note, printData, resolveMode } from "../output.js";
+import { createProfile, updateProfile } from "./profileSetup.js";
+
+function requireName(name: string | undefined, usage: string): string {
+    if (!name) {
+        throw new UsageError(`Profile name is required. Usage: ${usage}`);
+    }
+    return name;
+}
 
 export function registerProfileCommands(program: Command): void {
     const profile = program.command("profile").description("Manage profiles");
@@ -30,6 +38,51 @@ export function registerProfileCommands(program: Command): void {
             } else {
                 printData(mode, rows);
             }
+        });
+
+    profile
+        .command("create [name]")
+        .description("Create a new profile with credentials")
+        .option("--url <url>", "MAGDA site or API base URL")
+        .option("--key-id <id>", "API key ID")
+        .option("--key <key>", "API key")
+        .action(async (name: string | undefined, opts) => {
+            const target = requireName(name, "mgd profile create <name>");
+            await createProfile(target, {
+                url: opts.url,
+                keyId: opts.keyId,
+                key: opts.key
+            });
+        });
+
+    profile
+        .command("update [name]")
+        .description("Update an existing profile's credentials")
+        .option("--url <url>", "MAGDA site or API base URL")
+        .option("--key-id <id>", "API key ID")
+        .option("--key <key>", "API key")
+        .action(async (name: string | undefined, opts) => {
+            const target = requireName(name, "mgd profile update <name>");
+            await updateProfile(target, {
+                url: opts.url,
+                keyId: opts.keyId,
+                key: opts.key
+            });
+        });
+
+    profile
+        .command("remove [name]")
+        .description("Delete a profile")
+        .action(async (name: string | undefined) => {
+            const target = requireName(name, "mgd profile remove <name>");
+            const cfg = await loadConfig();
+            if (!cfg.profiles[target])
+                throw new UsageError(`No such profile: ${target}`);
+            delete cfg.profiles[target];
+            // If the removed profile was active, fall back to `default`.
+            if (cfg.activeProfile === target) delete cfg.activeProfile;
+            await saveConfig(cfg);
+            note(`Removed profile "${target}".`);
         });
 
     profile

--- a/packages/mgd/src/commands/profileSetup.ts
+++ b/packages/mgd/src/commands/profileSetup.ts
@@ -1,0 +1,156 @@
+import { UsageError } from "../errors.js";
+import { clientFor } from "../client.js";
+import { WHOAMI } from "../endpoints.js";
+import { loadConfig, saveConfig, Profile } from "../profile.js";
+import { promptText, promptHidden } from "../prompt.js";
+import { note, colors } from "../output.js";
+
+export async function normalizeBaseUrl(
+    input: string,
+    probe: (baseUrl: string) => Promise<boolean>
+): Promise<string> {
+    const trimmed = input.replace(/\/+$/, "");
+    const candidates = [trimmed];
+    if (!/\/api$/.test(new URL(trimmed).pathname)) {
+        candidates.push(`${trimmed}/api`);
+    }
+    for (const candidate of candidates) {
+        if (await probe(candidate)) return candidate;
+    }
+    throw new UsageError(
+        `Could not find a MAGDA API at ${input} (tried: ${candidates.join(
+            ", "
+        )}).`
+    );
+}
+
+async function probeApi(baseUrl: string): Promise<boolean> {
+    try {
+        const res = await fetch(`${baseUrl}${WHOAMI}`, {
+            headers: { accept: "application/json" }
+        });
+        const contentType = res.headers.get("content-type") || "";
+        return contentType.includes("json");
+    } catch {
+        return false;
+    }
+}
+
+/** Field flags shared by `profile create`, `profile update` and `auth login`. */
+export interface CredentialOptions {
+    url?: string;
+    keyId?: string;
+    key?: string;
+}
+
+/** Verify a profile's credentials against the API and return the whoami user. */
+async function verifyCredentials(profile: Profile): Promise<any> {
+    const client = clientFor(profile);
+    return client.json<any>("GET", WHOAMI);
+}
+
+function identityLabel(user: any): string {
+    return user?.displayName ? ` as ${user.displayName}` : " (anonymous)";
+}
+
+/**
+ * Create a new profile. Prompts for any of url/key-id/key not supplied, verifies
+ * the credentials, refuses to overwrite an existing profile, and makes the new
+ * profile active. Shared by `mgd profile create` and the deprecated `auth login`.
+ */
+export async function createProfile(
+    name: string,
+    opts: CredentialOptions
+): Promise<void> {
+    const cfg = await loadConfig();
+    if (cfg.profiles[name]) {
+        throw new UsageError(
+            `Profile "${name}" already exists. ` +
+                `Use \`mgd profile update ${name}\` to change it, or ` +
+                `\`mgd profile remove ${name}\` first.`
+        );
+    }
+
+    note(
+        "Create an API key in the MAGDA web UI (Settings -> API keys),\n" +
+            "then enter it below. Leave key fields empty for anonymous access.\n"
+    );
+    const rawUrl = opts.url || (await promptText("MAGDA site URL: "));
+    const baseUrl = await normalizeBaseUrl(rawUrl, probeApi);
+    const apiKeyId =
+        opts.keyId ??
+        (await promptText("API key ID (empty for anonymous): "));
+    const apiKey = apiKeyId
+        ? opts.key ?? (await promptHidden("API key: "))
+        : "";
+
+    const profile: Profile = {
+        baseUrl,
+        ...(apiKeyId ? { apiKeyId, apiKey } : {})
+    };
+    const user = await verifyCredentials(profile);
+
+    cfg.profiles[name] = profile;
+    cfg.activeProfile = name;
+    await saveConfig(cfg);
+
+    note(
+        colors.green(
+            `Created profile "${name}" for ${baseUrl}${identityLabel(user)}.`
+        )
+    );
+}
+
+/**
+ * Update an existing profile, patching ONLY the supplied url/key-id/key fields
+ * (no prompting). Verifies the resulting credentials before saving. Errors if
+ * the profile does not exist or if no field was supplied.
+ */
+export async function updateProfile(
+    name: string,
+    opts: CredentialOptions
+): Promise<void> {
+    if (
+        opts.url === undefined &&
+        opts.keyId === undefined &&
+        opts.key === undefined
+    ) {
+        throw new UsageError(
+            "Nothing to update. Supply at least one of --url, --key-id, --key."
+        );
+    }
+
+    const cfg = await loadConfig();
+    const existing = cfg.profiles[name];
+    if (!existing) {
+        throw new UsageError(
+            `No such profile: ${name}. ` +
+                `Use \`mgd profile create ${name}\` to create it.`
+        );
+    }
+
+    const next: Profile = { ...existing };
+    if (opts.url !== undefined) {
+        next.baseUrl = await normalizeBaseUrl(opts.url, probeApi);
+    }
+    if (opts.keyId !== undefined) next.apiKeyId = opts.keyId;
+    if (opts.key !== undefined) next.apiKey = opts.key;
+    // An empty key id means anonymous access — drop both credential fields.
+    if (!next.apiKeyId) {
+        delete next.apiKeyId;
+        delete next.apiKey;
+    }
+
+    const user = await verifyCredentials(next);
+
+    cfg.profiles[name] = next;
+    await saveConfig(cfg);
+
+    note(
+        colors.green(
+            `Updated profile "${name}" (${next.baseUrl}${identityLabel(
+                user
+            )}).`
+        )
+    );
+}

--- a/packages/mgd/src/profile.ts
+++ b/packages/mgd/src/profile.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { UsageError } from "./errors.js";
 
 export interface Profile {
     baseUrl: string;
@@ -69,4 +70,42 @@ export function resolveProfile(
         name: env.MGD_BASE_URL && !fromFile ? "env" : name,
         profile: overridden
     };
+}
+
+const ENV_HINT =
+    "set MGD_BASE_URL/MGD_API_KEY_ID/MGD_API_KEY for a one-off.";
+
+/**
+ * Build a context-aware error for when no usable profile could be resolved.
+ * Distinguishes "no profiles at all" from "profiles exist but none is active"
+ * (and the special case of MGD_PROFILE naming an unknown profile) so the
+ * message tells the user exactly what to do next.
+ */
+export function noProfileError(
+    cfg: ConfigFile,
+    env: NodeJS.ProcessEnv = process.env
+): UsageError {
+    const names = Object.keys(cfg.profiles);
+
+    if (names.length === 0) {
+        return new UsageError(
+            "No profiles configured. Run `mgd profile create <name>` to get " +
+                `started, or ${ENV_HINT}`
+        );
+    }
+
+    const available = `Available profiles: ${names.join(", ")}.`;
+
+    if (env.MGD_PROFILE) {
+        return new UsageError(
+            `Profile "${env.MGD_PROFILE}" (from MGD_PROFILE) not found. ` +
+                available
+        );
+    }
+
+    return new UsageError(
+        "No active profile. Set one with `mgd profile use <name>`, or select " +
+            `one per command via the MGD_PROFILE env var. ${available} ` +
+            `Alternatively, ${ENV_HINT}`
+    );
 }

--- a/packages/mgd/src/test/profile.spec.ts
+++ b/packages/mgd/src/test/profile.spec.ts
@@ -7,8 +7,10 @@ import {
     loadConfig,
     saveConfig,
     resolveProfile,
+    noProfileError,
     ConfigFile
 } from "../profile.js";
+import { UsageError, exitCodeFor } from "../errors.js";
 
 describe("profile store", () => {
     let tmp: string;
@@ -94,5 +96,47 @@ describe("profile store", () => {
         });
         expect(name).to.equal("p2");
         expect(profile?.baseUrl).to.equal("https://b/api");
+    });
+});
+
+describe("noProfileError", () => {
+    const env: NodeJS.ProcessEnv = {};
+
+    it("is a UsageError (exit 2)", () => {
+        const e = noProfileError({ profiles: {} }, env);
+        expect(e).to.be.instanceOf(UsageError);
+        expect(exitCodeFor(e)).to.equal(2);
+    });
+
+    it("points to `profile create` when no profiles exist", () => {
+        const e = noProfileError({ profiles: {} }, env);
+        expect(e.message).to.match(/profile create/);
+        expect(e.message).to.not.match(/profile use/);
+    });
+
+    it("points to `profile use` and lists profiles when some exist but none is active", () => {
+        const e = noProfileError(
+            {
+                profiles: {
+                    prod: { baseUrl: "https://a/api" },
+                    dev: { baseUrl: "https://b/api" }
+                }
+            },
+            env
+        );
+        expect(e.message).to.match(/profile use/);
+        expect(e.message).to.match(/MGD_PROFILE/);
+        expect(e.message).to.contain("prod");
+        expect(e.message).to.contain("dev");
+    });
+
+    it("names the missing profile when MGD_PROFILE points to an unknown one", () => {
+        const e = noProfileError(
+            { profiles: { prod: { baseUrl: "https://a/api" } } },
+            { ...env, MGD_PROFILE: "ghost" }
+        );
+        expect(e.message).to.contain("ghost");
+        expect(e.message).to.match(/MGD_PROFILE/);
+        expect(e.message).to.contain("prod");
     });
 });

--- a/packages/mgd/src/test/profileCmd.spec.ts
+++ b/packages/mgd/src/test/profileCmd.spec.ts
@@ -1,0 +1,339 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { registerProfileCommands } from "../commands/profileCmd.js";
+import { registerAuthCommands } from "../commands/auth.js";
+import { loadConfig, saveConfig } from "../profile.js";
+import { UsageError, exitCodeFor } from "../errors.js";
+import { startMockServer } from "./mockServer.js";
+
+const WHOAMI_ROUTE = {
+    method: "GET",
+    path: "/v0/auth/users/whoami",
+    body: { id: "u1", displayName: "Test User" }
+};
+
+/** Run argv against a fresh program and return the thrown error (or undefined). */
+async function run(
+    register: (p: Command) => void,
+    argv: string[]
+): Promise<unknown> {
+    const program = new Command();
+    register(program);
+    try {
+        await program.parseAsync(argv, { from: "user" });
+        return undefined;
+    } catch (e) {
+        return e;
+    }
+}
+
+describe("profile create/update/remove", () => {
+    let tmp: string;
+    const origEnv: Record<string, string | undefined> = {};
+
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-profcmd-"));
+        for (const k of [
+            "XDG_CONFIG_HOME",
+            "MGD_BASE_URL",
+            "MGD_API_KEY_ID",
+            "MGD_API_KEY",
+            "MGD_PROFILE"
+        ]) {
+            origEnv[k] = process.env[k];
+            delete process.env[k];
+        }
+        process.env.XDG_CONFIG_HOME = tmp;
+    });
+    afterEach(async () => {
+        for (const [k, v] of Object.entries(origEnv)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    describe("create", () => {
+        it("creates a profile, verifies whoami, saves and activates it", async () => {
+            const server = await startMockServer([WHOAMI_ROUTE]);
+            try {
+                const err = await run(registerProfileCommands, [
+                    "profile",
+                    "create",
+                    "prod",
+                    "--url",
+                    server.url,
+                    "--key-id",
+                    "kid",
+                    "--key",
+                    "kv"
+                ]);
+                expect(err).to.equal(undefined);
+                const cfg = await loadConfig();
+                expect(cfg.profiles.prod.baseUrl).to.equal(server.url);
+                expect(cfg.profiles.prod.apiKeyId).to.equal("kid");
+                expect(cfg.profiles.prod.apiKey).to.equal("kv");
+                expect(cfg.activeProfile).to.equal("prod");
+            } finally {
+                await server.close();
+            }
+        });
+
+        it("refuses to overwrite an existing profile (usage error, exit 2)", async () => {
+            await saveConfig({
+                activeProfile: "prod",
+                profiles: { prod: { baseUrl: "https://x/api" } }
+            });
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "create",
+                "prod",
+                "--url",
+                "https://y/api",
+                "--key-id",
+                "",
+                "--key",
+                ""
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+            // untouched
+            const cfg = await loadConfig();
+            expect(cfg.profiles.prod.baseUrl).to.equal("https://x/api");
+        });
+
+        it("errors (exit 2) when <name> is omitted", async () => {
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "create"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+    });
+
+    describe("update", () => {
+        beforeEach(async () => {
+            await saveConfig({
+                activeProfile: "prod",
+                profiles: {
+                    prod: {
+                        baseUrl: "https://x/api",
+                        apiKeyId: "old",
+                        apiKey: "oldkey"
+                    }
+                }
+            });
+        });
+
+        it("patches only supplied fields, verifies, leaves the rest", async () => {
+            const server = await startMockServer([WHOAMI_ROUTE]);
+            try {
+                // point baseUrl at the mock so verification hits it
+                await saveConfig({
+                    activeProfile: "prod",
+                    profiles: {
+                        prod: {
+                            baseUrl: server.url,
+                            apiKeyId: "old",
+                            apiKey: "oldkey"
+                        }
+                    }
+                });
+                const err = await run(registerProfileCommands, [
+                    "profile",
+                    "update",
+                    "prod",
+                    "--key-id",
+                    "new"
+                ]);
+                expect(err).to.equal(undefined);
+                const cfg = await loadConfig();
+                expect(cfg.profiles.prod.baseUrl).to.equal(server.url);
+                expect(cfg.profiles.prod.apiKeyId).to.equal("new");
+                // apiKey left unchanged
+                expect(cfg.profiles.prod.apiKey).to.equal("oldkey");
+                // active profile untouched by update
+                expect(cfg.activeProfile).to.equal("prod");
+            } finally {
+                await server.close();
+            }
+        });
+
+        it("errors (exit 2) when nothing was supplied", async () => {
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "update",
+                "prod"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+
+        it("errors (exit 2) when the profile does not exist", async () => {
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "update",
+                "ghost",
+                "--key-id",
+                "x"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+
+        it("errors (exit 2) when <name> is omitted", async () => {
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "update",
+                "--key-id",
+                "x"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+    });
+
+    describe("remove", () => {
+        it("deletes a profile and resets the active profile", async () => {
+            await saveConfig({
+                activeProfile: "prod",
+                profiles: {
+                    prod: { baseUrl: "https://x/api" },
+                    dev: { baseUrl: "https://y/api" }
+                }
+            });
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "remove",
+                "prod"
+            ]);
+            expect(err).to.equal(undefined);
+            const cfg = await loadConfig();
+            expect(cfg.profiles.prod).to.equal(undefined);
+            expect(cfg.profiles.dev).to.not.equal(undefined);
+            // active reset away from the removed profile
+            expect(cfg.activeProfile ?? "default").to.not.equal("prod");
+        });
+
+        it("keeps activeProfile when removing a non-active profile", async () => {
+            await saveConfig({
+                activeProfile: "prod",
+                profiles: {
+                    prod: { baseUrl: "https://x/api" },
+                    dev: { baseUrl: "https://y/api" }
+                }
+            });
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "remove",
+                "dev"
+            ]);
+            expect(err).to.equal(undefined);
+            const cfg = await loadConfig();
+            expect(cfg.activeProfile).to.equal("prod");
+        });
+
+        it("errors (exit 2) when the profile does not exist", async () => {
+            await saveConfig({ profiles: {} });
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "remove",
+                "ghost"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+
+        it("errors (exit 2) when <name> is omitted", async () => {
+            const err = await run(registerProfileCommands, [
+                "profile",
+                "remove"
+            ]);
+            expect(err).to.be.instanceOf(UsageError);
+            expect(exitCodeFor(err)).to.equal(2);
+        });
+    });
+});
+
+describe("auth login (deprecated alias of profile create)", () => {
+    let tmp: string;
+    const origEnv: Record<string, string | undefined> = {};
+
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mgd-authalias-"));
+        for (const k of [
+            "XDG_CONFIG_HOME",
+            "MGD_BASE_URL",
+            "MGD_API_KEY_ID",
+            "MGD_API_KEY",
+            "MGD_PROFILE"
+        ]) {
+            origEnv[k] = process.env[k];
+            delete process.env[k];
+        }
+        process.env.XDG_CONFIG_HOME = tmp;
+    });
+    afterEach(async () => {
+        for (const [k, v] of Object.entries(origEnv)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+        await fs.rm(tmp, { recursive: true, force: true });
+    });
+
+    it("creates the profile named by --profile (default `default`)", async () => {
+        const server = await startMockServer([WHOAMI_ROUTE]);
+        try {
+            const err = await run(registerAuthCommands, [
+                "auth",
+                "login",
+                "--url",
+                server.url,
+                "--key-id",
+                "kid",
+                "--key",
+                "kv"
+            ]);
+            expect(err).to.equal(undefined);
+            const cfg = await loadConfig();
+            expect(cfg.profiles.default.baseUrl).to.equal(server.url);
+            expect(cfg.profiles.default.apiKeyId).to.equal("kid");
+            expect(cfg.activeProfile).to.equal("default");
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("refuses to overwrite an existing profile, like profile create", async () => {
+        await saveConfig({
+            activeProfile: "default",
+            profiles: { default: { baseUrl: "https://x/api" } }
+        });
+        const err = await run(registerAuthCommands, [
+            "auth",
+            "login",
+            "--url",
+            "https://y/api",
+            "--key-id",
+            "",
+            "--key",
+            ""
+        ]);
+        expect(err).to.be.instanceOf(UsageError);
+        expect(exitCodeFor(err)).to.equal(2);
+    });
+
+    it("no longer registers `auth logout`", () => {
+        const program = new Command();
+        registerAuthCommands(program);
+        const auth = program.commands.find((c) => c.name() === "auth");
+        const subs = (auth?.commands ?? []).map((c) => c.name());
+        expect(subs).to.include("login");
+        expect(subs).to.include("status");
+        expect(subs).to.not.include("logout");
+    });
+});


### PR DESCRIPTION
Implements #3692.

Folds `mgd` credential setup into first-class `profile` management, reserving the `login` verb for the future interactive login (#3693).

## Changes

### New `profile` subcommands (each takes a compulsory positional `<name>`, except `list`)
- **`profile create <name>`** — prompts for any missing `--url`/`--key-id`/`--key`, verifies credentials against the API, activates the profile, and **refuses to overwrite** an existing one (usage error, exit 2).
- **`profile update <name>`** — patches **only** the supplied `--url`/`--key-id`/`--key` (no prompting), verifies before saving; errors (exit 2) if nothing supplied or the profile doesn't exist.
- **`profile remove <name>`** — deletes the profile and resets `activeProfile` when it was the active one.

### `auth` changes
- **`auth login`** is now a **deprecated alias** of `profile create` (keeps `--profile`, default `default`), prints a deprecation notice, and its `--help` points to `profile create`.
- **`auth logout` removed** — cleanup is `profile remove <name>`.

### Other
- Shared credential logic extracted to `src/commands/profileSetup.ts` (`createProfile`/`updateProfile`), reused by the commands and the alias (avoids a circular import).
- **Context-aware "no profile" errors**: distinguish *no profiles configured* (→ `profile create`), *profiles exist but none active* (→ `profile use` / `MGD_PROFILE`, lists available), and *`MGD_PROFILE` names an unknown profile*.
- README profile/auth docs and the `mgd-workflows` skill updated; fixed a stale URL-normalization note.

## Testing
- Unit tests: `profileCmd.spec.ts` (create/update/remove + `auth login` alias parity + `logout` removal) and `noProfileError` cases in `profile.spec.ts`. **95 passing**, `tsc --noEmit` clean, build clean.
- **E2E against dev.magda.io**: 25/25 checks passed (create/verify, refuse-overwrite, update patch, list/use, remove + active-reset, alias parity, `logout` gone) using an isolated config dir.

## Acceptance criteria (#3692)
- [x] Every `profile` subcommand except `list` requires `<name>` (omitting → exit 2).
- [x] `create` prompts for missing fields, verifies, errors if `<name>` exists.
- [x] `update` patches only supplied fields, errors on nothing-to-update / missing profile.
- [x] `remove` deletes and resets `activeProfile`.
- [x] `auth login` behaves identically to `profile create`, prints deprecation, `--help` points to `profile create`.
- [x] `auth logout` removed.
- [x] README updated (profile management + resolution precedence).
- [x] Tests cover create/update/remove, usage errors, and alias parity.