### PR TITLE
fix(magda-postgres): fail backup CronJob on backup-push error (v6)

### DIFF
--- a/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
@@ -33,8 +33,13 @@ spec:
                 # more details see the docker image repo
                 /usr/local/bin/adduser.sh
                 /usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g backup-push
+                # Capture the backup-push status immediately: any statement in
+                # between (e.g. a variable assignment) resets $? and would make a
+                # failed backup look successful -- which previously also let the
+                # retention step below prune the existing chain after a failure.
+                BACKUP_PUSH_RC=$?
                 RETAIN_BACKUP_NUM="{{ .Values.backupRestore.backup.numberOfBackupToRetain | default 7 }}"
-                if [[ $? = "0" ]] 
+                if [[ $BACKUP_PUSH_RC = "0" ]] 
                 then 
                   echo "New Base Backup Creation Completed!"
                   echo "Start to trim old backups and retain the recent $RETAIN_BACKUP_NUM backups..."
@@ -45,6 +50,10 @@ spec:
                   echo $OUTPUT
                   if [[ $ERROR_CODE = "1" ]]
                   then 
+                    # NOTE: this distinguishes "fewer backups than the retention
+                    # count" from a real error by matching wal-g's English output
+                    # text, which is fragile across wal-g versions. Revisit when
+                    # wal-g is upgraded (see epic #3740, sub-project 3).
                     if [[ ${OUTPUT: -9} = "not found" ]]
                     then
                       echo "There are less than $RETAIN_BACKUP_NUM backups available. Nothing needs to be deleted!"


### PR DESCRIPTION
Child of #3740 (epic: modernise in-cluster PostgreSQL). Closes #3746.

## Problem

The wal-g backup CronJob's inline script captured `$?` **after** a variable assignment, so a failed `wal-g backup-push` was reported as Job **success** — and `wal-g delete --confirm retain FULL` still ran, pruning the existing backup chain:

```bash
/usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g backup-push
RETAIN_BACKUP_NUM="{{ .Values.backupRestore.backup.numberOfBackupToRetain | default 7 }}"  # assignment returns 0
if [[ $? = "0" ]]   # <-- checks the assignment, not backup-push
```

The `else` branch (`"Failed to create new base backup!"; exit 1`) was therefore dead code. Any v6 operator with `backupRestore.backup.enabled: true` may have a **silently broken backup chain**. This is a data-safety fix, hence a v6 (`main`) patch.

## Fix

- Capture the `backup-push` exit code into `BACKUP_PUSH_RC` on the line immediately after the push, before any other statement, and gate the success branch (including retention) on it. A failed push now fails the Job (respecting `backoffLimit`) and does **not** prune.
- Add a comment flagging that the retention step's `"not found"` check depends on wal-g's English error text, which is fragile across versions (to be revisited when wal-g is upgraded — epic #3740, sub-project 3).

## Scope

Template-only, minimal v6 patch. No values-contract, secret-key, or rendered-field changes.

## Testing

A behavioural regression test (renders the CronJob, extracts the command, runs it under shimmed `wal-g`/`envdir`/`adduser.sh`, asserting a failed push fails the Job and skips pruning) is landing on `next`, where the chart assertion-test harness (`deploy/helm/magda-core/tests/`) lives — that harness does not exist on `main`. The identical template fix on `next` keeps that test green; this branch reaches parity via the regular `main`→`next` merge.