### PR TITLE
feat(mgd): maintain version aspect on high-level commands + add dist remove

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -270,6 +270,15 @@ metadata tools, with a distinct `name` marking their CLI provenance.
 > prints the exact commands to finish or undo — it never leaves silent partial
 > state.
 
+> **Versioning.** The CLI maintains the application-managed `version` aspect
+> automatically: `dataset create` / `add-file` seed and tag the initial
+> version, and `dataset update`, `dist update`, `dist replace-file`,
+> `add-file` and `dist remove` bump the changed record's version (tagged with
+> the registry event id, so past versions work with the registry's
+> time-travel API). `publish` / `unpublish` don't bump versions (lifecycle
+> state, not content). Don't hand-edit the `version` aspect; `dataset aspect set` / `aspect patch` / `aspect delete` are the manual escape hatch and
+> never auto-bump.
+
 ### Custom aspects
 
 The registry supports user-defined aspects with JSON-schema validation. `mgd`
@@ -323,28 +332,29 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 
 ## Command reference
 
-| Command                                               | Description                                             |
-| ----------------------------------------------------- | ------------------------------------------------------- |
-| `profile create <name>` / `update <name>` / `remove <name>` | Create / patch / delete a site profile            |
-| `profile list` / `profile use <name>`                 | List / switch profiles                                  |
-| `auth status`                                         | Show the active profile and authenticated user          |
-| `auth login`                                          | Deprecated alias of `profile create` (`--profile`)      |
-| `search datasets <query>`                             | Keyword dataset search                                  |
-| `search semantic <query>`                             | Semantic (embedding) search                             |
-| `dataset get <id>`                                    | Fetch a dataset record                                  |
-| `dataset distributions <id>`                          | List a dataset's distributions                          |
-| `dataset create`                                      | Create a dataset (draft by default)                     |
-| `dataset update <id>`                                 | Update dataset metadata                                 |
-| `dataset add-file <id> [file]`                        | Upload/attach a distribution (or `--access-url`)        |
-| `dataset aspect get/set/patch/delete <recordId> <aspectId>` | Read/write custom aspect data on any record (`set`=replace, `patch`=merge) |
-| `dist get <id>` / `dist update <id>`                  | Inspect / edit a distribution                           |
-| `dist download <id>`                                  | Download a distribution's file (`--resume`)             |
-| `dist replace-file <id> <file>`                       | Replace a distribution's file, bump version             |
-| `file upload <file>` / `file download <bucket/key>`   | Direct storage transfer                                 |
-| `aspect list` / `get <id>` / `create <id>` / `delete <id>` | Manage aspect definitions                               |
-| `api request <method> <path>`                         | Call any MAGDA API endpoint                             |
-| `skills install [--agent <name>]`                     | Install the agent skill (all agents, global by default) |
-| `skills uninstall [--agent <name>]`                   | Remove the agent skill                                  |
+| Command                                                     | Description                                                                                         |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `profile create <name>` / `update <name>` / `remove <name>` | Create / patch / delete a site profile                                                              |
+| `profile list` / `profile use <name>`                       | List / switch profiles                                                                              |
+| `auth status`                                               | Show the active profile and authenticated user                                                      |
+| `auth login`                                                | Deprecated alias of `profile create` (`--profile`)                                                  |
+| `search datasets <query>`                                   | Keyword dataset search                                                                              |
+| `search semantic <query>`                                   | Semantic (embedding) search                                                                         |
+| `dataset get <id>`                                          | Fetch a dataset record                                                                              |
+| `dataset distributions <id>`                                | List a dataset's distributions                                                                      |
+| `dataset create`                                            | Create a dataset (draft by default)                                                                 |
+| `dataset update <id>`                                       | Update dataset metadata                                                                             |
+| `dataset add-file <id> [file]`                              | Upload/attach a distribution (or `--access-url`)                                                    |
+| `dataset aspect get/set/patch/delete <recordId> <aspectId>` | Read/write custom aspect data on any record (`set`=replace, `patch`=merge)                          |
+| `dist get <id>` / `dist update <id>`                        | Inspect / edit a distribution                                                                       |
+| `dist download <id>`                                        | Download a distribution's file (`--resume`)                                                         |
+| `dist replace-file <id> <file>`                             | Replace a distribution's file, bump version                                                         |
+| `dist remove <id>`                                          | Remove a distribution from its dataset (deletes record + stored files; `--keep-files` to keep them) |
+| `file upload <file>` / `file download <bucket/key>`         | Direct storage transfer                                                                             |
+| `aspect list` / `get <id>` / `create <id>` / `delete <id>`  | Manage aspect definitions                                                                           |
+| `api request <method> <path>`                               | Call any MAGDA API endpoint                                                                         |
+| `skills install [--agent <name>]`                           | Install the agent skill (all agents, global by default)                                             |
+| `skills uninstall [--agent <name>]`                         | Remove the agent skill                                                                              |
 
 Run `mgd --help` or `mgd <command> --help` for full option documentation.
 

--- a/packages/mgd/skills/dataset-elicitation.md
+++ b/packages/mgd/skills/dataset-elicitation.md
@@ -87,4 +87,5 @@ When asked to improve an existing dataset (or after a quick-path creation):
   marking which values were inferred vs provided.
 - After mutations, report the record IDs and what changed.
 - Replacing a file (`mgd dist replace-file`) preserves version history; tell
-  the user the new version number.
+  the user the new version number. Dataset/distribution metadata updates and
+  `dist remove` also bump the affected record's version automatically.

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -33,6 +33,11 @@ your assistant environment, keep the rules.
    happens only when the user asked for it.
 6. **Report identifiers.** Every user-facing summary must include the dataset
    IDs, distribution IDs, local file paths, and upload targets you touched.
+7. **Versioning is automatic.** The CLI maintains the `version` aspect on
+   high-level commands (`create`/`update`/`add-file`/`replace-file`/`remove`)
+   and tags versions with registry event ids. `publish`/`unpublish` never bump
+   versions. Never hand-edit the `version` aspect; raw `aspect set`/`patch`/
+   `delete` never auto-bump.
 
 ## Keyword vs semantic search — use both
 
@@ -88,6 +93,13 @@ the metadata conversation first):
 
 ```sh
 mgd dataset add-file ds-abc ./analysis/summary.parquet --title "2026 summary" --json
+```
+
+Remove a distribution (unlinks it, bumps the dataset version, deletes the
+record and its stored files; `--keep-files` keeps the objects):
+
+```sh
+mgd dist remove dist-xyz --json
 ```
 
 Custom / domain metadata:

--- a/packages/mgd/src/client.ts
+++ b/packages/mgd/src/client.ts
@@ -148,3 +148,14 @@ export function clientFor(profile: Profile): MagdaClient {
         apiKey: profile.apiKey
     });
 }
+
+// Registry mutation responses carry the id of the event they created in the
+// `x-magda-event-id` header (same contract as the web client's
+// getEventIdFromHeaders). 0 means "unknown" and must never be written into
+// a version item.
+export function eventIdFrom(res: Response): number {
+    const v = res.headers.get("x-magda-event-id");
+    if (!v) return 0;
+    const n = parseInt(v, 10);
+    return Number.isNaN(n) ? 0 : n;
+}

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { Command } from "commander";
-import { clientFromProfile, MagdaClient } from "../client.js";
+import { clientFromProfile, MagdaClient, eventIdFrom } from "../client.js";
+import {
+    bumpRecordVersion,
+    tagCurrentVersion,
+    writeVersionAspect,
+    VersionAspectData
+} from "../versionAspect.js";
 import {
     registryRecord,
     registryRecordInFull,
@@ -65,17 +71,19 @@ export async function mergeAspect(
     recordId: string,
     aspectId: string,
     patch: Record<string, unknown>
-): Promise<void> {
+): Promise<{ eventId: number; merged: Record<string, unknown> }> {
     let current: Record<string, unknown> = {};
     try {
         current = await client.json("GET", recordAspect(recordId, aspectId));
     } catch (e) {
         if (!(e instanceof MgdApiError && e.status === 404)) throw e;
     }
-    await client.json("PUT", recordAspect(recordId, aspectId), {
+    const merged = { ...current, ...patch };
+    const res = await client.request("PUT", recordAspect(recordId, aspectId), {
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ...current, ...patch })
+        body: JSON.stringify(merged)
     });
+    return { eventId: eventIdFrom(res), merged };
 }
 
 export function registerDatasetCommands(program: Command): void {
@@ -197,13 +205,27 @@ export function registerDatasetCommands(program: Command): void {
                 sourceUrl: deriveSiteUrl(client.opts.baseUrl),
                 extraAspects
             });
+            let createEventId = 0;
             try {
-                await client.json("POST", REGISTRY_RECORDS, {
+                const res = await client.request("POST", REGISTRY_RECORDS, {
                     headers: { "content-type": "application/json" },
                     body: JSON.stringify(record)
                 });
+                createEventId = eventIdFrom(res);
             } catch (e) {
                 throw withAspectHint(e);
+            }
+            // Tag the seeded v0 with the creation event so the next edit
+            // bumps to v1 (an explicit --aspect version=... wins untouched).
+            if (!("version" in extraAspects)) {
+                const tagged = tagCurrentVersion(
+                    record.aspects.version as VersionAspectData,
+                    createEventId
+                );
+                if (tagged) {
+                    record.aspects.version = tagged;
+                    await writeVersionAspect(client, record.id, tagged);
+                }
             }
             if (opts.json) printData("json", record);
             else process.stdout.write(record.id + "\n");
@@ -229,39 +251,73 @@ export function registerDatasetCommands(program: Command): void {
             if (opts.title) scalarPatch.title = opts.title;
             if (opts.desc) scalarPatch.description = opts.desc;
             if (opts.license) scalarPatch.defaultLicense = opts.license;
+            const aspectArgs: { id: string; data: unknown }[] = [];
+            for (const arg of opts.aspect as string[]) {
+                aspectArgs.push(await parseAspectArg(arg));
+            }
             if (
                 Object.keys(scalarPatch).length === 0 &&
-                (opts.aspect as string[]).length === 0
+                aspectArgs.length === 0
             ) {
                 throw new UsageError(
                     "Nothing to update: pass --title/--desc/--license or --aspect."
                 );
             }
             const client = await clientFromProfile();
+            let lastEventId = 0;
+            let mergedTitle: string | undefined;
             if (Object.keys(scalarPatch).length > 0) {
                 scalarPatch.modified = new Date().toISOString();
-                await mergeAspect(
+                const { eventId, merged } = await mergeAspect(
                     client,
                     datasetId,
                     "dcat-dataset-strings",
                     scalarPatch
                 );
+                lastEventId = Math.max(lastEventId, eventId);
+                mergedTitle =
+                    typeof merged.title === "string" ? merged.title : undefined;
             }
-            for (const arg of opts.aspect as string[]) {
-                const { id, data } = await parseAspectArg(arg);
+            for (const { id, data } of aspectArgs) {
                 try {
-                    await client.json("PUT", recordAspect(datasetId, id), {
-                        headers: { "content-type": "application/json" },
-                        body: JSON.stringify(data)
-                    });
+                    const res = await client.request(
+                        "PUT",
+                        recordAspect(datasetId, id),
+                        {
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify(data)
+                        }
+                    );
+                    lastEventId = Math.max(lastEventId, eventIdFrom(res));
                 } catch (e) {
                     throw withAspectHint(e);
                 }
             }
-            if (opts.json) printData("json", { datasetId, ok: true });
+            let version: VersionAspectData | undefined;
+            // An explicit user write to `version` always wins: skip auto-bump.
+            if (!aspectArgs.some((a) => a.id === "version")) {
+                version = await bumpRecordVersion(client, datasetId, {
+                    eventId: lastEventId,
+                    now: new Date(),
+                    title: (opts.title as string | undefined) ?? mergedTitle,
+                    creatorId: (await fetchOwner(client))?.id,
+                    description: "Version created on update submission"
+                });
+            }
+            if (opts.json)
+                printData("json", {
+                    datasetId,
+                    ok: true,
+                    ...(version
+                        ? { versionNumber: version.currentVersionNumber }
+                        : {})
+                });
             else note(`Dataset ${datasetId} updated.`);
         });
 
+    // publish/unpublish deliberately do NOT bump the version aspect: a
+    // publishing-state flip is lifecycle metadata, not a content change, so a
+    // version entry per flip would be noise. See issue #3687.
     for (const verb of ["publish", "unpublish"] as const) {
         const state = verb === "publish" ? "published" : "draft";
         dataset
@@ -309,12 +365,7 @@ export function registerDatasetCommands(program: Command): void {
         .description("value: inline JSON, @file.json, or - for stdin")
         .option("--json", "output the result as JSON")
         .action(
-            async (
-                recordId: string,
-                aspectId: string,
-                value: string,
-                opts
-            ) => {
+            async (recordId: string, aspectId: string, value: string, opts) => {
                 const client = await clientFromProfile();
                 const data = await parseAspectValue(value);
                 try {
@@ -340,12 +391,7 @@ export function registerDatasetCommands(program: Command): void {
         )
         .option("--json", "output the result as JSON")
         .action(
-            async (
-                recordId: string,
-                aspectId: string,
-                value: string,
-                opts
-            ) => {
+            async (recordId: string, aspectId: string, value: string, opts) => {
                 const client = await clientFromProfile();
                 const data = await parseAspectValue(value);
                 try {
@@ -411,7 +457,8 @@ export function registerDatasetCommands(program: Command): void {
                     {
                         query: [
                             ["optionalAspect", "publishing"],
-                            ["optionalAspect", "dataset-distributions"]
+                            ["optionalAspect", "dataset-distributions"],
+                            ["optionalAspect", "dcat-dataset-strings"]
                         ]
                     }
                 );
@@ -477,17 +524,20 @@ export function registerDatasetCommands(program: Command): void {
                 });
 
                 let recordCreated = false;
+                let createEventId = 0;
+                let contentEventId = 0;
                 try {
-                    await client.json("POST", REGISTRY_RECORDS, {
+                    const res = await client.request("POST", REGISTRY_RECORDS, {
                         headers: { "content-type": "application/json" },
                         body: JSON.stringify(record)
                     });
+                    createEventId = eventIdFrom(res);
                     recordCreated = true;
                     const current: string[] = (
                         dataset.aspects?.["dataset-distributions"]
                             ?.distributions ?? []
                     ).map((d: any) => (typeof d === "string" ? d : d.id));
-                    await mergeAspect(
+                    const { eventId: e1 } = await mergeAspect(
                         client,
                         datasetId,
                         "dataset-distributions",
@@ -495,7 +545,7 @@ export function registerDatasetCommands(program: Command): void {
                             distributions: [...current, distId]
                         }
                     );
-                    await mergeAspect(
+                    const { eventId: e2 } = await mergeAspect(
                         client,
                         datasetId,
                         "dcat-dataset-strings",
@@ -503,6 +553,7 @@ export function registerDatasetCommands(program: Command): void {
                             modified: now.toISOString()
                         }
                     );
+                    contentEventId = Math.max(e1, e2);
                 } catch (e) {
                     if (recordCreated) {
                         try {
@@ -546,6 +597,29 @@ export function registerDatasetCommands(program: Command): void {
                     throw wrapped;
                 }
 
+                // Version maintenance (best-effort from here):
+                // 1. tag the new distribution's seeded v0 with its creation
+                //    event (skip when the user supplied the aspect);
+                if (!("version" in extraAspects)) {
+                    const tagged = tagCurrentVersion(
+                        record.aspects.version as VersionAspectData,
+                        createEventId
+                    );
+                    if (tagged) {
+                        await writeVersionAspect(client, distId, tagged);
+                    }
+                }
+                // 2. a new distribution is a new dataset version.
+                const dsVersion = await bumpRecordVersion(client, datasetId, {
+                    eventId: contentEventId,
+                    now,
+                    title:
+                        dataset.aspects?.["dcat-dataset-strings"]?.title ??
+                        dataset.name,
+                    creatorId: owner?.id,
+                    description: "Distribution added"
+                });
+
                 if (opts.json) {
                     printData("json", {
                         datasetId,
@@ -553,7 +627,15 @@ export function registerDatasetCommands(program: Command): void {
                         ...(downloadURL
                             ? { downloadURL, bytes: byteSize }
                             : {}),
-                        ...(opts.accessUrl ? { accessURL: opts.accessUrl } : {})
+                        ...(opts.accessUrl
+                            ? { accessURL: opts.accessUrl }
+                            : {}),
+                        ...(dsVersion
+                            ? {
+                                  datasetVersionNumber:
+                                      dsVersion.currentVersionNumber
+                              }
+                            : {})
                     });
                 } else {
                     process.stdout.write(distId + "\n");

--- a/packages/mgd/src/commands/dist.ts
+++ b/packages/mgd/src/commands/dist.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { Command } from "commander";
-import { clientFromProfile } from "../client.js";
+import { clientFromProfile, eventIdFrom } from "../client.js";
 import {
     registryRecord,
     registryRecordInFull,
@@ -16,16 +16,24 @@ import { mergeAspect, collect, withAspectHint, fetchOwner } from "./dataset.js";
 import { publishDistribution, renderPublishResult } from "../publishing.js";
 import {
     parseAspectArg,
-    appendVersion,
     storageDownloadUrl,
     getValidObjectKey,
     detectFormat,
     DATASETS_BUCKET_DEFAULT
 } from "../recordBuilders.js";
+import {
+    reconcileVersion,
+    bumpRecordVersion,
+    writeVersionAspect,
+    VersionAspectData
+} from "../versionAspect.js";
 
 export function registerDistCommands(program: Command): void {
     const dist = program.command("dist").description("Distribution records");
 
+    // publish/unpublish deliberately do NOT bump the version aspect: a
+    // publishing-state flip is lifecycle metadata, not a content change. See
+    // issue #3687.
     for (const verb of ["publish", "unpublish"] as const) {
         const state = verb === "publish" ? "published" : "draft";
         dist.command(`${verb} <distributionId>`)
@@ -90,36 +98,71 @@ export function registerDistCommands(program: Command): void {
             if (opts.desc) scalarPatch.description = opts.desc;
             if (opts.format) scalarPatch.format = opts.format;
             if (opts.license) scalarPatch.license = opts.license;
+            const aspectArgs: { id: string; data: unknown }[] = [];
+            for (const arg of opts.aspect as string[]) {
+                aspectArgs.push(await parseAspectArg(arg));
+            }
             if (
                 Object.keys(scalarPatch).length === 0 &&
-                (opts.aspect as string[]).length === 0
+                aspectArgs.length === 0
             ) {
                 throw new UsageError(
                     "Nothing to update: pass --title/--desc/--format/--license or --aspect."
                 );
             }
             const client = await clientFromProfile();
+            let lastEventId = 0;
+            let mergedTitle: string | undefined;
             if (Object.keys(scalarPatch).length > 0) {
                 scalarPatch.modified = new Date().toISOString();
-                await mergeAspect(
+                const { eventId, merged } = await mergeAspect(
                     client,
                     distributionId,
                     "dcat-distribution-strings",
                     scalarPatch
                 );
+                lastEventId = Math.max(lastEventId, eventId);
+                mergedTitle =
+                    typeof merged.title === "string" ? merged.title : undefined;
             }
-            for (const arg of opts.aspect as string[]) {
-                const { id, data } = await parseAspectArg(arg);
+            for (const { id, data } of aspectArgs) {
                 try {
-                    await client.json("PUT", recordAspect(distributionId, id), {
-                        headers: { "content-type": "application/json" },
-                        body: JSON.stringify(data)
-                    });
+                    const res = await client.request(
+                        "PUT",
+                        recordAspect(distributionId, id),
+                        {
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify(data)
+                        }
+                    );
+                    lastEventId = Math.max(lastEventId, eventIdFrom(res));
                 } catch (e) {
                     throw withAspectHint(e);
                 }
             }
-            if (opts.json) printData("json", { distributionId, ok: true });
+            let version: VersionAspectData | undefined;
+            // Divergence from the web client (deliberate, record-scoped model):
+            // a distribution-metadata edit bumps the DISTRIBUTION's version;
+            // the web client bumps nothing on such an edit (its session model
+            // folds it into the dataset-level bump). See issue #3687.
+            // An explicit user write to `version` always wins: skip auto-bump.
+            if (!aspectArgs.some((a) => a.id === "version")) {
+                version = await bumpRecordVersion(client, distributionId, {
+                    eventId: lastEventId,
+                    now: new Date(),
+                    title: (opts.title as string | undefined) ?? mergedTitle,
+                    creatorId: (await fetchOwner(client))?.id,
+                    description: "Distribution metadata updated"
+                });
+            }
+            if (opts.json)
+                printData("json", {
+                    distributionId,
+                    ok: true,
+                    ...(version
+                        ? { versionNumber: version.currentVersionNumber }
+                        : {})
+                });
             else note(`Distribution ${distributionId} updated.`);
         });
 
@@ -196,17 +239,10 @@ export function registerDistCommands(program: Command): void {
             progress.done();
 
             const title = opts.title ?? fileName;
-            const newVersionAspect = appendVersion(oldVersionAspect, {
-                title,
-                creatorId: owner?.id,
-                now,
-                internalDataFileUrl: newDownloadURL,
-                description: "Replaced superseded by a new distribution"
-            });
-
             const detectedFormat = detectFormat(fileName);
+            let contentEventId = 0;
             try {
-                await mergeAspect(
+                const { eventId } = await mergeAspect(
                     client,
                     distributionId,
                     "dcat-distribution-strings",
@@ -219,18 +255,7 @@ export function registerDistCommands(program: Command): void {
                         ...(detectedFormat ? { format: detectedFormat } : {})
                     }
                 );
-                try {
-                    await client.json(
-                        "PUT",
-                        recordAspect(distributionId, "version"),
-                        {
-                            headers: { "content-type": "application/json" },
-                            body: JSON.stringify(newVersionAspect)
-                        }
-                    );
-                } catch (e) {
-                    throw withAspectHint(e);
-                }
+                contentEventId = eventId;
             } catch (e) {
                 try {
                     await client.request(
@@ -251,6 +276,25 @@ export function registerDistCommands(program: Command): void {
                 }
                 throw e;
             }
+
+            // The content change is in; version maintenance is best-effort
+            // from here (a failure warns and the reconcile self-heals later).
+            //
+            // Divergence from the web client (deliberate): a file replacement
+            // bumps ONLY the distribution's version, not the parent dataset's
+            // (a web-client session would bump both). `forceBump` appends a new
+            // version even when the current one is untagged, so the new file's
+            // internalDataFileUrl is never lost from history. See issue #3687.
+            const newVersionAspect = reconcileVersion(oldVersionAspect, {
+                eventId: contentEventId,
+                title,
+                creatorId: owner?.id,
+                now,
+                internalDataFileUrl: newDownloadURL,
+                description: "Replaced superseded by a new distribution",
+                forceBump: true
+            }).data;
+            await writeVersionAspect(client, distributionId, newVersionAspect);
 
             let oldFileDeleted = false;
             if (
@@ -286,6 +330,143 @@ export function registerDistCommands(program: Command): void {
                 note(
                     `Replaced file of ${distributionId} (version ${newVersionAspect.currentVersionNumber}, ${uploaded.size} bytes).` +
                         (oldFileDeleted ? " Superseded object deleted." : "")
+                );
+            }
+        });
+
+    dist.command("remove <distributionId>")
+        .description(
+            "Remove a distribution from its dataset and delete it " +
+                "(bumps the dataset's version aspect)"
+        )
+        .option(
+            "--keep-files",
+            "do not delete the distribution's stored data files"
+        )
+        .option(
+            "--bucket <bucket>",
+            "storage bucket the data files live in",
+            DATASETS_BUCKET_DEFAULT
+        )
+        .option("--json", "output JSON result")
+        .action(async (distributionId: string, opts) => {
+            const client = await clientFromProfile();
+
+            // 1. find the parent dataset (with its distribution list, title)
+            const parents = await client.json<any>("GET", REGISTRY_RECORDS, {
+                query: [
+                    ["aspect", "dataset-distributions"],
+                    ["optionalAspect", "dcat-dataset-strings"],
+                    [
+                        "aspectQuery",
+                        `dataset-distributions.distributions:<|${distributionId}`
+                    ],
+                    ["limit", "1"]
+                ]
+            });
+            const parent = parents?.records?.[0];
+            if (!parent?.id) {
+                throw new MgdApiError(
+                    `Could not find the parent dataset of ${distributionId}.`,
+                    404,
+                    "parent-dataset-not-found",
+                    "If the distribution is unlinked, delete it directly: " +
+                        `mgd api request DELETE /v0/registry/records/${distributionId}`
+                );
+            }
+            const datasetId: string = parent.id;
+
+            // 2. fetch the distribution's stored-file URLs before deletion
+            const dist = await client.json<any>(
+                "GET",
+                registryRecord(distributionId),
+                {
+                    query: [
+                        ["optionalAspect", "dcat-distribution-strings"],
+                        ["optionalAspect", "version"]
+                    ]
+                }
+            );
+            const owner = await fetchOwner(client);
+            const now = new Date();
+
+            // 3. unlink from the dataset first so it never references a
+            //    deleted record
+            const current: string[] = (
+                parent.aspects?.["dataset-distributions"]?.distributions ?? []
+            ).map((d: any) => (typeof d === "string" ? d : d.id));
+            const { eventId: e1 } = await mergeAspect(
+                client,
+                datasetId,
+                "dataset-distributions",
+                { distributions: current.filter((id) => id !== distributionId) }
+            );
+            const { eventId: e2 } = await mergeAspect(
+                client,
+                datasetId,
+                "dcat-dataset-strings",
+                { modified: now.toISOString() }
+            );
+
+            // 4. removing a distribution is a new dataset version
+            const dsVersion = await bumpRecordVersion(client, datasetId, {
+                eventId: Math.max(e1, e2),
+                now,
+                title:
+                    parent.aspects?.["dcat-dataset-strings"]?.title ??
+                    parent.name,
+                creatorId: owner?.id,
+                description: "Distribution removed"
+            });
+
+            // 5. delete the distribution record
+            await client.request("DELETE", registryRecord(distributionId));
+
+            // 6. best-effort storage cleanup (current file + all versions)
+            const urls = new Set<string>();
+            const dl: unknown =
+                dist.aspects?.["dcat-distribution-strings"]?.downloadURL;
+            if (typeof dl === "string") urls.add(dl);
+            for (const v of dist.aspects?.version?.versions ?? []) {
+                if (typeof v?.internalDataFileUrl === "string")
+                    urls.add(v.internalDataFileUrl);
+            }
+            const filesDeleted: string[] = [];
+            if (!opts.keepFiles) {
+                for (const url of urls) {
+                    if (!url.startsWith("magda://storage-api/")) continue;
+                    const resolved = resolveDownloadUrl(url, opts.bucket);
+                    if (resolved.kind !== "storage") continue;
+                    try {
+                        await client.request("DELETE", resolved.path);
+                        filesDeleted.push(url);
+                    } catch {
+                        note(`Warning: could not delete stored object ${url}.`);
+                    }
+                }
+            }
+
+            if (opts.json) {
+                printData("json", {
+                    distributionId,
+                    datasetId,
+                    ...(dsVersion
+                        ? {
+                              datasetVersionNumber:
+                                  dsVersion.currentVersionNumber
+                          }
+                        : {}),
+                    filesDeleted
+                });
+            } else {
+                note(
+                    `Removed distribution ${distributionId} from dataset ${datasetId}` +
+                        (dsVersion
+                            ? ` (dataset version ${dsVersion.currentVersionNumber})`
+                            : "") +
+                        (filesDeleted.length
+                            ? `; deleted ${filesDeleted.length} stored file(s).`
+                            : ".")
                 );
             }
         });

--- a/packages/mgd/src/recordBuilders.ts
+++ b/packages/mgd/src/recordBuilders.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { randomUUID, createHash } from "node:crypto";
 import { UsageError } from "./errors.js";
+import { buildInitialVersionAspect } from "./versionAspect.js";
 
 export const DATASETS_BUCKET_DEFAULT = "magda-datasets";
 
@@ -188,59 +189,6 @@ function accessControlAspect(owner?: { id?: string; orgUnitId?: string }) {
             ...(owner.orgUnitId ? { orgUnitId: owner.orgUnitId } : {}),
             constraintExemption: false
         }
-    };
-}
-
-export function buildInitialVersionAspect(args: {
-    title: string;
-    creatorId?: string;
-    now: Date;
-    internalDataFileUrl?: string;
-}) {
-    return {
-        currentVersionNumber: 0,
-        versions: [
-            {
-                versionNumber: 0,
-                createTime: args.now.toISOString(),
-                ...(args.creatorId ? { creatorId: args.creatorId } : {}),
-                description: "initial version",
-                title: args.title,
-                ...(args.internalDataFileUrl
-                    ? { internalDataFileUrl: args.internalDataFileUrl }
-                    : {})
-            }
-        ]
-    };
-}
-
-export function appendVersion(
-    existing: { currentVersionNumber: number; versions: any[] } | undefined,
-    args: {
-        title: string;
-        creatorId?: string;
-        now: Date;
-        internalDataFileUrl?: string;
-        description: string;
-    }
-) {
-    const base = existing ?? { currentVersionNumber: -1, versions: [] };
-    const versionNumber = base.currentVersionNumber + 1;
-    return {
-        currentVersionNumber: versionNumber,
-        versions: [
-            ...base.versions,
-            {
-                versionNumber,
-                createTime: args.now.toISOString(),
-                ...(args.creatorId ? { creatorId: args.creatorId } : {}),
-                description: args.description,
-                title: args.title,
-                ...(args.internalDataFileUrl
-                    ? { internalDataFileUrl: args.internalDataFileUrl }
-                    : {})
-            }
-        ]
     };
 }
 

--- a/packages/mgd/src/test/addFile.spec.ts
+++ b/packages/mgd/src/test/addFile.spec.ts
@@ -263,4 +263,101 @@ describe("dataset add-file", () => {
             await server.close();
         }
     });
+
+    it("tags the distribution v0 and bumps the dataset version", async () => {
+        const local = path.join(tmp, "data.csv");
+        await fs.writeFile(local, "x,y\n");
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/ds-1$/,
+                body: {
+                    id: "ds-1",
+                    name: "My data",
+                    aspects: {
+                        publishing: { state: "draft" },
+                        "dataset-distributions": { distributions: [] },
+                        "dcat-dataset-strings": { title: "My data" }
+                    }
+                }
+            },
+            { method: "POST", path: /^\/v0\/storage\/upload\//, body: {} },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                body: {},
+                headers: { "x-magda-event-id": "60" }
+            },
+            {
+                method: "GET",
+                path: /aspects\/dataset-distributions$/,
+                body: { distributions: [] }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dataset-distributions$/,
+                body: {},
+                headers: { "x-magda-event-id": "61" }
+            },
+            {
+                method: "GET",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: { title: "My data" }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: {},
+                headers: { "x-magda-event-id": "62" }
+            },
+            {
+                method: "GET",
+                path: /records\/ds-1\/aspects\/version$/,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/version$/,
+                body: {},
+                headers: { "x-magda-event-id": "63" }
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(["dataset", "add-file", "ds-1", local], {
+                    from: "user"
+                })
+            );
+            const versionPuts = server.requests.filter(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            );
+            // one tag write on the new distribution, one bump on the dataset
+            expect(versionPuts).to.have.length(2);
+            const distTag = JSON.parse(versionPuts[0].body.toString());
+            expect(distTag.currentVersionNumber).to.equal(0);
+            expect(distTag.versions[0].eventId).to.equal(60);
+            const dsPut = versionPuts.find((r) =>
+                r.url.includes("/records/ds-1/")
+            )!;
+            const dsVersion = JSON.parse(dsPut.body.toString());
+            // dataset had no version aspect: seeded v0, tagged with the
+            // max content event id (62)
+            expect(dsVersion.currentVersionNumber).to.equal(0);
+            expect(dsVersion.versions[0].eventId).to.equal(62);
+            expect(dsVersion.versions[0].description).to.equal(
+                "initial version"
+            );
+        } finally {
+            await server.close();
+        }
+    });
 });

--- a/packages/mgd/src/test/datasetCreate.spec.ts
+++ b/packages/mgd/src/test/datasetCreate.spec.ts
@@ -84,4 +84,69 @@ describe("dataset create", () => {
             await server.close();
         }
     });
+
+    it("tags the seeded v0 with the creation event id", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                body: {},
+                headers: { "x-magda-event-id": "55" }
+            },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "create", "--title", "My data"],
+                    { from: "user" }
+                )
+            );
+            const versionPut = server.requests.find(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            )!;
+            expect(versionPut, "v0 should be tagged").to.not.equal(undefined);
+            const version = JSON.parse(versionPut.body.toString());
+            expect(version.currentVersionNumber).to.equal(0);
+            expect(version.versions[0].eventId).to.equal(55);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("skips v0 tagging when the response has no event id header", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "create", "--title", "My data"],
+                    { from: "user" }
+                )
+            );
+            const versionPuts = server.requests.filter(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            );
+            expect(versionPuts).to.have.length(0);
+        } finally {
+            await server.close();
+        }
+    });
 });

--- a/packages/mgd/src/test/distRemove.spec.ts
+++ b/packages/mgd/src/test/distRemove.spec.ts
@@ -1,0 +1,245 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDistCommands } from "../commands/dist.js";
+import { startMockServer, MockRoute } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+function routes(): MockRoute[] {
+    return [
+        { method: "GET", path: "/v0/auth/users/whoami", body: { id: "u1" } },
+        {
+            // parent lookup
+            method: "GET",
+            path: "/v0/registry/records",
+            body: {
+                records: [
+                    {
+                        id: "ds-1",
+                        name: "My data",
+                        aspects: {
+                            "dataset-distributions": {
+                                distributions: ["dist-1", "dist-2"]
+                            },
+                            "dcat-dataset-strings": { title: "My data" }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            // the distribution being removed
+            method: "GET",
+            path: /^\/v0\/registry\/records\/dist-1$/,
+            body: {
+                id: "dist-1",
+                aspects: {
+                    "dcat-distribution-strings": {
+                        downloadURL: "magda://storage-api/ds-1/dist-1/a.csv"
+                    },
+                    version: {
+                        currentVersionNumber: 1,
+                        versions: [
+                            {
+                                versionNumber: 0,
+                                createTime: "2026-01-01T00:00:00.000Z",
+                                description: "initial version",
+                                title: "old.csv",
+                                internalDataFileUrl:
+                                    "magda://storage-api/ds-1/dist-1/old.csv"
+                            },
+                            {
+                                versionNumber: 1,
+                                createTime: "2026-01-02T00:00:00.000Z",
+                                description:
+                                    "Replaced superseded by a new distribution",
+                                title: "a.csv",
+                                eventId: 5,
+                                internalDataFileUrl:
+                                    "magda://storage-api/ds-1/dist-1/a.csv"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            method: "GET",
+            path: /records\/ds-1\/aspects\/dataset-distributions$/,
+            body: { distributions: ["dist-1", "dist-2"] }
+        },
+        {
+            method: "PUT",
+            path: /records\/ds-1\/aspects\/dataset-distributions$/,
+            body: {},
+            headers: { "x-magda-event-id": "70" }
+        },
+        {
+            method: "GET",
+            path: /records\/ds-1\/aspects\/dcat-dataset-strings$/,
+            body: { title: "My data" }
+        },
+        {
+            method: "PUT",
+            path: /records\/ds-1\/aspects\/dcat-dataset-strings$/,
+            body: {},
+            headers: { "x-magda-event-id": "71" }
+        },
+        {
+            method: "GET",
+            path: /records\/ds-1\/aspects\/version$/,
+            body: {
+                currentVersionNumber: 0,
+                versions: [
+                    {
+                        versionNumber: 0,
+                        createTime: "2026-01-01T00:00:00.000Z",
+                        description: "initial version",
+                        title: "My data",
+                        eventId: 3
+                    }
+                ]
+            }
+        },
+        {
+            method: "PUT",
+            path: /records\/ds-1\/aspects\/version$/,
+            body: {}
+        },
+        {
+            method: "DELETE",
+            path: /^\/v0\/registry\/records\/dist-1$/,
+            body: {}
+        },
+        { method: "DELETE", path: /^\/v0\/storage\//, body: {} }
+    ];
+}
+
+async function run(argv: string[], mockRoutes = routes()) {
+    const server = await startMockServer(mockRoutes);
+    process.env.MGD_BASE_URL = server.url;
+    try {
+        const program = new Command();
+        registerDistCommands(program);
+        const out = await captureStdout(() =>
+            program.parseAsync(argv, { from: "user" })
+        );
+        return { requests: server.requests, out };
+    } finally {
+        await server.close();
+        delete process.env.MGD_BASE_URL;
+    }
+}
+
+describe("dist remove", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("unlinks, bumps the dataset version, deletes record and files", async () => {
+        const { requests } = await run(["dist", "remove", "dist-1"]);
+
+        const unlink = requests.find(
+            (r) =>
+                r.method === "PUT" &&
+                r.url.includes("/records/ds-1/aspects/dataset-distributions")
+        )!;
+        expect(JSON.parse(unlink.body.toString()).distributions).to.deep.equal([
+            "dist-2"
+        ]);
+
+        const versionPut = requests.find(
+            (r) =>
+                r.method === "PUT" &&
+                r.url.includes("/records/ds-1/aspects/version")
+        )!;
+        const version = JSON.parse(versionPut.body.toString());
+        expect(version.currentVersionNumber).to.equal(1);
+        expect(version.versions[1]).to.include({
+            description: "Distribution removed",
+            title: "My data",
+            eventId: 71,
+            creatorId: "u1"
+        });
+
+        const recordDelete = requests.find(
+            (r) =>
+                r.method === "DELETE" &&
+                r.url.includes("/registry/records/dist-1")
+        );
+        expect(recordDelete).to.not.equal(undefined);
+
+        const storageDeletes = requests.filter(
+            (r) => r.method === "DELETE" && r.url.includes("/v0/storage/")
+        );
+        // a.csv (downloadURL + v1 internalDataFileUrl, deduplicated) and
+        // old.csv (v0 internalDataFileUrl)
+        expect(storageDeletes).to.have.length(2);
+    });
+
+    it("--keep-files skips storage deletion", async () => {
+        const { requests } = await run([
+            "dist",
+            "remove",
+            "dist-1",
+            "--keep-files"
+        ]);
+        const storageDeletes = requests.filter(
+            (r) => r.method === "DELETE" && r.url.includes("/v0/storage/")
+        );
+        expect(storageDeletes).to.have.length(0);
+        // the record itself is still deleted
+        expect(
+            requests.find(
+                (r) =>
+                    r.method === "DELETE" &&
+                    r.url.includes("/registry/records/dist-1")
+            )
+        ).to.not.equal(undefined);
+    });
+
+    it("--json reports ids, version and deleted files", async () => {
+        const { out } = await run(["dist", "remove", "dist-1", "--json"]);
+        const parsed = JSON.parse(out);
+        expect(parsed.distributionId).to.equal("dist-1");
+        expect(parsed.datasetId).to.equal("ds-1");
+        expect(parsed.datasetVersionNumber).to.equal(1);
+        expect(parsed.filesDeleted).to.have.length(2);
+    });
+
+    it("--bucket targets a custom storage bucket", async () => {
+        const { requests } = await run([
+            "dist",
+            "remove",
+            "dist-1",
+            "--bucket",
+            "custom-bucket"
+        ]);
+        const storageDeletes = requests.filter(
+            (r) => r.method === "DELETE" && r.url.includes("/v0/storage/")
+        );
+        expect(storageDeletes).to.have.length(2);
+        for (const d of storageDeletes) {
+            expect(d.url).to.include("/v0/storage/custom-bucket/");
+        }
+    });
+
+    it("errors when the distribution has no parent dataset", async () => {
+        const noParent = routes().map((r) =>
+            r.method === "GET" && r.path === "/v0/registry/records"
+                ? { ...r, body: { records: [] } }
+                : r
+        );
+        let failed = false;
+        try {
+            await run(["dist", "remove", "dist-1"], noParent);
+        } catch (e) {
+            failed = true;
+            expect(e instanceof Error ? e.message : String(e)).to.include(
+                "parent dataset"
+            );
+        }
+        expect(failed).to.equal(true);
+    });
+});

--- a/packages/mgd/src/test/recordBuilders.spec.ts
+++ b/packages/mgd/src/test/recordBuilders.spec.ts
@@ -5,8 +5,6 @@ import {
     detectFormat,
     buildDatasetRecord,
     buildDistributionRecord,
-    buildInitialVersionAspect,
-    appendVersion,
     removeInvalidChars,
     getValidObjectKey,
     deriveSiteUrl
@@ -176,19 +174,5 @@ describe("recordBuilders", () => {
         expect(record.aspects.version.versions[0].internalDataFileUrl).to.equal(
             "magda://storage-api/ds/dist/data.csv"
         );
-    });
-
-    it("appends versions with an incremented number", () => {
-        const v0 = buildInitialVersionAspect({ title: "t", now: NOW });
-        const v1 = appendVersion(v0, {
-            title: "t2",
-            now: NOW,
-            internalDataFileUrl: "magda://storage-api/a/b/c",
-            description: "Replaced superseded by a new distribution"
-        });
-        expect(v1.currentVersionNumber).to.equal(1);
-        expect(v1.versions).to.have.length(2);
-        expect(v1.versions[1].versionNumber).to.equal(1);
-        expect(v0.versions).to.have.length(1); // input not mutated
     });
 });

--- a/packages/mgd/src/test/replaceFile.spec.ts
+++ b/packages/mgd/src/test/replaceFile.spec.ts
@@ -150,4 +150,74 @@ describe("dist replace-file", () => {
             await server.close();
         }
     });
+
+    it("tags the new version with the dcat merge's event id", async () => {
+        const local = path.join(tmp, "new.csv");
+        await fs.writeFile(local, "x\n");
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: /^\/v0\/registry\/records\/dist-1$/,
+                body: {
+                    id: "dist-1",
+                    aspects: {
+                        "dcat-distribution-strings": { title: "old.csv" },
+                        version: {
+                            currentVersionNumber: 0,
+                            versions: [
+                                {
+                                    versionNumber: 0,
+                                    createTime: "2026-01-01T00:00:00.000Z",
+                                    description: "initial version",
+                                    title: "old.csv"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { records: [{ id: "ds-1" }] }
+            },
+            { method: "POST", path: /^\/v0\/storage\/upload\//, body: {} },
+            {
+                method: "GET",
+                path: /aspects\/dcat-distribution-strings$/,
+                body: { title: "old.csv" }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dcat-distribution-strings$/,
+                body: {},
+                headers: { "x-magda-event-id": "99" }
+            },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDistCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(["dist", "replace-file", "dist-1", local], {
+                    from: "user"
+                })
+            );
+            const versionPut = server.requests.find(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            )!;
+            const version = JSON.parse(versionPut.body.toString());
+            // untagged v0 + forceBump: still appends a new version
+            expect(version.currentVersionNumber).to.equal(1);
+            expect(version.versions[1].eventId).to.equal(99);
+        } finally {
+            await server.close();
+        }
+    });
 });

--- a/packages/mgd/src/test/versionAspect.spec.ts
+++ b/packages/mgd/src/test/versionAspect.spec.ts
@@ -1,0 +1,168 @@
+import { expect } from "chai";
+import {
+    buildInitialVersionAspect,
+    reconcileVersion,
+    tagCurrentVersion,
+    VersionAspectData
+} from "../versionAspect.js";
+
+const NOW = new Date("2026-07-14T00:00:00.000Z");
+
+function tagged(eventId?: number): VersionAspectData {
+    return {
+        currentVersionNumber: 0,
+        versions: [
+            {
+                versionNumber: 0,
+                createTime: "2026-01-01T00:00:00.000Z",
+                description: "initial version",
+                title: "old title",
+                ...(eventId ? { eventId } : {})
+            }
+        ]
+    };
+}
+
+describe("reconcileVersion", () => {
+    const baseArgs = {
+        eventId: 42,
+        now: NOW,
+        title: "t",
+        creatorId: "u1",
+        description: "Version created on update submission"
+    };
+
+    it("seeds a tagged v0 when the aspect is absent", () => {
+        const { data, changed } = reconcileVersion(undefined, baseArgs);
+        expect(changed).to.equal(true);
+        expect(data.currentVersionNumber).to.equal(0);
+        expect(data.versions).to.have.length(1);
+        expect(data.versions[0]).to.include({
+            versionNumber: 0,
+            description: "initial version",
+            title: "t",
+            creatorId: "u1",
+            eventId: 42
+        });
+        expect(data.versions[0].createTime).to.equal(NOW.toISOString());
+    });
+
+    it("tags an untagged current version without bumping", () => {
+        const { data, changed } = reconcileVersion(tagged(), baseArgs);
+        expect(changed).to.equal(true);
+        expect(data.currentVersionNumber).to.equal(0);
+        expect(data.versions).to.have.length(1);
+        expect(data.versions[0].eventId).to.equal(42);
+        // tag-only keeps the item's original description/title
+        expect(data.versions[0].title).to.equal("old title");
+    });
+
+    it("bumps when the current version is tagged with a different event", () => {
+        const { data, changed } = reconcileVersion(tagged(7), baseArgs);
+        expect(changed).to.equal(true);
+        expect(data.currentVersionNumber).to.equal(1);
+        expect(data.versions).to.have.length(2);
+        expect(data.versions[1]).to.include({
+            versionNumber: 1,
+            eventId: 42,
+            title: "t",
+            description: "Version created on update submission"
+        });
+    });
+
+    it("is a no-op when the current version is tagged with the same event", () => {
+        const { data, changed } = reconcileVersion(tagged(42), baseArgs);
+        expect(changed).to.equal(false);
+        expect(data.versions).to.have.length(1);
+    });
+
+    it("is a no-op for eventId 0 on an untagged current version", () => {
+        const { changed } = reconcileVersion(tagged(), {
+            ...baseArgs,
+            eventId: 0
+        });
+        expect(changed).to.equal(false);
+    });
+
+    it("bumps for eventId 0 when current is tagged, without writing eventId 0", () => {
+        const { data, changed } = reconcileVersion(tagged(7), {
+            ...baseArgs,
+            eventId: 0
+        });
+        expect(changed).to.equal(true);
+        expect(data.currentVersionNumber).to.equal(1);
+        expect(data.versions[1]).to.not.have.property("eventId");
+    });
+
+    it("bumps when the current version item is missing", () => {
+        const broken: VersionAspectData = {
+            currentVersionNumber: 5,
+            versions: tagged().versions
+        };
+        const { data } = reconcileVersion(broken, baseArgs);
+        expect(data.currentVersionNumber).to.equal(1); // max(0)+1
+        expect(data.versions).to.have.length(2);
+    });
+
+    it("uses max(versionNumber)+1 when numbers have gaps", () => {
+        const gappy: VersionAspectData = {
+            currentVersionNumber: 4,
+            versions: [
+                { ...tagged(7).versions[0], versionNumber: 4, eventId: 7 },
+                { ...tagged().versions[0], versionNumber: 9 }
+            ]
+        };
+        const { data } = reconcileVersion(gappy, baseArgs);
+        expect(data.currentVersionNumber).to.equal(10);
+    });
+
+    it("forceBump appends even when the current version is untagged", () => {
+        const { data } = reconcileVersion(tagged(), {
+            ...baseArgs,
+            forceBump: true,
+            internalDataFileUrl: "magda://storage-api/a/b/c",
+            description: "Replaced superseded by a new distribution"
+        });
+        expect(data.currentVersionNumber).to.equal(1);
+        expect(data.versions[1].internalDataFileUrl).to.equal(
+            "magda://storage-api/a/b/c"
+        );
+    });
+
+    it("does not mutate its input", () => {
+        const input = tagged();
+        reconcileVersion(input, baseArgs);
+        expect(input.versions[0]).to.not.have.property("eventId");
+    });
+});
+
+describe("tagCurrentVersion", () => {
+    it("tags an untagged current version", () => {
+        const out = tagCurrentVersion(tagged(), 42)!;
+        expect(out.versions[0].eventId).to.equal(42);
+    });
+
+    it("returns undefined when already tagged, or eventId is 0", () => {
+        expect(tagCurrentVersion(tagged(7), 42)).to.equal(undefined);
+        expect(tagCurrentVersion(tagged(), 0)).to.equal(undefined);
+    });
+
+    it("does not mutate its input", () => {
+        const input = tagged();
+        tagCurrentVersion(input, 42);
+        expect(input.versions[0]).to.not.have.property("eventId");
+    });
+});
+
+describe("buildInitialVersionAspect", () => {
+    it("builds an untagged v0", () => {
+        const v = buildInitialVersionAspect({ title: "t", now: NOW });
+        expect(v.currentVersionNumber).to.equal(0);
+        expect(v.versions[0]).to.include({
+            versionNumber: 0,
+            description: "initial version",
+            title: "t"
+        });
+        expect(v.versions[0]).to.not.have.property("eventId");
+    });
+});

--- a/packages/mgd/src/test/versionBump.spec.ts
+++ b/packages/mgd/src/test/versionBump.spec.ts
@@ -1,0 +1,203 @@
+import { expect } from "chai";
+import { Command } from "commander";
+import { registerDatasetCommands } from "../commands/dataset.js";
+import { registerDistCommands } from "../commands/dist.js";
+import { startMockServer, MockRoute } from "./mockServer.js";
+import { captureStdout } from "./captureStdout.js";
+
+const TAGGED_V0 = {
+    currentVersionNumber: 0,
+    versions: [
+        {
+            versionNumber: 0,
+            createTime: "2026-01-01T00:00:00.000Z",
+            description: "initial version",
+            title: "Old",
+            eventId: 7
+        }
+    ]
+};
+
+function baseRoutes(kind: "dataset" | "distribution"): MockRoute[] {
+    const strings =
+        kind === "dataset"
+            ? "dcat-dataset-strings"
+            : "dcat-distribution-strings";
+    return [
+        { method: "GET", path: "/v0/auth/users/whoami", body: { id: "u1" } },
+        {
+            method: "GET",
+            path: new RegExp(`aspects/${strings}$`),
+            body: { title: "Old" }
+        },
+        {
+            method: "PUT",
+            path: new RegExp(`aspects/${strings}$`),
+            body: {},
+            headers: { "x-magda-event-id": "42" }
+        },
+        { method: "GET", path: /aspects\/version$/, body: TAGGED_V0 },
+        {
+            method: "PUT",
+            path: /aspects\/version$/,
+            body: {},
+            headers: { "x-magda-event-id": "43" }
+        }
+    ];
+}
+
+async function runUpdate(
+    routes: MockRoute[],
+    argv: string[],
+    register: (p: Command) => void
+) {
+    const server = await startMockServer(routes);
+    process.env.MGD_BASE_URL = server.url;
+    try {
+        const program = new Command();
+        register(program);
+        await captureStdout(() => program.parseAsync(argv, { from: "user" }));
+        return server.requests;
+    } finally {
+        await server.close();
+        delete process.env.MGD_BASE_URL;
+    }
+}
+
+describe("version maintenance on update commands", () => {
+    const origBaseUrl = process.env.MGD_BASE_URL;
+    afterEach(() => {
+        if (origBaseUrl === undefined) delete process.env.MGD_BASE_URL;
+        else process.env.MGD_BASE_URL = origBaseUrl;
+    });
+
+    it("dataset update bumps the dataset version, tagged with the content event", async () => {
+        const requests = await runUpdate(
+            baseRoutes("dataset"),
+            ["dataset", "update", "ds-1", "--title", "New"],
+            registerDatasetCommands
+        );
+        const versionPut = requests.find(
+            (r) => r.method === "PUT" && r.url.includes("aspects/version")
+        )!;
+        expect(versionPut, "version PUT should happen").to.not.equal(undefined);
+        const version = JSON.parse(versionPut.body.toString());
+        expect(version.currentVersionNumber).to.equal(1);
+        expect(version.versions).to.have.length(2);
+        expect(version.versions[1]).to.include({
+            versionNumber: 1,
+            eventId: 42,
+            title: "New",
+            creatorId: "u1",
+            description: "Version created on update submission"
+        });
+    });
+
+    it("dataset update tags an untagged current version instead of bumping", async () => {
+        const untagged = {
+            ...TAGGED_V0,
+            versions: [{ ...TAGGED_V0.versions[0] }]
+        };
+        delete (untagged.versions[0] as any).eventId;
+        const routes = baseRoutes("dataset").map((r) =>
+            r.method === "GET" && String(r.path).includes("version")
+                ? { ...r, body: untagged }
+                : r
+        );
+        const requests = await runUpdate(
+            routes,
+            ["dataset", "update", "ds-1", "--title", "New"],
+            registerDatasetCommands
+        );
+        const versionPut = requests.find(
+            (r) => r.method === "PUT" && r.url.includes("aspects/version")
+        )!;
+        const version = JSON.parse(versionPut.body.toString());
+        expect(version.currentVersionNumber).to.equal(0);
+        expect(version.versions).to.have.length(1);
+        expect(version.versions[0].eventId).to.equal(42);
+    });
+
+    it("dataset update seeds a tagged v0 when the version aspect is missing", async () => {
+        const routes = baseRoutes("dataset").filter(
+            (r) => !(r.method === "GET" && String(r.path).includes("version"))
+        );
+        routes.push({
+            method: "GET",
+            path: /aspects\/version$/,
+            status: 404,
+            body: { message: "not found" }
+        });
+        const requests = await runUpdate(
+            routes,
+            ["dataset", "update", "ds-1", "--title", "New"],
+            registerDatasetCommands
+        );
+        const versionPut = requests.find(
+            (r) => r.method === "PUT" && r.url.includes("aspects/version")
+        )!;
+        const version = JSON.parse(versionPut.body.toString());
+        expect(version.currentVersionNumber).to.equal(0);
+        expect(version.versions[0]).to.include({
+            description: "initial version",
+            eventId: 42
+        });
+    });
+
+    it("dataset update with an explicit --aspect version=... never auto-bumps", async () => {
+        const requests = await runUpdate(
+            baseRoutes("dataset"),
+            [
+                "dataset",
+                "update",
+                "ds-1",
+                "--aspect",
+                `version=${JSON.stringify(TAGGED_V0)}`
+            ],
+            registerDatasetCommands
+        );
+        const versionPuts = requests.filter(
+            (r) => r.method === "PUT" && r.url.includes("aspects/version")
+        );
+        // exactly the user's own write; no auto-bump read or second write
+        expect(versionPuts).to.have.length(1);
+        const body = JSON.parse(versionPuts[0].body.toString());
+        expect(body.currentVersionNumber).to.equal(0);
+        const versionGets = requests.filter(
+            (r) => r.method === "GET" && r.url.includes("aspects/version")
+        );
+        expect(versionGets).to.have.length(0);
+    });
+
+    it("dataset update still exits 0 when the version write fails", async () => {
+        const routes = baseRoutes("dataset").map((r) =>
+            r.method === "PUT" && String(r.path).includes("version")
+                ? { ...r, status: 500, body: { message: "boom" } }
+                : r
+        );
+        // must not throw
+        await runUpdate(
+            routes,
+            ["dataset", "update", "ds-1", "--title", "New"],
+            registerDatasetCommands
+        );
+    });
+
+    it("dist update bumps the distribution version", async () => {
+        const requests = await runUpdate(
+            baseRoutes("distribution"),
+            ["dist", "update", "dist-1", "--title", "New"],
+            registerDistCommands
+        );
+        const versionPut = requests.find(
+            (r) => r.method === "PUT" && r.url.includes("aspects/version")
+        )!;
+        const version = JSON.parse(versionPut.body.toString());
+        expect(version.currentVersionNumber).to.equal(1);
+        expect(version.versions[1]).to.include({
+            eventId: 42,
+            title: "New",
+            description: "Distribution metadata updated"
+        });
+    });
+});

--- a/packages/mgd/src/versionAspect.ts
+++ b/packages/mgd/src/versionAspect.ts
@@ -1,0 +1,247 @@
+import { MagdaClient } from "./client.js";
+import { recordAspect } from "./endpoints.js";
+import { MgdApiError } from "./errors.js";
+import { note } from "./output.js";
+
+// The application-managed `version` aspect on dataset/distribution records
+// (schema: magda-registry-aspects/version.schema.json). The registry never
+// touches it; this module ports the web client's maintenance rules
+// (RegistryApis.ts getInitialVersionAspectData / tagRecordVersionEventId,
+// DatasetAddCommon.ts createVersionForDatasetSubmission). Full design +
+// rationale: https://github.com/magda-io/magda/issues/3687.
+//
+// Key decisions baked into this module (see issue #3687 for the why):
+//  - Record-scoped bumps: the CLI is atomic (one command = one mutation), so
+//    each command bumps the version of the record it primarily mutates,
+//    rather than reproducing the web client's batch-session model.
+//  - eventId-gated reconcile: every version item is tagged with the registry
+//    `x-magda-event-id` of the mutation it corresponds to (like a git tag on
+//    a commit), which is what powers the registry time-travel API. `create`/
+//    `add-file` tag the seeded v0 so the first later edit bumps to v1 instead
+//    of staying "stuck at 0".
+//  - Tag both datasets AND distributions (the web client tags datasets only;
+//    uniform tagging is simpler and gives distributions time-travel too).
+
+export type VersionItem = {
+    versionNumber: number;
+    createTime: string;
+    creatorId?: string;
+    description: string;
+    title: string;
+    internalDataFileUrl?: string;
+    eventId?: number;
+};
+
+export type VersionAspectData = {
+    currentVersionNumber: number;
+    versions: VersionItem[];
+};
+
+export function buildInitialVersionAspect(args: {
+    title: string;
+    creatorId?: string;
+    now: Date;
+    internalDataFileUrl?: string;
+}): VersionAspectData {
+    return {
+        currentVersionNumber: 0,
+        versions: [
+            {
+                versionNumber: 0,
+                createTime: args.now.toISOString(),
+                ...(args.creatorId ? { creatorId: args.creatorId } : {}),
+                description: "initial version",
+                title: args.title,
+                ...(args.internalDataFileUrl
+                    ? { internalDataFileUrl: args.internalDataFileUrl }
+                    : {})
+            }
+        ]
+    };
+}
+
+export interface VersionBumpArgs {
+    eventId: number;
+    now: Date;
+    title: string;
+    creatorId?: string;
+    description: string;
+    internalDataFileUrl?: string;
+    // Always append a new version, bypassing the tag-only branch. Used by
+    // `dist replace-file`: a file replacement must be recorded as a new
+    // version even on an untagged record, or the new file's
+    // internalDataFileUrl would be lost from history.
+    forceBump?: boolean;
+}
+
+/**
+ * The eventId-gated reconcile: tag the untagged current version, bump when
+ * the current version already belongs to an earlier event, no-op when this
+ * event is already recorded. Pure — never mutates `existing`.
+ */
+export function reconcileVersion(
+    existing: VersionAspectData | undefined,
+    args: VersionBumpArgs
+): { data: VersionAspectData; changed: boolean } {
+    const makeItem = (versionNumber: number): VersionItem => ({
+        versionNumber,
+        createTime: args.now.toISOString(),
+        ...(args.creatorId ? { creatorId: args.creatorId } : {}),
+        description: args.description,
+        title: args.title,
+        ...(args.internalDataFileUrl
+            ? { internalDataFileUrl: args.internalDataFileUrl }
+            : {}),
+        ...(args.eventId ? { eventId: args.eventId } : {})
+    });
+
+    if (!existing?.versions?.length) {
+        return {
+            data: {
+                currentVersionNumber: 0,
+                versions: [{ ...makeItem(0), description: "initial version" }]
+            },
+            changed: true
+        };
+    }
+
+    const current = existing.versions.find(
+        (v) => v.versionNumber === existing.currentVersionNumber
+    );
+
+    if (
+        args.forceBump ||
+        !current ||
+        (current.eventId && current.eventId !== args.eventId)
+    ) {
+        const next = makeItem(
+            existing.versions.reduce(
+                (acc, v) => Math.max(acc, v.versionNumber),
+                0
+            ) + 1
+        );
+        return {
+            data: {
+                currentVersionNumber: next.versionNumber,
+                versions: [...existing.versions, next]
+            },
+            changed: true
+        };
+    }
+
+    if (!current.eventId && args.eventId) {
+        return {
+            data: {
+                ...existing,
+                versions: existing.versions.map((v) =>
+                    v === current ? { ...v, eventId: args.eventId } : v
+                )
+            },
+            changed: true
+        };
+    }
+
+    return { data: existing, changed: false };
+}
+
+/**
+ * Tag the current version item with a content event id, for records whose
+ * `version` aspect the caller just built locally (create/add-file).
+ * Returns the updated aspect, or undefined when there is nothing to do.
+ * Pure — never mutates `data`.
+ */
+export function tagCurrentVersion(
+    data: VersionAspectData,
+    eventId: number
+): VersionAspectData | undefined {
+    if (!eventId) return undefined;
+    const current = data.versions?.find(
+        (v) => v.versionNumber === data.currentVersionNumber
+    );
+    if (!current || current.eventId) return undefined;
+    return {
+        ...data,
+        versions: data.versions.map((v) =>
+            v === current ? { ...v, eventId } : v
+        )
+    };
+}
+
+/**
+ * PUT the version aspect, best-effort: the content mutation has already
+ * succeeded, so a version-maintenance failure only warns (the reconcile is
+ * self-healing on the next command).
+ */
+export async function writeVersionAspect(
+    client: MagdaClient,
+    recordId: string,
+    data: VersionAspectData
+): Promise<boolean> {
+    try {
+        await client.request("PUT", recordAspect(recordId, "version"), {
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(data)
+        });
+        return true;
+    } catch (e) {
+        note(
+            `Warning: failed to update the version aspect of ${recordId}: ${
+                e instanceof Error ? e.message : String(e)
+            }. The content change was applied; the version aspect will self-heal on the next command.`
+        );
+        return false;
+    }
+}
+
+/**
+ * GET → reconcile → PUT a record's version aspect. Best-effort throughout;
+ * returns the resulting aspect data, or undefined when it could not be
+ * read/written. `title` falls back to the current version item's title,
+ * then the record id.
+ */
+export async function bumpRecordVersion(
+    client: MagdaClient,
+    recordId: string,
+    args: Omit<VersionBumpArgs, "title"> & { title?: string }
+): Promise<VersionAspectData | undefined> {
+    if (!args.eventId) {
+        // Without an event id the version can't be tagged, so an edit may go
+        // unrecorded (the untagged-current branch is a no-op) — surface it.
+        note(
+            `Warning: the registry response for ${recordId} did not include ` +
+                `an event id; this change may not be recorded in the version history.`
+        );
+    }
+    let fetched: VersionAspectData | undefined;
+    try {
+        fetched = await client.json<VersionAspectData>(
+            "GET",
+            recordAspect(recordId, "version")
+        );
+    } catch (e) {
+        if (!(e instanceof MgdApiError && e.status === 404)) {
+            note(
+                `Warning: could not read the version aspect of ${recordId}: ${
+                    e instanceof Error ? e.message : String(e)
+                }. Skipping version maintenance for this command.`
+            );
+            return undefined;
+        }
+    }
+    // Snapshot into a const so the narrowing survives the closure below
+    // (strict mode: a captured `let` is not narrowed inside callbacks).
+    const existing = fetched;
+    const currentTitle = existing
+        ? existing.versions?.find(
+              (v) => v.versionNumber === existing.currentVersionNumber
+          )?.title
+        : undefined;
+    const { data, changed } = reconcileVersion(existing, {
+        ...args,
+        title: args.title ?? currentTitle ?? recordId
+    });
+    if (!changed) return data;
+    return (await writeVersionAspect(client, recordId, data))
+        ? data
+        : undefined;
+}


### PR DESCRIPTION
## What & why

High-level `mgd` commands now maintain the application-managed `version` aspect (schema: `magda-registry-aspects/version.schema.json`) with **eventId-gated, record-scoped bumps** on datasets and distributions, plus a new `dist remove` command. Previously a dataset edited via the CLI stayed at `currentVersionNumber: 0` because `dataset update` / `dist update` never touched the aspect and there was no removal command — unlike the same edits in the web UI.

Full design + rationale: **#3687**.

## Behaviour

| Command | Version effect |
| --- | --- |
| `dataset create` | seeds + tags dataset `v0` (`initial version`) |
| `dataset add-file` | tags the new distribution's `v0`; bumps the **dataset** (`Distribution added`) |
| `dataset update` | bumps the **dataset** (`Version created on update submission`) |
| `dist update` | bumps the **distribution** (`Distribution metadata updated`) |
| `dist replace-file` | bumps the **distribution** (`Replaced superseded by a new distribution`), keeps `internalDataFileUrl` |
| `dist remove` *(new)* | bumps the **dataset** (`Distribution removed`) |
| `publish` / `unpublish` | **no bump** (lifecycle state, not content) |
| `aspect set` / `patch` / `delete`, explicit `--aspect version=…` | **no bump** (manual escape hatch) |

Each version item is tagged with the registry's `x-magda-event-id` (like a git tag on a commit), which powers the registry time-travel API. `create` / `add-file` tag the seeded `v0` so the first later edit bumps to `v1` instead of staying "stuck at 0"; records created by older tooling upgrade gracefully (first edit tags, next bumps). Version maintenance is **best-effort** — a failed version write after a successful content mutation warns on stderr and the command still exits `0` (the reconcile self-heals on the next command).

## Key pieces

- **`src/versionAspect.ts`** — pure `reconcileVersion` (eventId-gated algorithm, unit-tested), `tagCurrentVersion`, and best-effort `bumpRecordVersion` / `writeVersionAspect`. `buildInitialVersionAspect` moved here; `appendVersion` removed.
- **`src/client.ts`** — `eventIdFrom(res)` reads `x-magda-event-id` (`0` = unknown, never written).
- **`dist remove <id>`** — `--keep-files`, `--bucket`, `--json`; unlink → bump dataset → delete record → best-effort storage cleanup.

## Deliberate divergences from the web client

Consequences of the record-scoped model (documented in code comments + #3687): `dist update` bumps the distribution (web client bumps nothing); `dist replace-file` bumps only the distribution, not the parent dataset; distributions carry `eventId` tags.

## Testing

- `yarn build && yarn test && yarn typecheck` — all green (148 passing).
- New specs: `versionAspect` (pure reconcile), `versionBump` (update commands + escape-hatch guard), `distRemove`; extended `datasetCreate`, `addFile`, `replaceFile`.
- **Verified end-to-end against a live minikube MAGDA deployment**: create (v0 tagged) → add-file (dataset v1) → update (v2) → dist update (dist v1) → replace-file (dist v2) → publish/unpublish (version unchanged) → dist remove (dataset v3, files deleted), all tagged with real gateway `x-magda-event-id`s.

## Follow-up

- #3706 — make the default storage bucket profile-configurable (it's a Helm option, `global.defaultDatasetBucket`); this PR keeps the existing hardcoded `magda-datasets` default, consistent with `add-file` / `replace-file`.

Closes #3687.
