### PR TITLE
feat(mgd): add `aspect delete <id>` command

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -280,6 +280,7 @@ exposes them (the web UI does not):
 mgd aspect list
 mgd aspect get <aspectId>
 mgd aspect create <aspectId> --name "My Aspect" --schema @schema.json
+mgd aspect delete <aspectId>                     # only if no record data references it
 
 # aspect data on any record (dataset or distribution)
 mgd dataset aspect get    magda-ds-<uuid> <aspectId>
@@ -340,7 +341,7 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 | `dist download <id>`                                  | Download a distribution's file (`--resume`)             |
 | `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version             |
 | `file upload <file>` / `file download <bucket/key>`   | Direct storage transfer                                 |
-| `aspect list` / `get <id>` / `create <id>`            | Manage aspect definitions                               |
+| `aspect list` / `get <id>` / `create <id>` / `delete <id>` | Manage aspect definitions                               |
 | `api request <method> <path>`                         | Call any MAGDA API endpoint                             |
 | `skills install [--agent <name>]`                     | Install the agent skill (all agents, global by default) |
 | `skills uninstall [--agent <name>]`                   | Remove the agent skill                                  |

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -95,6 +95,7 @@ Custom / domain metadata:
 ```sh
 mgd aspect list --jsonl                     # what aspect types exist here?
 mgd aspect create my-domain --name "My Domain" --schema @schema.json --json
+mgd aspect delete my-domain                 # remove a definition; refused (409) if records still use it
 mgd dataset aspect set ds-abc my-domain @values.json --json   # replace the whole aspect
 mgd dataset aspect patch ds-abc dcat-dataset-strings '{"keywords":["a","b"]}' --json  # merge one field, keep the rest
 mgd dataset aspect get ds-abc my-domain     # already JSON; --json optional

--- a/packages/mgd/src/commands/aspect.ts
+++ b/packages/mgd/src/commands/aspect.ts
@@ -53,4 +53,31 @@ export function registerAspectCommands(program: Command): void {
             if (opts.json) printData("json", { aspectId: id, ok: true });
             else note(`Aspect definition "${id}" saved.`);
         });
+
+    aspect
+        .command("delete <id>")
+        .description(
+            "Delete an aspect definition (only if no record data references it)"
+        )
+        .option("--json", "output the result as JSON")
+        .action(async (id: string, opts) => {
+            const client = await clientFromProfile();
+            const result = await client.json<{ deleted: boolean }>(
+                "DELETE",
+                registryAspect(id)
+            );
+            if (opts.json) {
+                printData("json", {
+                    aspectId: id,
+                    deleted: result.deleted,
+                    ok: true
+                });
+            } else {
+                note(
+                    result.deleted
+                        ? `Aspect definition "${id}" deleted.`
+                        : `Aspect definition "${id}" did not exist (nothing deleted).`
+                );
+            }
+        });
 }

--- a/packages/mgd/src/test/aspectDelete.spec.ts
+++ b/packages/mgd/src/test/aspectDelete.spec.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerAspectCommands } from "../commands/aspect.js";
+import { startMockServer, MockRoute } from "./mockServer.js";
+import { exitCodeFor, MgdApiError } from "../errors.js";
+
+// Runs the aspect command group against a mock server, capturing stdout,
+// stderr (where note() writes) and any thrown error. `note()` goes to
+// stderr, so the existing captureStdout helper is not enough here.
+async function run(
+    argv: string[],
+    routes: MockRoute[]
+): Promise<{ stdout: string; stderr: string; error: unknown }> {
+    const server = await startMockServer(routes);
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    process.env.MGD_BASE_URL = server.url;
+
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    let stdout = "";
+    let stderr = "";
+    (process.stdout as any).write = (c: any) => {
+        stdout += String(c);
+        return true;
+    };
+    (process.stderr as any).write = (c: any) => {
+        stderr += String(c);
+        return true;
+    };
+
+    let error: unknown = undefined;
+    try {
+        const program = new Command();
+        program.exitOverride();
+        registerAspectCommands(program);
+        await program.parseAsync(argv, { from: "user" });
+    } catch (e) {
+        error = e;
+    } finally {
+        process.stdout.write = origOut;
+        process.stderr.write = origErr;
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+        await server.close();
+    }
+    return { stdout, stderr, error };
+}
+
+describe("aspect delete", () => {
+    it("deletes an unused aspect definition (200 deleted=true)", async () => {
+        const { stdout, stderr, error } = await run(
+            ["aspect", "delete", "my-aspect"],
+            [
+                {
+                    method: "DELETE",
+                    path: /aspects\/my-aspect$/,
+                    body: { deleted: true }
+                }
+            ]
+        );
+        expect(error).to.equal(undefined);
+        expect(stderr).to.contain('Aspect definition "my-aspect" deleted.');
+        expect(stdout).to.equal("");
+    });
+
+    it("reports nothing deleted for an unknown id (200 deleted=false), exit 0", async () => {
+        const { stderr, error } = await run(
+            ["aspect", "delete", "ghost"],
+            [
+                {
+                    method: "DELETE",
+                    path: /aspects\/ghost$/,
+                    body: { deleted: false }
+                }
+            ]
+        );
+        expect(error).to.equal(undefined);
+        expect(stderr).to.contain(
+            'Aspect definition "ghost" did not exist (nothing deleted).'
+        );
+    });
+
+    it("refuses when in use (409) -> non-zero exit, surfaces server message", async () => {
+        const { error } = await run(
+            ["aspect", "delete", "in-use"],
+            [
+                {
+                    method: "DELETE",
+                    path: /aspects\/in-use$/,
+                    status: 409,
+                    body: {
+                        message:
+                            "Cannot delete the aspect definition: 1 record(s) still reference it. Delete the referencing record aspect data first."
+                    }
+                }
+            ]
+        );
+        expect(error).to.be.instanceOf(MgdApiError);
+        expect((error as MgdApiError).status).to.equal(409);
+        expect(exitCodeFor(error)).to.equal(1);
+        expect((error as Error).message).to.contain(
+            "1 record(s) still reference it"
+        );
+    });
+
+    it("--json emits { aspectId, deleted, ok }", async () => {
+        const { stdout, error } = await run(
+            ["aspect", "delete", "my-aspect", "--json"],
+            [
+                {
+                    method: "DELETE",
+                    path: /aspects\/my-aspect$/,
+                    body: { deleted: true }
+                }
+            ]
+        );
+        expect(error).to.equal(undefined);
+        expect(JSON.parse(stdout)).to.deep.equal({
+            aspectId: "my-aspect",
+            deleted: true,
+            ok: true
+        });
+    });
+});


### PR DESCRIPTION
Closes #3696

## Summary

Adds `mgd aspect delete <id> [--json]` to the `@magda/mgd` CLI, the follow-on to the registry `DELETE /v0/registry/aspects/{id}` endpoint (#3691). The CLI could create and read aspect **definitions** but not delete them.

The command issues `DELETE /v0/registry/aspects/{id}` via `clientFromProfile()` and surfaces the server's response semantics:

| Server result | CLI behaviour | Exit |
| --- | --- | --- |
| `200 {deleted:true}` | `note("Aspect definition \"<id>\" deleted.")` | `0` |
| `200 {deleted:false}` (unknown id) | `note("Aspect definition \"<id>\" did not exist (nothing deleted).")` | `0` |
| `409 Conflict` (still referenced) | server message (incl. referencing-record count) surfaced by the top-level error handler | `1` |
| `403 Forbidden` | auth error | `3` |

Because the server returns `200` for both the deleted and unknown-id cases, the command reads the response body's `deleted` flag to choose the message. The `409`/`403` cases are thrown by `client.json` and handled by the existing top-level handler (`printError` + `exitCodeFor`) — no new error-handling code.

`--json` emits `{ aspectId, deleted, ok: true }`, consistent with the mutation-output convention introduced in #3698.

## Changes

- `src/commands/aspect.ts` — the `aspect delete <id> [--json]` subcommand.
- `src/test/aspectDelete.spec.ts` — tests: delete-unused, refuse-when-in-use (409 + count, exit 1), unknown-id (exit 0), and `--json` shape.
- `README.md` + `skills/mgd-workflows.md` — document the command.

## Out of scope

- Any `force`/cascade delete that also removes referencing record-aspect data (the server refuses in-use deletes by design).

## Testing

- Unit (`npm test`): **111 passing, 0 failing**; `npm run typecheck` clean.
- End-to-end against a local minikube cluster through the gateway (API-key auth), using the built `mgd` binary: create aspect → create referencing record → `mgd aspect delete` (exit 1, surfaced 409 count message) → delete record → `mgd aspect delete` (exit 0, "deleted.") → `mgd aspect delete` again (exit 0, "did not exist") → `mgd aspect delete <unknown> --json` (`{aspectId, deleted:false, ok:true}`, exit 0). All as expected.
