### PR TITLE
docs: homepage install guidance + minikube/e2e clean-install notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -214,7 +214,7 @@ Magda is also completely open-source and can be used for free - to get it runnin
 
 ## Who’s Used Magda
 
-Magda has powered national- and state-level data portals, research infrastructure, and public sector data ecosystems. Some of the organizations who have previously deployed Magda include:
+Magda has powered national- and state-level data portals, research infrastructure, and public sector data ecosystems. Some of the organizations that have deployed or are using Magda include:
 
 - [Digital Transformation Agency](https://www.dta.gov.au/) and later the [Australian Bureau of Statistics](https://www.abs.gov.au/) – Deployed & Managed Magda platform for [data.gov.au](https://data.gov.au) from 2019 to June 2025
 - [CSIRO Land and Water](https://www.csiro.au/en/Research/LWF) – Knowledge Network V2
@@ -222,6 +222,7 @@ Magda has powered national- and state-level data portals, research infrastructur
 - [Department of the Environment and Energy](https://www.environment.gov.au/) – Private instance
 - [NSW Department of Customer Service](https://www.customerservice.nsw.gov.au/) – NSW Spatial Digital Twin
 - [QLD Department of Natural Resources, Mines and Energy](https://www.dnrme.qld.gov.au/) – QLD Spatial Digital Twin
+- [NSW Audit Office](https://www.audit.nsw.gov.au/) – Council Risk IQ Project
 
 Magda is used in a variety of contexts — from open data portals serving national audiences, to private, domain-specific platforms supporting research workflows and scientific discovery. Its flexibility makes it a good fit for governments, research agencies, and enterprises that need to integrate diverse datasets across complex technical landscapes.
 
@@ -243,8 +244,9 @@ Install Magda with [Helm](https://helm.sh/) (use [minikube](https://minikube.sig
 # create a namespace "magda" in your cluster
 kubectl create namespace magda
 
-# install Magda version v6.1.1 to namespace "magda", turn off openfaas function and expose the service via loadBalancer
-helm upgrade --namespace magda --install --version 6.1.1 --timeout 9999s --set magda-core.gateway.service.type=LoadBalancer magda oci://ghcr.io/magda-io/charts/magda
+# install the latest Magda release to namespace "magda", turn off openfaas function and expose the service via loadBalancer
+# (Helm installs the latest stable version by default; add --version <x.y.z> to pin a specific release)
+helm upgrade --namespace magda --install --timeout 9999s --set magda-core.gateway.service.type=LoadBalancer magda oci://ghcr.io/magda-io/charts/magda
 ```
 
 > Since v2, we release our helm charts to Github container registry: `oci://ghcr.io/magda-io/charts`

--- a/docs/docs/e2e-cluster-deployment-test.md
+++ b/docs/docs/e2e-cluster-deployment-test.md
@@ -32,6 +32,12 @@ kubectl get ns magda        # should return NotFound
 kubectl get pv | grep magda # should return nothing
 ```
 
+> **On minikube, the checks above are not sufficient.** minikube's default hostpath provisioner keys volume directories by namespace and PVC name, and deleting the namespace/PVCs does **not** reliably erase the underlying data on the node — so `kubectl get pv` can come back clean while stale PostgreSQL/MinIO/OpenSearch data survives on disk. Reusing it on a fresh install produces confusing failures, most notably MinIO crash-looping with `Unable to initialize config system: Invalid credentials` (the volume still holds config encrypted with the previous install's secrets). For a genuinely clean run, either `minikube delete` and start a fresh cluster, or clear the leftover data explicitly:
+>
+> ```bash
+> minikube ssh -- 'sudo rm -rf /tmp/hostpath-provisioner/magda'
+> ```
+
 ## Step 2: Fresh Install
 
 ```bash

--- a/docs/docs/running-on-minikube-without-building.md
+++ b/docs/docs/running-on-minikube-without-building.md
@@ -33,10 +33,12 @@ minikube start --driver=docker --memory=16384 --cpus=4 --disk-size=60g
 
 ```bash
 kubectl create namespace magda
-helm install magda oci://ghcr.io/magda-io/charts/magda --version <VERSION> -n magda
+helm install magda oci://ghcr.io/magda-io/charts/magda --version <VERSION> --timeout 9999s -n magda
 ```
 
 Replace `<VERSION>` with the release you want — see the [latest release](https://github.com/magda-io/magda/releases) (for example, `6.1.1`). Installing with default values deploys the full stack.
+
+> **Why `--timeout 9999s`?** A first-time full-stack install runs post-install hooks (database migrations) that wait for OpenSearch, PostgreSQL and MinIO to come up. On a fresh cluster this can take longer than Helm's default 5-minute timeout, and without the flag `helm install` may report `failed post-install: timed out waiting for the condition` even though the deployment is still coming up correctly. The long timeout lets Helm wait it out and report success.
 
 > Since v2, Magda's Helm charts are published to the GitHub Container Registry: `oci://ghcr.io/magda-io/charts`.
 
@@ -80,3 +82,9 @@ kubectl delete namespace magda
 # or remove the whole minikube cluster
 minikube delete
 ```
+
+> **Reinstalling on the same cluster?** minikube's default hostpath storage provisioner keys volume directories by namespace and PVC name, so deleting the `magda` namespace does **not** always erase the underlying data on the node. Reusing that stale data on a fresh install causes hard-to-diagnose failures — most notably MinIO crash-looping with `Unable to initialize config system: Invalid credentials`, because the volume still holds config encrypted with the previous install's secrets. For a genuinely clean reinstall, either run `minikube delete` and start fresh, or clear the leftover data on the node:
+>
+> ```bash
+> minikube ssh -- 'sudo rm -rf /tmp/hostpath-provisioner/magda'
+> ```


### PR DESCRIPTION
Follow-ups to the magda.io homepage refresh (#3727), verified against a local minikube deployment of the published `6.1.1` chart.

## Changes

**`docs/README.md`**
- Add **NSW Audit Office — Council Risk IQ Project** to *Who's Used Magda*, and reword the intro ("have deployed or are using") so a current project fits alongside past deployments.
- Drop the pinned `--version` from the Helm quick-start so it installs the latest stable release by default (Helm excludes prereleases), with a comment showing how to pin. Removes the per-release maintenance that caused earlier version drift.

**`docs/docs/running-on-minikube-without-building.md`**
- Add `--timeout 9999s` to the install command. Without it, `helm install` reports `failed post-install: timed out waiting for the condition` on first boot (migrations wait on OpenSearch/Postgres/MinIO past Helm's 5-minute default), even though the deployment is coming up fine.
- Add a *Reinstalling on the same cluster?* note: minikube's hostpath provisioner keeps volume data by namespace/PVC name, so deleting the namespace doesn't erase it — stale data causes MinIO `Invalid credentials` crash-loops on reinstall.

**`docs/docs/e2e-cluster-deployment-test.md`**
- Note that on minikube the existing `kubectl get pv | grep magda` purge check is insufficient (PV objects gone, hostpath data remains), with the explicit cleanup command.

## Verification
A clean install of published `6.1.1` with `--timeout` on cleared volumes reached `STATUS: deployed` in ~2m, 23/23 pods Running, and the gateway port-forward served the Magda UI + search/registry APIs.