### PR TITLE
chore(ci): bump builder base image to node22-ubuntu20-july-2026 (Helm 3.17.4)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ stages:
 
 yarn-install:
   stage: builders
-  image: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+  image: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   needs: []
   cache:
@@ -49,7 +49,7 @@ yarn-install:
 
 build-builder-image:
   stage: builders
-  image: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+  image: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   needs: []
   before_script:
@@ -781,7 +781,7 @@ dockerize:dockerExtensions:
   cache:
     paths: []
   image:
-    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   environment:
     name: preview/$CI_COMMIT_REF_NAME
@@ -859,7 +859,7 @@ Stop Preview: &stopPreview
   cache:
     paths: []
   image:
-    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   before_script: []
   environment:
@@ -888,7 +888,7 @@ Deploy Main Branch To Dev:
     - dockerize:dockerExtensions
     - buildtest:integration-tests
   image:
-    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   before_script: []
   environment:
@@ -1040,7 +1040,7 @@ Publish Helm Chart:
     - dockerize:dockerExtensions
     - buildtest:integration-tests
   image:
-    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+    name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
   script: |
     # release helm charts to github container registry

--- a/magda-builder-docker/Dockerfile
+++ b/magda-builder-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/magda-io/magda-builder-nodejs:node22-ubuntu20
+FROM ghcr.io/magda-io/magda-builder-nodejs:node22-ubuntu20-july-2026
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/magda-builder-scala/Dockerfile
+++ b/magda-builder-scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20
+FROM ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Follow-up to #3712. The dev deploy failed ([job 15359251693](https://gitlab.com/magda-data/magda/-/jobs/15359251693)) with:

```
UPGRADE FAILED ... helm-version-check.yaml: Magda requires Helm >= 3.17.0, but Helm v3.13.2 is in use.
```

The `magda-core` version guard from #3712 correctly blocked the deploy — but the **"Deploy Main Branch To Dev"** job runs `helm upgrade` inside the *static* runner image `ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20`, which still shipped **Helm 3.13.2**. That base image is built manually (nothing in CI republishes it), so #3712’s Dockerfile bump never reached the deploy job.

## Changes
- Rebuilt the builder chain (`magda-builder-nodejs` → `magda-builder-docker`) from `main` and **published a new tag `node22-ubuntu20-july-2026`** to ghcr (multi-arch `linux/amd64,linux/arm64`), carrying **Helm 3.17.4**. Using a new tag (vs overwriting `node22-ubuntu20`) avoids the same-tag/new-digest runner-cache ambiguity.
- `magda-builder-docker/Dockerfile` / `magda-builder-scala/Dockerfile`: `FROM` → new tag.
- `.gitlab-ci.yml`: the 6 `magda-builder-docker:node22-ubuntu20` job-image references → new tag.

## Verified
- Both images published multi-arch; `helm version` inside the pushed `magda-builder-docker:node22-ubuntu20-july-2026` (amd64) → `v3.17.4`.
- kubectl unchanged (`v1.29.0`).

## After merge
The "Deploy Main Branch To Dev" job will run on the new image (Helm 3.17.4) → the guard passes → dev deploys the fixed config and semantic search comes up.