### PR TITLE
Document semantic indexers: how-to guide, SDK README, and semantic search API docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v6.1.2
+
+- Add a "How to build a semantic indexer" developer guide (`docs/docs/how-to-build-a-semantic-indexer.md`) and a "Semantic Search & Semantic Indexers" section in the [Guide to Magda Internals](./docs/docs/architecture/Guide%20to%20Magda%20Internals.md), documenting the two indexing tiers, the representation-first design approach (designing the indexed text backward from retrieval), and the semantic query API.
+- Add a `README.md` for the [`@magda/semantic-indexer-sdk`](https://www.npmjs.com/package/@magda/semantic-indexer-sdk) package, which was previously blank on npm, linking to the new how-to guide.
+- #3730: Add apidoc annotations for the semantic search query API (`magda-semantic-search-api`) — `POST`/`GET /v0/semantic-search/search` and `POST /v0/semantic-search/retrieve` now appear in the generated API docs and OpenAPI spec. Doc-comment (`@apiGroup`/`@api`) change only; no route or behaviour change.
+
 ## v6.1.1
 
 - #3723: Fix `@magda/mgd` npm package publishing without its `bin/mgd.js` CLI bundle, which made `npm install -g @magda/mgd` install a broken `mgd` executable.

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ Magda combines complementary retrieval strategies so results match the meaning o
 - **Semantic search** — retrieval over meaning, so related datasets surface even when they don't share exact terms.
 - **PDF and CSV indexers** supplied with a standard Magda 6 deployment, so common document and tabular content becomes searchable out of the box.
 - **A semantic-indexer framework and published SDK** for teams that need format-specific or custom indexing strategies: [`@magda/semantic-indexer-sdk`](https://www.npmjs.com/package/@magda/semantic-indexer-sdk).
+- **Building a custom indexer?** See [How to build a semantic indexer](./docs/how-to-build-a-semantic-indexer.md).
 
 An indexer's job is *representation*: turning useful domain content into text suitable for retrieval, rather than treating every file format identically. Not every possible format becomes content-searchable automatically — the SDK exists precisely so teams can add the representations that matter to them.
 

--- a/docs/docs/architecture/Guide to Magda Internals.md
+++ b/docs/docs/architecture/Guide to Magda Internals.md
@@ -15,6 +15,7 @@
     - [Webhooks](#webhooks)
   - [Search API](#search-api)
   - [Search Indexer](#search-indexer)
+  - [Semantic Search & Semantic Indexers](#semantic-search--semantic-indexers)
   - [Storage API](#storage-api)
   - [Web Server](#web-server)
 - [Authentication (authn)](#authentication-authn)
@@ -219,7 +220,9 @@ It's implemented as a wrapper around the search engine [ElasticSearch](https://w
 
 > Note that unlike the Registry, we didn't implement the similar generic "record" / "aspect" based model in ElasticSearch. Instead, the data model is specifically designed to search datasets and "dataset oriented".
 
-> That's also the reason we introduced a more generic authorisation model in v2.0.0 - allows a single authorisation policy to cover the same data in different storage targets: Registry & ElasticSearch regardless the data model differences.
+> That's also the reason we introduced a more generic authorisation model in v2.0.0 - allows a single authorisation policy to cover the same data in different storage targets: Registry & OpenSearch regardless the data model differences.
+
+See also [Semantic Search & Semantic Indexers](#semantic-search--semantic-indexers) for content-level (vector) search, which complements this metadata search.
 
 ## Search Indexer
 
@@ -236,6 +239,50 @@ On first startup, the Indexer will also try to set up the regions index - at the
 The index definitions used by the Indexer change over time - within the code itself there are index definitions, and these have an integer describing their version. When the indexer starts up, it'll check for the existence of an index with its current version - if it can't find one, it'll create it and start populating it. Because the version used by the Search API is specified elsewhere, this means that you can have the indexer working on setting up `datasets41`, for instance, while the Search API is still querying against version `datasets40`.
 
 > You can config the index versions that search API uses via [search API Helm Chart config](../../../deploy/helm/internal-charts/search-api/README.md).
+
+This indexer covers dataset metadata only; see [Semantic Search & Semantic Indexers](#semantic-search--semantic-indexers) for indexing distribution content and custom aspects.
+
+## Semantic Search & Semantic Indexers
+
+Since v5/v6, Magda has **two indexing tiers** that serve different retrieval needs:
+
+| Tier | Indexes | Target index | Served by |
+|---|---|---|---|
+| `magda-indexer` (the [Search Indexer](#search-indexer) above) | Standard dataset **metadata** from the Registry | Main datasets index | [Search API](#search-api) — lexical, and (since v5) hybrid lexical+vector |
+| **Semantic indexers** | Vector **representations** of a chosen source | Semantic (knn-vector) index | `magda-semantic-search-api` (`/retrieve`, `/search`) |
+
+`magda-indexer` is fixed to the dataset metadata model. The **semantic-indexer
+framework** (`@magda/semantic-indexer-sdk`) is instead a general, minion-based
+toolkit: you write a strategy that turns *some source* into text, and it chunks,
+embeds and writes that into the semantic index. Its `itemType` is either:
+
+- `registryRecord` — index registry metadata, including **custom aspects** that
+  `magda-indexer` does not cover (e.g. a project-specific aspect); or
+- `storageObject` — index distribution **file content**. The shipped examples are
+  [`magda-pdf-semantic-indexer`](https://github.com/magda-io/magda-pdf-semantic-indexer)
+  (PDF → markdown) and [`magda-csv-semantic-indexer`](https://github.com/magda-io/magda-csv-semantic-indexer)
+  (CSV → data dictionary).
+
+A semantic indexer's core design decision is **representation**: what text should
+stand for the source, chosen with the intended retrieval use in mind. See
+[How to build a semantic indexer](../how-to-build-a-semantic-indexer.md).
+
+### Authorization for semantic queries
+
+The semantic index deliberately stores **no dataset/distribution metadata**, so
+access control cannot be evaluated from it alone. Instead it is delegated back to
+the Registry (the authoritative metadata store, with the existing OPA /
+partial-evaluation authz) at query time:
+
+- The Registry API exposes a **"filter records by access"** endpoint that returns,
+  from a list of record IDs, only those the current user can read.
+- **Phase 1:** `magda-semantic-search-api` retrieves semantically, then filters the
+  returned record IDs through that endpoint.
+- **Phase 2 (fallback):** if Phase 1 yields no authorised results, it narrows the
+  semantic retrieval to accessible records and retries.
+
+This was implemented in [PR #3643](https://github.com/magda-io/magda/pull/3643)
+(fixing [#3608](https://github.com/magda-io/magda/issues/3608)).
 
 ## Storage API
 

--- a/docs/docs/how-to-build-a-semantic-indexer.md
+++ b/docs/docs/how-to-build-a-semantic-indexer.md
@@ -1,0 +1,144 @@
+### What & when
+
+A semantic indexer is a minion that turns a chosen source — a distribution's content, a custom aspect, an external API — into vector-indexed text so it can be retrieved by *meaning* rather than by keyword. It listens for records the same way any other minion does, but instead of writing an aspect back to the registry, it produces text, has that text embedded, and writes the resulting vectors to Magda's semantic index. That index is what powers meaning-based retrieval for AI agents and the in-browser chatbot.
+
+It helps to keep two tiers in mind (see [Semantic Search & Semantic Indexers](<./architecture/Guide to Magda Internals.md#semantic-search--semantic-indexers>) for the full picture). `magda-indexer` is fixed to the dataset **metadata** model — titles, descriptions, keywords, publishers — and you do not need to touch it to get semantic search over that metadata. Build a semantic indexer when you need to make something *else* semantically searchable: the actual **content** inside a distribution (a PDF, a CSV), or a **custom aspect** your own connectors or minions have written. If all you want is meaning-based search over standard dataset metadata, rely on `magda-indexer` and stop here.
+
+### Designing your representation
+
+This is the part that matters most, and the part no framework can do for you. The text your indexer emits *is* its product. Everything downstream — the embedding model, the vector index, the ranking — operates on that text and nothing else. If the text does not contain the meaning someone will later search for, no amount of tuning recovers it.
+
+So design the text backward from the query. Picture the AI agent that will eventually search for it: it sends a natural-language query to `/search`, then calls `/retrieve` for the fuller passage once a hit looks promising. What question is it asking, and in what words? The text you emit should read like a good answer to that question. A row of coordinates is not searchable by "flood risk near the river"; a sentence that says "elevation samples along the Yarra River floodplain" is. You are not archiving the source faithfully — you are writing the description of the source that you wish existed when someone goes looking for it.
+
+Crucially, think beyond files. It is tempting to assume a "source" is a document you can read top to bottom, but as argued in ["Data is available — can your AI assistant help you actually use it?"](https://jacky-jiang.medium.com/data-is-available-can-your-ai-assistant-help-you-actually-use-it-464241e996ce), the most valuable data usually is *not* prose, and each format demands its own representation strategy:
+
+- **BIM / 3D models** carry their meaning in structured element schedules, space names, and system classifications — not in geometry.
+- **Images** may have no embedded text at all; their meaning lives in captions, alt text, and the surrounding document that refers to them — or in a description you generate for them (see below).
+- **Audio / video** need a transcript or a scene/segment summary before there is anything to embed — typically produced by a speech-to-text or captioning model.
+- **Tabular data** is defined by its columns, units, coverage, and a sample of representative values — not by dumping every cell.
+- **APIs** are described by what they return and the questions they answer, not by their raw payloads.
+
+**Generate the representation when the source doesn't carry one.** For media with little or no usable text, `createEmbeddingText` can *produce* the description with a model rather than only extracting text that already exists. Run a vision-language model (e.g. Qwen3-Omni) over an image to emit a structured caption — objects, scene, attributes, and any on-screen text — and an OCR engine (e.g. Tesseract) to capture embedded text verbatim; run a speech/audio model (e.g. Whisper or Qwen2-Audio) over audio and video for a transcript or a scene-by-scene summary. You then index the model's output, so keep its prompt search-oriented (ask for specific objects, attributes, counts, and verbatim visible text rather than free-form prose) — that generated text is all the retriever ever sees.
+
+A few concrete prompts to reason it through before you write any code:
+
+- *What would you index for a BIM file?* The element schedule (walls, doors, HVAC), the named spaces and levels, and a plain-language summary of what the building/asset is and what disciplines it covers.
+- *What would you index for a chart image?* The caption, and the nearby text that mentions it — "Figure 3 shows quarterly rainfall for the Murray-Darling Basin, 2010–2020" is far more retrievable than the pixels.
+- *What would you index for a tabular dataset?* The column names and units, the temporal and spatial coverage, and a short natural-language summary of what one row represents.
+
+Write these decisions down before you touch the SDK. Everything after this is plumbing.
+
+### The SDK & the indexer contract
+
+You build a semantic indexer with `@magda/semantic-indexer-sdk`. Its default export, `semanticIndexer(userConfig)`, wires up the minion lifecycle, and `commonYargs(defaultPort, defaultInternalUrl)` builds the standard argument set (registry, embedding API, OpenSearch, storage) shared by all indexers — exactly like `@magda/minion-sdk`'s `commonYargs`.
+
+Configuration is a `SemanticIndexerOptions` object:
+
+```ts
+interface SemanticIndexerOptions {
+    argv: SemanticIndexerArguments;
+    id: string;
+    itemType: ItemType;                  // "registryRecord" | "storageObject"
+    aspects?: string[];                  // required when itemType === "registryRecord"
+    optionalAspects?: string[];
+    formatTypes?: string[];              // required when itemType === "storageObject"
+    createEmbeddingText: CreateEmbeddingText;
+    chunkStrategy?: ChunkStrategyType;
+    chunkSizeLimit?: number;
+    overlap?: number;
+    autoDownloadFile?: boolean;          // storageObject only
+    timeout?: string;
+}
+```
+
+The heart of the contract is `createEmbeddingText` — this is where your representation design from the previous section becomes code:
+
+```ts
+type EmbeddingText = {
+    text: string;
+    subObjects?: Array<{
+        subObjectId?: string;
+        subObjectType?: string;
+        text: string;
+    }>;
+};
+
+type CreateEmbeddingTextParams = {
+    record: Record;
+    format: string | null;
+    filePath: string | null;
+    url: string | null;
+    readonlyRegistry: Registry;
+};
+
+type CreateEmbeddingText = (
+    params: CreateEmbeddingTextParams
+) => Promise<EmbeddingText>;
+```
+
+You are handed the triggering `record`, and — depending on the item type — the resolved `format`, a local `filePath` (if a file was downloaded), the source `url`, and a read-only registry client for pulling in related records. You return the `text` to embed, optionally broken into `subObjects` when a single source naturally contains several independently-retrievable pieces (e.g. the sheets of a workbook, or the sections of a document).
+
+**Chunking.** Embedding models have a bounded input window, so long text is split before embedding. By default the framework applies a recursive strategy governed by `chunkSizeLimit` (the maximum chunk size) and `overlap` (how much adjacent chunks share, so meaning that straddles a boundary is not lost — it must be less than half of `chunkSizeLimit`). Supply your own `chunkStrategy` if you have a smarter, format-aware way to split (for example, one chunk per table or per document section) rather than blind character-count slicing.
+
+**`autoDownloadFile`.** This applies to `storageObject` indexers only. When set, the framework downloads the distribution's file from Magda's internal storage ahead of time and passes you the local `filePath`, so your `createEmbeddingText` can open and parse the file directly instead of fetching it itself. Registry-record indexers never touch files, so this option has no effect there.
+
+### Worked example: a `registryRecord` indexer for a custom aspect
+
+```ts
+import semanticIndexer, {
+    commonYargs,
+    CreateEmbeddingText
+} from "@magda/semantic-indexer-sdk";
+
+const ID = "custom-notes-semantic-indexer";
+
+// Turn a custom "custom-dataset-notes" aspect into the text we want retrievable.
+// What you put here is a representation decision — see "Designing your representation".
+const createEmbeddingText: CreateEmbeddingText = async ({ record }) => {
+    const notes = (record.aspects && record.aspects["custom-dataset-notes"]) || {};
+    const parts = [notes.summary, notes.usageNotes].filter(Boolean);
+    return { text: parts.join("\n\n") };
+};
+
+const argv = commonYargs(6122, "http://localhost:6122");
+
+semanticIndexer({
+    argv,
+    id: ID,
+    itemType: "registryRecord",
+    aspects: ["custom-dataset-notes"],
+    createEmbeddingText
+});
+```
+
+Because `itemType` is `"registryRecord"`, the `aspects` list must be non-empty — these are the aspects that both *trigger* the indexer (a change to any of them re-runs it) and *feed* it (they are the data your `createEmbeddingText` reads). From there the framework does the rest: it chunks the returned `text`, embeds each chunk via the embedding API, and writes the vectors to the semantic index. Whatever string you return in `text` is exactly what gets embedded — no more, no less.
+
+### Deploy & register
+
+A semantic indexer is packaged and deployed like any other minion: build a Docker image, wrap it in a Helm chart, and add it to your deployment's dependencies. Rather than repeat those steps here, follow [How to build your own connectors/minions](./how-to-build-your-own-connectors-minions.md) — the packaging, CI, and chart-publishing flow is identical. Once deployed, the indexer processes records as they change; to build (or rebuild) the index over data that already exists, trigger the minion `recrawl` interface for a global reindex.
+
+### Verify via the query API
+
+With the indexer running, confirm results are searchable by querying `magda-semantic-search-api`:
+
+```bash
+# Port-forward the gateway (see the e2e cluster deployment test doc), then
+# run a natural-language query against /search:
+curl -s -X POST "$BASE/api/v0/semantic-search/search" \
+  -H "Content-Type: application/json" -H "X-Magda-Session: $JWT" \
+  -d '{"query":"budget notes for the smoke test dataset","max_num_results":5}'
+```
+
+`/search` returns scored chunks, each with the matching `text` and the `recordId` it came from — this is the discovery step. An agent typically searches first, then calls `/retrieve` with the IDs it cares about to pull the full text, or the surrounding chunks (via `mode` / `precedingChunksNum` / `subsequentChunksNum`), when it needs more context. Results are access-filtered for the current user (the two-phase filtering — Phase 1 / Phase 2 — is described in the [architecture section](<./architecture/Guide to Magda Internals.md#semantic-search--semantic-indexers>)), so you only get back what that user is allowed to see. The `/api/v0/semantic-search` prefix comes from the gateway route mapping (`deploy/helm/internal-charts/gateway/values.yaml`: route key `semantic-search` → `http://semantic-search-api/v0`).
+
+### Going further: content indexers
+
+For a source that is a **file** rather than an aspect, look at [`magda-pdf-semantic-indexer`](https://github.com/magda-io/magda-pdf-semantic-indexer) and [`magda-csv-semantic-indexer`](https://github.com/magda-io/magda-csv-semantic-indexer) as `storageObject` examples. Both set `autoDownloadFile` so the framework hands them the downloaded file, key their parsing strategy off the distribution's format via `formatTypes`, and turn the file's content — PDF text, CSV columns and rows — into the representation they emit. They are the natural template when you want to index distribution content instead of registry metadata.
+
+### See also
+
+- [Semantic Search & Semantic Indexers](<./architecture/Guide to Magda Internals.md#semantic-search--semantic-indexers>) — the conceptual overview and the two-tier model.
+- [Magda's hybrid search engine](./hybrid-search-engine.md) — how lexical and semantic search combine.
+- ["Data is available — can your AI assistant help you actually use it?"](https://jacky-jiang.medium.com/data-is-available-can-your-ai-assistant-help-you-actually-use-it-464241e996ce) — why representation, not files, is the real problem.
+- ["Magda v5.0.0 release: introducing hybrid search, in-browser LLM chatbot & SQL Console"](https://jacky-jiang.medium.com/magda-v5-0-0-release-introducing-hybrid-search-in-browser-llm-chatbot-sqlconsole-84c043dd461b) — the release that introduced hybrid search over metadata.
+- Example repositories: [`magda-pdf-semantic-indexer`](https://github.com/magda-io/magda-pdf-semantic-indexer) and [`magda-csv-semantic-indexer`](https://github.com/magda-io/magda-csv-semantic-indexer).

--- a/magda-semantic-search-api/src/api/createApiRouter.ts
+++ b/magda-semantic-search-api/src/api/createApiRouter.ts
@@ -119,17 +119,128 @@ export function createRoutes(
         }
     }
 
+    /**
+     * @apiDefine SemanticSearchHeaders
+     * @apiHeader {String} [X-Magda-Session] Magda internal session JWT identifying the current user. Without it, the request is treated as anonymous.
+     * @apiHeader {Number} [X-Magda-Tenant-Id=0] Tenant ID. Defaults to `0` when omitted.
+     */
+
+    /**
+     * @apiDefine SemanticSearchError
+     * @apiError (Error 400) {Object} error Request validation failed (a required parameter is missing or invalid).
+     * @apiError (Error 500) {String} error A short error label, e.g. `Internal Server Error` or `OpenSearch index not found`.
+     * @apiError (Error 500) {String} [message] A longer description — for a missing index, a hint to install a semantic indexer so the index is created.
+     * @apiErrorExample {json} 500 (no index yet)
+     *    {
+     *      "error": "OpenSearch index not found",
+     *      "message": "OpenSearch index not found: ... - Install at least one semantic indexer to create it automatically."
+     *    }
+     */
+
+    /**
+     * @apiGroup Semantic Search
+     * @api {post} /v0/semantic-search/retrieve Retrieve chunks by ID
+     * @apiName RetrieveSemanticChunks
+     * @apiDescription Retrieves semantic-index chunks by their `id`s (typically
+     *    those returned by `search`), optionally including neighbouring chunks for
+     *    more context. Results are access-filtered for the current user.
+     * @apiUse SemanticSearchHeaders
+     *
+     * @apiParam (body) {String[]} ids IDs of the index chunks to retrieve.
+     * @apiParam (body) {String="full","partial"} [mode=full] `full` returns the whole item's text; `partial` returns the matched chunk plus any requested neighbours.
+     * @apiParam (body) {Number{0-}} [precedingChunksNum=0] Number of chunks immediately before each result to include.
+     * @apiParam (body) {Number{0-}} [subsequentChunksNum=0] Number of chunks immediately after each result to include.
+     *
+     * @apiSuccess {Object[]} result JSON array of retrieved items (fields below are on each element).
+     * @apiSuccess {String} result.id Chunk ID.
+     * @apiSuccess {String} result.itemType `storageObject` or `registryRecord`.
+     * @apiSuccess {String} result.recordId The registry record the chunk was derived from.
+     * @apiSuccess {String} result.parentRecordId The parent record (e.g. the dataset of a distribution).
+     * @apiSuccess {String} result.fileFormat Source file format, when applicable.
+     * @apiSuccess {String} result.subObjectId Identifier of a sub-object within the source, when applicable.
+     * @apiSuccess {String} result.subObjectType Type of the sub-object, when applicable.
+     * @apiSuccess {String} result.text The indexed text.
+     * @apiUse SemanticSearchError
+     */
     router.post(
         "/retrieve",
         validate({ body: retrieveSchema }, { context: true }, {}),
         handleRetrieve
     );
 
+    /**
+     * @apiGroup Semantic Search
+     * @api {get} /v0/semantic-search/search Semantic search (GET)
+     * @apiName GetSemanticSearch
+     * @apiDescription Identical to `POST /v0/semantic-search/search`, but takes its
+     *    parameters from the query string. Convenient for quick manual testing.
+     * @apiUse SemanticSearchHeaders
+     *
+     * @apiParam (query) {String} query The natural-language query.
+     * @apiParam (query) {Number{1-500}} [max_num_results=100] Maximum number of results to return.
+     * @apiParam (query) {String="storageObject","registryRecord"} [itemType] Restrict results to one item type.
+     * @apiParam (query) {String} [fileFormat] Restrict results to a source file format (e.g. `PDF`).
+     * @apiParam (query) {String} [recordId] Restrict results to chunks derived from this registry record.
+     * @apiParam (query) {String} [subObjectId] Restrict results to a sub-object within the source.
+     * @apiParam (query) {String} [subObjectType] Restrict results to a sub-object type.
+     * @apiParam (query) {Number{0-1}} [minScore] Drop results whose relevance score is below this threshold.
+     *
+     * @apiSuccess {Object[]} result JSON array of matching chunks (same shape as the POST endpoint).
+     * @apiUse SemanticSearchError
+     */
     router.get(
         "/search",
         validate({ query: searchSchema }, { context: true }, {}),
         handleSearch
     );
+    /**
+     * @apiGroup Semantic Search
+     * @api {post} /v0/semantic-search/search Semantic search (POST)
+     * @apiName PostSemanticSearch
+     * @apiDescription Runs a natural-language semantic (vector) search over the
+     *    semantic index and returns the most relevant chunks, each with a
+     *    relevance score. This is the discovery step: to expand a hit into its
+     *    full text or neighbouring chunks, pass the returned chunk `id`s to
+     *    `POST /v0/semantic-search/retrieve`. Results are access-filtered for the
+     *    current user. The searchable content is produced by semantic indexers —
+     *    see [How to build a semantic indexer](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-build-a-semantic-indexer.md).
+     * @apiUse SemanticSearchHeaders
+     *
+     * @apiParam (body) {String} query The natural-language query.
+     * @apiParam (body) {Number{1-500}} [max_num_results=100] Maximum number of results to return.
+     * @apiParam (body) {String="storageObject","registryRecord"} [itemType] Restrict results to one item type.
+     * @apiParam (body) {String} [fileFormat] Restrict results to a source file format (e.g. `PDF`).
+     * @apiParam (body) {String} [recordId] Restrict results to chunks derived from this registry record.
+     * @apiParam (body) {String} [subObjectId] Restrict results to a sub-object within the source.
+     * @apiParam (body) {String} [subObjectType] Restrict results to a sub-object type.
+     * @apiParam (body) {Number{0-1}} [minScore] Drop results whose relevance score is below this threshold.
+     *
+     * @apiSuccess {Object[]} result JSON array of matching chunks (fields below are on each element).
+     * @apiSuccess {Number} result.score Relevance score (higher is more relevant).
+     * @apiSuccess {String} result.id Chunk ID (pass to `/retrieve`).
+     * @apiSuccess {String} result.itemType `storageObject` or `registryRecord`.
+     * @apiSuccess {String} result.recordId The registry record the chunk was derived from.
+     * @apiSuccess {String} result.parentRecordId The parent record (e.g. the dataset of a distribution).
+     * @apiSuccess {String} result.fileFormat Source file format, when applicable.
+     * @apiSuccess {String} result.subObjectId Identifier of a sub-object within the source, when applicable.
+     * @apiSuccess {String} result.subObjectType Type of the sub-object, when applicable.
+     * @apiSuccess {String} result.text The matched indexed text.
+     * @apiSuccessExample {json} 200
+     *    [
+     *      {
+     *        "score": 0.83,
+     *        "id": "storageObject-ds-abc-dist-1-0",
+     *        "itemType": "storageObject",
+     *        "recordId": "dist-1",
+     *        "parentRecordId": "ds-abc",
+     *        "fileFormat": "PDF",
+     *        "subObjectId": "",
+     *        "subObjectType": "",
+     *        "text": "..."
+     *      }
+     *    ]
+     * @apiUse SemanticSearchError
+     */
     router.post(
         "/search",
         validate({ body: searchSchema }, { context: true }, {}),

--- a/packages/semantic-indexer-sdk/README.md
+++ b/packages/semantic-indexer-sdk/README.md
@@ -1,0 +1,50 @@
+### MAGDA Semantic Indexer SDK
+
+A semantic indexer is a [Magda](https://github.com/magda-io/magda) minion that turns a chosen source — a distribution's file content, a registry record's aspects, or an external API — into vector-indexed text, so it can be retrieved by *meaning* rather than by keyword. The resulting vectors are written to Magda's semantic index and served by the semantic search query API (`magda-semantic-search-api`), which powers meaning-based retrieval for AI agents and the in-browser chatbot.
+
+This SDK provides the framework — the minion lifecycle, chunking, embedding, and OpenSearch indexing — so you can focus on the one decision that matters: **what text should represent your source**.
+
+> 📖 **Full guide:** [How to build a semantic indexer](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-build-a-semantic-indexer.md) — the concepts, the representation mindset (designing the text backward from how it will be searched), and a complete walkthrough.
+
+### Get Started
+
+```ts
+import semanticIndexer, {
+    commonYargs,
+    CreateEmbeddingText
+} from "@magda/semantic-indexer-sdk";
+
+const ID = "custom-notes-semantic-indexer";
+
+// What text should represent this source? That is the core design decision —
+// see the "Designing your representation" section of the guide.
+const createEmbeddingText: CreateEmbeddingText = async ({ record }) => {
+    const notes =
+        (record.aspects && record.aspects["custom-dataset-notes"]) || {};
+    const parts = [notes.summary, notes.usageNotes].filter(Boolean);
+    return { text: parts.join("\n\n") };
+};
+
+const argv = commonYargs(6122, "http://localhost:6122");
+
+semanticIndexer({
+    argv,
+    id: ID,
+    // "registryRecord" indexes registry metadata / custom aspects;
+    // use "storageObject" (with `formatTypes`) to index distribution file content.
+    itemType: "registryRecord",
+    aspects: ["custom-dataset-notes"],
+    createEmbeddingText
+}).catch((e: Error) => {
+    console.error("Error: " + e.message, e);
+    process.exit(1);
+});
+```
+
+The `itemType` selects what you index (`registryRecord` for metadata/custom aspects, `storageObject` for distribution file content), and `createEmbeddingText` returns the text to embed. The framework then chunks, embeds, and indexes it. See the guide for the full option reference and chunking controls.
+
+### Learn more
+
+- [How to build a semantic indexer](https://github.com/magda-io/magda/blob/main/docs/docs/how-to-build-a-semantic-indexer.md) — the full how-to guide.
+- [Semantic Search & Semantic Indexers](https://github.com/magda-io/magda/blob/main/docs/docs/architecture/Guide%20to%20Magda%20Internals.md#semantic-search--semantic-indexers) — where semantic indexers fit in Magda's architecture.
+- Example indexers: [`magda-pdf-semantic-indexer`](https://github.com/magda-io/magda-pdf-semantic-indexer) and [`magda-csv-semantic-indexer`](https://github.com/magda-io/magda-csv-semantic-indexer).


### PR DESCRIPTION
## What & why

Magda ships the semantic indexer framework (`@magda/semantic-indexer-sdk`), the semantic query API (`magda-semantic-search-api`) and the PDF/CSV example indexers, but there was **no documentation** explaining what a semantic indexer is, how it differs from `magda-indexer`, or how to build one — and the SDK's npm page was blank. This PR fills that gap.

## Changes

- **New how-to guide** — `docs/docs/how-to-build-a-semantic-indexer.md`. Covers the two indexing tiers, a **representation-first design** section (design the indexed text backward from how an agent will query `/search` then `/retrieve`, including non-file formats — BIM, images, audio/video, tabular, APIs — and generating the representation with a model where the source carries no usable text), the SDK contract, a runnable `registryRecord` custom-aspect example, deploy-by-reference, a verify-via-query-API step, and pointers to the PDF/CSV examples.
- **Architecture guide** — new "Semantic Search & Semantic Indexers" section in `Guide to Magda Internals.md` (two tiers, source-agnostic framework, the retrieve-then-filter access control from #3643), plus cross-links from the existing Search API / Search Indexer sections and an ElasticSearch→OpenSearch wording fix.
- **SDK README** — `packages/semantic-indexer-sdk/README.md` (the package previously rendered blank on npm), with a Get-Started snippet and links to the guide.
- **Semantic search API docs (Fixes #3730)** — apidoc annotations for `magda-semantic-search-api`'s `POST`/`GET /v0/semantic-search/search` and `POST /v0/semantic-search/retrieve`, so they appear in the generated in-browser API docs and OpenAPI spec. **Comment-only change** — no route or behaviour change.
- **README + CHANGES** — link the how-to from `docs/README.md`; changelog entries under `v6.1.2`.

## Verification

- Ran `apidoc` over `magda-semantic-search-api/src`: all three endpoints render with the correct group, params, `@apiUse` headers/errors, success fields/example, and the how-to link. (The full `openapi.json` conversion uses Magda's apidoc fork and wasn't run locally; the `(body)`/`(query)` param groups follow the documented convention that drives it.)
- The `createApiRouter.ts` diff is additions-only (comment blocks); route registrations, schemas and handlers are unchanged.

Related: #3731 (add example media semantic indexers).

> Note: changelog entries are placed under a new `v6.1.2` heading — adjust if the next release is intended to be a different version.