### PR TITLE
test(authorization-api): isolate deleteUser test in a throwaway database

### DIFF
--- a/magda-authorization-api/src/test/Database.deleteUser.spec.ts
+++ b/magda-authorization-api/src/test/Database.deleteUser.spec.ts
@@ -10,23 +10,23 @@ describe("Database.deleteUser (integration)", function (this: Mocha.Suite) {
     let pool: pg.Pool = null;
     let database: Database;
     const dbConfig = getTestDBConfig();
+    // --- Use a uniquely-named, throwaway database so this test is fully
+    // --- isolated from other suites that share the same Postgres instance in
+    // --- CI. Rebuilding the schema in a shared db (e.g. dropping every table)
+    // --- deadlocks against those concurrent sessions.
+    const testDbName = `test_delete_user_${Date.now()}_${Math.floor(
+        Math.random() * 1e6
+    )}`;
 
     before(async function () {
-        // --- connect to the default db first so we can (re)create the test db
-        pool = new pg.Pool({ ...dbConfig });
-        try {
-            await pool.query("CREATE database test");
-        } catch (e) {
-            // --- ignore the error if database `test` already exists
-            if ((e as any)?.code !== "42P04") {
-                throw e;
-            }
-        }
-        await pool.end();
+        // --- connect to the default db first so we can create our own db
+        let adminPool = new pg.Pool({ ...dbConfig });
+        await adminPool.query(`CREATE DATABASE "${testDbName}"`);
+        await adminPool.end();
 
-        // --- reconnect to the test db & rebuild a clean auth schema in it
-        pool = new pg.Pool({ ...dbConfig, database: "test" });
-        await runMigrationSql(pool, true);
+        // --- connect to the fresh db & build a clean auth schema in it
+        pool = new pg.Pool({ ...dbConfig, database: testDbName });
+        await runMigrationSql(pool);
 
         // --- `Database` builds its own pool (pointing at the `auth` db) in the
         // --- constructor. Swap in our test-db pool so we exercise the real SQL
@@ -41,6 +41,15 @@ describe("Database.deleteUser (integration)", function (this: Mocha.Suite) {
         if (pool) {
             await pool.end();
             pool = null;
+        }
+        // --- best-effort cleanup of the throwaway database
+        const adminPool = new pg.Pool({ ...dbConfig });
+        try {
+            await adminPool.query(`DROP DATABASE IF EXISTS "${testDbName}"`);
+        } catch (e) {
+            // --- ignore cleanup failures; the db is disposable
+        } finally {
+            await adminPool.end();
         }
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #3708. That PR's `Database.deleteUser` integration test broke CI: the `buildtest:typescript-apis-with-pg` pipeline failed with `84 passing, 1 failing`, the failure being the test's `before all` hook throwing `error: deadlock detected`.

**Cause:** the test rebuilt the auth schema in the shared `test` database via `runMigrationSql(pool, true)`, which drops every table with `CASCADE`. The CI PG job runs multiple packages' tests in parallel against a single Postgres instance, so nuking the shared schema contended with concurrent sessions and deadlocked. (It passed locally only because nothing else was using the DB.)

**Fix:** create a uniquely-named throwaway database per run, migrate a clean auth schema into it (no table-dropping), and drop it afterwards. This isolates the test from all concurrent activity — the same reason `NestedSetModelQueryer.spec` is safe (it only touches its own uniquely-named tables).

The production fix from #3708 (`DELETE FROM users`) is unchanged and already on `main`; this only touches the test.

## Verification

Ran locally against Postgres (twice, to confirm repeatability and that the throwaway database is cleaned up): `1 passing` each time, no leftover `test_delete_user_*` databases.