### PR TITLE
fix(db): non-default privileged DB user support + DB SSL (WIP)

### DIFF
--- a/deploy/helm/internal-charts/magda-postgres/templates/initdb-scripts-configmap.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/initdb-scripts-configmap.yaml
@@ -1,0 +1,15 @@
+{{- $username := .Values.global.postgresql.postgresqlUsername | default "postgres" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Values.postgresql.fullnameOverride }}-initdb-scripts"
+data:
+  # Runs once, at first boot, as the built-in `postgres` superuser (via the bitnami
+  # PostgreSQL initdb mechanism). Grants the privileged DB user the DDL privileges the
+  # Magda DB migrators need — `CREATEDB` (create per-service databases) and `CREATEROLE`
+  # (create the restricted `client` role). This matches the privilege level managed
+  # providers grant their admin account (RDS `rds_superuser`, Azure `azure_pg_admin`,
+  # GCP `cloudsqlsuperuser`) so a non-default privileged username works without a true
+  # superuser. For the default `postgres` user this grant is a harmless no-op.
+  10-grant-privileged-user.sql: |
+    ALTER ROLE "{{ $username }}" WITH CREATEDB CREATEROLE;

--- a/deploy/helm/internal-charts/magda-postgres/values.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/values.yaml
@@ -39,6 +39,16 @@ postgresql:
   # See more: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
   extraEnvVarsCM: "{{ .Values.fullnameOverride }}-extra-env-vars"
 
+  # -- the name of config map contains initdb scripts run at first boot.
+  # You should not change this value as this configMap is auto-generated (see `initdb-scripts-configmap.yaml`).
+  # The script grants `CREATEDB` & `CREATEROLE` to the privileged DB user so that, when a
+  # non-default (non-`postgres`) username is used, it can still create databases and the
+  # restricted `client` role for the DB migrators — matching the privilege level that
+  # managed providers (RDS `rds_superuser`, Azure `azure_pg_admin`, GCP `cloudsqlsuperuser`)
+  # grant their admin account, without requiring a true superuser. For the default `postgres`
+  # user the grant is a harmless no-op.
+  initdbScriptsConfigMap: "{{ .Values.fullnameOverride }}-initdb-scripts"
+
   primary:
     # -- extra volumes can be set here. 
     # e.g. map backup storage config secret as files in /etc/wal-g.d/env

--- a/deploy/helm/magda-core/templates/db-main-account-secret.yaml
+++ b/deploy/helm/magda-core/templates/db-main-account-secret.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.global.postgresql.autoCreateSecret }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.global.postgresql.existingSecret) | default dict }}
 {{- $legacySecret := (lookup "v1" "Secret" .Release.Namespace "cloudsql-db-credentials") | default dict }}
+{{- $secretData := (get $secret "data") | default dict }}
+{{- $username := .Values.global.postgresql.postgresqlUsername | default "postgres" }}
+{{- $usesExternalDb := or .Values.global.useCloudSql .Values.global.useAwsRdsDb }}
 {{- /* only attempt to create secret when secret not exists or the existing secret is part of current helm release */}}
 {{- if or (empty $secret) (include "magda.isPartOfRelease" (dict "objectData" $secret "root" .) | empty | not) }}
 apiVersion: v1
@@ -12,11 +15,22 @@ metadata:
 type: Opaque
 data:
 {{- if $secret }}
-  postgresql-password: {{ get (get $secret "data" | default dict) "postgresql-password" }}
-{{- else if and $legacySecret (or .Values.global.useCloudSql .Values.global.useAwsRdsDb) }}
+  postgresql-password: {{ get $secretData "postgresql-password" }}
+{{- else if and $legacySecret $usesExternalDb }}
   postgresql-password: {{ get (get $legacySecret "data" | default dict) "password" }}
 {{- else }}
   postgresql-password: {{ randAlphaNum 16 | b64enc | quote }}
+{{- end }}
+{{- /*
+  When a non-default privileged username is used with the in-cluster PostgreSQL, the
+  bitnami PostgreSQL container also requires a password for its built-in `postgres`
+  superuser via the `postgresql-postgres-password` key (`postgresql-password` is used
+  for the custom user). Generate it (preserving any existing value across upgrades) so
+  the in-cluster database starts without a manually supplied secret. External databases
+  (RDS / Cloud SQL) don't use this key.
+*/}}
+{{- if and (ne $username "postgres") (not $usesExternalDb) }}
+  postgresql-postgres-password: {{ (get $secretData "postgresql-postgres-password") | default (randAlphaNum 16 | b64enc) }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Makes external-DB and in-cluster deployments with a **non-default privileged DB username** work without manual steps, and (to follow) adds SSL/TLS support for service-to-database connections. Surfaced during #3636 / #3637 external-RDS end-to-end testing.

> **Draft / work in progress.** #3735 and #3736 are done; #3734 (SSL) will be added to this same PR in a follow-up session, and the whole set will be tested together (in-cluster TLS + non-default user).

## Done

### #3735 — auto-create `postgresql-postgres-password` for a non-default in-cluster user
`db-main-account-secret` now generates/preserves a `postgresql-postgres-password` key (for bitnami's built-in `postgres` superuser) when `postgresqlUsername` is non-default and an in-cluster DB is used, so the postgres pod starts without a manually supplied secret. Closes #3735.

### #3736 — grant `CREATEDB`/`CREATEROLE` to the in-cluster user (no superuser required)
magda-postgres now ships an initdb ConfigMap that runs `ALTER ROLE <user> WITH CREATEDB CREATEROLE;` at first boot — matching the privilege level managed providers grant their admin account (RDS `rds_superuser` / Azure `azure_pg_admin` / GCP `cloudsqlsuperuser`) without a true superuser. No-op for the default `postgres` user. Magda's migrations only require CREATEDB + CREATEROLE + the trusted `uuid-ossp`/`pg_trgm` extensions (trusted since PostgreSQL 13). Closes #3736.

## To follow (in this PR)

### #3734 — SSL/TLS for service-to-database connections
Node services build their pg pool with an explicit config that omits `ssl` (e.g. `magda-authorization-api/src/createPool.ts`), so this needs a shared pool SSL helper adopted across services, `sslmode` on registry-api's JDBC URL, the chart `sslmode` value, and in-cluster TLS for testing. Tracked in #3734.

## Testing
Not yet run — #3735/#3736 validated by inspection; full end-to-end validation (minikube, in-cluster TLS, non-default user) will be done together with #3734.
