### PR TITLE
docs(mgd): clarify permission-denied handling & document auth model

### DIFF
--- a/docs/docs/architecture/Guide to Magda Internals.md
+++ b/docs/docs/architecture/Guide to Magda Internals.md
@@ -302,6 +302,8 @@ Magda also supports API key based authentication. It's designed for the single r
 
 API Keys are created up-front - one user can have zero-to-many API Keys associated with it. An API Key consists of an ID, and the key itself. To create an API key, please refer to the [How to Create API Key Document](../how-to-create-api-key.md). Once the API key is created, you can attach `X-Magda-API-Key` and `X-Magda-API-Key-Id` headers to your request in order to get authenticated.
 
+Regardless of the authentication option used, you can call `GET /v0/auth/users/whoami` to retrieve the current user's profile, which includes the user's access-control metadata — the resolved `roles` & `permissions` plus the organisation unit(s) the user belongs to (an anonymous user for unauthenticated requests).
+
 ![Diagram explaining API key auth](./_resources/b7da510d241d4b13a4f6e1ab08e45be7.png)
 
 # Authorization (authz)
@@ -485,6 +487,8 @@ Since v2.0.0, we introduced a decision API as a new additional to the Auth API s
 - auto-create policy evaluation context data with user's profile including user's roles, permissions & user's current organisational unit.
 - auto-select OPA API endpoints (either for partial evaluation or making unconditional decision) based on information provided.
 - further evaluate the OPA decision response AST and resolve any possible cross references
+
+> Note: Magda's authorisation follows an attribute-based access control (ABAC) model, so the user's own access-control metadata (the `roles`, `permissions` & organisation units returned by `whoami`) is only one set of inputs. For a decision on a specific resource, the endpoint also injects the **subject (resource) attributes** the policy needs — e.g. a registry record's `access-control` aspect, or any other record field the policy logic references — and evaluates both together. So you should not try to compute access yourself from the permission list alone; the outcome is the policy engine's call over the user *and* resource attributes. When filtering a set of records we instead leave the record attributes `unknown` and let the engine partially evaluate the policy, which yields residual rules (referencing those record attributes) that translate into storage-engine query conditions such as an SQL `WHERE` clause — see [Policy Engine & Partial Evaluation](#policy-engine--partial-evaluation) above.
 
 #### Types of Decision Queries
 

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -203,8 +203,12 @@ record ID: `mgd dataset aspect set <id> dataset-publisher '{"publisher":"<orgId>
 - exit 3 + `unauthorized` → API key invalid/expired: ask the user to update the
   profile (`mgd profile update <name> --key-id … --key …`) or recreate it
   (`mgd profile create <name>`).
-- exit 3 + `forbidden` → the key works but lacks permission: report which
-  operation was denied; do not retry.
+- exit 3 + `forbidden` → the key is valid but the account lacks permission for
+  that operation. Common cause: the user assumed they could create/upload/publish
+  but haven't been granted those rights. Report which operation was denied,
+  explain it's a permissions grant (not a missing record or a bug), and advise
+  them to ask their MAGDA system administrator to grant the relevant
+  permission/role. Do not retry.
 - exit 4 → record/object doesn't exist: re-check the ID (search again) before
   reporting data as missing.
 - `semantic-search-unavailable` → use keyword search only.


### PR DESCRIPTION
## What

Two small, docs-only changes around authorization/permissions:

**`packages/mgd/skills/mgd-workflows.md`** — expand the `exit 3 + forbidden` error-triage entry so assistants:
- recognise a denied create/upload/publish as a **permissions grant** issue (not a missing record or a bug), and
- direct the user to ask their MAGDA system administrator to grant the relevant permission/role, rather than retrying.

Handling is deliberately **reactive only** — no proactive per-session warning (which would be noise), since users attempting to create a dataset already assume some permission is required; the real failure mode is a *wrong* assumption of access, best surfaced when the `403` actually occurs.

**`docs/docs/architecture/Guide to Magda Internals.md`** — fill two gaps in the auth section:
- Document that `GET /v0/auth/users/whoami` returns the current user's access-control metadata (`roles`, `permissions` and the organisation unit(s) the user belongs to). `whoami` wasn't mentioned anywhere in the doc before.
- Add an ABAC caveat to the Decision API section: user attributes are only one input; the policy engine also needs **subject (resource) attributes**, so access can't be computed from the permission list alone. Set-based record filtering deliberately leaves record attributes `unknown` and uses partial evaluation, yielding residual rules that translate into storage query conditions (SQL `WHERE` / ES DSL). Cross-links the existing "Policy Engine & Partial Evaluation" section.

## Why

The mgd skill previously stopped at "report which operation was denied" without the actionable admin-grant next step. The internals guide is otherwise current and thorough on authz, but `whoami`'s response shape and the ABAC "both user + resource attributes" point were undocumented.

## Scope

Documentation only — no code changes.