### PR TITLE
wal-g backup/restore integration harness + docs (PG13 baseline) (#3747)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add a `README.md` for the [`@magda/semantic-indexer-sdk`](https://www.npmjs.com/package/@magda/semantic-indexer-sdk) package, which was previously blank on npm, linking to the new how-to guide.
 - #3730: Add apidoc annotations for the semantic search query API (`magda-semantic-search-api`) — `POST`/`GET /v0/semantic-search/search` and `POST /v0/semantic-search/retrieve` now appear in the generated API docs and OpenAPI spec. Doc-comment (`@apiGroup`/`@api`) change only; no route or behaviour change.
 - #3746: Fix silently-succeeding wal-g backup CronJob
+- #3747: Add a wal-g backup/restore integration test harness (`magda-int-test-ts`) that exercises the real `magda-wal-g` image against PostgreSQL 13.7 + MinIO — base-backup round-trip with data-fidelity assertions, WAL push/fetch byte-identity, and point-in-time recovery (roll-forward vs `recovery_target=immediate`) — as a regression oracle for the in-cluster PostgreSQL modernisation baseline. Adds in-cluster DB backup/restore mechanics & RPO documentation (`docs/docs/in-cluster-database-backup-and-restore.md`).
 
 ## v6.1.1
 

--- a/docs/docs/architecture/Guide to Magda Internals.md
+++ b/docs/docs/architecture/Guide to Magda Internals.md
@@ -737,6 +737,12 @@ While Kubernetes and Helm can handle a lot of what makes Magda work, there are s
 
 This gap is optionally handled by Terraform - it can be used to provision the actual, vendor-specific cloud infrastructure that's needed in order to run Kubernetes so that we can start using tools like Helm. Potentially everything that Terraform currently does for us can also be done via tools like the GCloud command line or web control panel, but using a tool like Terraform allows us to easily write down and reproduce these configurations.
 
+## Database Backup & Restore
+
+When using the in-cluster PostgreSQL option, Magda backs up the database with two cooperating mechanisms: periodic full **base backups** (a CronJob running `wal-g backup-push`) and **continuous WAL archiving** (PostgreSQL's `archive_command` pushing each WAL segment via `wal-g`). Restore is an opt-in recovery mode that fetches a base backup and (optionally) replays archived WAL.
+
+For how this machinery works end-to-end — the scripts involved, the recovery flow, and the **data-loss window (RPO)** to expect in each failure scenario — see [In-cluster Database Backup & Restore — How It Works](../in-cluster-database-backup-and-restore.md). For how to configure it (storage secrets, helm values), see [How to Config Continuous Archiving and PITR](../how-to-recover-with-continuous-archive-backup.md).
+
 # Architectural Decisions
 
 ## Macro

--- a/docs/docs/how-to-recover-with-continuous-archive-backup.md
+++ b/docs/docs/how-to-recover-with-continuous-archive-backup.md
@@ -163,6 +163,12 @@ combined-db:
 
 By default, it will recover with the "LATEST" base backup. However, you can specify a different backup name with helm config option: `combined-db.magda-postgres.backupRestore.backup.recoveryMode.baseBackupName` or manually set environment variable `MAGDA_RECOVERY_BASE_BACKUP_NAME` on the relevant postgreSQL instance statefulset.
 
+> **Important — what "recovery" restores to.** The automated recovery restores the database to the state at the **end of the chosen base backup**, and then promotes. It does **not** roll forward through the WAL archived *since* that base backup, even though that WAL is present in the store. This is because the recovery config baked into the image (`magda-postgres/wal-g/recovery.conf`) sets `recovery_target = 'immediate'`, which ends replay as soon as a consistent state (the base-backup end) is reached. In other words, the "point-in-time" granularity you get today is **per base backup** (pick which one via `baseBackupName`), not an arbitrary transaction or timestamp.
+>
+> The practical consequence is the **recovery-point objective (RPO)**: automated recovery can lose up to one base-backup interval of data (e.g. up to ~1 week with the default weekly `backup.schedule`). Continuous WAL archiving still runs, but the shipped automated recovery does not replay it forward. To understand the failure scenarios and how to shrink the window, see [In-cluster Database Backup & Restore — How It Works (mechanics & RPO)](./in-cluster-database-backup-and-restore.md).
+>
+> There is currently **no helm/config option to enable roll-forward** (recover to the base backup *plus* the latest archived WAL) — it would require a change to the image's `recovery.conf` (making `recovery_target` configurable, or dropping `recovery_target = 'immediate'` so replay runs to the end of the archived WAL). Until then, rolling forward to (or near) the point of failure is a **manual** operation.
+
 More info can also be found from [wal-g backup fetch document](https://github.com/wal-g/wal-g/blob/master/docs/PostgreSQL.md#backup-fetch).
 
 ## 5> Backward Compatibility

--- a/docs/docs/in-cluster-database-backup-and-restore.md
+++ b/docs/docs/in-cluster-database-backup-and-restore.md
@@ -1,0 +1,123 @@
+# In-cluster Database Backup & Restore — How It Works
+
+This document explains **how** Magda's in-cluster PostgreSQL backup and restore machinery works internally: the two cooperating mechanisms, the scripts involved, the recovery flow, and — importantly — the **data-loss window (RPO)** you can expect in different failure scenarios.
+
+If you are looking for **how to configure** backup/restore (storage secrets, helm values, turning it on/off), see the companion how-to: [How to Config Continuous Archiving and Point-in-Time Recovery (PITR)](./how-to-recover-with-continuous-archive-backup.md). This document is the "how it works under the hood" counterpart.
+
+> Applies to the in-cluster PostgreSQL option (the [`magda-postgres`](../../deploy/helm/internal-charts/magda-postgres) chart, included by [`combined-db`](../../deploy/helm/internal-charts/combined-db)). If you use a managed cloud database service instead, backup/restore is handled by your provider and this document does not apply.
+>
+> Backup/restore is powered by [wal-g](https://github.com/wal-g/wal-g). The behaviour described here is for the currently shipped **wal-g 1.1.0**; the mechanics (command names, env, storage layout) may shift with future wal-g upgrades.
+
+## Overview: two mechanisms, one scheme
+
+When backup is enabled (`backupRestore.backup.enabled = true`), **two** mechanisms run and write to the **same** object store (S3/GCS/Azure/etc., configured via `backupRestore.storageConfig` / `storageSecretName`, exposed to wal-g as env files under `/etc/wal-g.d/env`):
+
+| Mechanism | What it produces | Cadence | Driven by |
+| --- | --- | --- | --- |
+| **Base backups** | Full snapshots of the cluster (`basebackups_005/…` in the store) | Periodic (default weekly) | A Kubernetes **CronJob** running `wal-g backup-push` |
+| **Continuous WAL archiving** | Every completed 16 MB write-ahead-log segment (`wal_005/…`) | Continuous — at least every `archive_timeout` (default 10 min) | PostgreSQL's `archive_command` calling `wal-g wal-push` |
+
+They are **not** two alternatives you pick between — they are complementary layers of a single continuous-archiving scheme, and both switch on together with `backup.enabled`:
+
+- A **base backup** is the anchor: a self-consistent full copy you can restore from.
+- The **WAL archive** is the fine-grained stream *between* base backups. Each base backup needs a little WAL to become internally consistent, and the archive is also what makes **roll-forward** point-in-time recovery possible (recover to a moment *after* the last base backup rather than only to the backup itself).
+
+Think of it as: *base backup = periodic full snapshot; WAL archive = the continuous change-log that lets you replay forward from a snapshot.*
+
+## Mechanism 1 — Base backups (the CronJob)
+
+Template: [`deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml`](../../deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml)
+
+A Kubernetes `CronJob` (`concurrencyPolicy: Forbid`, `backoffLimit: 3`, `restartPolicy: OnFailure`) runs the `magda-wal-g` image on `backup.schedule` (default `0 15 * * 6` — 15:00 UTC every Saturday). Each run:
+
+1. **`adduser.sh`** — adds a uid-1001 entry to `/etc/passwd`. The PostgreSQL client library refuses to run under a uid that is not present in `/etc/passwd`; without this, every wal-g command fails.
+2. **`wal-g backup-push`** — a **remote** base backup over PostgreSQL's replication protocol (`PGHOST` points at the DB service; no local data directory needed). This streams a full base backup to `basebackups_005/` in the store.
+3. **Capture the exit code immediately** (`BACKUP_PUSH_RC=$?`). This is deliberate: any statement between `backup-push` and reading `$?` would reset it and make a **failed** backup look successful — which previously also let the retention step below prune the existing backup chain after a failure. (See issue [#3746](https://github.com/magda-io/magda/issues/3746).)
+4. **Retention (success only)** — `wal-g delete --confirm retain FULL <numberOfBackupToRetain>` (default keep **7**) trims older base backups. It distinguishes "fewer backups than the retention count" from a real error by string-matching wal-g's `"not found"` output (fragile across wal-g versions; revisit on upgrade). On backup failure it **exits 1** and does **not** prune.
+
+Relevant values (chart [`magda-postgres`](../../deploy/helm/internal-charts/magda-postgres)):
+
+- `backupRestore.backup.schedule` — base-backup cron (default weekly).
+- `backupRestore.backup.numberOfBackupToRetain` — base backups to keep (default 7).
+- `backupRestore.backup.walgTarSizeThreshold` — backup bundle size (default 20 GB).
+
+## Mechanism 2 — Continuous WAL archiving
+
+Config: [`deploy/helm/internal-charts/magda-postgres/templates/extended-config-configmap.yaml`](../../deploy/helm/internal-charts/magda-postgres/templates/extended-config-configmap.yaml)
+
+When `backup.enabled = true`, the DB is configured with:
+
+```
+archive_mode = on
+wal_level = replica
+archive_command = /usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g wal-push "$PGDATA/%p"
+archive_timeout = 600   # seconds; values.yaml default = 10 minutes
+```
+
+Whenever PostgreSQL fills (or, via `archive_timeout`, force-closes) a 16 MB WAL segment, `archive_command` runs `wal-g wal-push` to upload it to `wal_005/` in the store. `archive_timeout = 600` guarantees at least one segment is closed and archived every ~10 minutes even on an idle database — this is the knob that bounds how much recent change can be *un-archived* at any instant.
+
+Also, at DB startup [`start.sh`](../../magda-postgres/start.sh) ensures a `host replication all 0.0.0.0/0 md5` entry exists in `pg_hba.conf` so the CronJob's remote `backup-push` can connect. (PostgreSQL's `all` database keyword does **not** match physical-replication connections, so an explicit `replication` entry is required.)
+
+## Restore / recovery flow
+
+Recovery is **opt-in** and only happens when an operator sets `backupRestore.recoveryMode.enabled = true` (→ env `MAGDA_RECOVERY_MODE=true`). On the next DB pod start, [`start.sh`](../../magda-postgres/start.sh) sees the flag (and that `/wal-g/recovery.complete` is absent) and runs the restore scripts baked into the image under `magda-postgres/wal-g/`:
+
+1. **[`recover.sh`](../../magda-postgres/wal-g/recover.sh)**:
+   - copies [`recovery.conf`](../../magda-postgres/wal-g/recovery.conf) into `conf.d`;
+   - swaps in a **local-only** [`pg_hba.conf`](../../magda-postgres/wal-g/pg_hba.conf) (blocks application traffic while recovering);
+   - **saves** the current `$PGDATA/pg_wal` aside (preserving any WAL not yet archived);
+   - wipes `$PGDATA`;
+   - `wal-g backup-fetch $PGDATA LATEST` (or a pinned `MAGDA_RECOVERY_BASE_BACKUP_NAME`);
+   - restores the saved `pg_wal` back over the fetched (empty) one;
+   - `touch recovery.signal` → PostgreSQL enters archive recovery.
+2. **[`recovery.conf`](../../magda-postgres/wal-g/recovery.conf)** governs replay:
+   ```
+   restore_command  = wal-g wal-fetch "%f" "$PGDATA/%p"   # pulls archived WAL as needed
+   recovery_target  = 'immediate'
+   recovery_target_action = 'promote'
+   recovery_end_command   = /wal-g/post-recovery.sh
+   ```
+3. **[`post-recovery.sh`](../../magda-postgres/wal-g/post-recovery.sh)** runs after promotion: marks `/wal-g/recovery.complete` (so a later pod restart won't re-enter recovery), removes `recovery.conf`, restores the normal `pg_hba.conf`, and reloads to re-open remote connections. Backup, if it was on, resumes automatically.
+
+You choose *which* base backup with `recoveryMode.baseBackupName` (default `LATEST`).
+
+## Data at risk (RPO) — the important part
+
+The recovery-point objective (maximum data loss) depends on the failure mode **and** on one config detail in `recovery.conf`:
+
+| Scenario | Data-loss window |
+| --- | --- |
+| **Pod restart / reschedule, data volume (PVC) intact** | **≈ 0.** Recovery mode is off by default; PostgreSQL just does normal crash recovery from its own `pg_wal`. Nothing is discarded. |
+| **Disaster, restore via the shipped auto-recovery** | **Up to one base-backup interval — default ≈ 7 days.** |
+| **Disaster, manual full point-in-time recovery (roll-forward)** | **≈ `archive_timeout` (~10 min)** of the most recent, not-yet-archived WAL. |
+
+The critical detail is **`recovery_target = 'immediate'`**: it tells PostgreSQL to end replay the instant it reaches a consistent state — the **end of the base backup** — and promote. It does **not** roll forward through the WAL archived *since* that backup, even though that WAL is in the store every ~10 minutes. So the shipped automated restore lands you at the **latest base backup** (weekly by default). This matches the existing how-to's wording that recovery restores "with the LATEST base backup".
+
+To actually exploit the ~10-minute WAL cadence you perform a **manual, full point-in-time recovery**: drop `recovery_target = immediate` (or set an explicit `recovery_target_time`) so replay rolls forward through the archived WAL to (or near) the moment of failure — bringing the RPO down to roughly `archive_timeout`, or to 0 if the local `pg_wal` survived and is replayed.
+
+Two levers to shrink the default window:
+
+- **Shorten `backupRestore.backup.schedule`** → more frequent base backups → smaller auto-recovery RPO.
+- **Lower `backupRestore.backup.archiveTimeout`** → smaller un-archived WAL tail (at the cost of more, smaller WAL objects), which is the floor a roll-forward recovery can reach.
+
+## Object-store layout (wal-g 1.1.0)
+
+Under your configured `WALG_S3_PREFIX`:
+
+```
+<prefix>/basebackups_005/base_<segment>/metadata.json
+<prefix>/basebackups_005/base_<segment>/tar_partitions/*.tar.lz4
+<prefix>/basebackups_005/base_<segment>_backup_stop_sentinel.json
+<prefix>/wal_005/<segment>.lz4          # one lz4 object per archived WAL segment
+```
+
+## Automated test coverage
+
+The wal-g mechanics are exercised as a regression oracle in `magda-int-test-ts` (`src/tests/walgBackupRestore.spec.ts`, added under [#3747](https://github.com/magda-io/magda/issues/3747)): base-backup → restore fidelity, WAL push/fetch byte-identity, and a point-in-time **roll-forward** restore that recovers writes made *after* the base backup (the property that gives continuous archiving its value). Those tests deliberately drive wal-g directly against a plain `postgres:13.7` + MinIO — they validate the wal-g command behaviour, not the in-cluster automation wiring (the CronJob manifest and PostgreSQL's `archive_command`), which is covered by the manual end-to-end scenario under [#3750](https://github.com/magda-io/magda/issues/3750) against the real `magda-postgres` image.
+
+## Related
+
+- [How to Config Continuous Archiving and Point-in-Time Recovery (PITR)](./how-to-recover-with-continuous-archive-backup.md) — configuration how-to (storage, helm values).
+- [`magda-postgres` chart reference](../../deploy/helm/internal-charts/magda-postgres) — all `backupRestore.*` options.
+- [PostgreSQL Continuous Archiving & PITR](https://www.postgresql.org/docs/13/continuous-archiving.html) — upstream reference.
+- [wal-g storage options](https://github.com/wal-g/wal-g/blob/master/docs/STORAGES.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,6 +26,7 @@
 - [Plugin UI Component SDK Doc](https://github.com/magda-io/magda/tree/master/packages/external-ui-plugin-sdk/docs/modules.md)
 - [How to build your own connectors / minions](./how-to-build-your-own-connectors-minions.md)
 - [Authentication Plugin Spec Document](./authentication-plugin-spec.md)
+- [In-cluster Database Backup & Restore — How It Works (mechanics & RPO)](./in-cluster-database-backup-and-restore.md)
 - [How to recover with continuous archive backup](./how-to-recover-with-continuous-archive-backup.md)
 - [Ports used when running locally](./local-ports.md)
 - [Windows Setup Instructions](./windows-instructions.md)

--- a/magda-int-test-ts/src/ServiceRunner.ts
+++ b/magda-int-test-ts/src/ServiceRunner.ts
@@ -16,7 +16,7 @@ import child_process, { ChildProcess } from "child_process";
 import { DEFAULT_ADMIN_USER_ID } from "magda-typescript-common/src/authorization-api/constants.js";
 import urijs from "urijs";
 import { requireResolve } from "@magda/esm-utils";
-import { Readable } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 import fetchRequest from "magda-typescript-common/src/fetchRequest.js";
 import treeKill from "magda-typescript-common/src/treeKill.js";
 
@@ -73,6 +73,7 @@ export default class ServiceRunner {
     private indexerSetupProcess: ChildProcess;
     private searchApiProcess: ChildProcess;
     private embeddingApiCompose: DockerCompose;
+    private walgPostgresCompose: DockerCompose;
 
     public shouldExit = false;
 
@@ -89,6 +90,15 @@ export default class ServiceRunner {
     // however, indexer will auto exit if this field is set to false.
     public enableIndexer = false;
     public searchApiConfig: string | null = null;
+
+    // when set to true, `create()` will only start MinIO + the wal-g test
+    // postgres (no OPA / registry / auth / ES / embedding) so that the
+    // wal-g backup/restore integration tests can drive them directly via
+    // `runWalg()`.
+    public enableWalg = false;
+    public walgImgTag: string = "1.1.0";
+    public walgBucket: string = "walg-test";
+    public walgS3Prefix: string = "";
 
     public jwtSecret: string = uuidV4();
     public authApiDebugMode = false;
@@ -113,7 +123,7 @@ export default class ServiceRunner {
         [key: string]: ChildProcess;
     } = {};
 
-    private minioClient?: MinioClient;
+    public minioClient?: MinioClient;
     public minioAccessKey: string = "minio";
     public minioSecretKey: string = "minio123";
     public minioDefaultRegion: string = "unspecified-region";
@@ -184,6 +194,16 @@ export default class ServiceRunner {
         try {
             await this.docker.info();
 
+            if (this.enableWalg) {
+                await this.createMinio();
+                await this.minioClient!.makeBucket(
+                    this.walgBucket,
+                    this.minioDefaultRegion
+                );
+                await this.createWalgPostgres();
+                return;
+            }
+
             if (this.enableAuthService) {
                 await Promise.all([this.createOpa(), this.createPostgres()]);
                 await this.createAuthApi();
@@ -242,7 +262,10 @@ export default class ServiceRunner {
             ...(this.enableStorageApi
                 ? [this.destroyMinio(), this.destroyStorageApi()]
                 : []),
-            ...(this.enableSearchApi ? [this.destroySearchApi()] : [])
+            ...(this.enableSearchApi ? [this.destroySearchApi()] : []),
+            ...(this.enableWalg
+                ? [this.destroyWalgPostgres(), this.destroyMinio()]
+                : [])
         ]);
         try {
             await Promise.all([
@@ -999,6 +1022,134 @@ export default class ServiceRunner {
         if (this.dockerServiceForwardHost) {
             await this.destroyPortForward(5432);
         }
+    }
+
+    async createWalgPostgres() {
+        // Absolute host path to the init scripts dir. The compose file is
+        // rewritten to a tmp path by createTmpDockerComposeFile, so a relative
+        // volume path would break - inject an absolute bind mount instead.
+        const initdbHostDir = path.resolve(
+            this.workspaceRoot,
+            "./magda-int-test-ts/src/walg-postgres/initdb.d"
+        );
+        const dockerComposeFile = this.createTmpDockerComposeFile(
+            path.resolve(
+                this.workspaceRoot,
+                "./magda-int-test-ts/src/walg-postgres/docker-compose.yml"
+            ),
+            undefined,
+            false,
+            (configData) => {
+                configData["services"]["test-walg-postgres"]["volumes"] = [
+                    `${initdbHostDir}:/docker-entrypoint-initdb.d:ro`
+                ];
+            }
+        );
+        this.walgPostgresCompose = new DockerCompose(
+            this.docker,
+            dockerComposeFile,
+            "test-walg-postgres"
+        );
+        try {
+            await Promise.all([
+                this.walgPostgresCompose.down({ volumes: true }),
+                this.pullImage(this.walgPostgresCompose)
+            ]);
+            await this.walgPostgresCompose.up();
+            await this.waitAlive(
+                "WalgPostgres",
+                this.testAlivePostgres.bind(this)
+            );
+            if (this.dockerServiceForwardHost) {
+                await this.createPortForward(5432);
+            }
+        } catch (e) {
+            await this.destroyWalgPostgres();
+            throw e;
+        }
+    }
+
+    async destroyWalgPostgres() {
+        if (this.walgPostgresCompose) {
+            await this.walgPostgresCompose.down({ volumes: true });
+        }
+        if (this.dockerServiceForwardHost) {
+            await this.destroyPortForward(5432);
+        }
+    }
+
+    /**
+     * Build the env (as `KEY=VALUE` strings, like `runMigrator`'s `Env`) that
+     * points wal-g at the host-published wal-g test postgres and the MinIO
+     * instance started by this ServiceRunner.
+     */
+    walgConfigEnv(): string[] {
+        const host = this.dockerServiceForwardHost || "localhost";
+        const s3Prefix = this.walgS3Prefix || `s3://${this.walgBucket}/pg`;
+        return [
+            `PGHOST=${host}`,
+            "PGUSER=postgres",
+            "PGPASSWORD=password",
+            `WALG_S3_PREFIX=${s3Prefix}`,
+            `AWS_ACCESS_KEY_ID=${this.minioAccessKey}`,
+            `AWS_SECRET_ACCESS_KEY=${this.minioSecretKey}`,
+            `AWS_ENDPOINT=http://${host}:9000`,
+            "AWS_S3_FORCE_PATH_STYLE=true",
+            `AWS_REGION=${this.minioDefaultRegion}`
+        ];
+    }
+
+    /**
+     * Run the `magda-wal-g` image as a one-shot container invoking the
+     * `wal-g` binary with `args` (e.g. `["backup-list"]`). The image's
+     * default uid (1001) is not present in `/etc/passwd`, so the container
+     * must run as root (`User: "0"`). Runs with `NetworkMode: "host"` so it
+     * can reach the host-published wal-g postgres / MinIO ports via
+     * `localhost` (or `dockerServiceForwardHost`), mirroring `runMigrator`.
+     *
+     * @param args arguments to pass to the `wal-g` binary, e.g. `["backup-list"]`
+     * @param extraEnv additional env vars merged on top of `walgConfigEnv()`
+     * @param binds optional host binds (e.g. to share a postgres data dir)
+     */
+    async runWalg(
+        args: string[],
+        extraEnv: Record<string, string> = {},
+        binds?: string[]
+    ): Promise<{ exitCode: number; output: string }> {
+        const walgImg = `${this.publicImgRegistry}/magda-wal-g:${this.walgImgTag}`;
+        await this.pullImage(walgImg);
+
+        const outputChunks: Buffer[] = [];
+        const outStream = new PassThrough();
+        outStream.on("data", (chunk: Buffer) => {
+            outputChunks.push(chunk);
+        });
+
+        const [data] = (await this.docker.run(
+            walgImg,
+            ["wal-g", ...args],
+            outStream,
+            {
+                Tty: true,
+                User: "0",
+                HostConfig: {
+                    NetworkMode: "host",
+                    AutoRemove: true,
+                    Binds: binds
+                },
+                Env: [
+                    ...this.walgConfigEnv(),
+                    ...Object.entries(extraEnv).map(
+                        ([key, value]) => `${key}=${value}`
+                    )
+                ]
+            }
+        )) as [any, Container];
+
+        return {
+            exitCode: data?.StatusCode,
+            output: Buffer.concat(outputChunks).toString("utf8")
+        };
     }
 
     async createElasticSearch() {

--- a/magda-int-test-ts/src/tests/walgBackupRestore.spec.ts
+++ b/magda-int-test-ts/src/tests/walgBackupRestore.spec.ts
@@ -1,0 +1,806 @@
+import {} from "mocha";
+import { expect } from "chai";
+import { execFileSync } from "child_process";
+import crypto from "crypto";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import pg from "pg";
+import { v4 as uuidV4 } from "uuid";
+import ServiceRunner from "../ServiceRunner.js";
+
+/** WAL segment size (16 MiB), used as a sanity bound on fetched segments. */
+const WAL_SEGMENT_SIZE = 16777216;
+
+/** SHA-256 hex digest of a file's contents. */
+function sha256File(filePath: string): string {
+    return crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(filePath))
+        .digest("hex");
+}
+
+const ENV_SETUP_TIME_OUT = 600000; // 10 mins
+
+// --- small local helpers -------------------------------------------------
+
+/**
+ * Run the docker CLI and return its trimmed stdout. `ignoreError` swallows a
+ * non-zero exit (used by best-effort cleanup so one failure doesn't mask
+ * others).
+ */
+function docker(args: string[], ignoreError = false): string {
+    try {
+        return execFileSync("docker", args, { encoding: "utf8" }).trim();
+    } catch (e) {
+        if (ignoreError) {
+            return "";
+        }
+        throw e;
+    }
+}
+
+/**
+ * List object names under `prefix` in the wal-g bucket via the structured
+ * MinIO client (NOT the CRLF-laden `runWalg().output`).
+ */
+function listWalgObjects(
+    serviceRunner: ServiceRunner,
+    prefix: string
+): Promise<string[]> {
+    return new Promise<string[]>((resolve, reject) => {
+        const names: string[] = [];
+        const stream = serviceRunner.minioClient!.listObjectsV2(
+            serviceRunner.walgBucket,
+            prefix,
+            true
+        );
+        stream.on("data", (o: any) => {
+            if (o?.name) {
+                names.push(o.name);
+            }
+        });
+        stream.on("error", reject);
+        stream.on("end", () => resolve(names));
+    });
+}
+
+/** Build a pg client config for a plain-trust postgres on the given port. */
+function pgConfig(host: string, port: number, password?: string) {
+    return {
+        host,
+        port,
+        user: "postgres",
+        database: "postgres",
+        password,
+        // fail fast so the restore-readiness poll loops quickly
+        connectionTimeoutMillis: 5000
+    } as pg.ClientConfig;
+}
+
+/**
+ * Poll `pg.Client` connect against the given config until it accepts a
+ * connection or `timeoutMs` elapses (mirrors ServiceRunner.waitAlive).
+ */
+async function waitForPg(
+    config: pg.ClientConfig,
+    timeoutMs = 120000
+): Promise<void> {
+    const start = Date.now();
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const client = new pg.Client(config);
+        try {
+            await client.connect();
+            await client.query("SELECT 1");
+            await client.end();
+            return;
+        } catch (e) {
+            try {
+                await client.end();
+            } catch {
+                // ignore
+            }
+            if (Date.now() - start >= timeoutMs) {
+                throw new Error(
+                    `Restore postgres failed to accept connections in ${
+                        timeoutMs / 1000
+                    }s: ${e}`
+                );
+            }
+            await new Promise((r) => setTimeout(r, 1000));
+        }
+    }
+}
+
+/** Find the running source walg-postgres container name (there is exactly one). */
+function sourceWalgContainer(): string {
+    const name = docker([
+        "ps",
+        "--filter",
+        "name=test-walg-postgres",
+        "--format",
+        "{{.Names}}"
+    ])
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean)[0];
+    if (!name) {
+        throw new Error("source walg-postgres container not found");
+    }
+    return name;
+}
+
+/**
+ * Restore the LATEST base backup into a fresh instance and start postgres on
+ * it, pre-staging `segments` into pg_wal so recovery can replay them. The plain
+ * postgres image has no `restore_command`, so whatever is present in pg_wal
+ * bounds how far recovery rolls forward; with no `recovery_target` set,
+ * postgres replays to the end of the staged WAL and promotes.
+ */
+async function restoreLatestBackup(
+    serviceRunner: ServiceRunner,
+    opts: {
+        vol: string;
+        name: string;
+        port: number;
+        segments: string[];
+        // when set, passed as postgres `recovery_target` (e.g. "immediate",
+        // which mirrors the shipped magda-postgres recovery.conf and stops
+        // replay at the base-backup consistency point). Omit to roll forward
+        // to the end of the staged WAL.
+        recoveryTarget?: string;
+    }
+): Promise<void> {
+    docker(["volume", "create", opts.vol]);
+    const fetched = await serviceRunner.runWalg(
+        ["backup-fetch", "/restore", "LATEST"],
+        {},
+        [`${opts.vol}:/restore`]
+    );
+    if (fetched.exitCode !== 0) {
+        throw new Error(`backup-fetch failed: ${fetched.output}`);
+    }
+    for (const seg of opts.segments) {
+        const walFetch = await serviceRunner.runWalg(
+            ["wal-fetch", seg, `/restore/pg_wal/${seg}`],
+            {},
+            [`${opts.vol}:/restore`]
+        );
+        if (walFetch.exitCode !== 0) {
+            throw new Error(`wal-fetch ${seg} failed: ${walFetch.output}`);
+        }
+    }
+    // `recovery.signal` puts postgres into ARCHIVE recovery (not crash recovery),
+    // so it rolls forward through the staged WAL past the base-backup consistency
+    // point instead of stopping at it. With no `recovery_target`, replay runs to
+    // the end of the available WAL and then promotes.
+    docker([
+        "run",
+        "--rm",
+        "-v",
+        `${opts.vol}:/restore`,
+        "--user",
+        "0",
+        "--entrypoint",
+        "sh",
+        "postgres:13.7",
+        "-c",
+        "touch /restore/recovery.signal && chown -R 999:999 /restore && chmod 700 /restore"
+    ]);
+    // PG13 refuses archive recovery without a restore_command. The plain image
+    // has no wal-g, so we point it at `/bin/false`: every archive fetch "misses",
+    // postgres falls back to the segments pre-staged in pg_wal, replays them, and
+    // ends recovery (promotes) once the next segment is neither in the archive nor
+    // pg_wal. No recovery_target => it rolls forward to the end of the staged WAL.
+    const pgArgs = [
+        "run",
+        "-d",
+        "--name",
+        opts.name,
+        "-p",
+        `${opts.port}:5432`,
+        "-v",
+        `${opts.vol}:/var/lib/postgresql/data`,
+        "postgres:13.7",
+        "-c",
+        "restore_command=/bin/false"
+    ];
+    if (opts.recoveryTarget) {
+        pgArgs.push(
+            "-c",
+            `recovery_target=${opts.recoveryTarget}`,
+            "-c",
+            "recovery_target_action=promote"
+        );
+    }
+    docker(pgArgs);
+    await serviceRunner.createPortForward(opts.port);
+    const host = serviceRunner.dockerServiceForwardHost || "localhost";
+    try {
+        await waitForPg(pgConfig(host, opts.port));
+    } catch (e) {
+        const logs = docker(["logs", "--tail", "80", opts.name], true);
+        throw new Error(`${e}\n--- restore postgres logs ---\n${logs}`);
+    }
+}
+
+describe("wal-g backup / restore integration tests", () => {
+    const serviceRunner = new ServiceRunner();
+    serviceRunner.enableWalg = true;
+
+    const runId = uuidV4().slice(0, 8);
+    const restoreVol = `walg-restore-vol-${runId}`;
+    const restoreName = `walg-restore-pg-${runId}`;
+    const restorePort = 5433;
+    const hostTmpDirs: string[] = [];
+    // additional restore instances (name/vol/port) to tear down in `after`.
+    const extraRestores: { name: string; vol: string; port: number }[] = [];
+
+    before(async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+        await serviceRunner.create();
+    });
+
+    after(async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+        // best-effort cleanup of the restore instance + volume + host tmp dirs,
+        // running regardless of assertion outcome.
+        try {
+            await serviceRunner.destroyPortForward(restorePort);
+        } catch {
+            // no-op if no forward exists (e.g. not on k8s)
+        }
+        docker(["rm", "-f", restoreName], true);
+        docker(["volume", "rm", restoreVol], true);
+        for (const r of extraRestores) {
+            try {
+                await serviceRunner.destroyPortForward(r.port);
+            } catch {
+                // no-op if no forward exists (e.g. not on k8s)
+            }
+            docker(["rm", "-f", r.name], true);
+            docker(["volume", "rm", r.vol], true);
+        }
+        for (const dir of hostTmpDirs) {
+            try {
+                fs.removeSync(dir);
+            } catch {
+                // ignore
+            }
+        }
+        await serviceRunner.destroy();
+    });
+
+    it("wal-g backup base-backup round-trip preserves data, sequence, owner and extension", async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+
+        const host = serviceRunner.dockerServiceForwardHost || "localhost";
+
+        // 1. Load the fixture into the source postgres.
+        const source = new pg.Client(pgConfig(host, 5432, "password"));
+        await source.connect();
+        try {
+            await source.query("CREATE ROLE appowner;");
+            await source.query("CREATE EXTENSION pgcrypto;");
+            await source.query(
+                "CREATE TABLE t(id bigserial primary key, v text);"
+            );
+            await source.query(
+                "INSERT INTO t(v) SELECT 'row ' || g FROM generate_series(1, 500) g;"
+            );
+            await source.query("ALTER TABLE t OWNER TO appowner;");
+            await source.query("SELECT setval('t_id_seq', 90000);");
+            await source.query("CHECKPOINT;");
+        } finally {
+            await source.end();
+        }
+
+        // 2. Base backup (remote form; runWalg invokes wal-g as root).
+        const push = await serviceRunner.runWalg(["backup-push"]);
+        expect(push.exitCode).to.equal(0);
+
+        // 3. Assert >=1 base backup object and extract the backup-start segment.
+        const baseObjects = await listWalgObjects(
+            serviceRunner,
+            "pg/basebackups_005/"
+        );
+        expect(baseObjects.length).to.be.greaterThan(0);
+
+        const baseNameMatch = baseObjects
+            .map((name) => name.match(/base_([0-9A-Fa-f]{24})/))
+            .find((m) => m !== null);
+        expect(baseNameMatch, "could not find base_<segment> object").to.not
+            .be.undefined;
+        const seg = baseNameMatch![1];
+
+        // 4. backup-push does NOT archive WAL (archive_mode off). Complete the
+        // backup-start segment, copy it out of the running source container and
+        // wal-push it so restore recovery can replay to consistency.
+        const switchClient = new pg.Client(pgConfig(host, 5432, "password"));
+        await switchClient.connect();
+        try {
+            await switchClient.query("SELECT pg_switch_wal();");
+        } finally {
+            await switchClient.end();
+        }
+
+        const sourceContainer = docker([
+            "ps",
+            "--filter",
+            "name=test-walg-postgres",
+            "--format",
+            "{{.Names}}"
+        ])
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean)[0];
+        expect(sourceContainer, "source walg-postgres container not found").to
+            .not.be.undefined;
+
+        const walPushDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "walg-walpush-")
+        );
+        hostTmpDirs.push(walPushDir);
+        docker([
+            "cp",
+            `${sourceContainer}:/var/lib/postgresql/data/pg_wal/${seg}`,
+            path.join(walPushDir, seg)
+        ]);
+        const walPush = await serviceRunner.runWalg(
+            ["wal-push", `/share/${seg}`],
+            {},
+            [`${walPushDir}:/share:ro`]
+        );
+        expect(walPush.exitCode).to.equal(0);
+
+        const walObjects = await listWalgObjects(serviceRunner, "pg/wal_005/");
+        expect(walObjects).to.include(`pg/wal_005/${seg}.lz4`);
+
+        // 5. Restore into a fresh instance (exact handoff from spike findings).
+        docker(["volume", "create", restoreVol]);
+
+        const fetch = await serviceRunner.runWalg(
+            ["backup-fetch", "/restore", "LATEST"],
+            {},
+            [`${restoreVol}:/restore`]
+        );
+        expect(fetch.exitCode, `backup-fetch failed: ${fetch.output}`).to.equal(
+            0
+        );
+
+        const walFetch = await serviceRunner.runWalg(
+            ["wal-fetch", seg, `/restore/pg_wal/${seg}`],
+            {},
+            [`${restoreVol}:/restore`]
+        );
+        expect(
+            walFetch.exitCode,
+            `wal-fetch failed: ${walFetch.output}`
+        ).to.equal(0);
+
+        // fix ownership/mode for the postgres uid (999) using a helper container
+        docker([
+            "run",
+            "--rm",
+            "-v",
+            `${restoreVol}:/restore`,
+            "--user",
+            "0",
+            "--entrypoint",
+            "sh",
+            "postgres:13.7",
+            "-c",
+            "chown -R 999:999 /restore && chmod 700 /restore"
+        ]);
+
+        // start a fresh postgres on the fetched datadir (already initialised ->
+        // entrypoint skips initdb and drives recovery via backup_label)
+        docker([
+            "run",
+            "-d",
+            "--name",
+            restoreName,
+            "-p",
+            `${restorePort}:5432`,
+            "-v",
+            `${restoreVol}:/var/lib/postgresql/data`,
+            "postgres:13.7"
+        ]);
+
+        // In the k8s/dind CI runner, published ports need the same socat bridge
+        // the framework sets up for its own services; a no-op locally (not on
+        // k8s).
+        await serviceRunner.createPortForward(restorePort);
+
+        try {
+            await waitForPg(
+                pgConfig(
+                    serviceRunner.dockerServiceForwardHost || "localhost",
+                    restorePort
+                )
+            );
+        } catch (e) {
+            // surface recovery logs to aid debugging if postgres never opened
+            const logs = docker(["logs", "--tail", "80", restoreName], true);
+            throw new Error(`${e}\n--- restore postgres logs ---\n${logs}`);
+        }
+
+        // 6. Assert data fidelity on the RESTORED instance (no password).
+        const restored = new pg.Client(
+            pgConfig(
+                serviceRunner.dockerServiceForwardHost || "localhost",
+                restorePort
+            )
+        );
+        await restored.connect();
+        try {
+            const countRes = await restored.query(
+                "SELECT count(*)::int AS c FROM t"
+            );
+            expect(countRes.rows[0].c).to.equal(500);
+
+            const seqRes = await restored.query(
+                "SELECT last_value FROM t_id_seq"
+            );
+            expect(Number(seqRes.rows[0].last_value)).to.be.at.least(90000);
+
+            const ownerRes = await restored.query(
+                "SELECT r.rolname FROM pg_class c JOIN pg_roles r ON c.relowner = r.oid WHERE c.relname = 't'"
+            );
+            expect(ownerRes.rows[0].rolname).to.equal("appowner");
+
+            const extRes = await restored.query(
+                "SELECT extname FROM pg_extension WHERE extname = 'pgcrypto'"
+            );
+            expect(extRes.rows.length).to.equal(1);
+        } finally {
+            await restored.end();
+        }
+    });
+
+    it("wal-g WAL push/fetch round-trip is byte-identical", async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+
+        const host = serviceRunner.dockerServiceForwardHost || "localhost";
+
+        // 1. Write a row for content, then capture the CURRENT segment and
+        // force a WAL switch so that segment becomes complete/archivable.
+        const source = new pg.Client(pgConfig(host, 5432, "password"));
+        await source.connect();
+        let seg: string;
+        try {
+            await source.query(
+                "CREATE TABLE IF NOT EXISTS wal_marker(id bigserial primary key, v text);"
+            );
+            await source.query("INSERT INTO wal_marker(v) VALUES ('marker');");
+            const segRes = await source.query(
+                "SELECT pg_walfile_name(pg_current_wal_lsn()) AS s"
+            );
+            seg = segRes.rows[0].s;
+            await source.query("SELECT pg_switch_wal();");
+        } finally {
+            await source.end();
+        }
+
+        // 2. Copy the now-completed segment out of the running source
+        // container into a fresh host tmp dir; this is the byte-identity
+        // reference copy.
+        const sourceContainer = docker([
+            "ps",
+            "--filter",
+            "name=test-walg-postgres",
+            "--format",
+            "{{.Names}}"
+        ])
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean)[0];
+        expect(sourceContainer, "source walg-postgres container not found").to
+            .not.be.undefined;
+
+        const walSrcDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "walg-wal-src-")
+        );
+        hostTmpDirs.push(walSrcDir);
+        docker([
+            "cp",
+            `${sourceContainer}:/var/lib/postgresql/data/pg_wal/${seg}`,
+            path.join(walSrcDir, seg)
+        ]);
+
+        // 3. wal-push the segment.
+        const walPush = await serviceRunner.runWalg(
+            ["wal-push", `/share/${seg}`],
+            {},
+            [`${walSrcDir}:/share:ro`]
+        );
+        expect(walPush.exitCode, `wal-push failed: ${walPush.output}`).to.equal(
+            0
+        );
+
+        // 4. Assert the pushed segment object exists in MinIO.
+        const walObjects = await listWalgObjects(serviceRunner, "pg/wal_005/");
+        expect(walObjects).to.include(`pg/wal_005/${seg}.lz4`);
+
+        // 5. wal-fetch it back into a fresh host dest dir.
+        const walDestDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "walg-wal-dest-")
+        );
+        hostTmpDirs.push(walDestDir);
+        const walFetch = await serviceRunner.runWalg(
+            ["wal-fetch", seg, `/dest/${seg}`],
+            {},
+            [`${walDestDir}:/dest`]
+        );
+        expect(
+            walFetch.exitCode,
+            `wal-fetch failed: ${walFetch.output}`
+        ).to.equal(0);
+
+        // 6. Byte-identity assertion: fetched file matches the reference copy
+        // taken directly from the source's pg_wal, and is a sane WAL segment
+        // size.
+        const fetchedPath = path.join(walDestDir, seg);
+        const referencePath = path.join(walSrcDir, seg);
+
+        const fetchedSize = fs.statSync(fetchedPath).size;
+        expect(fetchedSize).to.be.greaterThan(0);
+        expect(fetchedSize % WAL_SEGMENT_SIZE).to.equal(0);
+
+        expect(sha256File(fetchedPath)).to.equal(sha256File(referencePath));
+    });
+
+    it("wal-g point-in-time roll-forward recovers writes made after the base backup", async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+
+        const host = serviceRunner.dockerServiceForwardHost || "localhost";
+
+        // 1. Create a table with a known row count and take a base backup.
+        const source = new pg.Client(pgConfig(host, 5432, "password"));
+        await source.connect();
+        try {
+            await source.query(
+                "CREATE TABLE pitr(id bigserial primary key, v text);"
+            );
+            await source.query(
+                "INSERT INTO pitr(v) SELECT 'base ' || g FROM generate_series(1, 100) g;"
+            );
+            await source.query("CHECKPOINT;");
+        } finally {
+            await source.end();
+        }
+
+        const push = await serviceRunner.runWalg(["backup-push"]);
+        expect(push.exitCode, `backup-push failed: ${push.output}`).to.equal(0);
+
+        // Identify the base-backup start segment (the latest base_<seg>).
+        const baseObjects = await listWalgObjects(
+            serviceRunner,
+            "pg/basebackups_005/"
+        );
+        const baseSegments = baseObjects
+            .map((n) => n.match(/base_([0-9A-Fa-f]{24})/))
+            .filter((m): m is RegExpMatchArray => m !== null)
+            .map((m) => m[1]);
+        expect(baseSegments.length, "no base_<segment> object found").to.be.greaterThan(
+            0
+        );
+        const startSeg = baseSegments.sort().reverse()[0];
+
+        // 2. Write MORE rows AFTER the base backup - these exist ONLY in the WAL,
+        // not in the base backup, then complete the segment(s) holding them.
+        const source2 = new pg.Client(pgConfig(host, 5432, "password"));
+        await source2.connect();
+        // The WAL segment that ends up holding the post-backup writes. Captured
+        // from the *insert* LSN (mid-segment) BEFORE the switch: reading
+        // pg_walfile_name(pg_current_wal_lsn()) AFTER the switch lands on an exact
+        // segment boundary and reports the just-completed segment, which is
+        // off-by-one for a range upper bound.
+        let lastSeg: string;
+        try {
+            await source2.query(
+                "INSERT INTO pitr(v) SELECT 'wal ' || g FROM generate_series(1, 50) g;"
+            );
+            lastSeg = (
+                await source2.query(
+                    "SELECT pg_walfile_name(pg_current_wal_insert_lsn()) AS s"
+                )
+            ).rows[0].s;
+            // complete `lastSeg` so it can be archived
+            await source2.query("SELECT pg_switch_wal();");
+        } finally {
+            await source2.end();
+        }
+
+        // 3. Archive every completed segment from the base-backup start up to
+        // (but not including) the current active segment. backup-push archives
+        // no WAL here (archive_mode is off), so push them explicitly - this is
+        // the continuous-archiving stream the restore will roll forward through.
+        const container = sourceWalgContainer();
+        const listing = docker([
+            "exec",
+            container,
+            "sh",
+            "-c",
+            "ls /var/lib/postgresql/data/pg_wal"
+        ]);
+        const segments = listing
+            .split(/\s+/)
+            .map((s) => s.trim())
+            .filter((s) => /^[0-9A-Fa-f]{24}$/.test(s))
+            // [base-backup start .. the segment holding the post-backup writes],
+            // inclusive. pg_wal also contains the current active segment and
+            // pre-allocated future segments, which must NOT be staged.
+            .filter((s) => s >= startSeg && s <= lastSeg)
+            .sort();
+        expect(
+            segments.length,
+            "expected at least one completed WAL segment to archive"
+        ).to.be.greaterThan(0);
+
+        const walDir = fs.mkdtempSync(path.join(os.tmpdir(), "walg-rollfwd-"));
+        hostTmpDirs.push(walDir);
+        for (const seg of segments) {
+            docker([
+                "cp",
+                `${container}:/var/lib/postgresql/data/pg_wal/${seg}`,
+                path.join(walDir, seg)
+            ]);
+            const walPush = await serviceRunner.runWalg(
+                ["wal-push", `/share/${seg}`],
+                {},
+                [`${walDir}:/share:ro`]
+            );
+            expect(
+                walPush.exitCode,
+                `wal-push ${seg} failed: ${walPush.output}`
+            ).to.equal(0);
+        }
+
+        // 4. Restore into a fresh instance, pre-staging ALL archived segments,
+        // and let recovery roll forward (no recovery_target) to the end of WAL.
+        const vol = `walg-rollfwd-vol-${runId}`;
+        const name = `walg-rollfwd-pg-${runId}`;
+        const port = 5434;
+        extraRestores.push({ name, vol, port });
+        await restoreLatestBackup(serviceRunner, { vol, name, port, segments });
+
+        // 5. Assert the post-backup rows were recovered via WAL replay: 100 base
+        // rows + 50 rows that existed ONLY in the archived WAL.
+        const restored = new pg.Client(
+            pgConfig(serviceRunner.dockerServiceForwardHost || "localhost", port)
+        );
+        await restored.connect();
+        try {
+            const countRes = await restored.query(
+                "SELECT count(*)::int AS c FROM pitr"
+            );
+            expect(countRes.rows[0].c).to.equal(150);
+        } finally {
+            await restored.end();
+        }
+    });
+
+    it("wal-g recovery_target=immediate stops at the base backup (no roll-forward)", async function (this) {
+        this.timeout(ENV_SETUP_TIME_OUT);
+
+        const host = serviceRunner.dockerServiceForwardHost || "localhost";
+
+        // 1. Fresh table with a known base count, then a base backup.
+        const source = new pg.Client(pgConfig(host, 5432, "password"));
+        await source.connect();
+        try {
+            await source.query(
+                "CREATE TABLE pitr_immediate(id bigserial primary key, v text);"
+            );
+            await source.query(
+                "INSERT INTO pitr_immediate(v) SELECT 'base ' || g FROM generate_series(1, 100) g;"
+            );
+            await source.query("CHECKPOINT;");
+        } finally {
+            await source.end();
+        }
+
+        const push = await serviceRunner.runWalg(["backup-push"]);
+        expect(push.exitCode, `backup-push failed: ${push.output}`).to.equal(0);
+
+        const baseObjects = await listWalgObjects(
+            serviceRunner,
+            "pg/basebackups_005/"
+        );
+        const startSeg = baseObjects
+            .map((n) => n.match(/base_([0-9A-Fa-f]{24})/))
+            .filter((m): m is RegExpMatchArray => m !== null)
+            .map((m) => m[1])
+            .sort()
+            .reverse()[0];
+        expect(startSeg, "no base_<segment> object found").to.not.be.undefined;
+
+        // 2. Post-backup writes that exist ONLY in the WAL.
+        const source2 = new pg.Client(pgConfig(host, 5432, "password"));
+        await source2.connect();
+        let lastSeg: string;
+        try {
+            await source2.query(
+                "INSERT INTO pitr_immediate(v) SELECT 'wal ' || g FROM generate_series(1, 50) g;"
+            );
+            lastSeg = (
+                await source2.query(
+                    "SELECT pg_walfile_name(pg_current_wal_insert_lsn()) AS s"
+                )
+            ).rows[0].s;
+            await source2.query("SELECT pg_switch_wal();");
+        } finally {
+            await source2.end();
+        }
+
+        // 3. Archive the same WAL range the roll-forward test would.
+        const container = sourceWalgContainer();
+        const listing = docker([
+            "exec",
+            container,
+            "sh",
+            "-c",
+            "ls /var/lib/postgresql/data/pg_wal"
+        ]);
+        const segments = listing
+            .split(/\s+/)
+            .map((s) => s.trim())
+            .filter((s) => /^[0-9A-Fa-f]{24}$/.test(s))
+            .filter((s) => s >= startSeg && s <= lastSeg)
+            .sort();
+
+        const walDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "walg-immediate-")
+        );
+        hostTmpDirs.push(walDir);
+        for (const seg of segments) {
+            docker([
+                "cp",
+                `${container}:/var/lib/postgresql/data/pg_wal/${seg}`,
+                path.join(walDir, seg)
+            ]);
+            const walPush = await serviceRunner.runWalg(
+                ["wal-push", `/share/${seg}`],
+                {},
+                [`${walDir}:/share:ro`]
+            );
+            expect(
+                walPush.exitCode,
+                `wal-push ${seg} failed: ${walPush.output}`
+            ).to.equal(0);
+        }
+
+        // 4. Restore with the SHIPPED production setting recovery_target=immediate:
+        // identical staged WAL to the roll-forward test, but replay must STOP at
+        // the base-backup consistency point instead of rolling forward.
+        const vol = `walg-immediate-vol-${runId}`;
+        const name = `walg-immediate-pg-${runId}`;
+        const port = 5435;
+        extraRestores.push({ name, vol, port });
+        await restoreLatestBackup(serviceRunner, {
+            vol,
+            name,
+            port,
+            segments,
+            recoveryTarget: "immediate"
+        });
+
+        // 5. The 50 post-backup rows must NOT be present: recovery_target=immediate
+        // recovers only to the base backup (the RPO gap #3754 addresses). This is
+        // the same setup as the roll-forward test, changing ONLY recovery_target.
+        const restored = new pg.Client(
+            pgConfig(serviceRunner.dockerServiceForwardHost || "localhost", port)
+        );
+        await restored.connect();
+        try {
+            const countRes = await restored.query(
+                "SELECT count(*)::int AS c FROM pitr_immediate"
+            );
+            expect(countRes.rows[0].c).to.equal(100);
+        } finally {
+            await restored.end();
+        }
+    });
+});

--- a/magda-int-test-ts/src/walg-postgres/docker-compose.yml
+++ b/magda-int-test-ts/src/walg-postgres/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  test-walg-postgres:
+    image: postgres:13.7
+    command:
+      [
+        "-c",
+        "wal_level=replica",
+        "-c",
+        "max_wal_senders=3",
+        "-c",
+        "archive_mode=off"
+      ]
+    expose:
+      - 5432
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: "password"
+      POSTGRES_HOST_AUTH_METHOD: "trust"

--- a/magda-int-test-ts/src/walg-postgres/initdb.d/01-replication-hba.sh
+++ b/magda-int-test-ts/src/walg-postgres/initdb.d/01-replication-hba.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+# wal-g backup-push streams a base backup over the replication protocol.
+# Postgres's `all` DATABASE value does not match replication connections,
+# so an explicit replication entry is required. Runner connects via
+# NetworkMode:host, i.e. from the host; allow it with trust (matches the
+# POSTGRES_HOST_AUTH_METHOD=trust choice for normal connections).
+cat >> "$PGDATA/pg_hba.conf" <<'EOF'
+host replication postgres 0.0.0.0/0 trust
+EOF


### PR DESCRIPTION
Part of epic #3740 (modernise in-cluster PostgreSQL). Closes #3747.

Adds an automated integration test harness that captures the current in-cluster wal-g backup/restore behaviour as a **regression oracle**, plus documentation of how the machinery works and its data-loss characteristics. This is the **functional baseline** — it targets `main` (v6) and will merge into `next` (v7) — so it is in place *before* the bitnami subchart / PostgreSQL / wal-g version bumps (#3748, #3749) and can catch behavioural regressions those introduce.

## What's included

**Test harness** (`magda-int-test-ts`, reuses the existing `dockerode`/`dockerode-compose` + MinIO + `pg` framework):
- `ServiceRunner` gains a standalone wal-g mode — `enableWalg`, `createWalgPostgres`, a `runWalg` one-shot runner (`NetworkMode: host`, `User: "0"`, invoking the `wal-g` binary), `walgConfigEnv`, and `create()`/`destroy()` wiring; `minioClient` is exposed. Mirrors the existing `runMigrator`/`createPostgres` patterns.
- A `postgres:13.7` compose tuned for base backup (`wal_level=replica`, `max_wal_senders`, `archive_mode=off`) + an initdb script adding the `pg_hba` replication entry a remote `backup-push` needs.
- Spec (`walgBackupRestore.spec.ts`), 4 tests:
  1. base-backup round-trip with data-fidelity assertions (row count, advanced sequence, non-default table owner, installed extension) on the restored instance;
  2. WAL `wal-push`/`wal-fetch` byte-identity (SHA-256);
  3. **point-in-time roll-forward** — recovers rows written *after* the base backup by replaying archived WAL;
  4. **`recovery_target=immediate`** — identical staged WAL as (3) but stops at the base backup (no roll-forward). Together (3)+(4) pin the recovery-target behaviour and demonstrate the RPO gap tracked in #3754.

**Docs**:
- New `docs/docs/in-cluster-database-backup-and-restore.md` — the two mechanisms (base-backup CronJob + continuous WAL archiving), the recovery flow/scripts, object-store layout, and the RPO in each failure scenario. Linked from `index.md` and the "Guide to Magda Internals".
- Clarifies the existing how-to's PITR section: the shipped auto-recovery uses `recovery_target=immediate`, so it restores to the chosen base backup and does not roll forward through archived WAL (RPO up to one base-backup interval); roll-forward is not a config option today (#3754).

## Design notes

- Deliberately uses plain `postgres:13.7` (resolvable user), **not** the bitnami `magda-postgres` image, to avoid the uid-1001 archiving hang (#3753). Real-image end-to-end coverage is tracked separately.
- Services communicate over host-published ports via `NetworkMode: host` (mirroring the existing `runMigrator`), not a shared docker network.
- No `.gitlab-ci.yml` change needed: the existing `buildtest:integration-tests` job runs the whole suite via `yarn test` and picks up the new spec through the mocha glob.

## Testing

All 4 tests pass locally on real Docker (`cd magda-int-test-ts && yarn test --grep "wal-g"` → 4 passing); `tsc -b` clean. They run in CI under the existing `buildtest:integration-tests` (dind) job.

## Related

Epic #3740 · #3746 (done) · #3753 (uid-1001, baseline) · #3754 (roll-forward config, baseline) · #3749 (wal-g 3.0.8 upgrade — this is its oracle).
