### PR TITLE
fix(authorization-api): add missing FROM in deleteUser DELETE statement

### DIFF
--- a/magda-authorization-api/src/Database.ts
+++ b/magda-authorization-api/src/Database.ts
@@ -564,7 +564,7 @@ export default class Database {
         }
 
         await this.pool.query(
-            ...sqls`DELETE users WHERE id = ${userId}`.toQuery()
+            ...sqls`DELETE FROM users WHERE id = ${userId}`.toQuery()
         );
     }
 

--- a/magda-authorization-api/src/test/Database.deleteUser.spec.ts
+++ b/magda-authorization-api/src/test/Database.deleteUser.spec.ts
@@ -1,0 +1,87 @@
+import "mocha";
+import pg from "pg";
+import { expect } from "chai";
+import getTestDBConfig from "./getTestDBConfig.js";
+import runMigrationSql from "./runMigrationSql.js";
+import Database from "../Database.js";
+
+describe("Database.deleteUser (integration)", function (this: Mocha.Suite) {
+    this.timeout(30000);
+    let pool: pg.Pool = null;
+    let database: Database;
+    const dbConfig = getTestDBConfig();
+
+    before(async function () {
+        // --- connect to the default db first so we can (re)create the test db
+        pool = new pg.Pool({ ...dbConfig });
+        try {
+            await pool.query("CREATE database test");
+        } catch (e) {
+            // --- ignore the error if database `test` already exists
+            if ((e as any)?.code !== "42P04") {
+                throw e;
+            }
+        }
+        await pool.end();
+
+        // --- reconnect to the test db & rebuild a clean auth schema in it
+        pool = new pg.Pool({ ...dbConfig, database: "test" });
+        await runMigrationSql(pool, true);
+
+        // --- `Database` builds its own pool (pointing at the `auth` db) in the
+        // --- constructor. Swap in our test-db pool so we exercise the real SQL
+        // --- against the migrated schema.
+        database = new Database({ dbHost: dbConfig.host, dbPort: 5432 });
+        const throwawayPool = database.getPool();
+        (database as any).pool = pool;
+        await throwawayPool.end();
+    });
+
+    after(async function () {
+        if (pool) {
+            await pool.end();
+            pool = null;
+        }
+    });
+
+    it("deletes the user record and cascades to its role associations", async () => {
+        const created = await database.createUser({
+            displayName: "delete-me",
+            email: "delete-me@example.com",
+            photoURL: "",
+            source: "test-source",
+            sourceId: "delete-me-source-id"
+        });
+        expect(created.id).to.be.a("string");
+
+        // --- sanity check: the user & its auto-assigned role association exist
+        const userBefore = await pool.query(
+            `SELECT id FROM users WHERE id = $1`,
+            [created.id]
+        );
+        expect(userBefore.rows).to.have.lengthOf(1);
+        const rolesBefore = await pool.query(
+            `SELECT 1 FROM user_roles WHERE user_id = $1`,
+            [created.id]
+        );
+        expect(rolesBefore.rows).to.have.lengthOf(1);
+
+        // --- the behaviour under test. Before the fix this threw
+        // --- `syntax error at or near "users"` because the DELETE statement
+        // --- was missing the `FROM` keyword (see issue #3677).
+        await database.deleteUser(created.id);
+
+        const userAfter = await pool.query(
+            `SELECT id FROM users WHERE id = $1`,
+            [created.id]
+        );
+        expect(userAfter.rows).to.have.lengthOf(0);
+
+        // --- the documented cascade removes the user's role associations too
+        const rolesAfter = await pool.query(
+            `SELECT 1 FROM user_roles WHERE user_id = $1`,
+            [created.id]
+        );
+        expect(rolesAfter.rows).to.have.lengthOf(0);
+    });
+});

--- a/magda-authorization-api/src/test/runMigrationSql.ts
+++ b/magda-authorization-api/src/test/runMigrationSql.ts
@@ -3,6 +3,10 @@ import fse from "fs-extra";
 import recursive from "recursive-readdir";
 import getTestDBConfig from "./getTestDBConfig.js";
 import path from "path";
+import { fileURLToPath } from "url";
+
+// --- `__dirname` is not available in ESM; derive it from `import.meta.url`
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function getVersionNumber(fileName: string) {
     const matches = fileName.match(/^V(\d+(_\d+)*)/i);


### PR DESCRIPTION
## Summary

`DELETE /api/v0/auth/users/:userId` always failed with a 500 and never deleted the user. `Database.deleteUser` issued `DELETE users WHERE id = ...`, which is invalid SQL — PostgreSQL requires `DELETE FROM users ...` — so it threw `syntax error at or near "users"`. As a result the endpoint's documented cascade (removing the user's API keys, credentials, and role associations) never ran.

Fix: use `DELETE FROM users WHERE id = ...` (matching the correct form already used by `deleteUserApiKey`).

## Test

Adds a DB-backed integration test `Database.deleteUser.spec.ts` that:
- builds a clean auth schema in a throwaway `test` database
- creates a user, then calls `deleteUser`
- asserts the user row is gone **and** its `user_roles` association was cascade-removed

Against the unfixed code this test reproduces the ticket error (`syntax error at or near "users"`); with the fix it passes. Full `magda-authorization-api` suite: 85 passing.

Also makes the previously-unused `runMigrationSql` test helper ESM-compatible — it relied on `__dirname`, which is undefined under the ESM/tsx test runner — so the new test can rebuild the schema.

Fixes #3677