### PR TITLE
fix(mgd): build and verify CLI bundle before npm publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,6 +353,10 @@ buildtest:typescript-apis-stateless:
     - yarn run in-submodules -- -f language=typescript -f categories.api=true -f categories.stateless=true -- run test --include-filtered-dependencies
     - yarn run in-submodules -- -f categories.npmPackage=true -f categories.useCommonLib=true -- run build
     - yarn run in-submodules -- -f categories.npmPackage=true -f categories.useMinionLib=true -- run build
+    # Build, unit-test and packaging smoke-test the CLI npm package (@magda/mgd)
+    # so a broken or incomplete release tarball fails here, before publish. See #3723.
+    - yarn run in-submodules -- -f categories.npmPackage=true -f categories.cli=true -- run test
+    - yarn run in-submodules -- -f categories.npmPackage=true -f categories.cli=true -- run smoke:pack
     - yarn run in-submodules -- -f language=typescript -f categories.dockerizedTool=true -- run build --include-filtered-dependencies
     - yarn run in-submodules -- -f language=typescript -f categories.dockerizedTool=true -- run test --include-filtered-dependencies
   artifacts:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.1.1
+
+- #3723: Fix `@magda/mgd` npm package publishing without its `bin/mgd.js` CLI bundle, which made `npm install -g @magda/mgd` install a broken `mgd` executable.
+
 ## v6.1.0
 
 - Added `@magda/mgd`, an installable local CLI for working with MAGDA catalogs, including profile and API-key authentication, keyword and semantic search, dataset and distribution management, resumable file transfers, custom aspects, publishing workflows, version tracking, machine-readable output and installable coding-agent skills (#3648, #3683).

--- a/packages/mgd/package.json
+++ b/packages/mgd/package.json
@@ -12,8 +12,10 @@
   "scripts": {
     "prebuild": "rimraf bin",
     "build": "node esbuild.js",
+    "prepack": "npm run build",
     "typecheck": "tsc --noEmit",
     "test": "c8 mocha",
+    "smoke:pack": "node scripts/smoke-pack.mjs",
     "release": "node \"$(git rev-parse --show-toplevel)/ci-scripts/npm-publish-release.js\""
   },
   "author": "",
@@ -52,7 +54,8 @@
   "magda": {
     "language": "typescript",
     "categories": {
-      "npmPackage": true
+      "npmPackage": true,
+      "cli": true
     }
   },
   "keywords": [

--- a/packages/mgd/scripts/smoke-pack.mjs
+++ b/packages/mgd/scripts/smoke-pack.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Packaging smoke test for @magda/mgd.
+ *
+ * Reproduces the real npm release path: `npm pack` (which runs the `prepack`
+ * lifecycle script to build the git-ignored bin/mgd.js bundle), then installs
+ * the resulting tarball into a clean, throwaway project and runs the installed
+ * `mgd --version`.
+ *
+ * Guards against regressions of #3723, where a clean release checkout published
+ * @magda/mgd without bin/mgd.js, so `npm install -g @magda/mgd` produced no
+ * working `mgd` executable even though package.json declared the `mgd` bin.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const pkg = JSON.parse(
+    fs.readFileSync(path.join(pkgDir, "package.json"), "utf8")
+);
+const expectedVersion = pkg.version;
+
+// npm prefixes every path inside a package tarball with "package/".
+const REQUIRED_FILES = [
+    "package/bin/mgd.js",
+    "package/skills/SKILL.md",
+    "package/skills/mgd-workflows.md",
+    "package/skills/dataset-elicitation.md"
+];
+
+function run(cmd, args, opts = {}) {
+    return execFileSync(cmd, args, {
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 64,
+        ...opts
+    });
+}
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mgd-smoke-"));
+try {
+    // 1. Pack. `npm pack` runs the `prepack` script, which builds bin/mgd.js.
+    //    The last non-empty stdout line is the produced tarball's filename.
+    const packOut = run("npm", ["pack", "--pack-destination", workDir], {
+        cwd: pkgDir
+    });
+    const tarballName = packOut.trim().split("\n").pop().trim();
+    const tarball = path.join(workDir, tarballName);
+    if (!fs.existsSync(tarball)) {
+        throw new Error(`npm pack did not produce a tarball at ${tarball}`);
+    }
+
+    // 2. Verify the tarball contains the CLI bundle and the skill files.
+    const listing = run("tar", ["-tzf", tarball])
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+    for (const required of REQUIRED_FILES) {
+        if (!listing.includes(required)) {
+            throw new Error(
+                `packed tarball is missing ${required}\n` +
+                    `tarball contents:\n${listing.join("\n")}`
+            );
+        }
+    }
+
+    // 3. Install the tarball into a clean, throwaway consumer project.
+    const projDir = path.join(workDir, "consumer");
+    fs.mkdirSync(projDir);
+    fs.writeFileSync(
+        path.join(projDir, "package.json"),
+        JSON.stringify({ name: "mgd-smoke-consumer", private: true }, null, 2)
+    );
+    run("npm", ["install", "--no-audit", "--no-fund", tarball], {
+        cwd: projDir,
+        stdio: ["ignore", "inherit", "inherit"]
+    });
+
+    // 4. Installing the package must create the `mgd` executable.
+    const binPath = path.join(projDir, "node_modules", ".bin", "mgd");
+    if (!fs.existsSync(binPath)) {
+        throw new Error(`installed package did not create ${binPath}`);
+    }
+
+    // 5. `mgd --version` must succeed and report the package version.
+    const version = run(binPath, ["--version"], { cwd: projDir }).trim();
+    if (version !== expectedVersion) {
+        throw new Error(
+            `mgd --version reported "${version}", expected "${expectedVersion}"`
+        );
+    }
+
+    console.log(`ok - packaging smoke test passed (mgd ${version})`);
+} catch (e) {
+    console.error(`FAIL - packaging smoke test: ${e.message}`);
+    process.exitCode = 1;
+} finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Problem

The published `@magda/mgd` package declares an `mgd` bin at `bin/mgd.js`, but
that bundle is a generated, git-ignored artifact (`.gitignore` contains `bin/`).
Nothing built it before publish and `@magda/mgd` was never built in CI, so a
clean release checkout published the package **without** `bin/mgd.js`. As a
result `npm install -g @magda/mgd && mgd --version` installs a broken `mgd`
executable.

Reproduced: in a clean checkout, `npm pack --dry-run` produced only the
`skills/` files — `bin/mgd.js` was absent.

Closes #3723.

## Changes

- **`prepack` lifecycle script** in `packages/mgd/package.json` so `bin/mgd.js`
  is always built before `npm pack` / `npm publish`.
- **Packaging smoke test** (`packages/mgd/scripts/smoke-pack.mjs`, `npm run
  smoke:pack`) that packs the real tarball, verifies it contains `bin/mgd.js`
  and the coding-agent skill files, installs it into a clean throwaway project,
  and asserts the `mgd` executable exists and `mgd --version` matches the
  package version.
- **CI gating** in `.gitlab-ci.yml`: run the CLI package unit tests and the
  packaging smoke test in `buildtest:typescript-apis-stateless` (a `needs`
  dependency of `Publish NPM Packages`), so an absent/broken CLI bundle fails
  the pipeline before publish. A `cli` category was added to the package so CI
  can target it.
- **`CHANGES.md`**: added a `v6.1.1` entry.

## Verification

- Clean `npm run smoke:pack` (with `bin/` removed first): tarball includes
  `bin/mgd.js` + skill files, clean install creates the `mgd` executable,
  `mgd --version` succeeds.
- `npm test` → 148 passing. `npm run typecheck` → clean.

## Follow-up (release-time)

The corrected package needs a patch release. Version is managed by
`lerna version` at tag time, so a maintainer should cut/tag `v6.1.1` to
publish the fixed package (npm `6.1.0` cannot be replaced).