### PR TITLE
feat(mgd): add dataset/dist publish & unpublish with distribution cascade

### DIFF
--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -25,6 +25,7 @@ import {
     DATASETS_BUCKET_DEFAULT
 } from "../recordBuilders.js";
 import { uploadFile } from "../transfer.js";
+import { publishDataset, renderPublishResult } from "../publishing.js";
 
 export async function fetchOwner(
     client: MagdaClient
@@ -260,6 +261,30 @@ export function registerDatasetCommands(program: Command): void {
             if (opts.json) printData("json", { datasetId, ok: true });
             else note(`Dataset ${datasetId} updated.`);
         });
+
+    for (const verb of ["publish", "unpublish"] as const) {
+        const state = verb === "publish" ? "published" : "draft";
+        dataset
+            .command(`${verb} <datasetId>`)
+            .description(
+                `Set the dataset's publishing state to ${state} and ` +
+                    `cascade to all its distributions (opt out with ` +
+                    `--without-distributions)`
+            )
+            .option(
+                "--without-distributions",
+                "change the dataset record only, not its distributions"
+            )
+            .option("--json", "output the result as JSON")
+            .action(async (datasetId: string, opts) => {
+                const client = await clientFromProfile();
+                const records = await publishDataset(client, datasetId, {
+                    state,
+                    withoutDistributions: Boolean(opts.withoutDistributions)
+                });
+                renderPublishResult(records, resolveMode(opts));
+            });
+    }
 
     const datasetAspect = dataset
         .command("aspect")

--- a/packages/mgd/src/commands/dist.ts
+++ b/packages/mgd/src/commands/dist.ts
@@ -13,6 +13,7 @@ import { printData, resolveMode, note } from "../output.js";
 import { resolveDownloadUrl, downloadToFile, uploadFile } from "../transfer.js";
 import { makeProgress } from "../progress.js";
 import { mergeAspect, collect, withAspectHint, fetchOwner } from "./dataset.js";
+import { publishDistribution, renderPublishResult } from "../publishing.js";
 import {
     parseAspectArg,
     appendVersion,
@@ -24,6 +25,22 @@ import {
 
 export function registerDistCommands(program: Command): void {
     const dist = program.command("dist").description("Distribution records");
+
+    for (const verb of ["publish", "unpublish"] as const) {
+        const state = verb === "publish" ? "published" : "draft";
+        dist.command(`${verb} <distributionId>`)
+            .description(`Set a distribution's publishing state to ${state}`)
+            .option("--json", "output the result as JSON")
+            .action(async (distributionId: string, opts) => {
+                const client = await clientFromProfile();
+                const records = await publishDistribution(
+                    client,
+                    distributionId,
+                    state
+                );
+                renderPublishResult(records, resolveMode(opts));
+            });
+    }
 
     dist.command("get <distributionId>")
         .description("Fetch a distribution record")

--- a/packages/mgd/src/endpoints.ts
+++ b/packages/mgd/src/endpoints.ts
@@ -22,6 +22,12 @@ export const registryRecordInFull = (id: string) =>
 export const recordAspect = (recordId: string, aspectId: string) =>
     `${registryRecord(recordId)}/aspects/${encodeURIComponent(aspectId)}`;
 
+// Bulk endpoint: set one aspect's data across a list of records in a single
+// (transactional) request. Body: { recordIds, data }; use ?merge=true to
+// deep-merge into existing aspect data instead of replacing it.
+export const recordsAspect = (aspectId: string) =>
+    `${REGISTRY_RECORDS}/aspects/${encodeURIComponent(aspectId)}`;
+
 export const registryAspect = (id: string) =>
     `${REGISTRY_ASPECTS}/${encodeURIComponent(id)}`;
 

--- a/packages/mgd/src/publishing.ts
+++ b/packages/mgd/src/publishing.ts
@@ -1,0 +1,94 @@
+import { MagdaClient } from "./client.js";
+import { registryRecord, recordsAspect } from "./endpoints.js";
+import { OutputMode, printData, note } from "./output.js";
+
+export type PublishState = "published" | "draft";
+
+export interface AffectedRecord {
+    id: string;
+    type: "dataset" | "distribution";
+    state: PublishState;
+}
+
+// Report each affected record and its new state, honouring the output contract
+// (data -> stdout, summary -> stderr). Shared by the dataset and dist commands.
+export function renderPublishResult(
+    records: AffectedRecord[],
+    mode: OutputMode
+): void {
+    const state = records[0].state;
+    if (mode === "human") {
+        for (const r of records) {
+            process.stdout.write(`${r.type.padEnd(13)}${r.id}\t${r.state}\n`);
+        }
+        const verb = state === "published" ? "Published" : "Unpublished";
+        if (records[0].type === "dataset") {
+            const distCount = records.length - 1;
+            note(
+                `${verb} dataset ${records[0].id}` +
+                    (distCount ? ` and ${distCount} distribution(s).` : `.`)
+            );
+        } else {
+            note(`${verb} distribution ${records[0].id}.`);
+        }
+    } else {
+        printData(mode, { state, records });
+    }
+}
+
+// Set the `publishing` aspect's `state` across a list of records in a single
+// transactional bulk request. ?merge=true deep-merges { state } into the
+// existing aspect (preserving other publishing fields) and upserts if absent.
+export async function setPublishingState(
+    client: MagdaClient,
+    recordIds: string[],
+    state: PublishState
+): Promise<void> {
+    await client.json("PUT", recordsAspect("publishing"), {
+        query: { merge: true },
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ recordIds, data: { state } })
+    });
+}
+
+// Read a dataset's distribution ids from its dataset-distributions aspect.
+// Array elements may be id strings or dereferenced records ({ id }).
+export async function getDistributionIds(
+    client: MagdaClient,
+    datasetId: string
+): Promise<string[]> {
+    const record = await client.json<any>("GET", registryRecord(datasetId), {
+        query: [["optionalAspect", "dataset-distributions"]]
+    });
+    const distributions: unknown[] =
+        record.aspects?.["dataset-distributions"]?.distributions ?? [];
+    return distributions.map((d) =>
+        typeof d === "string" ? d : (d as { id: string }).id
+    );
+}
+
+export async function publishDataset(
+    client: MagdaClient,
+    datasetId: string,
+    opts: { state: PublishState; withoutDistributions: boolean }
+): Promise<AffectedRecord[]> {
+    const distIds = opts.withoutDistributions
+        ? []
+        : await getDistributionIds(client, datasetId);
+    const recordIds = [datasetId, ...distIds];
+    await setPublishingState(client, recordIds, opts.state);
+    return recordIds.map((id, i) => ({
+        id,
+        type: i === 0 ? "dataset" : "distribution",
+        state: opts.state
+    }));
+}
+
+export async function publishDistribution(
+    client: MagdaClient,
+    distId: string,
+    state: PublishState
+): Promise<AffectedRecord[]> {
+    await setPublishingState(client, [distId], state);
+    return [{ id: distId, type: "distribution", state }];
+}

--- a/packages/mgd/src/test/publish.spec.ts
+++ b/packages/mgd/src/test/publish.spec.ts
@@ -1,0 +1,160 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { registerDistCommands } from "../commands/dist.js";
+import { startMockServer, MockRoute, RecordedRequest } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+// A dataset record carrying a dataset-distributions aspect.
+function datasetRoute(
+    datasetId: string,
+    distributions: unknown[]
+): MockRoute {
+    return {
+        method: "GET",
+        path: new RegExp(`/records/${datasetId}$`),
+        body: {
+            id: datasetId,
+            aspects: { "dataset-distributions": { distributions } }
+        }
+    };
+}
+
+// The bulk records-aspect merge endpoint; returns a list of event ids.
+const bulkPublishRoute: MockRoute = {
+    method: "PUT",
+    path: "/v0/registry/records/aspects/publishing",
+    body: [1, 2, 3]
+};
+
+interface RunResult {
+    out: string;
+    requests: RecordedRequest[];
+    bulkPut: RecordedRequest;
+    bulkBody: { recordIds: string[]; data: { state: string } };
+}
+
+async function run(argv: string[], routes: MockRoute[]): Promise<RunResult> {
+    const server = await startMockServer(routes);
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    process.env.MGD_BASE_URL = server.url;
+    try {
+        const program = new Command();
+        registerDatasetCommands(program);
+        registerDistCommands(program);
+        const out = await captureStdout(() =>
+            program.parseAsync(argv, { from: "user" })
+        );
+        const bulkPut = server.requests.find(
+            (r) =>
+                r.method === "PUT" &&
+                r.url.startsWith("/v0/registry/records/aspects/publishing")
+        )!;
+        return {
+            out,
+            requests: server.requests,
+            bulkPut,
+            bulkBody: bulkPut && JSON.parse(bulkPut.body.toString())
+        };
+    } finally {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+        await server.close();
+    }
+}
+
+describe("dataset publish / unpublish", () => {
+    it("cascades to every distribution via one merge-PUT to the bulk endpoint", async () => {
+        const { bulkPut, bulkBody } = await run(
+            ["dataset", "publish", "ds-1"],
+            [datasetRoute("ds-1", ["dist-1", "dist-2"]), bulkPublishRoute]
+        );
+        expect(bulkPut.url).to.match(/[?&]merge=true(&|$)/);
+        expect(bulkBody.recordIds).to.deep.equal(["ds-1", "dist-1", "dist-2"]);
+        expect(bulkBody.data).to.deep.equal({ state: "published" });
+    });
+
+    it("--without-distributions sets only the dataset record", async () => {
+        const { bulkBody } = await run(
+            ["dataset", "publish", "ds-1", "--without-distributions"],
+            [datasetRoute("ds-1", ["dist-1", "dist-2"]), bulkPublishRoute]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["ds-1"]);
+        expect(bulkBody.data).to.deep.equal({ state: "published" });
+    });
+
+    it("unpublish sets state back to draft, cascading by default", async () => {
+        const { bulkBody } = await run(
+            ["dataset", "unpublish", "ds-1"],
+            [datasetRoute("ds-1", ["dist-1"]), bulkPublishRoute]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["ds-1", "dist-1"]);
+        expect(bulkBody.data).to.deep.equal({ state: "draft" });
+    });
+
+    it("handles a dataset with zero distributions", async () => {
+        const { bulkBody } = await run(
+            ["dataset", "publish", "ds-1"],
+            [datasetRoute("ds-1", []), bulkPublishRoute]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["ds-1"]);
+    });
+
+    it("reads distribution ids from both id strings and dereferenced objects", async () => {
+        const { bulkBody } = await run(
+            ["dataset", "publish", "ds-1"],
+            [
+                datasetRoute("ds-1", ["dist-1", { id: "dist-2" }]),
+                bulkPublishRoute
+            ]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["ds-1", "dist-1", "dist-2"]);
+    });
+
+    it("emits a structured result with --json", async () => {
+        const { out } = await run(
+            ["dataset", "publish", "ds-1", "--json"],
+            [datasetRoute("ds-1", ["dist-1"]), bulkPublishRoute]
+        );
+        expect(JSON.parse(out)).to.deep.equal({
+            state: "published",
+            records: [
+                { id: "ds-1", type: "dataset", state: "published" },
+                { id: "dist-1", type: "distribution", state: "published" }
+            ]
+        });
+    });
+});
+
+describe("dist publish / unpublish", () => {
+    it("publish sets a single distribution to published", async () => {
+        const { bulkBody } = await run(
+            ["dist", "publish", "dist-9"],
+            [bulkPublishRoute]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["dist-9"]);
+        expect(bulkBody.data).to.deep.equal({ state: "published" });
+    });
+
+    it("unpublish sets a single distribution to draft", async () => {
+        const { bulkBody } = await run(
+            ["dist", "unpublish", "dist-9"],
+            [bulkPublishRoute]
+        );
+        expect(bulkBody.recordIds).to.deep.equal(["dist-9"]);
+        expect(bulkBody.data).to.deep.equal({ state: "draft" });
+    });
+
+    it("emits a structured result with --json", async () => {
+        const { out } = await run(
+            ["dist", "publish", "dist-9", "--json"],
+            [bulkPublishRoute]
+        );
+        expect(JSON.parse(out)).to.deep.equal({
+            state: "published",
+            records: [
+                { id: "dist-9", type: "distribution", state: "published" }
+            ]
+        });
+    });
+});


### PR DESCRIPTION
## What

Adds first-class publish/unpublish commands to the `mgd` CLI that **cascade to a dataset's distributions by default**:

- `mgd dataset publish <datasetId>` / `mgd dataset unpublish <datasetId>` — sets the dataset's `publishing.state` and **every** distribution's; opt out of the cascade with `--without-distributions`.
- `mgd dist publish <distributionId>` / `mgd dist unpublish <distributionId>` — a single distribution.
- All accept `--json`.

`unpublish` targets `draft` (not `archived`).

Closes #3685.

## Why

Publication state lives in the `publishing` aspect independently on the dataset record and on each distribution; the registry does **not** cascade it. Previously the only way to publish "a dataset and its files" was a manual, per-record `aspect set` for the dataset and every distribution — error-prone and easy for a coding agent to get wrong (forget a distribution). Cascade-by-default matches user intent and removes the footgun.

## How

State is written via a **single transactional bulk merge-PUT**:

```
PUT /v0/registry/records/aspects/publishing?merge=true
Body: { "recordIds": [ "<datasetId>", "<distId>", ... ], "data": { "state": "published" } }
```

- **One request** for the whole cascade.
- **Transactional** — the endpoint runs in one `DB localTx`, first verifies the caller may update **all** the records (403 otherwise), then applies to each and rolls back on the first failure. So the cascade is all-or-nothing; no partial-publish state.
- **`?merge=true`** deep-merges `{ state }` into the existing aspect, preserving other `publishing` fields (`hasEverPublished`, `custodianOrgUnitId`, `level`, …) and upserting if absent.

Chosen over a per-record loop (N requests, non-atomic) and over the RFC-6902 `PATCH /v0/registry/records` (needs `add` vs `replace` branching, can't upsert).

### Relationship to `create --publish`

Unchanged and complementary: `create --publish` forward-inherits to files added *afterwards* (`add-file` stamps each new distribution with the dataset's live state); this new `dataset publish` retroactively syncs a dataset **and its already-attached distributions** — fixing the `create` draft → `add-file` draft → later publish order.

## Code

- New `packages/mgd/src/publishing.ts`: `setPublishingState`, `getDistributionIds`, `publishDataset`, `publishDistribution`, `renderPublishResult` (keeps the already-large `dataset.ts` focused).
- New `recordsAspect(aspectId)` endpoint helper in `endpoints.ts`.
- Commands registered in `dataset.ts` / `dist.ts`; they only format output.

## Tests

- `packages/mgd/src/test/publish.spec.ts` — 9 mock-server tests: cascade, `--without-distributions`, `unpublish→draft`, dist single, `--json` shape, zero distributions, and distribution arrays containing both id strings and dereferenced `{ id }` objects. Full suite: **120 passing**; `tsc --noEmit` clean.
- **E2E** against a local minikube cluster (locally-built `mgd` → gateway → registry, state verified independently via direct registry reads): draft→cascade publish→cascade unpublish→`--without-distributions`→single dist publish all behaved as expected, and a merge check confirmed `?merge=true` preserved an extra `publishing` field across the state change. Test records cleaned up.

## Notes

Docs (README + agent skill) are tracked separately by the docs ticket #3688.
