### PR TITLE
docs: PostgreSQL v6→v7 upgrade & migration pathways (#3750 Part 1)

### DIFF
--- a/deploy/helm/internal-charts/magda-postgres/README.md
+++ b/deploy/helm/internal-charts/magda-postgres/README.md
@@ -12,7 +12,7 @@ The docker image used by the chart is built from [bitnami postgreSQL Docker Imag
 
 ## TLS
 
-When `global.postgresql.tls.enabled` is `true` (the default for the in-cluster
+When `postgresql.tls.enabled` is `true` (the default for the in-cluster
 database), `templates/tls-secret.yaml` generates a self-signed CA and server
 certificate and preserves them across `helm upgrade` using Helm's `lookup`
 function to read back the existing secret, re-using it instead of minting a

--- a/deploy/helm/internal-charts/magda-postgres/README.md.gotmpl
+++ b/deploy/helm/internal-charts/magda-postgres/README.md.gotmpl
@@ -13,7 +13,7 @@ The docker image used by the chart is built from [bitnami postgreSQL Docker Imag
 
 ## TLS
 
-When `global.postgresql.tls.enabled` is `true` (the default for the in-cluster
+When `postgresql.tls.enabled` is `true` (the default for the in-cluster
 database), `templates/tls-secret.yaml` generates a self-signed CA and server
 certificate and preserves them across `helm upgrade` using Helm's `lookup`
 function to read back the existing secret, re-using it instead of minting a

--- a/docs/docs/e2e-test-cases/README.md
+++ b/docs/docs/e2e-test-cases/README.md
@@ -20,6 +20,7 @@ scripted, assertion/checksum-based driver), and how to clean up.
 - [Distribution version aspect in the Web UI](./distribution-version-web-ui.md)
 - [In-cluster PostgreSQL wal-g cross-version backup / restore (roll-forward + PITR)](./postgres-walg-cross-version-restore.md)
 - [In-cluster PostgreSQL major upgrade (PG 13 → 17 logical dump / restore)](./postgres-major-upgrade.md)
+- [Migrate the in-cluster PostgreSQL to a managed/cloud database (Pathway B)](./postgres-in-cluster-to-managed-db-migration.md)
 - [Fresh install on PostgreSQL 17 — client authentication (SCRAM)](./postgres-fresh-install-auth.md)
 
 ## Adding a new case

--- a/docs/docs/e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md
+++ b/docs/docs/e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md
@@ -1,0 +1,336 @@
+# E2E Test Case: migrate the in-cluster PostgreSQL to a managed/cloud database (Pathway B)
+
+A step-by-step end-to-end test for **Pathway B** — moving off the bundled
+in-cluster PostgreSQL onto a managed/cloud database — run against a real cluster
+(e.g. minikube). It gates the operator procedure in
+[How to migrate the in-cluster database to a managed / cloud database](../migration/in-cluster-postgres-to-managed-db.md),
+which explains what each step does and why.
+
+Because a CI cluster has no real RDS/Azure/Cloud SQL instance, the managed
+database is **simulated in-cluster** by a stock `postgres:17` pod configured with
+the two constraints that actually break a naive migration:
+
+- **TLS is enforced** — a `hostssl`-only `pg_hba.conf`, mimicking AWS RDS
+  `rds.force_ssl=1` / Azure's enforced TLS. A non-TLS TCP client is rejected.
+- **The master account is not a superuser** — a `CREATEDB CREATEROLE` but
+  `NOSUPERUSER` role, mimicking an RDS master. This is the constraint that makes a
+  single `pg_dumpall` restore fail and silently drop data, and is the whole reason
+  the how-to uses per-database `pg_dump --no-owner --no-privileges` + explicit
+  `client` grants.
+
+This mirrors how
+[DB TLS + non-default privileged user](./db-tls-and-privileged-user.md) fakes
+provider constraints locally. It validates the migration **mechanics**, not any
+one vendor's exact privilege model (see Notes).
+
+## What it covers
+
+1. **Deploy a simulated managed DB** (TLS-enforced, non-superuser master).
+2. **Install v6, seed data** via the registry and auth APIs (identical to the
+   [Pathway A case](./postgres-major-upgrade.md), step 1).
+3. **Negative control** — show that the naive `pg_dumpall | psql` as the
+   non-superuser master fails and loses the registry data in the shared
+   `postgres` database.
+4. **Migrate with the documented per-database procedure** — create `client`,
+   `pg_dump --no-owner --no-privileges` each database, grant `client` — and assert
+   every database, its row counts, sequences, and `client`'s own read/write access
+   landed on the managed DB over TLS.
+5. **Reconfigure Magda (still v6)** to the managed DB and assert the application is
+   healthy against it.
+6. **Upgrade to v7** as an external-DB upgrade and assert data and health.
+
+## Prerequisites
+
+- A cluster with your `kubectl` context pointed at it (e.g. `minikube start`),
+  plus `helm` and `openssl`.
+- A published **v6** chart version (default `global.useCombinedDb: true`,
+  bundled PostgreSQL 13) and a published **v7** build (a real release, or a
+  [PR preview / branch build](../ci-version-release.md)).
+- [`@magda/acs-cmd`](https://www.npmjs.com/package/@magda/acs-cmd) available via
+  `yarn acs-cmd` (to mint an admin session JWT), as in the Pathway A case.
+
+```bash
+export NS=pg-managed-migration-e2e
+export V6_VERSION=6.2.0
+export V7_VERSION=7.0.0-pr.3750.1
+export MANAGED_HOST=managed-pg.$NS.svc.cluster.local   # the simulated managed endpoint
+export MASTER_USER=magda_admin
+export MASTER_PW=dstpass
+kubectl create namespace "$NS"
+```
+
+## 0. Deploy the simulated managed database
+
+Generate a self-signed server certificate and load it, plus the TLS-enforcing
+`pg_hba.conf` and a non-superuser master role, into the namespace:
+
+```bash
+cd $(mktemp -d)
+openssl req -new -x509 -days 365 -nodes -text -out server.crt -keyout server.key \
+  -subj "/CN=managed-pg" -addext "subjectAltName=DNS:managed-pg"
+kubectl -n "$NS" create secret generic managed-certs \
+  --from-file=server.crt=server.crt --from-file=server.key=server.key
+
+cat > pg_hba.conf <<'EOF'
+local   all   all                trust
+# TCP MUST use TLS (mimics RDS rds.force_ssl / Azure): only hostssl lines
+hostssl all   all   0.0.0.0/0    md5
+hostssl all   all   ::/0         md5
+EOF
+cat > init.sql <<EOF
+-- master account: privileged but NOT a superuser (mimics an RDS master)
+CREATE ROLE $MASTER_USER WITH LOGIN CREATEDB CREATEROLE PASSWORD '$MASTER_PW';
+EOF
+kubectl -n "$NS" create configmap managed-pgcfg \
+  --from-file=pg_hba.conf=pg_hba.conf --from-file=init.sql=init.sql
+```
+
+```bash
+kubectl -n "$NS" apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata: { name: managed-pg, labels: { app: managed-pg } }
+spec:
+  initContainers:
+    - name: prep-certs
+      image: busybox:1.36
+      command: ["sh","-c","cp /in/* /certs/ && chown 999:999 /certs/server.* && chmod 600 /certs/server.key && chmod 644 /certs/server.crt"]
+      volumeMounts: [{ name: certs-in, mountPath: /in }, { name: certs, mountPath: /certs }]
+  containers:
+    - name: pg
+      image: postgres:17
+      env: [{ name: POSTGRES_PASSWORD, value: bootstrap }]
+      args: ["-c","ssl=on","-c","ssl_cert_file=/certs/server.crt","-c","ssl_key_file=/certs/server.key","-c","hba_file=/etc/pgcfg/pg_hba.conf"]
+      volumeMounts:
+        - { name: certs, mountPath: /certs }
+        - { name: pgcfg, mountPath: /etc/pgcfg }
+        - { name: initdb, mountPath: /docker-entrypoint-initdb.d }
+  volumes:
+    - { name: certs-in, secret: { secretName: managed-certs } }
+    - { name: certs, emptyDir: {} }
+    - name: pgcfg
+      configMap: { name: managed-pgcfg, items: [{ key: pg_hba.conf, path: pg_hba.conf }] }
+    - name: initdb
+      configMap: { name: managed-pgcfg, items: [{ key: init.sql, path: init.sql }] }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: managed-pg }
+spec: { selector: { app: managed-pg }, ports: [{ port: 5432, targetPort: 5432 }] }
+EOF
+kubectl -n "$NS" wait --for=condition=Ready pod/managed-pg --timeout=180s
+```
+
+Assert TLS is enforced (this is what a managed provider does):
+
+```bash
+kubectl run tlscheck -n "$NS" --rm -i --restart=Never --image=postgres:17 \
+  --env=P="$MASTER_PW" --command -- sh -c "
+    echo '--- sslmode=disable (expect REJECTED) ---'
+    PGPASSWORD=\$P psql 'host=managed-pg user=$MASTER_USER dbname=postgres sslmode=disable' -tAc 'SELECT 1' 2>&1 | head -1
+    echo '--- sslmode=require (expect ssl=true) ---'
+    PGPASSWORD=\$P psql 'host=managed-pg user=$MASTER_USER dbname=postgres sslmode=require' -tAc \
+      \"SELECT 'ssl='||ssl FROM pg_stat_ssl WHERE pid=pg_backend_pid();\" 2>&1 | head -1
+  "
+# expect: the disable attempt fails with 'no pg_hba.conf entry ... no encryption';
+#         the require attempt prints 'ssl=t'
+```
+
+## 1. Install v6 and seed data
+
+Follow [Pathway A case, step 1](./postgres-major-upgrade.md#1-install-v6-and-seed-data)
+verbatim (install v6, port-forward the gateway, seed one registry record and one
+auth user, record counts). In brief:
+
+```bash
+helm install magda oci://ghcr.io/magda-io/charts/magda --version "$V6_VERSION" -n "$NS" \
+  --wait --timeout 3600s
+export PGPASSWORD=$(kubectl get secret -n "$NS" db-main-account-secret -o jsonpath='{.data.postgresql-password}' | base64 -d)
+export CLIENT_PW=$(kubectl get secret -n "$NS" combined-db-password -o jsonpath='{.data.password}' | base64 -d)
+# ... seed a registry record + auth user via the gateway (see Pathway A step 1) ...
+kubectl -n "$NS" exec combined-db-postgresql-0 -- env PGPASSWORD="$PGPASSWORD" \
+  psql -U postgres -h 127.0.0.1 -d postgres -tAc "SELECT count(*) FROM records;" | tee /tmp/registry-count.txt
+kubectl -n "$NS" exec combined-db-postgresql-0 -- env PGPASSWORD="$PGPASSWORD" \
+  psql -U postgres -h 127.0.0.1 -d auth -tAc "SELECT count(*) FROM users;" | tee /tmp/auth-count.txt
+```
+
+## 2. Stop application writes
+
+```bash
+kubectl -n "$NS" scale deployment --replicas=0 \
+  $(kubectl -n "$NS" get deploy -o name | grep -E 'registry-api|authorization-api|content-api|tenant-api|gateway' | paste -sd' ' -)
+```
+
+Also stop any connectors/minions. (Read-only is fine, but a clean cutover is
+simplest with writers paused.)
+
+## 3. Negative control — the naive `pg_dumpall` loses data
+
+This step demonstrates *why* the how-to does not use `pg_dumpall`; skip it if you
+only want the passing path. Run the single-stream `pg_dumpall` as the
+non-superuser master and observe it fail partway:
+
+```bash
+kubectl run pg-dumpall-bad -n "$NS" --rm -i --restart=Never --image=postgres:17 \
+  --env=SRC="$PGPASSWORD" --env=DST="$MASTER_PW" --command -- sh -c "
+    PGPASSWORD=\$SRC pg_dumpall --host=combined-db-postgresql --username=postgres \
+    | PGPASSWORD=\$DST psql 'host=managed-pg user=$MASTER_USER dbname=postgres sslmode=require'
+  " 2>&1 | grep -iE 'must be able to SET ROLE|must be owner|permission denied|does not exist' | sort | uniq -c
+# expect: 'must be able to SET ROLE "postgres"/"client"' and, as a consequence,
+#         'relation ... does not exist' — the registry tables never got created.
+kubectl exec -n "$NS" managed-pg -- env PGPASSWORD=bootstrap \
+  psql -U postgres -d postgres -tAc "SELECT count(*) FROM records;" 2>&1 | head -1
+# expect: ERROR: relation "records" does not exist  -> registry data was silently dropped
+```
+
+Then reset the target before the real run:
+
+```bash
+kubectl exec -n "$NS" managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -v ON_ERROR_STOP=0 -c "
+  DROP DATABASE IF EXISTS auth; DROP DATABASE IF EXISTS content;
+  DROP DATABASE IF EXISTS session; DROP DATABASE IF EXISTS tenant;
+  REASSIGN OWNED BY client TO postgres; DROP OWNED BY client; DROP ROLE IF EXISTS client;
+  GRANT CREATE, USAGE ON SCHEMA public TO $MASTER_USER;"   # let the master manage the shared postgres db
+```
+
+> The final `GRANT` models what a managed provider's admin (e.g. `rds_superuser`)
+> can do to the shared `postgres` database. On a real provider you either already
+> have this or run it once from the provider console; see the how-to's Step 3 note.
+
+## 4. Migrate with the documented per-database procedure
+
+Run exactly [the how-to's Step 3](../migration/in-cluster-postgres-to-managed-db.md#step-3--create-roles-restore-each-database-grant-client):
+create `client`, `pg_dump --no-owner --no-privileges` each database into the
+managed DB, grant `client`. Condensed into one pod:
+
+```bash
+kubectl run pg-migrate -n "$NS" --rm -i --restart=Never --image=postgres:17 \
+  --env=SRC="$PGPASSWORD" --env=CLIENT_PW="$CLIENT_PW" --env=DST="$MASTER_PW" --command -- sh -c '
+set -e; set -o pipefail
+SRC_C="host=combined-db-postgresql user=postgres sslmode=disable"
+DST_C="host=managed-pg user='"$MASTER_USER"' sslmode=require"
+export PGPASSWORD=$DST
+psql "$DST_C dbname=postgres" -v ON_ERROR_STOP=1 -c "CREATE ROLE client LOGIN PASSWORD '"'"'$CLIENT_PW'"'"';"
+for db in auth content session tenant; do
+  psql "$DST_C dbname=postgres" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$db\";"
+  PGPASSWORD=$SRC pg_dump "$SRC_C dbname=$db" --no-owner --no-privileges | psql "$DST_C dbname=$db" -v ON_ERROR_STOP=1 >/dev/null
+done
+PGPASSWORD=$SRC pg_dump "$SRC_C dbname=postgres" --no-owner --no-privileges | psql "$DST_C dbname=postgres" -v ON_ERROR_STOP=1 >/dev/null
+for db in auth content session tenant postgres; do
+  psql "$DST_C dbname=$db" -v ON_ERROR_STOP=1 >/dev/null <<SQL
+GRANT USAGE ON SCHEMA public TO client;
+GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA public TO client;
+GRANT USAGE,SELECT ON ALL SEQUENCES IN SCHEMA public TO client;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT,INSERT,UPDATE,DELETE ON TABLES TO client;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE,SELECT ON SEQUENCES TO client;
+SQL
+done
+echo "migration complete"'
+# expect: no pg_dump/psql errors, ending "migration complete"
+```
+
+Assert the data landed and — crucially — that **`client` itself** can read it over
+TLS (this catches both missing data and missing grants):
+
+```bash
+kubectl run verify -n "$NS" --rm -i --restart=Never --image=postgres:17 \
+  --env=CP="$CLIENT_PW" --command -- sh -c "
+    C='host=managed-pg user=client sslmode=require'
+    PGPASSWORD=\$CP psql \"\$C dbname=postgres\" -tAc 'SELECT count(*) FROM records;'
+    PGPASSWORD=\$CP psql \"\$C dbname=auth\"     -tAc 'SELECT count(*) FROM users;'
+    PGPASSWORD=\$CP psql \"\$C dbname=postgres\" -tAc \"SELECT datname FROM pg_database WHERE datname NOT LIKE 'template%' AND datname <> '$MASTER_USER' ORDER BY 1;\"
+  "
+# expect: records count == /tmp/registry-count.txt; users count == /tmp/auth-count.txt;
+#         databases auth/content/postgres/session/tenant present, NO 'registry' db.
+```
+
+## 5. Reconfigure Magda (still v6) to the managed database
+
+Point the master-account secret and the external-DB values at the managed DB:
+
+```bash
+kubectl create secret generic db-main-account-secret -n "$NS" \
+  --from-literal=postgresql-password="$MASTER_PW" --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade magda oci://ghcr.io/magda-io/charts/magda --version "$V6_VERSION" -n "$NS" \
+  --reuse-values \
+  --set global.useCombinedDb=false \
+  --set global.useAwsRdsDb=true \
+  --set global.awsRdsEndpoint="$MANAGED_HOST" \
+  --set global.postgresql.postgresqlUsername="$MASTER_USER" \
+  --timeout 3600s
+kubectl -n "$NS" scale deployment --replicas=1 \
+  $(kubectl -n "$NS" get deploy -o name | grep -E 'registry-api|authorization-api|content-api|tenant-api|gateway' | paste -sd' ' -)
+```
+
+Assert the `*-db` Services are now `ExternalName` aliases and the app is healthy
+against the managed DB:
+
+```bash
+kubectl -n "$NS" get svc authorization-db content-db session-db registry-db -o \
+  custom-columns=NAME:.metadata.name,TYPE:.spec.type,TO:.spec.externalName
+# expect: all type ExternalName -> $MANAGED_HOST
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:18080/api/v0/auth/users/whoami   # 200
+curl -s "http://localhost:18080/api/v0/registry/records?limit=1" -H "X-Magda-Tenant-Id: 0" | head -c 200
+```
+
+## 6. Upgrade to v7 (external-DB upgrade)
+
+```bash
+helm upgrade magda oci://ghcr.io/magda-io/charts/magda --version "$V7_VERSION" -n "$NS" \
+  --reuse-values \
+  --set global.postgresql.auth.username="$MASTER_USER" \
+  --timeout 3600s
+```
+
+> The master-username key moved from `global.postgresql.postgresqlUsername` (v6)
+> to `global.postgresql.auth.username` (v7). Do **not** set any `majorUpgrade.*`
+> value — it has no effect on an external database.
+
+Assert data and health after the upgrade:
+
+```bash
+kubectl run verify7 -n "$NS" --rm -i --restart=Never --image=postgres:17 \
+  --env=CP="$CLIENT_PW" --command -- sh -c "
+    PGPASSWORD=\$CP psql 'host=managed-pg user=client dbname=postgres sslmode=require' -tAc 'SELECT count(*) FROM records;'
+  "
+# expect: still == /tmp/registry-count.txt
+curl -s "http://localhost:18080/api/v0/search/datasets?query=PG%20Upgrade%20E2E" \
+  -H "X-Magda-Session: $(cat /tmp/admin.jwt)"   # expect the seeded dataset
+```
+
+## Cleanup
+
+```bash
+kill %1 2>/dev/null   # the gateway port-forward from step 1
+helm uninstall magda -n "$NS"
+kubectl delete namespace "$NS" --wait=true --timeout=180s
+rm -f /tmp/registry-count.txt /tmp/auth-count.txt /tmp/admin.jwt
+```
+
+## Notes
+
+- **What is simulated vs. real.** The managed database is a local `postgres:17`
+  pod with TLS enforced and a non-superuser master — the two constraints that
+  govern the migration mechanics. It is **not** a substitute for validating
+  against a specific vendor's exact privilege model (RDS `rds_superuser`, Cloud
+  SQL's `cloudsqlsuperuser`, Azure's `azure_pg_admin`); the shared-`postgres`-db
+  `GRANT` in step 3 approximates what those admin roles allow.
+- **What has been exercised locally.** Steps 0, 3 and 4 (TLS enforcement, the
+  negative `pg_dumpall` control, and the per-database migration with `client`
+  read/write over TLS) were verified on minikube. Steps 5–6 (reconfiguring the
+  full Magda release and the v7 external-DB upgrade) are the broader gate this
+  case defines: run them when validating a release. In particular, watch whether
+  the v7 DB **migrators** run cleanly as the non-superuser master against the
+  already-migrated, pre-populated databases — that is the highest-risk assertion
+  and the main reason to run the full flow.
+- Run this whenever the Pathway B how-to or the external-DB value contract
+  (`useAwsRdsDb`/`awsRdsEndpoint`, the master-username key, `sslmode` handling)
+  changes.
+- On Apple-Silicon minikube the amd64 Magda images run under emulation — size the
+  `--timeout` and waits accordingly, as in the Pathway A case.
+- See also
+  [How to migrate the in-cluster database to a managed / cloud database](../migration/in-cluster-postgres-to-managed-db.md)
+  (operator explanation) and
+  [PostgreSQL Upgrade & Migration Pathways](../postgres-upgrade-migration-pathways.md)
+  (how to pick a pathway).

--- a/docs/docs/how-to-recover-with-continuous-archive-backup.md
+++ b/docs/docs/how-to-recover-with-continuous-archive-backup.md
@@ -128,7 +128,7 @@ Once the backup is turn on, base backup will created by the schedule defined by 
 
 ## 4> Point-in-Time Recovery (PITR)
 
-To recovery from a backup, you can simply set `combined-db.magda-postgres.backupRestore.backup.recoveryMode.enabled`=`true`. Other backup related config options can be found from [magda-postgres](../../deploy/helm/internal-charts/magda-postgres) chart document.
+To recovery from a backup, you can simply set `combined-db.magda-postgres.backupRestore.recoveryMode.enabled`=`true`. Other backup related config options can be found from [magda-postgres](../../deploy/helm/internal-charts/magda-postgres) chart document.
 
 Here is a complete example with recovery mode turned on:
 
@@ -161,7 +161,7 @@ combined-db:
 
 > You don't have to turn off the backup function in order to turn on recovery mode. The backup will be temporarily disabled when the recovery is in progress and will be auto turned back on (if it was on) once the recovery is complete.
 
-By default, it will recover with the "LATEST" base backup. However, you can specify a different backup name with helm config option: `combined-db.magda-postgres.backupRestore.backup.recoveryMode.baseBackupName` or manually set environment variable `MAGDA_RECOVERY_BASE_BACKUP_NAME` on the relevant postgreSQL instance statefulset.
+By default, it will recover with the "LATEST" base backup. However, you can specify a different backup name with helm config option: `combined-db.magda-postgres.backupRestore.recoveryMode.baseBackupName` or manually set environment variable `MAGDA_RECOVERY_BASE_BACKUP_NAME` on the relevant postgreSQL instance statefulset.
 
 > **Recovery target — how far recovery replays.** `combined-db.magda-postgres.backupRestore.recoveryMode.recoveryTarget` controls where WAL replay stops:
 >

--- a/docs/docs/in-cluster-database-backup-and-restore.md
+++ b/docs/docs/in-cluster-database-backup-and-restore.md
@@ -144,6 +144,7 @@ The wal-g mechanics are exercised as a regression oracle in `magda-int-test-ts` 
 
 ## Related
 
+- [PostgreSQL Upgrade & Migration Pathways (v6 → v7)](./postgres-upgrade-migration-pathways.md) — pick the right route when moving to v7; explains why wal-g is a rollback net, not a migration tool.
 - [How to Config Continuous Archiving and Point-in-Time Recovery (PITR)](./how-to-recover-with-continuous-archive-backup.md) — configuration how-to (storage, helm values).
 - [`magda-postgres` chart reference](../../deploy/helm/internal-charts/magda-postgres) — all `backupRestore.*` options.
 - [PostgreSQL Continuous Archiving & PITR](https://www.postgresql.org/docs/17/continuous-archiving.html) — upstream reference.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,6 +6,7 @@
 - [Testing a PR with a Preview Release Before Merging](./pr-preview-release-testing.md)
 - [End-to-End Full Cluster Deployment Test](./e2e-cluster-deployment-test.md)
 - [Migration & Upgrade Documents](./migration/)
+- [PostgreSQL Upgrade & Migration Pathways (v6 → v7)](./postgres-upgrade-migration-pathways.md)
 - [Deploy Magda with helm charts release](https://github.com/magda-io/magda-config)
 - [Magda Helm Chart Reference](./helm-charts-docs-index.md)
 - [How to update Helm chart docs (helm-docs)](./how-to-update-helm-chart-docs.md)

--- a/docs/docs/migration/in-cluster-postgres-to-managed-db.md
+++ b/docs/docs/migration/in-cluster-postgres-to-managed-db.md
@@ -351,3 +351,4 @@ single `awsRdsEndpoint`.
 - [Deploy Magda on AWS EKS](../deploy-to-aws.md) / [Azure AKS](../deploy-to-azure.md) — external-database provisioning and the value contract.
 - [Upgrading Google Cloud SQL using Google DMS](./upgrade-google-cloud-sql-using-google-dms.md) — a provider-driven major upgrade of an already-managed database.
 - [In-cluster Database Backup & Restore — How It Works](../in-cluster-database-backup-and-restore.md) — why wal-g is a rollback net, not a migration tool.
+- [E2E test case: migrate the in-cluster PostgreSQL to a managed/cloud database](../e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md) — a repeatable gate for this procedure against a simulated (TLS-enforced, non-superuser-master) managed DB.

--- a/docs/docs/migration/in-cluster-postgres-to-managed-db.md
+++ b/docs/docs/migration/in-cluster-postgres-to-managed-db.md
@@ -1,0 +1,353 @@
+# How to migrate the in-cluster database to a managed / cloud database
+
+This is **Pathway B** of the
+[PostgreSQL Upgrade & Migration Pathways](../postgres-upgrade-migration-pathways.md):
+moving off Magda's bundled in-cluster PostgreSQL onto a managed / cloud database
+(AWS RDS, Azure Database for PostgreSQL, or GCP Cloud SQL). Do this **while still
+on Magda v6**, verify Magda runs against the managed database, then upgrade to v7 —
+at which point PostgreSQL is operated by your provider and the in-cluster
+`majorUpgrade` mechanism does not apply to you.
+
+Use this pathway if v7 is the moment you want to stop running PostgreSQL yourself.
+If you want to keep the database in-cluster, use
+[Pathway A](../postgres-major-upgrade-runbook.md) instead. If you are already on a
+managed database, you are on
+[Pathway C](../postgres-upgrade-migration-pathways.md#pathway-c--already-on-a-managed--cloud-database).
+
+## wal-g backups are not a migration path
+
+The in-cluster [wal-g backup/restore mechanism](../in-cluster-database-backup-and-restore.md)
+is **not** a way to load data into a managed database. `wal-g backup-fetch`
+restores a **physical** copy of a PostgreSQL 13 data directory, which only a
+PostgreSQL 13 server running the same on-disk layout can read — not a managed
+service you do not control the file system of. This migration is a **logical**
+`pg_dump` / `psql` load, which is portable across servers and versions.
+
+## The shape of the migration
+
+1. Provision the managed database and make it reachable from the cluster.
+2. Stop application writes so the dump is a clean, consistent point.
+3. Create the `client` login role, then `pg_dump` each database out of the
+   running in-cluster server and load it into the managed database, and grant
+   `client` its privileges.
+4. Verify every database restored and `client` can read its data.
+5. Reconfigure Magda (still v6) to use the managed database; verify.
+6. Upgrade Magda to v7.
+7. Decommission the in-cluster database.
+
+Steps 2–5 are the downtime window. Plan for it: the dump reads the whole database
+over the network and the load replays it, so the window scales with your data
+size.
+
+## Before you start
+
+- **A managed PostgreSQL instance** running a version Magda supports (**13–17**),
+  reachable from inside the cluster on port 5432. For AWS, the VPC peering /
+  security-group / DNS setup is the same as a fresh external-DB install — see
+  [Deploy Magda on AWS EKS](../deploy-to-aws.md), step 3. Azure Database for
+  PostgreSQL and any other directly-addressable endpoint use the same Magda
+  configuration path as RDS (below).
+- **The managed instance's master username and password.** The master user does
+  not need to be named `postgres`, but it must be able to create databases and
+  roles. Note that managed services (AWS RDS, Azure, Cloud SQL) do **not** give
+  you a real PostgreSQL superuser — your master account is privileged but not
+  `SUPERUSER`. This is why this how-to uses per-database `pg_dump` with
+  `--no-owner --no-privileges` plus an explicit `client` grant, rather than a
+  single `pg_dumpall`: a `pg_dumpall` stream recreates the source's superuser
+  roles and object ownership and issues `SET ROLE` to them, which a non-superuser
+  master cannot do — the restore then fails partway and can **silently drop data**
+  (most dangerously the registry tables in the shared `postgres` database), while
+  still creating the empty databases so the failure is easy to miss.
+- **The in-cluster superuser password.** In a default combined-db install it is in
+  the secret named by `global.postgresql.existingSecret` (default
+  `db-main-account-secret`), key `postgresql-password`, and the user is `postgres`
+  (`global.postgresql.postgresqlUsername`).
+- **A rough size estimate**, to gauge the downtime window:
+  ```sql
+  SELECT pg_size_pretty(sum(pg_database_size(datname))) FROM pg_database;
+  ```
+
+Throughout, replace `magda` with your Helm release name and `magda` (namespace)
+with your install namespace. The commands assume the default **combined-db**
+topology; for a per-service (`useInK8sDbInstance`) topology see
+[Per-service topology](#per-service-topology) at the end.
+
+## Step 1 — Provision and confirm reachability
+
+Create the managed instance and confirm a pod in the cluster can reach it. A quick
+check from a throwaway client pod:
+
+```bash
+kubectl run pg-check --namespace magda --rm -it --restart=Never \
+  --image=postgres:17 -- \
+  psql "host=<MANAGED_ENDPOINT> port=5432 user=<MASTER_USER> dbname=postgres sslmode=require" -c '\conninfo'
+```
+
+(You will be prompted for the master password.) Most managed services require TLS;
+`sslmode=require` satisfies AWS RDS `rds.force_ssl=1` and Azure's enforced TLS. If
+your provider does not enforce TLS you may use `sslmode=disable`.
+
+## Step 2 — Stop application writes
+
+To make the dump a single consistent point, stop everything that writes to the
+database before you dump. The safest option is a brief full downtime — scale the
+writing services to zero:
+
+```bash
+kubectl scale deployment --namespace magda --replicas=0 \
+  registry-api-full authorization-api content-api tenant-api gateway
+```
+
+Also stop any running connectors and minions (they write to the registry). Read
+traffic can continue if you only scale down the writers, but a clean cutover is
+simplest with everything paused.
+
+> Confirm the exact Deployment names in your release with
+> `kubectl get deploy -n magda`; they are prefixed by conventions your values may
+> change.
+
+## Step 3 — Create roles, restore each database, grant `client`
+
+Run everything **from inside the cluster** so it can reach both the in-cluster
+database Service and the managed endpoint. The steps below all run in one
+throwaway `postgres:17` pod. First gather the passwords:
+
+```bash
+# In-cluster superuser password (default combined-db install)
+export SRC_PASSWORD=$(kubectl get secret db-main-account-secret -n magda \
+  -o jsonpath='{.data.postgresql-password}' | base64 --decode)
+# The app 'client' role's password, so it matches after cutover (see Step 5)
+export CLIENT_PASSWORD=$(kubectl get secret combined-db-password -n magda \
+  -o jsonpath='{.data.password}' | base64 --decode)
+# The managed instance's master password
+export DST_PASSWORD='<MASTER_PASSWORD>'
+```
+
+Then open a shell in a client pod:
+
+```bash
+kubectl run pg-migrate --namespace magda --rm -i --restart=Never \
+  --image=postgres:17 \
+  --env=SRC_PASSWORD="$SRC_PASSWORD" \
+  --env=CLIENT_PASSWORD="$CLIENT_PASSWORD" \
+  --env=DST_PASSWORD="$DST_PASSWORD" \
+  --command -- sh
+```
+
+Inside that shell, set the two connection strings. The in-cluster v6 database
+speaks plaintext (`sslmode=disable`); the managed database almost always requires
+TLS (`sslmode=require`, which satisfies AWS RDS `rds.force_ssl=1` and Azure's
+enforced TLS):
+
+```sh
+SRC="host=combined-db-postgresql port=5432 user=postgres sslmode=disable"
+DST="host=<MANAGED_ENDPOINT> port=5432 user=<MASTER_USER> sslmode=require"
+export PGPASSWORD="$DST_PASSWORD"
+set -e
+```
+
+**1. Create the `client` login role** with the same password Magda already uses,
+so the credentials line up after cutover (see Step 5):
+
+```sh
+psql "$DST dbname=postgres" -v ON_ERROR_STOP=1 \
+  -c "CREATE ROLE client LOGIN PASSWORD '$CLIENT_PASSWORD';"
+```
+
+**2. Restore each database.** Dump with `--no-owner --no-privileges` so objects
+are created owned by your master account (not the source's superuser, which does
+not exist on a managed service), and pipe straight in. The registry's tables live
+in the shared `postgres` database, which already exists on the target, so it is
+restored in place rather than created:
+
+```sh
+# Application databases — created fresh, then restored
+for db in auth content session tenant; do   # drop 'tenant' if you don't run multi-tenancy
+  psql "$DST dbname=postgres" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$db\";"
+  PGPASSWORD="$SRC_PASSWORD" pg_dump "$SRC dbname=$db" --no-owner --no-privileges \
+    | PGPASSWORD="$DST_PASSWORD" psql "$DST dbname=$db" -v ON_ERROR_STOP=1
+done
+
+# Registry data — lives in the shared 'postgres' database (there is no 'registry' db)
+PGPASSWORD="$SRC_PASSWORD" pg_dump "$SRC dbname=postgres" --no-owner --no-privileges \
+  | PGPASSWORD="$DST_PASSWORD" psql "$DST dbname=postgres" -v ON_ERROR_STOP=1
+```
+
+> If a `CREATE TABLE` in the `postgres` database is rejected with
+> `permission denied for schema public`, your master account cannot create objects
+> in that database's `public` schema. Grant it first (as the master, or via your
+> provider's console): `GRANT CREATE, USAGE ON SCHEMA public TO "<MASTER_USER>";`
+> then re-run the registry restore.
+
+**3. Grant `client` its privileges** in every database — this replaces the grants
+the in-cluster migrators normally set up, and includes default privileges so
+tables created later by the v7 migrators are also reachable:
+
+```sh
+for db in auth content session tenant postgres; do   # match the databases you restored
+  PGPASSWORD="$DST_PASSWORD" psql "$DST dbname=$db" -v ON_ERROR_STOP=1 <<'SQL'
+GRANT USAGE ON SCHEMA public TO client;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO client;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO client;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO client;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO client;
+SQL
+done
+```
+
+Notes:
+
+- Using the **PostgreSQL 17 client** to dump a PostgreSQL 13 server is supported and
+  recommended (dump with a client at least as new as the source).
+- `pg_dump` preserves each table's rows **and its sequences' current values**, so
+  auto-increment columns (e.g. the registry's `events` sequence) continue from
+  where they left off.
+- `--no-privileges` drops the source's grants (which reference in-cluster-only
+  roles); step 3 re-establishes exactly the grants `client` needs.
+
+## Step 4 — Verify the restore
+
+Confirm the databases restored and, crucially, that **`client` itself** can read
+the data over TLS — this is how Magda's services will connect, so it catches both
+missing data and missing grants:
+
+```bash
+kubectl run pg-check --namespace magda --rm -it --restart=Never \
+  --image=postgres:17 --env=CP='<CLIENT_PASSWORD>' -- sh -c '
+    C="host=<MANAGED_ENDPOINT> port=5432 user=client sslmode=require"
+    PGPASSWORD=$CP psql "$C dbname=postgres" -c "\l" -c "\dt" \
+      -c "SELECT count(*) FROM records;"   # registry data in the postgres db
+  '
+```
+
+Confirm that:
+
+- A default combined-db install shows `auth`, `content` and `session` as
+  databases, plus `tenant` if you run multi-tenancy. **There is no `registry`
+  database** — the registry's tables (`records`, `aspects`, `events`,
+  `recordaspects`, `webhooks`, `webhookevents`, `eventtypes`) live in the
+  `postgres` database, because `registry-api` connects with no `POSTGRES_DB`.
+- Those registry tables are present in the `postgres` database with the row counts
+  you expect, and the `SELECT count(*) FROM records` above **succeeds as `client`**
+  (not just as the master) — that proves both the data and the grants landed.
+- The `client` role's password matches the `combined-db-password` secret
+  (key `password`) you used in Step 3, so Magda's services authenticate after
+  cutover without any secret change.
+
+## Step 5 — Reconfigure Magda to use the managed database (still v6)
+
+Switch the release over to the managed database with a `helm upgrade` that keeps
+your current Magda version and changes only the database configuration.
+
+First, create the master-account secret Magda's migrators use (it is separate from
+the app's `client` credentials):
+
+```bash
+kubectl create secret generic db-main-account-secret --namespace magda \
+  --from-literal=postgresql-password='<MASTER_PASSWORD>'
+# If the secret already exists (in-cluster installs create it), update it instead:
+#   kubectl create secret generic db-main-account-secret -n magda \
+#     --from-literal=postgresql-password='<MASTER_PASSWORD>' \
+#     --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Then set the external-database values. On **v6** the master username key is
+`global.postgresql.postgresqlUsername`:
+
+```yaml
+global:
+  useCombinedDb: false
+  useCloudSql: false
+  useAwsRdsDb: true                       # generic direct-endpoint path — RDS and Azure DB
+  awsRdsEndpoint: "<MANAGED_ENDPOINT>"    # e.g. mydb.abc123.ap-southeast-2.rds.amazonaws.com
+  postgresql:
+    postgresqlUsername: "<MASTER_USER>"   # v6 key
+    # client sslmode: `require` (default) suits RDS/Azure; use `disable` only for a plaintext DB
+    # client:
+    #   sslmode: require
+```
+
+Leave **`tags.combined-db: true`** (the default). Even with no in-cluster database,
+the `combined-db` chart is what creates and preserves the `combined-db-password`
+secret holding the `client` credentials your services use — turning it off would
+drop those credentials.
+
+Setting `useCombinedDb: false` + `useAwsRdsDb: true` turns every `*-db` Service
+(`authorization-db`, `content-db`, `session-db`, `registry-db`, `tenant-db`) into a
+Kubernetes `ExternalName` alias for `awsRdsEndpoint`, so all services resolve to
+your single managed instance. **The value paths above are `global.*` and apply
+unprefixed even on the umbrella `magda` chart.**
+
+Apply it, then scale the services you stopped back up and verify: the gateway is
+reachable, dataset search returns your existing data, and login works. Do not
+proceed to v7 until Magda v6 is healthy against the managed database.
+
+## Step 6 — Upgrade to v7
+
+With Magda running on the managed database, upgrade to v7 as a normal external-DB
+upgrade — this is [Pathway C](../postgres-upgrade-migration-pathways.md#pathway-c--already-on-a-managed--cloud-database).
+The only value change is the master-username key, which v7 moved from
+`global.postgresql.postgresqlUsername` to **`global.postgresql.auth.username`**:
+
+```yaml
+global:
+  useCombinedDb: false
+  useAwsRdsDb: true
+  awsRdsEndpoint: "<MANAGED_ENDPOINT>"
+  postgresql:
+    auth:
+      username: "<MASTER_USER>"           # v7 key (renamed from postgresqlUsername)
+```
+
+Do **not** set any `majorUpgrade.*` value — it applies only to the in-cluster
+option and has no effect on an external database. Use a generous `--timeout` so the
+schema migrators have time to run:
+
+```bash
+helm upgrade magda <chart> --namespace magda -f your-values.yaml --timeout 3600s
+```
+
+The v7 upgrade re-applies the Magda schema migrations against the managed database;
+because the data is already present, these are effectively no-ops or forward
+migrations, not a reload.
+
+## Step 7 — Decommission the in-cluster database
+
+Once v7 is healthy on the managed database and you are confident you will not roll
+back:
+
+1. Confirm no service still points in-cluster (all `*-db` Services are
+   `ExternalName`): `kubectl get svc -n magda | grep -E 'authorization-db|content-db|session-db|registry-db|tenant-db'`.
+2. Delete the old in-cluster PostgreSQL data PVC(s) (`data-combined-db-postgresql-0`,
+   or `data-<db>-postgresql-0` per service) once you no longer need them for
+   rollback. Until deleted they consume storage but are otherwise inert.
+3. If you had wal-g backups configured for the in-cluster instance, remember they
+   are now a dead-end PostgreSQL 13 chain (see the wal-g note above) — your managed
+   provider owns backups from here on.
+
+## Rolling back
+
+Because `pg_dump` only **reads** the in-cluster database, the source is
+untouched by this migration. If anything goes wrong before you delete the
+in-cluster PVCs, revert the `helm upgrade` from Step 5 (restore `useCombinedDb:
+true` and drop the external-DB values, or `helm rollback`), and Magda goes back to
+the in-cluster PostgreSQL 13 instance with its data exactly as it was.
+
+## Per-service topology
+
+If you run individual in-cluster instances (`global.useCombinedDb: false` with
+`global.useInK8sDbInstance.<db>: true`) rather than a combined database, each
+service has its own PostgreSQL pod and Service (`authorization-db-postgresql`,
+`content-db-postgresql`, …), each with its own `postgres` database holding that
+service's data. In Step 3, point `SRC` at each service's Service name in turn
+(`host=<db>-postgresql`) and `pg_dump` its `postgres` database into the matching
+target database, then set `global.useInK8sDbInstance.<db>: false` for every service
+alongside the external-DB values in Step 5. All services still resolve to the
+single `awsRdsEndpoint`.
+
+## See also
+
+- [PostgreSQL Upgrade & Migration Pathways](../postgres-upgrade-migration-pathways.md) — the overview and how to pick a pathway.
+- [Deploy Magda on AWS EKS](../deploy-to-aws.md) / [Azure AKS](../deploy-to-azure.md) — external-database provisioning and the value contract.
+- [Upgrading Google Cloud SQL using Google DMS](./upgrade-google-cloud-sql-using-google-dms.md) — a provider-driven major upgrade of an already-managed database.
+- [In-cluster Database Backup & Restore — How It Works](../in-cluster-database-backup-and-restore.md) — why wal-g is a rollback net, not a migration tool.

--- a/docs/docs/postgres-major-upgrade-runbook.md
+++ b/docs/docs/postgres-major-upgrade-runbook.md
@@ -7,6 +7,11 @@ Magda v7 upgrades the **bundled, in-cluster** PostgreSQL from 13.7 to 17.5 (the
 `postgresql` subchart). This runbook covers moving your **existing v6 data** into
 the new PostgreSQL 17 instance as part of a v6 → v7 `helm upgrade`.
 
+This is **Pathway A** of the
+[PostgreSQL Upgrade & Migration Pathways](./postgres-upgrade-migration-pathways.md) —
+keeping the database in-cluster. If you instead want to move to a managed / cloud
+database, see that overview for Pathways B and C.
+
 It applies only to the in-cluster option — every database chart
 (`combined-db`, `registry-db`, `authorization-db`, `content-db`, `session-db`,
 `tenant-db`) that embeds `magda-postgres` and runs its own PostgreSQL pod. If you

--- a/docs/docs/postgres-upgrade-migration-pathways.md
+++ b/docs/docs/postgres-upgrade-migration-pathways.md
@@ -1,0 +1,110 @@
+# PostgreSQL Upgrade & Migration Pathways (v6 → v7)
+
+Magda v7 upgrades the **bundled, in-cluster** PostgreSQL from 13.7 to 17.5. If you
+run the in-cluster database, your existing v6 data does **not** move into
+PostgreSQL 17 by itself — a plain `helm upgrade` gives you a new, empty PostgreSQL
+17 instance. This page helps you pick the right route to carry your data forward,
+and links to the detailed procedure for each.
+
+If you already run a **managed / cloud** database (AWS RDS, Azure Database for
+PostgreSQL, GCP Cloud SQL), the upgrade is mostly a no-op — see Pathway C.
+
+## First: wal-g backups are not a migration path
+
+Before you choose a route, clear up the single most common misconception. The
+in-cluster [wal-g backup/restore mechanism](./in-cluster-database-backup-and-restore.md)
+is a **rollback net, not a migration tool**:
+
+- `wal-g backup-fetch` restores a **physical** copy of the data directory. A base
+  backup taken from a PostgreSQL 13 server can only ever be restored into a
+  PostgreSQL **13** server — the on-disk files are not readable by PostgreSQL 17.
+- So enabling wal-g before an upgrade gives you **rollback-to-13**. It is **not** a
+  way to load data into PostgreSQL 17, and **not** a way to load data into a
+  managed database either.
+
+Every migration below therefore uses a **logical** dump/restore
+(`pg_dumpall` / `pg_dump` + `psql`), which is immune to the on-disk format change
+and works across servers.
+
+## Pick your pathway
+
+| | Your database today | Where you want to end up | Route |
+| --- | --- | --- | --- |
+| **A** | In-cluster PostgreSQL 13 (the bundled `magda-postgres`) | In-cluster PostgreSQL 17 (bundled DB stays) | Automated in-cluster dump/restore during the v7 `helm upgrade` |
+| **B** | In-cluster PostgreSQL 13 | A managed / cloud database (RDS / Azure / Cloud SQL) | Move to the managed DB first (still on v6), then upgrade to v7 |
+| **C** | Already on a managed / cloud database | Same managed DB, on v7 | Mostly a no-op — external-DB config carries over |
+
+If more than one looks plausible: choose **A** to keep operating the database
+yourself with the least change; choose **B** if v7 is the moment you want to hand
+PostgreSQL operation to a cloud provider; you are on **C** only if Magda already
+talks to an external database today (`global.useAwsRdsDb`, `global.useCloudSql`, or
+a per-service external host).
+
+## Pathway A — in-cluster PostgreSQL 13 → in-cluster PostgreSQL 17
+
+The bundled database stays in the cluster. During the v6 → v7 `helm upgrade`, a
+Helm-hook Job does a **logical** `pg_dumpall` from the still-running PostgreSQL 13
+instance over the network and loads it into the new PostgreSQL 17 instance,
+**before** the schema migrators run. The old PostgreSQL 13 data PVC is never
+touched, so a rollback is `helm rollback` plus flipping back to the old instance.
+
+- **[Runbook: PostgreSQL Major Upgrade (in-cluster)](./postgres-major-upgrade-runbook.md)** —
+  the operator-facing procedure: enabling `majorUpgrade`, the `--timeout` you must
+  set, verification, rollback, and per-service instances.
+- **[How the in-cluster major upgrade works](./postgres-major-upgrade-mechanism.md)** —
+  the mechanism internals: the hook Jobs, the `magda_major_upgrade` marker table,
+  and why reading over the network avoids the physical `pg_upgrade` collation
+  hazard.
+
+Downtime lasts for the duration of the dump plus the restore; size your
+`--timeout` and staging volume accordingly (both covered in the runbook).
+
+## Pathway B — in-cluster PostgreSQL 13 → managed / cloud database
+
+Use this when v7 is the point at which you want to stop running PostgreSQL
+in-cluster and hand it to a cloud provider. You do the database move **while still
+on v6**, then upgrade Magda to v7 pointed at the managed database — at which point
+the version of PostgreSQL is owned by your provider and the in-cluster
+`majorUpgrade` mechanism does not apply.
+
+The move is a **logical** `pg_dump` of each database over the network from the
+still-running in-cluster database into the managed database (plus recreating the
+`client` role and its grants), followed by reconfiguring Magda to use the external
+database and decommissioning the in-cluster instance. (A single `pg_dumpall` is
+deliberately **not** used — managed services provide no superuser, so its role and
+ownership assumptions fail; the how-to explains why.)
+
+- **[How to migrate the in-cluster database to a managed / cloud database](./migration/in-cluster-postgres-to-managed-db.md)** —
+  the full procedure, including the wal-g caveat, the exact dump/restore commands,
+  the Helm values to switch Magda to the external database, verification and
+  cutover.
+
+Your managed instance must run a PostgreSQL version Magda supports (13–17). Once
+you have moved, subsequent Magda upgrades follow Pathway C.
+
+## Pathway C — already on a managed / cloud database
+
+If Magda already talks to an external database, the v7 upgrade **does not touch
+your data**. The `majorUpgrade.*` values apply only to the in-cluster option and
+have no effect here; the PostgreSQL version — and any major-version upgrade of it —
+is owned by your provider.
+
+To upgrade:
+
+1. Make sure your managed instance runs a PostgreSQL version Magda supports
+   (**13–17**). If you need to move it to a newer major version, that is a
+   provider-side operation — see your provider's tooling (for GCP,
+   [Upgrading Google Cloud SQL using Google DMS](./migration/upgrade-google-cloud-sql-using-google-dms.md)
+   is an existing example of a provider-driven major upgrade).
+2. Run the v7 `helm upgrade` with your existing external-database values
+   unchanged. See [Deploy Magda on AWS EKS](./deploy-to-aws.md) and
+   [Deploy Magda on Azure AKS](./deploy-to-azure.md) for the external-database
+   value contract (`global.useCombinedDb`, `global.useAwsRdsDb` /
+   `global.useCloudSql`, `global.awsRdsEndpoint`, `global.postgresql.auth.username`).
+
+## See also
+
+- [In-cluster Database Backup & Restore — How It Works (mechanics & RPO)](./in-cluster-database-backup-and-restore.md)
+- [Runbook: PostgreSQL Major Upgrade (in-cluster)](./postgres-major-upgrade-runbook.md)
+- [How the in-cluster major upgrade works](./postgres-major-upgrade-mechanism.md)
+- [How to migrate the in-cluster database to a managed / cloud database](./migration/in-cluster-postgres-to-managed-db.md)


### PR DESCRIPTION
## What

Part 1 of #3750 (docs). Adds the operator-facing PostgreSQL upgrade/migration pathway docs and fixes two config-key doc bugs.

### New docs
- **`docs/docs/postgres-upgrade-migration-pathways.md`** — overview of the three routes to v7 (A: in-cluster PG13→PG17; B: in-cluster→managed/cloud DB; C: already managed), leading with the wal-g caveat (physical PG13 restore = rollback net, **not** a cross-major / cross-server migration) and a decision table.
- **`docs/docs/migration/in-cluster-postgres-to-managed-db.md`** — Pathway B how-to: create the `client` role, per-database `pg_dump --no-owner --no-privileges` from the still-running in-cluster DB into the managed DB, grant `client`; reconfigure Magda for the external DB (`useCombinedDb=false` + `useAwsRdsDb`/`awsRdsEndpoint`, master-username key, `db-main-account-secret`); verify; cut over; decommission.

### Cross-links
- `in-cluster-database-backup-and-restore.md` and `postgres-major-upgrade-runbook.md` (now labelled Pathway A) link the overview; overview added to the docs index.

### Doc-bug fixes (also on `next`)
- `magda-postgres/README.md.gotmpl`: `global.postgresql.tls.enabled` → **`postgresql.tls.enabled`** (real subchart-value gate). Regenerated `README.md` via helm-docs.
- `how-to-recover-with-continuous-archive-backup.md`: `backupRestore.backup.recoveryMode.*` → `backupRestore.recoveryMode.*` (same fix as #3764 to main).

## Verification (minikube)
Verified the claims against the charts and a live cluster:
- **Config keys (`helm template`):** only `backupRestore.recoveryMode.enabled=true` sets `MAGDA_RECOVERY_MODE=true` (old key is a no-op); only `postgresql.tls.enabled=false` drops the TLS secret (old key is a no-op); `useAwsRdsDb=true` renders each `*-db` Service as `ExternalName → awsRdsEndpoint`.
- **Pathway B, simulated managed DB:** stood up a PG17 target with **TLS enforced** (`hostssl`-only pg_hba, mimicking RDS `rds.force_ssl`) and a **non-superuser master** (mimicking RDS). Confirmed `sslmode=disable` is rejected and `sslmode=require` connects. A naive `pg_dumpall | psql` as the non-superuser master **failed and silently dropped the registry data** (shared `postgres` db) via `SET ROLE`/ownership errors — which is exactly why the how-to uses per-database `pg_dump --no-owner --no-privileges` + explicit `client` grants instead. The documented per-database procedure restored every database (PG13→PG17), preserved sequences, and let the `client` role read/write over TLS.

## Notes
- Docs target `next`; they reach `main` when `next` merges at v7.0.0.
- Closing #3750 closes epic #3740.

### E2E test case (added)
- **`docs/docs/e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md`** — a repeatable gate for Pathway B against a **managed DB simulated in-cluster** (TLS-enforced `hostssl` pg_hba + non-superuser master). Includes a negative control (naive `pg_dumpall` loses registry data), the documented per-database procedure with row-count/sequence/TLS assertions, and the Magda reconfigure + v7 external-DB upgrade. Indexed in the e2e README and linked from the how-to. The DB-level steps were exercised on minikube; the full app reconfigure/upgrade is the broader gate the case defines (Notes say which is which).


### Full end-to-end run (minikube) — added
Ran the complete flow on minikube: **v6 `6.1.2-pr.3759.0` → simulated managed PG17 (TLS enforced, non-superuser master) → v7 `7.0.0-pr.3762.4`**. After the v7 cutover, `whoami` returned 200 and the seeded dataset was served **through the registry API** from the managed DB over TLS, row counts intact. Two findings surfaced and are folded into the how-to, overview, and e2e case:

- **Cut over at the v7 upgrade, not before.** Pre-v7 DB migrators build their Flyway (pgjdbc) URL without `sslmode`, so against a TLS-enforcing managed DB (RDS `force_ssl`/Azure) the `registry-db-migrator` hook fails (`no pg_hba.conf entry ... no encryption`) and the upgrade fails — even though the running services (which append `sslmode`) connect fine. v7 migrators set `PGSSLMODE=require` and carry it into the Flyway URL, so the cutover must be the v7 upgrade itself.
- **The registry restore needs `CREATE ON DATABASE`** on the target (for the trusted `uuid-ossp` extension) in addition to `CREATE ON SCHEMA public`; a non-superuser master has neither by default.
