### PR TITLE
feat(mgd): add `dataset aspect patch` for partial (merge) aspect updates

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -283,9 +283,15 @@ mgd aspect create <aspectId> --name "My Aspect" --schema @schema.json
 
 # aspect data on any record (dataset or distribution)
 mgd dataset aspect get    magda-ds-<uuid> <aspectId>
-mgd dataset aspect set    magda-ds-<uuid> <aspectId> @data.json    # inline JSON, @file, or - for stdin
+mgd dataset aspect set    magda-ds-<uuid> <aspectId> @data.json    # full replace: inline JSON, @file, or - for stdin
+mgd dataset aspect patch  magda-ds-<uuid> <aspectId> '{"keywords":["a","b"]}'  # partial: merge these fields, keep the rest
 mgd dataset aspect delete magda-ds-<uuid> <aspectId>
 ```
+
+Use `set` to **replace** the whole aspect and `patch` to change **only the
+supplied fields** (a server-side deep merge via the registry's `?merge=true`, so
+untouched fields survive). For advanced RFC 6902 operations (remove/test/move),
+call the raw endpoint: `mgd api request PATCH /v0/registry/records/<id>/aspects/<aspectId> --body @patch.json`.
 
 Every mutation command also accepts repeatable `--aspect <id>=<json|@file|->` to
 attach custom aspect data at create/update time.
@@ -329,7 +335,7 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 | `dataset create`                                      | Create a dataset (draft by default)                     |
 | `dataset update <id>`                                 | Update dataset metadata                                 |
 | `dataset add-file <id> [file]`                        | Upload/attach a distribution (or `--access-url`)        |
-| `dataset aspect get/set/delete <recordId> <aspectId>` | Read/write custom aspect data on any record             |
+| `dataset aspect get/set/patch/delete <recordId> <aspectId>` | Read/write custom aspect data on any record (`set`=replace, `patch`=merge) |
 | `dist get <id>` / `dist update <id>`                  | Inspect / edit a distribution                           |
 | `dist download <id>`                                  | Download a distribution's file (`--resume`)             |
 | `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version             |

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -19,7 +19,7 @@ your assistant environment, keep the rules.
    (one JSON object per line) on every command whose output you consume.
    Never scrape human-mode output. Read and list commands emit their data as
    JSON; the aspect/record mutations (`aspect create`, `dataset aspect set`/
-   `delete`, `dataset`/`dist update`) print a compact `{…, "ok": true}` result in
+   `patch`/`delete`, `dataset`/`dist update`) print a compact `{…, "ok": true}` result in
    `--json` mode; and `aspect get` / `dataset aspect get` emit JSON already (the
    flag is optional there). Downloads write the file itself, so they take no
    `--json`.
@@ -27,7 +27,7 @@ your assistant environment, keep the rules.
    `3` auth error (key missing/invalid or no permission); `4` not found;
    `1` anything else. In `--json` mode a failing command prints
    `{"error": {"code", "message", "status", "hint"}}` on stderr.
-5. **Confirm before mutating or publishing.** Never run `dataset create --publish`, `add-file`, `replace-file`, `update`, `aspect create/set/delete`,
+5. **Confirm before mutating or publishing.** Never run `dataset create --publish`, `add-file`, `replace-file`, `update`, `aspect create/set/patch/delete`,
    or any `api request` with POST/PUT/PATCH/DELETE without the user's explicit
    go-ahead in this conversation. Uploading or attaching generated artifacts
    happens only when the user asked for it.
@@ -95,9 +95,16 @@ Custom / domain metadata:
 ```sh
 mgd aspect list --jsonl                     # what aspect types exist here?
 mgd aspect create my-domain --name "My Domain" --schema @schema.json --json
-mgd dataset aspect set ds-abc my-domain @values.json --json
+mgd dataset aspect set ds-abc my-domain @values.json --json   # replace the whole aspect
+mgd dataset aspect patch ds-abc dcat-dataset-strings '{"keywords":["a","b"]}' --json  # merge one field, keep the rest
 mgd dataset aspect get ds-abc my-domain     # already JSON; --json optional
 ```
+
+**`set` replaces the whole aspect; `patch` merges.** To change one field (e.g.
+add `keywords` to `dcat-dataset-strings`) use `patch` — it deep-merges your
+partial object server-side and leaves the other fields intact. Reach for `set`
+only when you intend to overwrite the entire aspect. For advanced RFC 6902 ops
+(remove/test/move), use `mgd api request PATCH …/aspects/<id> --body @patch.json`.
 
 Raw fallback (documented REST endpoints only):
 

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -307,6 +307,41 @@ export function registerDatasetCommands(program: Command): void {
         );
 
     datasetAspect
+        .command("patch <recordId> <aspectId> <value>")
+        .description(
+            "Merge a partial aspect object into the existing aspect " +
+                "(value: inline JSON, @file.json, or - for stdin). Only the " +
+                "supplied fields change; use `set` to replace the whole aspect."
+        )
+        .option("--json", "output the result as JSON")
+        .action(
+            async (
+                recordId: string,
+                aspectId: string,
+                value: string,
+                opts
+            ) => {
+                const client = await clientFromProfile();
+                const data = await parseAspectValue(value);
+                try {
+                    // ?merge=true asks the registry to deep-merge the partial
+                    // body into the existing aspect server-side (JsonUtils.merge),
+                    // so we never read-then-replace and can't drop fields.
+                    await client.json("PUT", recordAspect(recordId, aspectId), {
+                        query: { merge: true },
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify(data)
+                    });
+                } catch (e) {
+                    throw withAspectHint(e);
+                }
+                if (opts.json)
+                    printData("json", { recordId, aspectId, ok: true });
+                else note(`Aspect "${aspectId}" patched on ${recordId}.`);
+            }
+        );
+
+    datasetAspect
         .command("delete <recordId> <aspectId>")
         .option("--json", "output the result as JSON")
         .action(async (recordId: string, aspectId: string, opts) => {

--- a/packages/mgd/src/test/aspectPatch.spec.ts
+++ b/packages/mgd/src/test/aspectPatch.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { startMockServer } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+describe("dataset aspect patch", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    async function runPatch(extraArgs: string[]) {
+        const server = await startMockServer([
+            {
+                method: "PUT",
+                path: /records\/ds-1\/aspects\/dcat-dataset-strings$/,
+                body: {}
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            const out = await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "aspect",
+                        "patch",
+                        "ds-1",
+                        "dcat-dataset-strings",
+                        '{"keywords":["a","b"]}',
+                        ...extraArgs
+                    ],
+                    { from: "user" }
+                )
+            );
+            return { server, out };
+        } finally {
+            await server.close();
+        }
+    }
+
+    it("delegates the merge to the registry via ?merge=true with only the supplied fields", async () => {
+        const { server } = await runPatch([]);
+        // The CLI must not read-then-replace: no GET, a single merge PUT.
+        expect(server.requests.map((r) => r.method)).to.deep.equal(["PUT"]);
+        const put = server.requests[0];
+        expect(put.url).to.match(/[?&]merge=true(&|$)/);
+        expect(JSON.parse(put.body.toString())).to.deep.equal({
+            keywords: ["a", "b"]
+        });
+    });
+
+    it("emits a structured result with --json", async () => {
+        const { out } = await runPatch(["--json"]);
+        expect(JSON.parse(out)).to.deep.equal({
+            recordId: "ds-1",
+            aspectId: "dcat-dataset-strings",
+            ok: true
+        });
+    });
+});


### PR DESCRIPTION
Closes #3686. Part of epic #3648.

## What

Adds `mgd dataset aspect patch <recordId> <aspectId> <value>` — a **partial** aspect update, complementing `dataset aspect set` (full replace).

- `<value>` is a partial aspect object (inline JSON, `@file.json`, or `-` for stdin).
- Implemented via `PUT .../aspects/{aspectId}?merge=true`, so the **registry deep-merges** the partial body into the existing aspect server-side (`JsonUtils.merge`) — only the supplied fields change, the rest survive. The CLI never read-then-replaces, so it can't drop fields and there's no race.
- Works on any record (dataset or distribution), shares `set`'s value parsing and the `withAspectHint` "create the aspect definition first" hint, and emits `{ recordId, aspectId, ok: true }` under `--json` for parity with the other mutations.
- Raw RFC 6902 JSON Patch (remove/test/move) is intentionally **not** wrapped — power users call `mgd api request PATCH /v0/registry/records/<id>/aspects/<aspectId> --body @patch.json`.

**Naming:** went with `patch` (matches the issue's acceptance criteria); the issue's "revisit `merge`?" note is resolved in favour of `patch`.

## Tests

New `src/test/aspectPatch.spec.ts` (TDD):
- Asserts the CLI issues a single `PUT ...?merge=true` carrying **only** the supplied fields and **no** prior `GET` (proving it delegates the merge rather than replacing).
- Asserts the `--json` structured result.

Full suite: **107 passing**; `typecheck` and `build` clean.

## E2E (local minikube, real registry via gateway + API key)

- Set `dcat-dataset-strings` (title + description), then `patch '{"keywords":[…]}'` → **title and description survived**, `keywords` added.
- Deep-merge: seeded `a:{x:1,y:2}, top:"keep"`, patched `{a:{y:99,z:3}}` → `a:{x:1,y:99,z:3}, top:"keep"` (nested siblings preserved).
- `--json` returned `{ recordId, aspectId, ok: true }`.
- Test record + aspect definition + API key cleaned up afterwards.

## Docs

README (aspect examples, `set` vs `patch` guidance, command table) and the agent skill (`mgd-workflows.md`: example, an explicit "`set` replaces / `patch` merges" note, plus the rule-3 machine-output list and rule-5 confirmation list) now distinguish the two so agents pick correctly.