### PR TITLE
fix(mgd): correct Codex global skill path and harden agent install prompts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v6.1.1
 
 - #3723: Fix `@magda/mgd` npm package publishing without its `bin/mgd.js` CLI bundle, which made `npm install -g @magda/mgd` install a broken `mgd` executable.
+- #3724: Fix `mgd skills install --agent codex` installing the global Codex skill to `~/.codex/skills` instead of the discovered `~/.agents/skills` location (install/uninstall now also clean up the legacy path), and harden the coding-agent install prompts in the README to resolve a Node.js 22+ runtime via an existing version manager in non-interactive shells where bare `node`/`npm` is not on `PATH`.
 
 ## v6.1.0
 

--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -36,18 +36,27 @@ will guide you through installing both the `mgd` CLI and its MAGDA skill.
 ```text
 Help me install and configure the MAGDA mgd CLI for use with Claude Code.
 
-1. Detect my operating system and check `node --version` and `npm --version`.
-   mgd requires Node.js 22 or newer. If Node.js is missing or too old, explain
-   the recommended installation or upgrade and ask for my confirmation before
-   changing my system. Prefer my existing version manager or an official
-   Node.js distribution. Do not use sudo, change my shell configuration, or
-   execute a remote installation script without explicit approval.
-2. Install the CLI with `npm install -g @magda/mgd`, then verify it with
-   `mgd --version`. If npm reports a permissions problem, explain it and
-   recommend a user-level Node.js/npm setup instead of escalating privileges.
-3. Install only the Claude Code skill with
-   `mgd skills install --agent claude`. Tell me if I need to start a new Claude
-   Code session before the skill will be discovered.
+1. Detect my operating system and resolve a Node.js 22+ runtime. First try
+   `node --version` and `npm --version`. If they report missing or too old —
+   common in a non-interactive agent shell that has not loaded my login/shell
+   startup files — check for an already-installed version manager (fnm, nvm,
+   volta, asdf, or mise) and any Node.js 22+ it manages before proposing any
+   system change. If a suitable managed runtime exists, make it available to this
+   session's commands only (resolve its `node`/`npm` bin path, or use the
+   manager's own `exec`/`run` form); do not modify my shell configuration. Settle
+   on one concrete runtime and reuse the same `node`/`npm` for every later step.
+   Only if no compatible runtime is found, explain the recommended install or
+   upgrade and ask for my confirmation before changing my system, preferring my
+   existing version manager or an official Node.js distribution. Do not use sudo
+   or execute a remote installation script without explicit approval.
+2. Using that resolved runtime, install the CLI with `npm install -g @magda/mgd`,
+   then verify it with `mgd --version` — invoke `mgd` through the same resolved
+   runtime/PATH so a global install performed via a version manager is actually
+   found. If npm reports a permissions problem, explain it and recommend a
+   user-level Node.js/npm setup instead of escalating privileges.
+3. Install only the Claude Code skill with `mgd skills install --agent claude`
+   (using the same resolved runtime). Then start a new Claude Code session so the
+   newly installed skill is discovered.
 4. When I am ready to configure MAGDA access, offer to open a new visible,
    interactive terminal window and start `mgd profile create default`. Ask
    before opening it. Launch only that command: do not automate keystrokes,
@@ -70,17 +79,28 @@ Help me install and configure the MAGDA mgd CLI for use with Claude Code.
 ```text
 Help me install and configure the MAGDA mgd CLI for use with Codex.
 
-1. Detect my operating system and check `node --version` and `npm --version`.
-   mgd requires Node.js 22 or newer. If Node.js is missing or too old, explain
-   the recommended installation or upgrade and ask for my confirmation before
-   changing my system. Prefer my existing version manager or an official
-   Node.js distribution. Do not use sudo, change my shell configuration, or
-   execute a remote installation script without explicit approval.
-2. Install the CLI with `npm install -g @magda/mgd`, then verify it with
-   `mgd --version`. If npm reports a permissions problem, explain it and
-   recommend a user-level Node.js/npm setup instead of escalating privileges.
-3. Install only the Codex skill with `mgd skills install --agent codex`. Tell me
-   if I need to start a new Codex session before the skill will be discovered.
+1. Detect my operating system and resolve a Node.js 22+ runtime. First try
+   `node --version` and `npm --version`. If they report missing or too old —
+   common in a non-interactive agent shell that has not loaded my login/shell
+   startup files — check for an already-installed version manager (fnm, nvm,
+   volta, asdf, or mise) and any Node.js 22+ it manages before proposing any
+   system change. If a suitable managed runtime exists, make it available to this
+   session's commands only (resolve its `node`/`npm` bin path, or use the
+   manager's own `exec`/`run` form); do not modify my shell configuration. Settle
+   on one concrete runtime and reuse the same `node`/`npm` for every later step.
+   Only if no compatible runtime is found, explain the recommended install or
+   upgrade and ask for my confirmation before changing my system, preferring my
+   existing version manager or an official Node.js distribution. Do not use sudo
+   or execute a remote installation script without explicit approval.
+2. Using that resolved runtime, install the CLI with `npm install -g @magda/mgd`,
+   then verify it with `mgd --version` — invoke `mgd` through the same resolved
+   runtime/PATH so a global install performed via a version manager is actually
+   found. If npm reports a permissions problem, explain it and recommend a
+   user-level Node.js/npm setup instead of escalating privileges.
+3. Install only the Codex skill with `mgd skills install --agent codex` (using
+   the same resolved runtime). The global Codex skill installs to
+   `~/.agents/skills/magda-mgd/`. Then start a new Codex task/session so the newly
+   installed skill metadata is discovered.
 4. When I am ready to configure MAGDA access, offer to open a new visible,
    interactive terminal window and start `mgd profile create default`. Ask
    before opening it. Launch only that command: do not automate keystrokes,
@@ -103,18 +123,27 @@ Help me install and configure the MAGDA mgd CLI for use with Codex.
 ```text
 Help me install and configure the MAGDA mgd CLI for use with opencode.
 
-1. Detect my operating system and check `node --version` and `npm --version`.
-   mgd requires Node.js 22 or newer. If Node.js is missing or too old, explain
-   the recommended installation or upgrade and ask for my confirmation before
-   changing my system. Prefer my existing version manager or an official
-   Node.js distribution. Do not use sudo, change my shell configuration, or
-   execute a remote installation script without explicit approval.
-2. Install the CLI with `npm install -g @magda/mgd`, then verify it with
-   `mgd --version`. If npm reports a permissions problem, explain it and
-   recommend a user-level Node.js/npm setup instead of escalating privileges.
-3. Install only the opencode skill with
-   `mgd skills install --agent opencode`. Tell me if I need to start a new
-   opencode session before the skill will be discovered.
+1. Detect my operating system and resolve a Node.js 22+ runtime. First try
+   `node --version` and `npm --version`. If they report missing or too old —
+   common in a non-interactive agent shell that has not loaded my login/shell
+   startup files — check for an already-installed version manager (fnm, nvm,
+   volta, asdf, or mise) and any Node.js 22+ it manages before proposing any
+   system change. If a suitable managed runtime exists, make it available to this
+   session's commands only (resolve its `node`/`npm` bin path, or use the
+   manager's own `exec`/`run` form); do not modify my shell configuration. Settle
+   on one concrete runtime and reuse the same `node`/`npm` for every later step.
+   Only if no compatible runtime is found, explain the recommended install or
+   upgrade and ask for my confirmation before changing my system, preferring my
+   existing version manager or an official Node.js distribution. Do not use sudo
+   or execute a remote installation script without explicit approval.
+2. Using that resolved runtime, install the CLI with `npm install -g @magda/mgd`,
+   then verify it with `mgd --version` — invoke `mgd` through the same resolved
+   runtime/PATH so a global install performed via a version manager is actually
+   found. If npm reports a permissions problem, explain it and recommend a
+   user-level Node.js/npm setup instead of escalating privileges.
+3. Install only the opencode skill with `mgd skills install --agent opencode`
+   (using the same resolved runtime). Then start a new opencode session so the
+   newly installed skill is discovered.
 4. When I am ready to configure MAGDA access, offer to open a new visible,
    interactive terminal window and start `mgd profile create default`. Ask
    before opening it. Launch only that command: do not automate keystrokes,
@@ -523,7 +552,7 @@ This drops the skill into each agent's native skills directory:
 | Agent       | Global (default)                       | With `--project [dir]`              |
 | ----------- | -------------------------------------- | ----------------------------------- |
 | Claude Code | `~/.claude/skills/magda-mgd/`          | `<dir>/.claude/skills/magda-mgd/`   |
-| Codex       | `~/.codex/skills/magda-mgd/`           | `<dir>/.agents/skills/magda-mgd/`   |
+| Codex       | `~/.agents/skills/magda-mgd/`          | `<dir>/.agents/skills/magda-mgd/`   |
 | opencode    | `~/.config/opencode/skills/magda-mgd/` | `<dir>/.opencode/skills/magda-mgd/` |
 
 All three natively auto-discover `SKILL.md` skills and load the instructions on

--- a/packages/mgd/src/skills.ts
+++ b/packages/mgd/src/skills.ts
@@ -40,10 +40,11 @@ function globalBase(agent: AgentName, env: NodeJS.ProcessEnv): string {
         case "claude":
             return path.join(homeDir(env), ".claude", "skills");
         case "codex":
-            return path.join(
-                env.CODEX_HOME || path.join(homeDir(env), ".codex"),
-                "skills"
-            );
+            // Current Codex discovers global (user-level) skills in
+            // ~/.agents/skills (project skills live in <repo>/.agents/skills).
+            // This is NOT under CODEX_HOME. See legacyCodexGlobalDir() for the
+            // location older mgd versions used.
+            return path.join(homeDir(env), ".agents", "skills");
         case "opencode":
             return path.join(
                 env.XDG_CONFIG_HOME || path.join(homeDir(env), ".config"),
@@ -51,6 +52,17 @@ function globalBase(agent: AgentName, env: NodeJS.ProcessEnv): string {
                 "skills"
             );
     }
+}
+
+// Where mgd <= 6.1.x installed the GLOBAL Codex skill: ${CODEX_HOME:-~/.codex}/skills.
+// Codex does not discover skills there, so we clean it up on install/uninstall to
+// avoid leaving an orphaned, undiscovered copy behind.
+function legacyCodexGlobalDir(env: NodeJS.ProcessEnv): string {
+    return path.join(
+        env.CODEX_HOME || path.join(homeDir(env), ".codex"),
+        "skills",
+        SKILL_SUBDIR
+    );
 }
 
 // Per-agent PROJECT skills dir (each tool's native project location).
@@ -117,6 +129,9 @@ export async function installSkill(opts: {
             path.join(dir, name)
         );
     }
+    if (opts.agent === "codex" && opts.scope === "global") {
+        await removeLegacyCodexGlobal(dir, opts.env);
+    }
     return {
         agent: opts.agent,
         scope: opts.scope,
@@ -135,11 +150,28 @@ export async function uninstallSkill(opts: {
     const dir = resolveSkillDir(opts);
     const existed = existsSync(dir);
     if (existed) await fs.rm(dir, { recursive: true, force: true });
+    let legacyRemoved = false;
+    if (opts.agent === "codex" && opts.scope === "global") {
+        legacyRemoved = await removeLegacyCodexGlobal(dir, opts.env);
+    }
     return {
         agent: opts.agent,
         scope: opts.scope,
         dir,
         files: [],
-        action: existed ? "removed" : "absent"
+        action: existed || legacyRemoved ? "removed" : "absent"
     };
+}
+
+// Remove the legacy global Codex skill copy, unless it happens to resolve to the
+// same path as the current install dir (never true today, but keep it safe).
+// Returns whether a legacy copy was actually removed.
+async function removeLegacyCodexGlobal(
+    currentDir: string,
+    env: NodeJS.ProcessEnv
+): Promise<boolean> {
+    const legacy = legacyCodexGlobalDir(env);
+    if (legacy === currentDir || !existsSync(legacy)) return false;
+    await fs.rm(legacy, { recursive: true, force: true });
+    return true;
 }

--- a/packages/mgd/src/test/skillsInstall.spec.ts
+++ b/packages/mgd/src/test/skillsInstall.spec.ts
@@ -54,7 +54,7 @@ describe("skills install", () => {
                 projectDir: tmp,
                 env
             })
-        ).to.equal(path.join(tmp, "codexhome", "skills", "magda-mgd"));
+        ).to.equal(path.join(tmp, ".agents", "skills", "magda-mgd"));
         expect(
             resolveSkillDir({
                 agent: "opencode",
@@ -171,6 +171,59 @@ describe("skills install", () => {
             env
         });
         expect(second.action).to.equal("absent");
+    });
+
+    it("codex global skill installs into ~/.agents/skills", async () => {
+        const res = await installSkill({
+            agent: "codex",
+            scope: "global",
+            projectDir: tmp,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+        expect(res.dir).to.equal(
+            path.join(tmp, ".agents", "skills", "magda-mgd")
+        );
+        expect(existsSync(path.join(res.dir, "SKILL.md"))).to.equal(true);
+    });
+
+    it("codex global install cleans up a legacy ~/.codex/skills copy", async () => {
+        // Simulate a skill installed by an older mgd under the (now wrong)
+        // ${CODEX_HOME:-~/.codex}/skills location.
+        const legacy = path.join(tmp, "codexhome", "skills", "magda-mgd");
+        await fs.mkdir(legacy, { recursive: true });
+        await fs.writeFile(path.join(legacy, "SKILL.md"), "stale");
+
+        const res = await installSkill({
+            agent: "codex",
+            scope: "global",
+            projectDir: tmp,
+            skillsDir: SKILLS_DIR,
+            env
+        });
+
+        expect(existsSync(path.join(res.dir, "SKILL.md"))).to.equal(true);
+        expect(existsSync(legacy)).to.equal(false);
+    });
+
+    it("codex global uninstall removes both current and legacy locations", async () => {
+        const current = path.join(tmp, ".agents", "skills", "magda-mgd");
+        const legacy = path.join(tmp, "codexhome", "skills", "magda-mgd");
+        await fs.mkdir(current, { recursive: true });
+        await fs.writeFile(path.join(current, "SKILL.md"), "x");
+        await fs.mkdir(legacy, { recursive: true });
+        await fs.writeFile(path.join(legacy, "SKILL.md"), "x");
+
+        const res = await uninstallSkill({
+            agent: "codex",
+            scope: "global",
+            projectDir: tmp,
+            env
+        });
+
+        expect(res.action).to.equal("removed");
+        expect(existsSync(current)).to.equal(false);
+        expect(existsSync(legacy)).to.equal(false);
     });
 
     it("parseAgents: default all, single, and bad value", () => {


### PR DESCRIPTION
## Problems (both from #3724)

1. **Codex global skill location.** `mgd skills install --agent codex` installed the global skill to `${CODEX_HOME:-~/.codex}/skills/magda-mgd`, but current Codex discovers global (user-level) skills in `~/.agents/skills` (project skills in `<repo>/.agents/skills`, which the installer already used). So a globally installed Codex skill was never discovered. Verified against the Codex customization docs and reproduced with the `v6.1.1-pr.3725.0` build.
2. **Non-interactive version-manager PATH.** The guided install prompts open with bare `node`/`npm` and use bare `npm`/`mgd` throughout. A coding-agent's non-interactive, non-login shell doesn't source the rc files that activate `fnm`/`nvm`/`volta`/`asdf`/`mise`, so an installed Node 22 looks missing and a global install may not be on `PATH` for later bare commands.

## Changes

- **`src/skills.ts`**: global Codex skill location → `~/.agents/skills`. Install cleans up a stale legacy `${CODEX_HOME:-~/.codex}/skills/magda-mgd`; uninstall removes both new and legacy dirs. Project path unchanged.
- **`README.md` skill-location table**: Codex "Global" → `~/.agents/skills/magda-mgd/`.
- **`README.md` install prompts (all three agents)**: detect an existing supported version manager + Node ≥22 before proposing a system change; resolve one runtime for the current commands only (no shell-config edits) and reuse it for install, `mgd --version`, skill install and verification; keep existing safeguards; give deterministic new-task/session guidance for skill discovery.
- **Tests** (`skillsInstall.spec.ts`): corrected global-codex path + new legacy-cleanup coverage (install and uninstall).
- **`CHANGES.md`**: `#3724` entry under `v6.1.1`.

## Verification

- `mgd` unit tests: 151 passing; `tsc --noEmit` clean.
- **Local E2E in the exact reported scenario** (fnm-managed Node, non-interactive shell): bare `node`/`npm` absent → resolved Node 22 via `fnm exec` (no shell-config changes) → installed `@magda/mgd` globally through that runtime → `mgd --version` works → `mgd skills install --agent codex` lands in `~/.agents/skills/magda-mgd` and the stale `~/.codex/skills/magda-mgd` is cleaned up.

## Acceptance criteria

- [x] Prompt detects an existing compatible version-manager runtime before recommending install/upgrade
- [x] No shell startup files changed to activate the runtime
- [x] Same resolved runtime installs the package, runs `mgd --version`, and runs `mgd skills install --agent codex`
- [x] Global skill installs to a supported discovered location (`~/.agents/skills`), with legacy location cleaned up
- [x] Docs give explicit new-task/session guidance after install
- [x] Non-interactive PATH case covered by a documented, reproduced E2E session