### PR TITLE
docs(mgd): document create/edit/publish workflow & common aspects in agent skill + README

### DIFF
--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -257,6 +257,10 @@ mgd dataset update magda-ds-<uuid> --title "River gauge readings (2025, v2)"
 
 # 5. Replace the file behind a distribution (adds a new version entry)
 mgd dist replace-file magda-dist-<uuid> ./readings-corrected.csv
+
+# 6. Publish — cascades to the dataset's distributions (--without-distributions to opt out)
+mgd dataset publish magda-ds-<uuid>          # unpublish the same way
+mgd dist publish magda-dist-<uuid>           # or flip a single distribution
 ```
 
 Datasets created by the CLI are stamped with a `source` aspect
@@ -278,6 +282,23 @@ metadata tools, with a distinct `name` marking their CLI provenance.
 > time-travel API). `publish` / `unpublish` don't bump versions (lifecycle
 > state, not content). Don't hand-edit the `version` aspect; `dataset aspect set` / `aspect patch` / `aspect delete` are the manual escape hatch and
 > never auto-bump.
+
+### Common aspects
+
+Records carry data in named **aspects**. The ones the CLI reads or writes most:
+
+| Aspect | Record | Holds / notes |
+| --- | --- | --- |
+| `dcat-dataset-strings` | dataset | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified` |
+| `dcat-distribution-strings` | distribution | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize` |
+| `publishing` | dataset & distribution | `{ "state": "draft" \| "published" }` — use `publish`/`unpublish`, don't hand-edit |
+| `dataset-distributions` | dataset | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit |
+| `version` | dataset & distribution | CLI-managed history — don't hand-edit |
+| `access-control` | dataset | `ownerId`, `orgUnitId`, `constraintExemption` |
+| `source` | dataset | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`) |
+| `dataset-publisher` | dataset | `{ "publisher": "<organisation record id>" }` — publishing org shown in the web UI; the CLI does not set it yet ([#3715](https://github.com/magda-io/magda/issues/3715)) |
+| `temporal-coverage` | dataset | *optional* — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range |
+| `spatial-coverage` | dataset | *optional* — bounding box / named region; set manually when the data has a spatial extent |
 
 ### Custom aspects
 
@@ -364,6 +385,7 @@ Run `mgd --help` or `mgd <command> --help` for full option documentation.
 drive the catalog safely. The [`skills/`](./skills/) folder contains:
 
 - **`mgd-workflows.md`** — command usage, output modes, search strategy, recipes,
+  the create → enrich → add-file → publish workflow, a common-aspects reference,
   safety rules and error triage;
 - **`dataset-elicitation.md`** — "metadata consultant" behaviour for guided
   dataset creation (infer before asking, quick vs guided path, confirm-then-write);

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -30,7 +30,8 @@ your assistant environment, keep the rules.
 5. **Confirm before mutating or publishing.** Never run `dataset create --publish`, `add-file`, `replace-file`, `update`, `aspect create/set/patch/delete`,
    or any `api request` with POST/PUT/PATCH/DELETE without the user's explicit
    go-ahead in this conversation. Uploading or attaching generated artifacts
-   happens only when the user asked for it.
+   happens only when the user asked for it. For *how* to create and publish once
+   the user has agreed, see "Creating, editing & publishing datasets" below.
 6. **Report identifiers.** Every user-facing summary must include the dataset
    IDs, distribution IDs, local file paths, and upload targets you touched.
 7. **Versioning is automatic.** The CLI maintains the `version` aspect on
@@ -102,7 +103,9 @@ record and its stored files; `--keep-files` keeps the objects):
 mgd dist remove dist-xyz --json
 ```
 
-Custom / domain metadata:
+Custom / domain metadata — when the standard aspects don't fit your data,
+define your own JSON-schema-validated aspect (the CLI exposes this; the web UI
+doesn't):
 
 ```sh
 mgd aspect list --jsonl                     # what aspect types exist here?
@@ -124,6 +127,76 @@ Raw fallback (documented REST endpoints only):
 ```sh
 mgd api request GET /v0/registry/records --query limit=3 --query aspect=dcat-dataset-strings
 ```
+
+## Creating, editing & publishing datasets
+
+Metadata first: when creating or editing dataset metadata, follow
+`dataset-elicitation.md` (infer before asking, quick vs guided path,
+confirm-then-write). This section covers the *command mechanics* once you know
+what to write. Every mutation here is subject to ground rule 5 — get the user's
+go-ahead first.
+
+Canonical sequence — **create → enrich → add files → publish**:
+
+```sh
+# 1. Create a draft (draft is the default; --publish would create it published)
+mgd dataset create --title "River gauge readings 2025" \
+  --desc "Daily river height and flow measurements." --json   # -> magda-ds-<uuid>
+
+# 2. Enrich metadata (patch merges these fields, keeping the rest — see set vs patch above)
+mgd dataset aspect patch magda-ds-<uuid> dcat-dataset-strings \
+  '{"keywords":["river","hydrology"],"themes":["water"]}' --json
+
+# 3. Add a file (--format overrides the extension-detected format)
+mgd dataset add-file magda-ds-<uuid> ./readings.csv --title "2025 readings" --format csv --json
+
+# 4. Publish — cascades to all the dataset's distributions
+mgd dataset publish magda-ds-<uuid> --json
+```
+
+**Publishing commands:**
+
+- `mgd dataset create --publish` — create published instead of the default draft.
+- `mgd dataset publish <id>` / `mgd dataset unpublish <id>` — set the dataset's
+  `publishing.state` and **cascade to every distribution**. Add
+  `--without-distributions` to change only the dataset record.
+- `mgd dist publish <distId>` / `mgd dist unpublish <distId>` — flip a single
+  distribution.
+- Publishing never bumps the `version` aspect (lifecycle state, not content).
+
+**Distributions are records too.** `mgd dataset get` lists only distribution IDs;
+use `mgd dataset distributions <id> --jsonl` for full distribution metadata, and
+`mgd dataset aspect get/set/patch <distId> …` to read or edit a distribution's
+aspects directly.
+
+**Downloading.** A distribution's `downloadURL` is an internal address
+(`magda://storage-api/...`), not a fetchable URL. Always download with
+`mgd dist download <distId> -o <path>` — never fetch the raw `downloadURL`.
+
+### Common aspects
+
+| Aspect | Record | Holds / notes |
+| --- | --- | --- |
+| `dcat-dataset-strings` | dataset | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified` |
+| `dcat-distribution-strings` | distribution | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize` |
+| `publishing` | dataset & distribution | `{ "state": "draft" \| "published" }` — use publish/unpublish, don't hand-edit |
+| `dataset-distributions` | dataset | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit |
+| `version` | dataset & distribution | CLI-managed history — never hand-edit (ground rule 7) |
+| `access-control` | dataset | `ownerId`, `orgUnitId`, `constraintExemption` |
+| `source` | dataset | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`) |
+| `dataset-publisher` | dataset | `{ "publisher": "<organisation record id>" }` — the web UI shows this org before the dates. **The CLI does not set it** (see note below) |
+| `temporal-coverage` | dataset | *optional* — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range |
+| `spatial-coverage` | dataset | *optional* — bounding box / named region; set manually when the data has a spatial extent |
+
+**Need a field these don't cover?** Define a custom, JSON-schema-validated
+aspect — `mgd aspect create <id> --name "…" --schema @schema.json`, then attach
+data with `dataset aspect set`/`patch` (see "Custom / domain metadata" above).
+
+**Publisher gap.** CLI-created datasets omit `dataset-publisher`, so the web UI
+shows no publishing organisation. Populating it correctly needs an
+`organisation` record ID (not a name), which the CLI doesn't yet resolve —
+tracked in issue #3715. Interim workaround, only if you already know the org's
+record ID: `mgd dataset aspect set <id> dataset-publisher '{"publisher":"<orgId>"}'`.
 
 ## Error triage
 


### PR DESCRIPTION
Closes #3688.

Documentation-only change (no code/flag changes). Surfaces existing `mgd` CLI capabilities positively in the agent skill and README so coding agents stop running `--help` for every command or inventing workarounds.

## `packages/mgd/skills/mgd-workflows.md`
New **"Creating, editing & publishing datasets"** section:
- Canonical **create → enrich → add-file → publish** example.
- Publishing guidance: `dataset create --publish`, `dataset publish/unpublish <id>` (cascade + `--without-distributions`), `dist publish/unpublish <distId>`. Ground rule 5's caution now cross-references the how-to (it was previously the only mention of `--publish`).
- `add-file --format`, distributions-are-records reminder, and an explicit "download via `mgd dist download`, never the raw internal `magda://` URL" rule.
- A **common-aspects** table: `dcat-dataset-strings`, `dcat-distribution-strings`, `publishing`, `dataset-distributions` and `version` (marked CLI-managed), `access-control`, `source`, `dataset-publisher`, and optional `temporal-coverage`/`spatial-coverage`.
- Positive framing for defining custom, JSON-schema-validated aspects.

## `packages/mgd/README.md`
- Publish step added to the create/edit example.
- Matching common-aspects table (sits directly above the existing "Custom aspects" section).
- Workflow/aspect pointer in the "Using `mgd` with a coding agent" section.

Install docs and `dataset-elicitation.md` are untouched; `SKILL.md` routes create/edit tasks to both files — `dataset-elicitation.md` owns the metadata conversation, the new section owns the command mechanics.

## Follow-up
- **#3715** — CLI doesn't set `dataset-publisher` (publishing organisation), so CLI datasets show no publisher in the web UI. Verified it needs an `organisation` record ID (not a name); the proper fix is CLI code. Documented here as an interim note + workaround.

## Verification
Docs-only; prettier doesn't cover markdown. Every documented command/flag was cross-checked against `packages/mgd/src/commands/{dataset,dist}.ts`, and aspect shapes against `recordBuilders.ts` and live `dev.magda.io` records. Code-fence balance and table structure checked.