### PR TITLE
feat(mgd): return all aspects from dataset get / dist get

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -196,9 +196,15 @@ dataset ID.
 ```sh
 mgd dataset get magda-ds-<uuid>                       # dataset record
 mgd dataset get magda-ds-<uuid> --json                # full record as JSON
+mgd dataset get magda-ds-<uuid> --aspect <aspectId>   # just one aspect
 mgd dataset distributions magda-ds-<uuid> --jsonl     # its distributions
 mgd dist get magda-dist-<uuid> --json                 # a single distribution
 ```
+
+`--json` returns the **complete** record with every aspect attached to it,
+including any custom aspects you have set (`mgd aspect create` + `--aspect` /
+`mgd dataset aspect set`). Human-mode output shows the curated highlights only;
+pass `--json` (and pipe through `jq`) to see everything.
 
 Distribution records carry metadata under aspects such as
 `dcat-distribution-strings` (title, format, `downloadURL`/`accessURL`). Use

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -51,7 +51,9 @@ jq -r '.identifier' kw.jsonl > ids.txt
 jq -r '.recordId' sem.jsonl | grep -v -x -F -f ids.txt >> ids.txt
 ```
 
-Then inspect the top candidates with `mgd dataset get <id> --json`.
+Then inspect the top candidates with `mgd dataset get <id> --json`. This returns
+the complete record with **all** aspects attached to it, including any custom
+aspects (`.aspects["<aspectId>"]`); use `--aspect <aspectId>` to fetch just one.
 
 ## Common recipes
 

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { clientFromProfile, MagdaClient } from "../client.js";
 import {
     registryRecord,
+    registryRecordInFull,
     recordAspect,
     WHOAMI,
     REGISTRY_RECORDS,
@@ -24,21 +25,6 @@ import {
     DATASETS_BUCKET_DEFAULT
 } from "../recordBuilders.js";
 import { uploadFile } from "../transfer.js";
-
-export const DATASET_OPTIONAL_ASPECTS = [
-    "dcat-dataset-strings",
-    "dataset-distributions",
-    "publishing",
-    "access-control",
-    "source",
-    "version",
-    "currency",
-    "provenance",
-    "spatial-coverage",
-    "temporal-coverage",
-    "information-security",
-    "access"
-];
 
 export async function fetchOwner(
     client: MagdaClient
@@ -111,13 +97,7 @@ export function registerDatasetCommands(program: Command): void {
             }
             const record = await client.json<any>(
                 "GET",
-                registryRecord(datasetId),
-                {
-                    query: DATASET_OPTIONAL_ASPECTS.map((a): [
-                        string,
-                        string
-                    ] => ["optionalAspect", a])
-                }
+                registryRecordInFull(datasetId)
             );
             const mode = resolveMode(opts);
             if (mode === "human") {

--- a/packages/mgd/src/commands/dist.ts
+++ b/packages/mgd/src/commands/dist.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { clientFromProfile } from "../client.js";
 import {
     registryRecord,
+    registryRecordInFull,
     recordAspect,
     REGISTRY_RECORDS,
     storageObject
@@ -21,14 +22,6 @@ import {
     DATASETS_BUCKET_DEFAULT
 } from "../recordBuilders.js";
 
-export const DIST_OPTIONAL_ASPECTS = [
-    "dcat-distribution-strings",
-    "version",
-    "publishing",
-    "access-control",
-    "source"
-];
-
 export function registerDistCommands(program: Command): void {
     const dist = program.command("dist").description("Distribution records");
 
@@ -39,13 +32,7 @@ export function registerDistCommands(program: Command): void {
             const client = await clientFromProfile();
             const record = await client.json<any>(
                 "GET",
-                registryRecord(distributionId),
-                {
-                    query: DIST_OPTIONAL_ASPECTS.map((a): [string, string] => [
-                        "optionalAspect",
-                        a
-                    ])
-                }
+                registryRecordInFull(distributionId)
             );
             const mode = resolveMode(opts);
             if (mode === "human") {

--- a/packages/mgd/src/endpoints.ts
+++ b/packages/mgd/src/endpoints.ts
@@ -14,6 +14,11 @@ export const REGISTRY_ASPECTS = "/v0/registry/aspects";
 export const registryRecord = (id: string) =>
     `${REGISTRY_RECORDS}/${encodeURIComponent(id)}`;
 
+// Returns the record with ALL attached aspect data (including custom aspects),
+// filtered by the caller's read permission server-side.
+export const registryRecordInFull = (id: string) =>
+    `${REGISTRY_RECORDS}/inFull/${encodeURIComponent(id)}`;
+
 export const recordAspect = (recordId: string, aspectId: string) =>
     `${registryRecord(recordId)}/aspects/${encodeURIComponent(aspectId)}`;
 

--- a/packages/mgd/src/test/datasetRead.spec.ts
+++ b/packages/mgd/src/test/datasetRead.spec.ts
@@ -11,11 +11,11 @@ describe("dataset read commands", () => {
         else process.env.MGD_BASE_URL = origBaseUrl;
     });
 
-    it("gets a dataset record with optional aspects", async () => {
+    it("gets a full dataset record via the inFull endpoint", async () => {
         const server = await startMockServer([
             {
                 method: "GET",
-                path: /^\/v0\/registry\/records\/ds-1$/,
+                path: /^\/v0\/registry\/records\/inFull\/ds-1$/,
                 body: {
                     id: "ds-1",
                     name: "Water Data",
@@ -39,8 +39,47 @@ describe("dataset read commands", () => {
             );
             expect(JSON.parse(out).id).to.equal("ds-1");
             expect(server.requests[0].url).to.contain(
-                "optionalAspect=dcat-dataset-strings"
+                "/v0/registry/records/inFull/ds-1"
             );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("includes custom aspects in dataset get --json", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/inFull\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    name: "Sensor Dataset",
+                    aspects: {
+                        "dcat-dataset-strings": { title: "Sensor Dataset" },
+                        "sensor-network": {
+                            sensorCount: 42,
+                            operator: "Acme Air"
+                        }
+                    }
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(["dataset", "get", "ds-1", "--json"], {
+                        from: "user"
+                    })
+                    .then(() => {})
+            );
+            const record = JSON.parse(out);
+            expect(record.aspects["sensor-network"]).to.deep.equal({
+                sensorCount: 42,
+                operator: "Acme Air"
+            });
         } finally {
             await server.close();
         }

--- a/packages/mgd/src/test/distRead.spec.ts
+++ b/packages/mgd/src/test/distRead.spec.ts
@@ -1,0 +1,86 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDistCommands } from "../commands/dist.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dist read commands", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("gets a full distribution record via the inFull endpoint", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/inFull\/dist-1$/,
+                body: {
+                    id: "dist-1",
+                    name: "file.csv",
+                    aspects: {
+                        "dcat-distribution-strings": {
+                            title: "file.csv",
+                            format: "CSV"
+                        }
+                    }
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDistCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(["dist", "get", "dist-1", "--json"], {
+                        from: "user"
+                    })
+                    .then(() => {})
+            );
+            expect(JSON.parse(out).id).to.equal("dist-1");
+            expect(server.requests[0].url).to.contain(
+                "/v0/registry/records/inFull/dist-1"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("includes custom aspects in dist get --json", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/inFull\/dist-1$/,
+                body: {
+                    id: "dist-1",
+                    name: "file.csv",
+                    aspects: {
+                        "dcat-distribution-strings": { title: "file.csv" },
+                        "sensor-reading": { unit: "ppm", precision: 3 }
+                    }
+                }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDistCommands(program);
+            const out = await captureStdout(() =>
+                program
+                    .parseAsync(["dist", "get", "dist-1", "--json"], {
+                        from: "user"
+                    })
+                    .then(() => {})
+            );
+            const record = JSON.parse(out);
+            expect(record.aspects["sensor-reading"]).to.deep.equal({
+                unit: "ppm",
+                precision: 3
+            });
+        } finally {
+            await server.close();
+        }
+    });
+});


### PR DESCRIPTION
## What

`mgd dataset get` and `mgd dist get` now return **all** aspects attached to a
record — including user-defined custom aspects — instead of a fixed, curated
`optionalAspect` list.

Fixes #3689.

## Why

`get` requested a hard-coded set of well-known aspects
(`DATASET_OPTIONAL_ASPECTS` / `DIST_OPTIONAL_ASPECTS`), so any custom aspect was
silently dropped from the projection. You could *write* a custom aspect
(`mgd aspect create`, `--aspect`, `dataset aspect set`) but a plain `get --json`
made it look absent — during an end-to-end test two of three coding agents
independently concluded "data missing" because of this.

## How

- Add a `registryRecordInFull(id)` endpoint helper →
  `GET /v0/registry/records/inFull/{id}`, which returns the complete record with
  every attached aspect in a single, server-side auth-filtered call.
- `dataset get` / `dist get` fetch via `inFull`. `--json` now carries the full
  aspect set (custom aspects included).
- Human-mode output is **unchanged** (curated highlights, read from the full
  record); `dataset get --aspect <name>` (single-aspect mode) is **unchanged**;
  `dataset distributions` is **not** touched (keeps its `dereference=true` fetch).
- Remove the now-unused `DATASET_OPTIONAL_ASPECTS` / `DIST_OPTIONAL_ASPECTS`
  constants.
- Document the behaviour in the README and the `mgd-workflows` skill.

Default-include (rather than a `--full` opt-in flag) and the `inFull` mechanism
were both confirmed on the issue.

## Testing

- `datasetRead.spec.ts`: updated to assert the `inFull` path; added a test that
  `dataset get --json` includes a custom aspect.
- `distRead.spec.ts` (new): `dist get` uses the `inFull` path and `--json`
  includes a custom aspect.
- Full `mgd` suite: 98 passing · `tsc --noEmit` clean · esbuild build OK.
- Live check on dev.magda.io: `dataset get --json` now returns non-curated
  aspects (`ckan-dataset`, `dataset-publisher`, `dataset-linked-data-rating`,
  `dataset-quality-rating`); `dist get --json` returns `ckan-resource`,
  `dataset-format` — all previously omitted.

Part of epic #3648.
