### PR TITLE
docs: group bulk record-write endpoints (#3704) and document the API-docs pipeline (#3703)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - #3672: Add large file upload & download support to `storage-api` — S3 multipart upload proxy endpoints (`/v0/storage/multipart/{initiate,part,parts,complete,abort}`) and HTTP Range support on object download, enabling resumable transfers of large (multi-GB) files without raising the ingress body-size limit. Adds `recommendedPartSize`, `maxPartSize`, `multipartUploadExpiry` & `incompleteUploadExpiryDays` chart options.
 - #3678: Fix `storage-api` create-bucket route being registered at `/v0/storage/{bucketid}` instead of the documented `/v0/storage/buckets/{bucketid}`
 - #3691: Add `DELETE /v0/registry/aspects/{id}` to `registry-api` — deletes an aspect definition only when no record aspect data still references it within the tenant; otherwise responds `409 Conflict` (including the referencing-record count) and deletes nothing. Deleting a non-existent aspect responds `200 {"deleted": false}` (mirroring record delete). Emits a `DeleteAspectDefinitionEvent`, is permission-gated via `object/aspect/delete` and tenant-scoped.
+- #3704: `registry-api` API docs — move the bulk (multi-record) aspect-write endpoints `PUT /v0/registry/records/aspects/{aspectId}` and `DELETE /v0/registry/records/aspectArrayItems/{aspectId}` from the "Registry Record Aspects" group into "Registry Record Service", so all "operate on a list of records" endpoints are grouped together with `PATCH /v0/registry/records`. Doc-comment (`@apiGroup`) change only; no route or behaviour change.
 
 ## v6.0.0
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Great! Take a look at https://github.com/magda-io/magda/blob/master/.github/CONT
 ## Documentation links
 
 - [Magda API Reference](https://magda-io.github.io/api-docs/index.html)
+- [How API docs are generated & served (`magda-apidocs-server`)](magda-apidocs-server/README.md)
 - [Magda Helm Chart Reference](docs/docs/helm-charts-docs-index.md)
 - [Migration & Upgrade Documents](docs/docs/migration)
 - [Other documentations](docs/docs/index.md)

--- a/docs/docs/api-documentation-howto.md
+++ b/docs/docs/api-documentation-howto.md
@@ -1,19 +1,27 @@
-# How to keep API documented
+# How to document APIs
 
-For this project, a tool called apidocjs is being used for API documentation.
-With this package, API documentation is maintained along with implementation
-in source code.
-This tool and additional scripts are then used to generate api HTML
-documentation and also swagger/openapi specification files.
+For this project, a tool called [apidocjs](https://apidocjs.com/) is used for API
+documentation. API documentation is maintained **alongside the implementation**,
+as comment blocks in the source code. Those comments are then collected and
+rendered into the in-browser API docs (and into `swagger.json` / `openapi.json`)
+by the `magda-apidocs-server` component.
 
-Please document apis like the following:
+> This page covers **how to write** the apidoc comments. For how the docs are
+> **generated and served** (the build pipeline, the forked apidoc, nginx serving,
+> and the GitHub Pages publish), see
+> [`magda-apidocs-server/README.md`](../../magda-apidocs-server/README.md).
+
+## Examples
+
+A simple `GET` endpoint:
 
 <pre>
 
 /**
  * @apiGroup Feedback
  * @api {get} /v0/healthz Health Check
- * @apiDescription TODO
+ * @apiDescription Returns 200 OK when the service is healthy. Used by
+ *    Kubernetes liveness/readiness probes.
  * @apiSuccessExample {string} 200
  *    OK
  */
@@ -23,18 +31,20 @@ app.get("/v0/healthz", function(req, res, next) {
 
 </pre>
 
+A `POST` endpoint with a request body, success and error responses:
+
 <pre>
 
 /**
  * @apiGroup Feedback
  * @api {post} /v0/user Post User Feedback
- * @apiDescription TODO
+ * @apiDescription Submits a user feedback item.
  *
- * @apiParam (Request body) {string} [title] TODO
- * @apiParam (Request body) {string} [name] TODO
- * @apiParam (Request body) {string} [email] TODO
- * @apiParam (Request body) {string} comment TODO
- * @apiParam (Request body) {string} [shareLink] TODO
+ * @apiParam (body) {string} [title] Optional short title for the feedback.
+ * @apiParam (body) {string} [name] Optional name of the person submitting.
+ * @apiParam (body) {string} [email] Optional contact email.
+ * @apiParam (body) {string} comment The feedback text (required).
+ * @apiParam (body) {string} [shareLink] Optional link to the page being reported.
  *
  * @apiSuccess {string} result SUCCESS
  *
@@ -54,3 +64,75 @@ app.post("/v0/user", function(req, res, next) {
     ...
 
 </pre>
+
+## Annotation reference
+
+These are the apidoc annotations commonly used across the `magda-*` components:
+
+| Annotation | Purpose |
+| --- | --- |
+| `@apiGroup <Name>` | The sidebar section the endpoint appears under (and the `tag` in the generated swagger/openapi). Keep the name stable — grouping is purely by this string. |
+| `@api {method} /path Title` | Declares the endpoint: HTTP method, path, and the title shown in the list. Required for a block to be treated as an endpoint. |
+| `@apiName <Name>` | A unique name for the endpoint (used by apidoc for versioning/diffing). |
+| `@apiDescription <text>` | Longer description shown in the endpoint detail. |
+| `@apiParam (<group>) {type} [field] description` | A request parameter. The `(<group>)` label decides where it goes — see [Param groups](#param-groups) below. Wrap a `field` in `[...]` to mark it optional. |
+| `@apiParamExample {type} <title>` | An example request payload. |
+| `@apiHeader {type} <name>` | A request header (e.g. `X-Magda-Session`, `X-Magda-Tenant-Id`). |
+| `@apiSuccess {type} field description` | A field returned on success. |
+| `@apiSuccessExample {type} <title>` | An example success response body. |
+| `@apiError {type} field description` | A field returned on error. |
+| `@apiErrorExample {type} <title>` | An example error response body. |
+| `@apiUse <Name>` | Includes a reusable block defined with `@apiDefine` — see [Reusable blocks](#reusable-blocks). |
+| `@apiDefine <Name>` | Defines a reusable block (of params, errors, etc.) to be pulled in with `@apiUse`. |
+| `@apiDeprecated [text]` | Marks the endpoint as deprecated. |
+| `@apiPrivate` | Marks the endpoint as private. The build runs with `--private true`, so private endpoints **are** included in Magda's generated docs. |
+
+## Param groups
+
+The `(<group>)` label on `@apiParam` is significant. When the apidoc output is
+converted to `swagger.json` / `openapi.json`, a parameter is placed into the
+**request body** when its group name contains the word `body`
+(case-insensitive); otherwise it is emitted as a **query parameter**.
+
+To keep the generated specs correct and consistent, prefer these group labels:
+
+- `(path)` — path/URL parameters.
+- `(query)` — query-string parameters.
+- `(body)` — request-body fields.
+
+> Because body-vs-query is decided purely by matching `body` in the group name,
+> an inconsistent label (e.g. putting a body field under `(Request Body JSON)`
+> works, but a path param under a label containing `body` would wrongly land in
+> the request body). Sticking to `(path)` / `(query)` / `(body)` avoids surprises.
+> Note that path parameters are currently emitted as query parameters in the
+> generated spec — a known limitation of the converter.
+
+## Reusable blocks
+
+Repeated content (typically a common error response) is defined once with
+`@apiDefine` and pulled into each endpoint with `@apiUse`. The most common one is
+`GenericError`, defined once per component and referenced from most endpoints:
+
+<pre>
+
+/**
+ * @apiDefine GenericError
+ * @apiError (Error 500) {string} response Something went wrong.
+ * @apiErrorExample {json} 500
+ *    { "isError": true, "errorCode": 500, "errorMessage": "..." }
+ */
+
+/**
+ * @apiGroup Registry Record Service
+ * @api {get} /v0/registry/records Get a list of records
+ * ...
+ * @apiUse GenericError
+ */
+
+</pre>
+
+## See also
+
+- [`magda-apidocs-server/README.md`](../../magda-apidocs-server/README.md) — how
+  the API docs are generated (the forked apidoc, the scan of every `magda-*/src`)
+  and served (deployed cluster + GitHub Pages mirror).

--- a/docs/docs/architecture/Guide to Magda Internals.md
+++ b/docs/docs/architecture/Guide to Magda Internals.md
@@ -535,7 +535,7 @@ The request sent to decision API can be simply like:
 
 The detailed document of the decision API can be found from [here](https://github.com/magda-io/magda/blob/e10a202de7cc0c3610b206ca9daaaabddb00e79f/magda-authorization-api/src/createOpaRouter.ts#L220)
 
-> The HTML version doc can be accessed via the footer link of a deployed Magda site. You can also build Magda's API doc manually to avoid the deployment. Just go to `magda-apidocs-server` module and run `yarn build`. The HTML version API docs will be available from `build` folder.
+> The HTML version doc can be accessed via the footer link of a deployed Magda site. You can also build Magda's API doc manually to avoid the deployment. Just go to `magda-apidocs-server` module and run `yarn build`. The HTML version API docs will be available from `build` folder. See [`magda-apidocs-server/README.md`](../../../magda-apidocs-server/README.md) for how the API docs are generated and served.
 
 > We implemented decision API integration code as [Directives](https://github.com/magda-io/magda/blob/next/magda-scala-common/src/main/scala/au/csiro/data61/magda/directives/AuthDirectives.scala) in scala code base and [middlewares](https://github.com/magda-io/magda/blob/e10a202de7cc0c3610b206ca9daaaabddb00e79f/magda-typescript-common/src/authorization-api/authMiddleware.ts#L83) in nodejs codebase. You can choose to reuse those code or write your own.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,6 +15,7 @@
 - [How to use APIs](./using-api.md)
 - [`mgd` CLI — terminal & coding-agent access to a catalog (search, download, create/edit datasets; Claude Code / Codex / opencode skills)](https://github.com/magda-io/magda/tree/main/packages/mgd)
 - [How to document APIs](./api-documentation-howto.md)
+- [How API docs are generated & served (`magda-apidocs-server`)](../../magda-apidocs-server/README.md)
 - [How to create API key](./how-to-create-api-key.md)
 - [How to set/unset admin users](./how-to-set-user-as-admin-user.md)
 - [How to manage users, roles & permissions](https://www.npmjs.com/package/@magda/acs-cmd)

--- a/magda-apidocs-server/README.md
+++ b/magda-apidocs-server/README.md
@@ -1,0 +1,123 @@
+# @magda/apidocs-server
+
+The microservice that serves MAGDA's **in-browser API documentation**.
+
+The docs are auto-generated from [apidocjs](https://apidocjs.com/)-format
+comments embedded in the source of every `magda-*` component, then served as a
+static site. You can view them:
+
+- On a deployed cluster at `/api/v0/apidocs/index.html`.
+- On the GitHub Pages mirror at https://magda-io.github.io/api-docs (published
+  from `main` — see [Serving & publishing](#serving--publishing) below).
+
+> This README covers **how the docs are generated and served**. For **how to
+> write** the apidoc comments in your component's source, see
+> [`docs/docs/api-documentation-howto.md`](../docs/docs/api-documentation-howto.md).
+
+## Where the docs come from
+
+Nothing is authored in this component. The content is the set of apidocjs
+comment blocks embedded next to the endpoint handlers in each `magda-*`
+component (Scala, TypeScript and JavaScript source). This component only
+**collects** those comments and renders them.
+
+## How the docs are generated
+
+`yarn build` runs the `build` script in `package.json`:
+
+```
+generate-api-documentation --config ./apidoc.json --output ./build
+```
+
+`generate-api-documentation` is [`scripts/generate-api-documentation.js`](../scripts/generate-api-documentation.js)
+(from the `@magda/scripts` package). It:
+
+1. Scans the repo root for sibling folders matching `^magda-.*$` and, for each
+   one that has a `src` directory, adds `<component>/src` as an apidoc input.
+2. Runs apidoc across those inputs, restricted to `.scala`, `.ts` and `.js`
+   files, with `--private true` (so `@apiPrivate` endpoints are included):
+
+   ```
+   apidoc --debug --private true \
+     -i <each magda-*/src> \
+     -f ".*\.scala$" -f ".*\.ts$" -f ".*\.js$" \
+     -o ./build -c ./apidoc.json
+   ```
+
+   This writes the apidoc single-page app (`index.html` + assets) plus the
+   intermediate `api_project.json` / `api_data.json` into `./build`.
+3. Converts that apidoc output into OpenAPI/Swagger specs, writing
+   `build/swagger.json` (Swagger 2.0) and `build/openapi.json` (OpenAPI 3.0.1).
+
+`apidoc.json` in this folder supplies the project-level `name`, `title`,
+`description`, `url` and footer used across all three outputs.
+
+### Forked apidoc
+
+The build uses a **fork** of apidoc, not the upstream npm package. It is pinned
+in [`scripts/package.json`](../scripts/package.json):
+
+```json
+"apidoc": "https://github.com/magda-io/apidoc"
+```
+
+Keep this in mind when debugging generation behaviour or upgrading — upstream
+apidoc releases do not necessarily apply.
+
+## How comments map to the rendered output
+
+- `@apiGroup <Name>` controls **which sidebar section** an endpoint appears
+  under in the SPA, and becomes the **`tag`** on the endpoint in the generated
+  `swagger.json` / `openapi.json`. If an endpoint shows up in an unexpected
+  section, its `@apiGroup` is the first thing to check.
+- `@api {method} /path Title` defines the endpoint entry (HTTP method, path and
+  the title shown in the list).
+- Request parameters are split between query and request body by the
+  **`@apiParam` group label**: a group name containing `body` (e.g.
+  `@apiParam (body) ...`) is emitted into the request body of the generated
+  spec; every other group becomes a query parameter. See the
+  [param-group convention](../docs/docs/api-documentation-howto.md) in the
+  how-to for the recommended labels.
+
+## Build & preview locally
+
+```bash
+# from the repo root
+yarn install
+
+cd magda-apidocs-server
+yarn build
+
+# then open ./build/index.html in a browser
+```
+
+The generated `build/` folder contains everything served: the apidoc SPA plus
+`swagger.json` and `openapi.json`.
+
+## Serving & publishing
+
+- **On a deployed cluster:** the Docker image (`Dockerfile`) is `nginx:alpine`
+  with `default.conf` and the generated `build/` copied in; nginx serves the
+  static site (health/readiness probes at `/healthz`, `/status/live`,
+  `/status/ready`). It is reachable through the gateway at
+  `/api/v0/apidocs/index.html`.
+- **GitHub Pages mirror:** the
+  [`Deploy Latest API Docs`](../.github/workflows/deploy-api-docs-main.yaml)
+  workflow runs on every push to `main`. It runs `yarn build`, swaps in
+  `doc-repo-readme.md` as the published `README.md`, and pushes the `build/`
+  folder to the [`magda-io/api-docs`](https://github.com/magda-io/api-docs)
+  repository, which GitHub Pages serves at
+  https://magda-io.github.io/api-docs.
+
+## Generated artifacts (`./build`)
+
+| File | Description |
+| --- | --- |
+| `index.html` (+ assets) | The apidoc single-page documentation site. |
+| `swagger.json` | Swagger 2.0 spec generated from the apidoc data. |
+| `openapi.json` | OpenAPI 3.0.1 spec generated from the apidoc data. |
+
+## See also
+
+- [How to document APIs](../docs/docs/api-documentation-howto.md) — the apidoc
+  comment format and conventions (how to author the docs this component renders).

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -750,7 +750,7 @@ class RecordsService(
   }
 
   /**
-    * @apiGroup Registry Record Aspects
+    * @apiGroup Registry Record Service
     * @api {put} /v0/registry/records/aspects/:aspectId Modify a list of records's aspect with same new data
     *
     * @apiDescription  Modify a list of records's aspect with same new data
@@ -882,7 +882,7 @@ class RecordsService(
   }
 
   /**
-    * @apiGroup Registry Record Aspects
+    * @apiGroup Registry Record Service
     * @api {delete} /v0/registry/records/aspectArrayItems/:aspectId Remove items from records' aspect data
     *
     * @apiDescription  this API goes through the aspect data that is specified by aspectId of a list of registry records


### PR DESCRIPTION
Combined docs-only PR covering two related API-docs issues.

## #3704 — group bulk multi-record write endpoints together

Move the bulk (multi-record) aspect-write endpoints into the same apidoc group as `PATCH /v0/registry/records`, so all "operate on a list of records" endpoints sit together in the generated docs:

- `PUT /v0/registry/records/aspects/:aspectId` (`putRecordsAspect`)
- `DELETE /v0/registry/records/aspectArrayItems/:aspectId` (`deleteRecordsAspectArrayItems`)

`@apiGroup` doc-comment change only (`Registry Record Aspects` → `Registry Record Service`); no route or behaviour change. Adds a `CHANGES.md` entry.

Closes #3704

## #3703 — document how API docs are generated & served

The generate→serve pipeline was undocumented (`magda-apidocs-server/README.md` was empty; the how-to covered comment format only).

- **New `magda-apidocs-server/README.md`** — full pipeline reference: what it is & where served (deployed cluster + GitHub Pages), generation flow (build script → `generate-api-documentation.js` scanning every `magda-*/src` → forked `magda-io/apidoc` → apidoc SPA + `swagger.json`/`openapi.json`), `@apiGroup`/`@api` → output mapping, local preview, nginx serving + the GitHub Pages publish CI, and generated artifacts.
- **Enriched `docs/docs/api-documentation-howto.md`** (comment format) — removed `TODO` placeholders, added an annotation reference, the `(path)`/`(query)`/`(body)` param-group convention and its `body`-matching caveat, reusable `@apiDefine`/`@apiUse GenericError` guidance, and bidirectional cross-links to the README.
- **Discoverability links** to the new README from `docs/docs/index.md`, the architecture guide, and the root `README.md`.

Docs only; no route, behaviour, CI or nginx changes.

Closes #3703
