### PR TITLE
feat(mgd): make `--json` consistent across aspect/mutation subcommands

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -153,6 +153,11 @@ mgd auth status
   details. Suppress diagnostics with `2>/dev/null`.
 - `--json` prints one pretty JSON document. `--jsonl` prints one JSON object per
   line for list results — ideal for streaming into `jq`, `grep`, `xargs`, etc.
+- Read and list commands emit their data as JSON. The aspect/record mutations
+  (`aspect create`, `dataset aspect set`/`delete`, `dataset`/`dist update`) print a
+  compact `{…, "ok": true}` result in `--json` mode, while `aspect get` /
+  `dataset aspect get` emit JSON already (the flag is optional there). Downloads
+  write the file itself and take no `--json`.
 - In `--json`/`--jsonl` mode, errors are emitted to stderr as a structured object
   `{"error":{"code","message","status","hint"}}` so agents can parse failures.
 

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -17,7 +17,12 @@ your assistant environment, keep the rules.
    covers the endpoint, and mention that you did.
 3. **Always parse machine output.** Use `--json` (single document) or `--jsonl`
    (one JSON object per line) on every command whose output you consume.
-   Never scrape human-mode output.
+   Never scrape human-mode output. Read and list commands emit their data as
+   JSON; the aspect/record mutations (`aspect create`, `dataset aspect set`/
+   `delete`, `dataset`/`dist update`) print a compact `{…, "ok": true}` result in
+   `--json` mode; and `aspect get` / `dataset aspect get` emit JSON already (the
+   flag is optional there). Downloads write the file itself, so they take no
+   `--json`.
 4. **Respect exit codes.** `0` ok; `2` usage error (your command line is wrong);
    `3` auth error (key missing/invalid or no permission); `4` not found;
    `1` anything else. In `--json` mode a failing command prints
@@ -89,8 +94,9 @@ Custom / domain metadata:
 
 ```sh
 mgd aspect list --jsonl                     # what aspect types exist here?
-mgd aspect create my-domain --name "My Domain" --schema @schema.json
-mgd dataset aspect set ds-abc my-domain @values.json
+mgd aspect create my-domain --name "My Domain" --schema @schema.json --json
+mgd dataset aspect set ds-abc my-domain @values.json --json
+mgd dataset aspect get ds-abc my-domain     # already JSON; --json optional
 ```
 
 Raw fallback (documented REST endpoints only):

--- a/packages/mgd/src/commands/aspect.ts
+++ b/packages/mgd/src/commands/aspect.ts
@@ -26,10 +26,13 @@ export function registerAspectCommands(program: Command): void {
             }
         });
 
-    aspect.command("get <id>").action(async (id: string) => {
-        const client = await clientFromProfile();
-        printData("json", await client.json("GET", registryAspect(id)));
-    });
+    aspect
+        .command("get <id>")
+        .option("--json", "output JSON (default)")
+        .action(async (id: string) => {
+            const client = await clientFromProfile();
+            printData("json", await client.json("GET", registryAspect(id)));
+        });
 
     aspect
         .command("create <id>")
@@ -39,6 +42,7 @@ export function registerAspectCommands(program: Command): void {
             "--schema <schema>",
             "JSON schema: inline JSON, @file.json, or -"
         )
+        .option("--json", "output the result as JSON")
         .action(async (id: string, opts) => {
             const client = await clientFromProfile();
             const jsonSchema = await parseAspectValue(opts.schema);
@@ -46,6 +50,7 @@ export function registerAspectCommands(program: Command): void {
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify({ id, name: opts.name, jsonSchema })
             });
-            note(`Aspect definition "${id}" saved.`);
+            if (opts.json) printData("json", { aspectId: id, ok: true });
+            else note(`Aspect definition "${id}" saved.`);
         });
 }

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -222,6 +222,7 @@ export function registerDatasetCommands(program: Command): void {
             collect,
             []
         )
+        .option("--json", "output the result as JSON")
         .action(async (datasetId: string, opts) => {
             const scalarPatch: Record<string, unknown> = {};
             if (opts.title) scalarPatch.title = opts.title;
@@ -256,7 +257,8 @@ export function registerDatasetCommands(program: Command): void {
                     throw withAspectHint(e);
                 }
             }
-            note(`Dataset ${datasetId} updated.`);
+            if (opts.json) printData("json", { datasetId, ok: true });
+            else note(`Dataset ${datasetId} updated.`);
         });
 
     const datasetAspect = dataset
@@ -267,6 +269,7 @@ export function registerDatasetCommands(program: Command): void {
 
     datasetAspect
         .command("get <recordId> <aspectId>")
+        .option("--json", "output JSON (default)")
         .action(async (recordId: string, aspectId: string) => {
             const client = await clientFromProfile();
             const data = await client.json(
@@ -279,26 +282,38 @@ export function registerDatasetCommands(program: Command): void {
     datasetAspect
         .command("set <recordId> <aspectId> <value>")
         .description("value: inline JSON, @file.json, or - for stdin")
-        .action(async (recordId: string, aspectId: string, value: string) => {
-            const client = await clientFromProfile();
-            const data = await parseAspectValue(value);
-            try {
-                await client.json("PUT", recordAspect(recordId, aspectId), {
-                    headers: { "content-type": "application/json" },
-                    body: JSON.stringify(data)
-                });
-            } catch (e) {
-                throw withAspectHint(e);
+        .option("--json", "output the result as JSON")
+        .action(
+            async (
+                recordId: string,
+                aspectId: string,
+                value: string,
+                opts
+            ) => {
+                const client = await clientFromProfile();
+                const data = await parseAspectValue(value);
+                try {
+                    await client.json("PUT", recordAspect(recordId, aspectId), {
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify(data)
+                    });
+                } catch (e) {
+                    throw withAspectHint(e);
+                }
+                if (opts.json)
+                    printData("json", { recordId, aspectId, ok: true });
+                else note(`Aspect "${aspectId}" set on ${recordId}.`);
             }
-            note(`Aspect "${aspectId}" set on ${recordId}.`);
-        });
+        );
 
     datasetAspect
         .command("delete <recordId> <aspectId>")
-        .action(async (recordId: string, aspectId: string) => {
+        .option("--json", "output the result as JSON")
+        .action(async (recordId: string, aspectId: string, opts) => {
             const client = await clientFromProfile();
             await client.json("DELETE", recordAspect(recordId, aspectId));
-            note(`Aspect "${aspectId}" deleted from ${recordId}.`);
+            if (opts.json) printData("json", { recordId, aspectId, ok: true });
+            else note(`Aspect "${aspectId}" deleted from ${recordId}.`);
         });
 
     dataset

--- a/packages/mgd/src/commands/dist.ts
+++ b/packages/mgd/src/commands/dist.ts
@@ -66,6 +66,7 @@ export function registerDistCommands(program: Command): void {
             collect,
             []
         )
+        .option("--json", "output the result as JSON")
         .action(async (distributionId: string, opts) => {
             const scalarPatch: Record<string, unknown> = {};
             if (opts.title) scalarPatch.title = opts.title;
@@ -101,7 +102,8 @@ export function registerDistCommands(program: Command): void {
                     throw withAspectHint(e);
                 }
             }
-            note(`Distribution ${distributionId} updated.`);
+            if (opts.json) printData("json", { distributionId, ok: true });
+            else note(`Distribution ${distributionId} updated.`);
         });
 
     dist.command("replace-file <distributionId> <localFile>")

--- a/packages/mgd/src/test/jsonConsistency.spec.ts
+++ b/packages/mgd/src/test/jsonConsistency.spec.ts
@@ -1,0 +1,178 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { registerDistCommands } from "../commands/dist.js";
+import { registerAspectCommands } from "../commands/aspect.js";
+import { startMockServer, MockRoute } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+async function run(
+    register: (program: Command) => void,
+    argv: string[],
+    routes: MockRoute[]
+): Promise<string> {
+    const server = await startMockServer(routes);
+    const orig = process.env.MGD_BASE_URL;
+    process.env.MGD_BASE_URL = server.url;
+    try {
+        const program = new Command();
+        program.exitOverride();
+        register(program);
+        return await captureStdout(() =>
+            program.parseAsync(argv, { from: "user" })
+        );
+    } finally {
+        if (orig === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = orig;
+        await server.close();
+    }
+}
+
+describe("consistent --json handling", () => {
+    describe("read commands accept --json without erroring", () => {
+        it("aspect get <id> --json", async () => {
+            const out = await run(
+                registerAspectCommands,
+                ["aspect", "get", "my-aspect", "--json"],
+                [
+                    {
+                        method: "GET",
+                        path: /aspects\/my-aspect$/,
+                        body: { id: "my-aspect", name: "My Aspect" }
+                    }
+                ]
+            );
+            expect(JSON.parse(out).id).to.equal("my-aspect");
+        });
+
+        it("dataset aspect get <recordId> <aspectId> --json", async () => {
+            const out = await run(
+                registerDatasetCommands,
+                ["dataset", "aspect", "get", "ds-1", "custom", "--json"],
+                [
+                    {
+                        method: "GET",
+                        path: /records\/ds-1\/aspects\/custom$/,
+                        body: { hello: "world" }
+                    }
+                ]
+            );
+            expect(JSON.parse(out).hello).to.equal("world");
+        });
+    });
+
+    describe("mutation commands emit structured --json output", () => {
+        it("aspect create emits { aspectId, ok }", async () => {
+            const out = await run(
+                registerAspectCommands,
+                [
+                    "aspect",
+                    "create",
+                    "my-aspect",
+                    "--name",
+                    "My Aspect",
+                    "--schema",
+                    "{}",
+                    "--json"
+                ],
+                [{ method: "PUT", path: /aspects\/my-aspect$/, body: {} }]
+            );
+            expect(JSON.parse(out)).to.deep.equal({
+                aspectId: "my-aspect",
+                ok: true
+            });
+        });
+
+        it("dataset aspect set emits { recordId, aspectId, ok }", async () => {
+            const out = await run(
+                registerDatasetCommands,
+                [
+                    "dataset",
+                    "aspect",
+                    "set",
+                    "ds-1",
+                    "custom",
+                    "{}",
+                    "--json"
+                ],
+                [
+                    {
+                        method: "PUT",
+                        path: /records\/ds-1\/aspects\/custom$/,
+                        body: {}
+                    }
+                ]
+            );
+            expect(JSON.parse(out)).to.deep.equal({
+                recordId: "ds-1",
+                aspectId: "custom",
+                ok: true
+            });
+        });
+
+        it("dataset aspect delete emits { recordId, aspectId, ok }", async () => {
+            const out = await run(
+                registerDatasetCommands,
+                ["dataset", "aspect", "delete", "ds-1", "custom", "--json"],
+                [
+                    {
+                        method: "DELETE",
+                        path: /records\/ds-1\/aspects\/custom$/,
+                        body: {}
+                    }
+                ]
+            );
+            expect(JSON.parse(out)).to.deep.equal({
+                recordId: "ds-1",
+                aspectId: "custom",
+                ok: true
+            });
+        });
+
+        it("dataset update emits { datasetId, ok }", async () => {
+            const out = await run(
+                registerDatasetCommands,
+                ["dataset", "update", "ds-1", "--title", "New", "--json"],
+                [
+                    {
+                        method: "GET",
+                        path: /aspects\/dcat-dataset-strings$/,
+                        body: { title: "Old" }
+                    },
+                    {
+                        method: "PUT",
+                        path: /aspects\/dcat-dataset-strings$/,
+                        body: {}
+                    }
+                ]
+            );
+            expect(JSON.parse(out)).to.deep.equal({
+                datasetId: "ds-1",
+                ok: true
+            });
+        });
+
+        it("dist update emits { distributionId, ok }", async () => {
+            const out = await run(
+                registerDistCommands,
+                ["dist", "update", "dist-1", "--title", "New", "--json"],
+                [
+                    {
+                        method: "GET",
+                        path: /aspects\/dcat-distribution-strings$/,
+                        body: { title: "Old" }
+                    },
+                    {
+                        method: "PUT",
+                        path: /aspects\/dcat-distribution-strings$/,
+                        body: {}
+                    }
+                ]
+            );
+            expect(JSON.parse(out)).to.deep.equal({
+                distributionId: "dist-1",
+                ok: true
+            });
+        });
+    });
+});


### PR DESCRIPTION
Closes #3690. Part of epic #3648.

## What

Makes `--json` handling consistent across the `mgd` CLI so agents following the skill rule "pass `--json` on every command whose output you consume" don't hit avoidable errors.

- **Mutations now emit a compact structured result** in `--json` mode (parity with `dataset create`/`add-file`):
  - `aspect create` → `{ aspectId, ok: true }`
  - `dataset aspect set`/`delete` → `{ recordId, aspectId, ok: true }`
  - `dataset update` → `{ datasetId, ok: true }`
  - `dist update` → `{ distributionId, ok: true }`
- **`aspect get` / `dataset aspect get`** already emit JSON unconditionally; they now **accept** `--json` as an optional no-op instead of erroring on it.
- **Docs**: the agent skill (`mgd-workflows.md`) and README describe the mutation result shape and the reads-emit-JSON behaviour.

## Scope decision (`--json` by command semantics)

The issue's Proposal said "every command accepts `--json`", but that isn't the well-motivated goal. Grounded in the original agent-failure cases, `--json` is scoped by what a command produces:

- **Read/list commands** → `--json` returns the data (all already do, incl. `profile list`).
- **Mutation commands** → `--json` returns `{…, ok: true}` (this PR, for the aspect/record mutations).
- **Downloads** → take **no** `--json`: the file itself is the output (with `-o -` the bytes occupy stdout), so the flag is genuinely inapplicable and errors cleanly like any unknown option.

Credential/profile setup mutations (`profile create/update/remove/use`, deprecated `auth login`) are left human-only — that's interactive/`MGD_*`-env territory (#3692's surface), and their output isn't consumed as data.

## Tests

New `src/test/jsonConsistency.spec.ts`: asserts `--json` is accepted on the aspect read commands and that each mutation emits its structured result. Full suite green (105 passing), `typecheck` and `build` clean.