### PR TITLE
feat(registry-api): add DELETE endpoint for aspect definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - `@magda/mgd`: added `mgd skills install` / `mgd skills uninstall` — installs the coding-agent skill (`SKILL.md`) into Claude Code, Codex and opencode; installs for all three globally by default (`--agent` to pick one, `--project` for repo-local), so the skill is available from any working directory (#3682)
 - #3672: Add large file upload & download support to `storage-api` — S3 multipart upload proxy endpoints (`/v0/storage/multipart/{initiate,part,parts,complete,abort}`) and HTTP Range support on object download, enabling resumable transfers of large (multi-GB) files without raising the ingress body-size limit. Adds `recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry` & `incompleteUploadExpiryDays` chart options.
 - #3678: Fix `storage-api` create-bucket route being registered at `/v0/storage/{bucketid}` instead of the documented `/v0/storage/buckets/{bucketid}`
+- #3691: Add `DELETE /v0/registry/aspects/{id}` to `registry-api` — deletes an aspect definition only when no record aspect data still references it within the tenant; otherwise responds `409 Conflict` (including the referencing-record count) and deletes nothing. Deleting a non-existent aspect responds `200 {"deleted": false}` (mirroring record delete). Emits a `DeleteAspectDefinitionEvent`, is permission-gated via `object/aspect/delete` and tenant-scoped.
 
 ## v6.0.0
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectPersistence.scala
@@ -18,6 +18,18 @@ import au.csiro.data61.magda.model.TenantId._
 import au.csiro.data61.magda.util.SQLUtils
 import scalikejdbc.interpolation.SQLSyntax
 
+/**
+  * Thrown by `AspectPersistence.deleteById` when the aspect definition is still referenced by
+  * record aspect data and therefore must not be deleted. A dedicated exception type lets the
+  * `AspectsService` delete route distinguish this "in use" case (mapped to `409 Conflict`) from
+  * other failures (mapped to `400`). `recordCount` is the number of referencing records and is
+  * surfaced in the error message.
+  */
+class AspectInUseException(val recordCount: Long)
+    extends Exception(
+      s"Cannot delete the aspect definition: $recordCount record(s) still reference it. Delete the referencing record aspect data first."
+    )
+
 object AspectPersistence extends Protocols with DiffsonProtocol {
 
   def getAll(
@@ -218,6 +230,58 @@ object AspectPersistence extends Protocols with DiffsonProtocol {
         .apply()
       aspect
     }
+  }
+
+  /**
+    * Delete an aspect definition, tenant-scoped. Mirrors `RecordPersistence.deleteRecord`.
+    *
+    * Safety guard: the definition is deleted only when NO record aspect data references the
+    * aspect within the tenant. If any does, this returns `Failure(AspectInUseException)` and
+    * nothing is deleted (no event emitted). When the aspect does not exist, nothing is deleted
+    * and no event is emitted either.
+    *
+    * A `DeleteAspectDefinitionEvent` is emitted only when a row is actually removed. The whole
+    * operation runs in the caller's transaction (`DB localTx`), so the in-use check and the
+    * delete are atomic with respect to that transaction.
+    *
+    * @return `(deleted, eventId)` — `deleted` is true iff a row was removed; `eventId` is the
+    *         generated event id, or `0L` when nothing was deleted.
+    */
+  def deleteById(
+      aspectId: String,
+      tenantId: SpecifiedTenantId,
+      userId: String
+  )(implicit session: DBSession): Try[(Boolean, Long)] = {
+    for {
+      // count record-aspect data referencing this aspect within the tenant
+      referencingCount <- Try {
+        sql"select count(*) from RecordAspects where (aspectId, tenantId)=($aspectId, ${tenantId.tenantId})"
+          .map(_.long(1))
+          .single
+          .apply()
+          .getOrElse(0L)
+      }
+      // refuse (and delete nothing) when the aspect is still in use
+      _ <- if (referencingCount > 0)
+        Failure(new AspectInUseException(referencingCount))
+      else Success(referencingCount)
+      rowsDeleted <- Try {
+        sql"""delete from Aspects where (aspectId, tenantId)=($aspectId, ${tenantId.tenantId})""".update
+          .apply()
+      }
+      eventId <- Try {
+        if (rowsDeleted > 0) {
+          // --- only generate event when the aspect was actually removed
+          val eventJson =
+            DeleteAspectDefinitionEvent(aspectId, tenantId.tenantId).toJson.compactPrint
+          sql"insert into Events (eventTypeId, userId, tenantId, data) values (${DeleteAspectDefinitionEvent.Id}, ${userId}::uuid, ${tenantId.tenantId}, $eventJson::json)".updateAndReturnGeneratedKey
+            .apply()
+        } else {
+          // --- No aspect was deleted, return 0 as event ID
+          0L
+        }
+      }
+    } yield (rowsDeleted > 0, eventId)
   }
 
   private def rowToAspect(rs: WrappedResultSet): AspectDefinition = {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectsService.scala
@@ -5,21 +5,28 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
-import au.csiro.data61.magda.client.AuthApiClient
+import akka.http.scaladsl.model.headers.RawHeader
+import au.csiro.data61.magda.client.{AuthApiClient, AuthDecisionReqConfig}
 import au.csiro.data61.magda.directives.AuthDirectives.{
   requirePermission,
+  requireUnconditionalAuthDecision,
   requireUserId
 }
 import au.csiro.data61.magda.directives.TenantDirectives.requiresSpecifiedTenantId
 import au.csiro.data61.magda.model.Registry._
-import au.csiro.data61.magda.registry.Directives.requireAspectUpdateOrCreateWhenNonExistPermission
+import au.csiro.data61.magda.registry.Directives.{
+  requireAspectUpdateOrCreateWhenNonExistPermission,
+  requireAspectPermission
+}
 import com.typesafe.config.Config
 import gnieh.diffson.sprayJson._
 import io.swagger.annotations._
 import org.postgresql.util.PSQLException
 
 import javax.ws.rs.Path
-import scalikejdbc._
+// Hide scalikejdbc's `delete` so it does not clash with akka-http's `delete` route directive
+// (used by the deleteById route below). Everything else from scalikejdbc is still imported.
+import scalikejdbc.{delete => _, _}
 import spray.json.JsObject
 
 import scala.util.{Failure, Success}
@@ -390,9 +397,139 @@ class AspectsService(
     }
   }
 
+  /**
+    * @apiGroup Registry Aspects
+    * @api {delete} /v0/registry/aspects/{id} Delete an aspect definition by ID
+    *
+    * @apiDescription Deletes an aspect definition.
+    *
+    *   The aspect definition can only be deleted when no record aspect data references it
+    *   (within the current tenant). If any record still stores data under the aspect, the
+    *   request is refused with a `409 Conflict` response and nothing is deleted; delete the
+    *   referencing record aspect data first.
+    *
+    *   Deleting an aspect that does not exist responds with `200` and `{ "deleted": false }`
+    *   (rather than `404`), mirroring the behaviour of `DELETE /v0/registry/records/{recordId}`.
+    *
+    * @apiParam (path) {string} id ID of the aspect to be deleted.
+    * @apiHeader {number} X-Magda-Tenant-Id 0 unless it is a multi-tenant magda deployment.
+    * @apiHeader {string} X-Magda-Session Magda internal session id
+    *
+    * @apiHeader {string} x-magda-event-id This is a **response header** that is **ONLY** available when the operation is completed successfully.
+    *           If the operation did make changes and triggered an event (i.e. the aspect was actually deleted), the header value will be the eventId.
+    *           Otherwise (i.e. no aspect was deleted), this header value will be "0".
+    *
+    * @apiSuccess (Success 200) {json} Response the aspect definition deletion result
+    * @apiSuccessExample {json} Response:
+    *   {
+    *     "deleted": true
+    *   }
+    * @apiError (Error 409) {string} Response Returned when record aspect data still references the aspect; nothing is deleted.
+    * @apiErrorExample {json} 409-Conflict:
+    *   {
+    *     "message": "Cannot delete the aspect definition: 3 record(s) still reference it. Delete the referencing record aspect data first."
+    *   }
+    * @apiUse GenericError
+    */
+  @Path("/{id}")
+  @ApiOperation(
+    value = "Delete an aspect definition by ID",
+    nickname = "deleteById",
+    httpMethod = "DELETE",
+    response = classOf[DeleteResult],
+    notes =
+      "Deletes an aspect definition. The aspect definition can only be deleted when no record aspect data references it (within the tenant); otherwise a 409 response is returned and nothing is deleted."
+  )
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(
+        name = "X-Magda-Tenant-Id",
+        required = true,
+        dataType = "number",
+        paramType = "header",
+        value = "0"
+      ),
+      new ApiImplicitParam(
+        name = "id",
+        required = true,
+        dataType = "string",
+        paramType = "path",
+        value = "ID of the aspect to be deleted."
+      ),
+      new ApiImplicitParam(
+        name = "X-Magda-Session",
+        required = true,
+        dataType = "String",
+        paramType = "header",
+        value = "Magda internal session id"
+      )
+    )
+  )
+  @ApiResponses(
+    Array(
+      new ApiResponse(
+        code = 409,
+        message =
+          "The aspect definition could not be deleted because record aspect data still references it.",
+        response = classOf[ApiError]
+      )
+    )
+  )
+  def deleteById: Route = delete {
+    path(Segment) { id: String =>
+      requireUserId { userId =>
+        requireAspectPermission(
+          authClient,
+          "object/aspect/delete",
+          id,
+          // when the aspect doesn't exist (or isn't accessible within the current tenant)
+          // we check the "unconditional" delete permission so behaviour matches record delete:
+          // a user with unconditional delete permission gets 200 + deleted=false;
+          // others won't be able to learn whether the aspect existed.
+          onAspectNotFound = Some(
+            () =>
+              requireUnconditionalAuthDecision(
+                authClient,
+                AuthDecisionReqConfig("object/aspect/delete")
+              ) & pass
+          )
+        ) {
+          requiresSpecifiedTenantId { tenantId =>
+            onCompleteBlockingTask {
+              val theResult = DB localTx { implicit session =>
+                session.queryTimeout(this.defaultQueryTimeout)
+                AspectPersistence.deleteById(id, tenantId, userId) match {
+                  case Success(result) =>
+                    complete(
+                      StatusCodes.OK,
+                      List(RawHeader("x-magda-event-id", result._2.toString)),
+                      DeleteResult(result._1)
+                    )
+                  case Failure(e: AspectInUseException) =>
+                    complete(
+                      StatusCodes.Conflict,
+                      ApiError(e.getMessage)
+                    )
+                  case Failure(exception) =>
+                    complete(
+                      StatusCodes.BadRequest,
+                      ApiError(exception.getMessage)
+                    )
+                }
+              }
+              webHookActor ! WebHookActor.Process()
+              theResult
+            }
+          }
+        }
+      }
+    }
+  }
+
   override def route: Route =
     super.route ~
       putById ~
       patchById ~
-      create
+      create ~
+      deleteById
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/DeleteAspectDefinitionEvent.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/DeleteAspectDefinitionEvent.scala
@@ -1,0 +1,18 @@
+package au.csiro.data61.magda.registry
+
+/**
+  * Event emitted when an aspect definition is deleted (see `AspectPersistence.deleteById`).
+  * Mirrors the record-delete event pattern (`DeleteRecordEvent`).
+  *
+  * The `aspectId` field name is significant: `WebHookProcessor` handles every event for which
+  * `EventType.isAspectDefinitionEvent` is true (which now includes this event) by reading
+  * `event.data.fields("aspectId")`. The serialized JSON must therefore carry an `aspectId`
+  * field. The spray-json format is registered in `Protocols`.
+  */
+case class DeleteAspectDefinitionEvent(aspectId: String, tenantId: BigInt)
+
+object DeleteAspectDefinitionEvent {
+  // Must match EventType.DeleteAspectDefinition (id 7) in magda-scala-common's Registry.scala.
+  // That enum entry already existed before this event class was added, so no enum change was needed.
+  val Id = 7 // from EventTypes table
+}

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Directives.scala
@@ -555,13 +555,21 @@ object Directives extends Protocols with SprayJsonSupport {
     * @param authApiClient
     * @param operationUri
     * @param aspectId
+    * @param onAspectNotFound Optional fallthrough for when the aspect does not exist (or is not
+    *        accessible within the current tenant). Mirrors `requireRecordPermission`'s
+    *        `onRecordNotFound`. When supplied, it runs instead of failing the request, so a
+    *        caller (e.g. the delete route) can, for example, check the unconditional permission
+    *        and let the request proceed to a "nothing to do" result. When `None` (the default,
+    *        used by all pre-existing callers), a missing aspect yields the previous
+    *        InternalServerError behaviour.
     * @param session
     * @return
     */
   def requireAspectPermission(
       authApiClient: AuthApiClient,
       operationUri: String,
-      aspectId: String
+      aspectId: String,
+      onAspectNotFound: Option[() => Directive0] = None
   ): Directive0 =
     (extractLog & extractActorSystem & requiresTenantId)
       .tflatMap { t =>
@@ -582,6 +590,22 @@ object Directives extends Protocols with SprayJsonSupport {
               input =
                 Some(JsObject("object" -> JsObject("aspect" -> aspectData)))
             )
+          case Tuple1(Failure(e: NoRecordFoundException)) =>
+            if (onAspectNotFound.isDefined) {
+              onAspectNotFound.get()
+            } else {
+              log.error(
+                "Failed to create aspect context data for auth decision. aspect ID: {}. Error: {}",
+                aspectId,
+                e
+              )
+              complete(
+                InternalServerError,
+                ApiError(
+                  s"An error occurred while creating aspect context data for auth decision."
+                )
+              )
+            }
           case Tuple1(Failure(e)) =>
             log.error(
               "Failed to create aspect context data for auth decision. aspect ID: {}. Error: {}",

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -26,6 +26,9 @@ trait Protocols extends DiffsonProtocol {
   implicit val createAspectDefinitionEventFormat = jsonFormat4(
     CreateAspectDefinitionEvent.apply
   )
+  implicit val deleteAspectDefinitionEventFormat = jsonFormat2(
+    DeleteAspectDefinitionEvent.apply
+  )
   implicit val createRecordEventFormat = jsonFormat3(CreateRecordEvent.apply)
   implicit val createRecordAspectEventFormat = jsonFormat4(
     CreateRecordAspectEvent.apply

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceAuthSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceAuthSpec.scala
@@ -6,6 +6,7 @@ import au.csiro.data61.magda.model.Auth.{
   ConciseExpression,
   ConciseOperand,
   ConciseRule,
+  UnconditionalFalseDecision,
   UnconditionalTrueDecision
 }
 import au.csiro.data61.magda.model.Registry._
@@ -683,6 +684,82 @@ class AspectsServiceAuthSpec extends ApiSpec {
               "Cannot locate aspect record by id"
             )
           }
+      }
+
+    }
+
+    describe("Delete endpoint {delete} /v0/registry/aspects/{id}: ") {
+
+      describe("When there is an existing aspect:") {
+
+        endpointStandardAuthTestCase(
+          Delete(s"/v0/aspects/testId"),
+          List("object/aspect/delete"),
+          hasPermissionCheck = param => {
+            status shouldEqual StatusCodes.OK
+            responseAs[DeleteResult].deleted shouldBe true
+
+            param.authFetcher
+              .callTimesByOperationUri("object/aspect/delete") shouldBe 1
+          },
+          noPermissionCheck = param => {
+            status shouldEqual StatusCodes.Forbidden
+            param.authFetcher
+              .callTimesByOperationUri("object/aspect/delete") shouldBe 1
+          },
+          beforeRequest = param => {
+            // create the aspect before deleting it
+            param.authFetcher.setAuthDecision(
+              "object/aspect/create",
+              UnconditionalTrueDecision
+            )
+            val aspectDefinition =
+              AspectDefinition("testId", "testName", Some(JsObject()))
+            Post("/v0/aspects", aspectDefinition) ~> addUserId() ~> addTenantIdHeader(
+              TENANT_1
+            ) ~> param.api(Full).routes ~> check {
+              status shouldEqual StatusCodes.OK
+            }
+            param.authFetcher.resetMock()
+          },
+          requireUserId = true
+        )
+
+      }
+
+      describe("When the aspect doesn't exist:") {
+
+        endpointStandardAuthTestCase(
+          Delete(s"/v0/aspects/testId"),
+          List("object/aspect/delete"),
+          hasPermissionCheck = param => {
+            status shouldEqual StatusCodes.OK
+            responseAs[DeleteResult].deleted shouldBe false
+            param.authFetcher
+              .callTimesByOperationUri("object/aspect/delete") shouldBe 1
+          },
+          noPermissionCheck = param => {
+            status shouldEqual StatusCodes.Forbidden
+            param.authFetcher
+              .callTimesByOperationUri("object/aspect/delete") shouldBe 1
+          },
+          requireUserId = true
+        )
+
+        it(
+          "should respond 403 when a user doesn't have unconditional delete permission"
+        ) { param =>
+          param.authFetcher.setAuthDecision(
+            "object/aspect/delete",
+            UnconditionalFalseDecision
+          )
+          Delete(s"/v0/aspects/testId") ~> addUserId() ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(Full).routes ~> check {
+            status shouldEqual StatusCodes.Forbidden
+          }
+        }
+
       }
 
     }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceMultiTenantSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceMultiTenantSpec.scala
@@ -28,7 +28,8 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
     List(
       ("POST", Post.apply, "/v0/aspects"),
       ("PUT", Put.apply, "/v0/aspects/1"),
-      ("PATCH", Patch.apply, "/v0/aspects/1")
+      ("PATCH", Patch.apply, "/v0/aspects/1"),
+      ("DELETE", Delete.apply, "/v0/aspects/1")
     )
   )
 
@@ -369,6 +370,58 @@ class AspectsServiceMultiTenantSpec extends ApiSpec {
               )
             }
           }
+        }
+      }
+    }
+
+    describe("DELETE") {
+      it(
+        "in-use check is tenant-scoped: deletes in an unaffected tenant, refuses in the referencing tenant"
+      ) { param =>
+        val aspectDefinition = AspectDefinition("shared", "shared", None)
+
+        // create the same aspect id in both tenants
+        Post("/v0/aspects", aspectDefinition) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+        Post("/v0/aspects", aspectDefinition) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_2
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        // only TENANT_1 has a record that references the aspect
+        val record =
+          Record("recId", "recName", Map("shared" -> JsObject()), Some("blah"))
+        Post("/v0/records", record) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        // TENANT_2 has no referencing record -> delete succeeds
+        Delete("/v0/aspects/shared") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_2
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[DeleteResult].deleted shouldBe true
+        }
+
+        // TENANT_1 still has the referencing record -> delete refused with 409
+        Delete("/v0/aspects/shared") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.Conflict
+          responseAs[ApiError].message should include("1 record")
+        }
+
+        // the TENANT_1 aspect must still exist
+        Get("/v0/aspects/shared") ~> addTenantIdHeader(TENANT_1) ~> param
+          .api(role)
+          .routes ~> check {
+          status shouldEqual StatusCodes.OK
         }
       }
     }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/AspectsServiceSpec.scala
@@ -26,7 +26,8 @@ class AspectsServiceSpec extends ApiSpec {
     List(
       ("POST", Post.apply, "/v0/aspects"),
       ("PUT", Put.apply, "/v0/aspects/1"),
-      ("PATCH", Patch.apply, "/v0/aspects/1")
+      ("PATCH", Patch.apply, "/v0/aspects/1"),
+      ("DELETE", Delete.apply, "/v0/aspects/1")
     )
   )
 
@@ -362,6 +363,112 @@ class AspectsServiceSpec extends ApiSpec {
               )
             }
           }
+        }
+      }
+    }
+
+    describe("DELETE") {
+      it("can delete an aspect definition that is not referenced by any record") {
+        param =>
+          val aspectDefinition =
+            AspectDefinition("testId", "testName", Some(JsObject()))
+          Post("/v0/aspects", aspectDefinition) ~> addUserId() ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(role).routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          var eventId: Option[String] = None
+          Delete("/v0/aspects/testId") ~> addUserId() ~> addTenantIdHeader(
+            TENANT_1
+          ) ~> param.api(role).routes ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[DeleteResult].deleted shouldBe true
+            eventId = header("x-magda-event-id").map(_.value())
+          }
+
+          // the delete response should carry a real (non-zero) event id
+          eventId.isDefined shouldBe true
+          eventId.get should not equal "0"
+
+          // the aspect should no longer exist
+          Get("/v0/aspects/testId") ~> addTenantIdHeader(TENANT_1) ~> param
+            .api(role)
+            .routes ~> check {
+            status shouldEqual StatusCodes.NotFound
+          }
+
+          // exactly one DeleteAspectDefinition event should have been recorded
+          DB readOnly { implicit session =>
+            val count =
+              sql"""select count(*) from events
+                    where eventtypeid = ${DeleteAspectDefinitionEvent.Id}
+                    and data->>'aspectId' = 'testId'"""
+                .map(_.long(1))
+                .single
+                .apply()
+                .getOrElse(0L)
+            count shouldEqual 1
+          }
+      }
+
+      it(
+        "refuses with 409 and deletes nothing when record aspect data still references the aspect"
+      ) { param =>
+        val aspectDefinition = AspectDefinition("testId", "testName", None)
+        Post("/v0/aspects", aspectDefinition) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        // a record that stores data under the aspect
+        val record =
+          Record("recId", "recName", Map("testId" -> JsObject()), Some("blah"))
+        Post("/v0/records", record) ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Delete("/v0/aspects/testId") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.Conflict
+          responseAs[ApiError].message should include("1 record")
+        }
+
+        // the aspect must still exist (nothing deleted)
+        Get("/v0/aspects/testId") ~> addTenantIdHeader(TENANT_1) ~> param
+          .api(role)
+          .routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        // no DeleteAspectDefinition event should have been recorded
+        DB readOnly { implicit session =>
+          val count =
+            sql"""select count(*) from events
+                  where eventtypeid = ${DeleteAspectDefinitionEvent.Id}
+                  and data->>'aspectId' = 'testId'"""
+              .map(_.long(1))
+              .single
+              .apply()
+              .getOrElse(0L)
+          count shouldEqual 0
+        }
+      }
+
+      it(
+        "returns 200 and deleted=false when asked to delete an aspect that doesn't exist"
+      ) { param =>
+        Delete("/v0/aspects/doesnotexist") ~> addUserId() ~> addTenantIdHeader(
+          TENANT_1
+        ) ~> param.api(role).routes ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[DeleteResult].deleted shouldBe false
+          // event id is 0 as no event is generated
+          header("x-magda-event-id").map(_.value()).get shouldEqual "0"
         }
       }
     }


### PR DESCRIPTION
Closes #3691

## Summary

Adds `DELETE /v0/registry/aspects/{id}` to `registry-api`. Aspect **definitions** previously had no removal path (only records did), so obsolete/test definitions accumulated permanently.

An aspect definition can be deleted only when **no record aspect data still references it** within the tenant. Behaviour:

| Situation | Response |
| --- | --- |
| Deleted (existed, unused) | `200 {"deleted": true}` + `x-magda-event-id: <eventId>` |
| Aspect does not exist | `200 {"deleted": false}` + `x-magda-event-id: 0` |
| Still referenced by record aspect data | `409 Conflict` + `ApiError` including the referencing-record count; nothing deleted, no event |
| Missing permission | `403` |

The endpoint mirrors the existing record-delete pattern (`RecordsService.deleteById` → `RecordPersistence.deleteRecord` → `DeleteRecordEvent`). The not-found → `200 {"deleted": false}` behaviour is a deliberate divergence from the ticket's suggested `404`, chosen for consistency with `DELETE /v0/registry/records/{id}` (see issue #3691 for the full rationale).

## Changes

- **New event** `DeleteAspectDefinitionEvent` + spray-json format (matches the pre-existing `EventType.DeleteAspectDefinition`, id 7; carries `aspectId` as required by `WebHookProcessor`).
- **`AspectPersistence.deleteById`** — tenant-scoped in-use guard, deletes only when unused, emits the event only when a row is removed; `AspectInUseException` distinguishes the 409 case.
- **`AspectsService`** — the `DELETE` route (permission-gated on `object/aspect/delete`, tenant-scoped) with API docs (apidoc) comment.
- **`Directives.requireAspectPermission`** — new optional `onAspectNotFound` fallthrough (mirrors `requireRecordPermission`'s `onRecordNotFound`); existing callers unaffected.

No rego policy or auth-DB migration changes were required — `object/aspect/delete` is already registered and enforced by the existing aspect policy. Confirmed safe for the minion framework (the new event type is not subscribed by existing minions and is safely ignored).

## Out of scope

- A `force`/cascade variant that also deletes referencing record aspect data (the safe "refuse if used" behaviour is the ask).
- The `mgd aspect delete <id>` CLI command (follow-on under epic #3648).

## Testing

- Unit/integration (`sbt registryApi/test`, real Postgres): **594 passed, 0 failed**. New coverage: delete-when-unused, refuse-when-in-use (incl. count in message), not-found, multi-tenant isolation, and authorization (with/without permission).
- E2E in a minikube cluster through the gateway with real admin auth: create aspect → create referencing record → `DELETE` aspect (409) → delete record → `DELETE` aspect (`200 deleted=true`, event id emitted) → `DELETE` again (`200 deleted=false`, event id `0`) → `GET` deleted aspect (404). All as expected.
