### PR TITLE
docs: correct Pathway B from full end-to-end minikube run (follow-up to #3765)

### DIFF
--- a/docs/docs/e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md
+++ b/docs/docs/e2e-test-cases/postgres-in-cluster-to-managed-db-migration.md
@@ -35,9 +35,10 @@ one vendor's exact privilege model (see Notes).
    `pg_dump --no-owner --no-privileges` each database, grant `client` — and assert
    every database, its row counts, sequences, and `client`'s own read/write access
    landed on the managed DB over TLS.
-5. **Reconfigure Magda (still v6)** to the managed DB and assert the application is
-   healthy against it.
-6. **Upgrade to v7** as an external-DB upgrade and assert data and health.
+5. **Cut over by upgrading to v7** pointed at the managed DB, and assert the
+   migrators connect over TLS, the application is healthy, and the seeded dataset
+   is served through the API from the managed DB. (Includes the verified reason to
+   cut over at v7 rather than pointing an earlier version at the managed DB first.)
 
 ## Prerequisites
 
@@ -148,11 +149,18 @@ helm install magda oci://ghcr.io/magda-io/charts/magda --version "$V6_VERSION" -
 export PGPASSWORD=$(kubectl get secret -n "$NS" db-main-account-secret -o jsonpath='{.data.postgresql-password}' | base64 -d)
 export CLIENT_PW=$(kubectl get secret -n "$NS" combined-db-password -o jsonpath='{.data.password}' | base64 -d)
 # ... seed a registry record + auth user via the gateway (see Pathway A step 1) ...
+# capture the dataset id you PUT — step 5 reads it back through the API:
+echo "<your-dataset-id>" > /tmp/dsid.txt
 kubectl -n "$NS" exec combined-db-postgresql-0 -- env PGPASSWORD="$PGPASSWORD" \
   psql -U postgres -h 127.0.0.1 -d postgres -tAc "SELECT count(*) FROM records;" | tee /tmp/registry-count.txt
 kubectl -n "$NS" exec combined-db-postgresql-0 -- env PGPASSWORD="$PGPASSWORD" \
   psql -U postgres -h 127.0.0.1 -d auth -tAc "SELECT count(*) FROM users;" | tee /tmp/auth-count.txt
 ```
+
+> The admin session JWT (`X-Magda-Session`) is `jwt.sign({userId, session:{}}, jwtSecret)`
+> for the built-in admin `00000000-0000-4000-8000-000000000000`. If `acs-cmd` isn't
+> handy, mint it with the `jwt-secret` from the `auth-secrets` secret:
+> `node -e "console.log(require('jsonwebtoken').sign({userId:'00000000-0000-4000-8000-000000000000',session:{}}, process.argv[1]))" "$JWT_SECRET"`.
 
 ## 2. Stop application writes
 
@@ -190,12 +198,17 @@ kubectl exec -n "$NS" managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -v
   DROP DATABASE IF EXISTS auth; DROP DATABASE IF EXISTS content;
   DROP DATABASE IF EXISTS session; DROP DATABASE IF EXISTS tenant;
   REASSIGN OWNED BY client TO postgres; DROP OWNED BY client; DROP ROLE IF EXISTS client;
-  GRANT CREATE, USAGE ON SCHEMA public TO $MASTER_USER;"   # let the master manage the shared postgres db
+  GRANT CREATE, USAGE ON SCHEMA public TO $MASTER_USER;
+  GRANT CREATE ON DATABASE postgres TO $MASTER_USER;"   # let the master manage the shared postgres db
 ```
 
-> The final `GRANT` models what a managed provider's admin (e.g. `rds_superuser`)
-> can do to the shared `postgres` database. On a real provider you either already
-> have this or run it once from the provider console; see the how-to's Step 3 note.
+> The two `GRANT`s model what a managed provider's admin (e.g. `rds_superuser`) can
+> do to the shared `postgres` database. Both were needed in verification: the
+> schema grant so the master can create the registry tables in `public`, and the
+> database grant so it can `CREATE EXTENSION "uuid-ossp"` (a trusted extension —
+> no superuser required, but `CREATE` on the database is). On a real provider you
+> either already have these or run them once from the provider console; see the
+> how-to's Step 3 note.
 
 ## 4. Migrate with the documented per-database procedure
 
@@ -244,68 +257,64 @@ kubectl run verify -n "$NS" --rm -i --restart=Never --image=postgres:17 \
 #         databases auth/content/postgres/session/tenant present, NO 'registry' db.
 ```
 
-## 5. Reconfigure Magda (still v6) to the managed database
+## 5. Cut over to the managed database (upgrade to v7)
 
-Point the master-account secret and the external-DB values at the managed DB:
+Point the master-account secret at the managed master, then **upgrade straight to
+v7** with the external-DB values — do not point v6 at the managed DB first (see the
+caveat below):
 
 ```bash
 kubectl create secret generic db-main-account-secret -n "$NS" \
   --from-literal=postgresql-password="$MASTER_PW" --dry-run=client -o yaml | kubectl apply -f -
 
-helm upgrade magda oci://ghcr.io/magda-io/charts/magda --version "$V6_VERSION" -n "$NS" \
-  --reuse-values \
+helm upgrade magda oci://ghcr.io/magda-io/charts/magda --version "$V7_VERSION" -n "$NS" \
   --set global.useCombinedDb=false \
   --set global.useAwsRdsDb=true \
   --set global.awsRdsEndpoint="$MANAGED_HOST" \
-  --set global.postgresql.postgresqlUsername="$MASTER_USER" \
-  --timeout 3600s
-kubectl -n "$NS" scale deployment --replicas=1 \
-  $(kubectl -n "$NS" get deploy -o name | grep -E 'registry-api|authorization-api|content-api|tenant-api|gateway' | paste -sd' ' -)
+  --set global.postgresql.auth.username="$MASTER_USER" \
+  --wait --timeout 3600s
 ```
 
-Assert the `*-db` Services are now `ExternalName` aliases and the app is healthy
-against the managed DB:
+> Do **not** pass `--reuse-values` (v7 restructured the values contract and it trips
+> the `validate-tls` guard), and do **not** set any `majorUpgrade.*` value (no effect
+> on an external DB). The upgrade must **succeed** — its post-upgrade migrator hooks
+> connect to the managed DB over TLS.
+
+Assert the switch and health:
 
 ```bash
 kubectl -n "$NS" get svc authorization-db content-db session-db registry-db -o \
   custom-columns=NAME:.metadata.name,TYPE:.spec.type,TO:.spec.externalName
 # expect: all type ExternalName -> $MANAGED_HOST
+kubectl -n "$NS" port-forward svc/gateway 18080:80 & sleep 6
 curl -s -o /dev/null -w "%{http_code}\n" http://localhost:18080/api/v0/auth/users/whoami   # 200
-curl -s "http://localhost:18080/api/v0/registry/records?limit=1" -H "X-Magda-Tenant-Id: 0" | head -c 200
-```
-
-## 6. Upgrade to v7 (external-DB upgrade)
-
-```bash
-helm upgrade magda oci://ghcr.io/magda-io/charts/magda --version "$V7_VERSION" -n "$NS" \
-  --reuse-values \
-  --set global.postgresql.auth.username="$MASTER_USER" \
-  --timeout 3600s
-```
-
-> The master-username key moved from `global.postgresql.postgresqlUsername` (v6)
-> to `global.postgresql.auth.username` (v7). Do **not** set any `majorUpgrade.*`
-> value — it has no effect on an external database.
-
-Assert data and health after the upgrade:
-
-```bash
+curl -s "http://localhost:18080/api/v0/registry/records/$(cat /tmp/dsid.txt)" -H "X-Magda-Tenant-Id: 0" | head -c 200
+# expect: the seeded record, served THROUGH THE APP from the managed DB over TLS
 kubectl run verify7 -n "$NS" --rm -i --restart=Never --image=postgres:17 \
   --env=CP="$CLIENT_PW" --command -- sh -c "
     PGPASSWORD=\$CP psql 'host=managed-pg user=client dbname=postgres sslmode=require' -tAc 'SELECT count(*) FROM records;'
   "
 # expect: still == /tmp/registry-count.txt
-curl -s "http://localhost:18080/api/v0/search/datasets?query=PG%20Upgrade%20E2E" \
-  -H "X-Magda-Session: $(cat /tmp/admin.jwt)"   # expect the seeded dataset
 ```
+
+> **Why cut over at the v7 upgrade, not by pointing v6 at the managed DB first?**
+> Verified negative result: a `helm upgrade` that points a **pre-v7** release at a
+> TLS-enforcing managed DB **fails** at the `registry-db-migrator` post-upgrade hook
+> with `FATAL: no pg_hba.conf entry ... no encryption`. Pre-v7 migrators build their
+> Flyway (pgjdbc) URL without an `sslmode` parameter, so they connect in plaintext
+> and the managed DB rejects them — even though the running services (which append
+> `sslmode`) connect fine. v7 migrators set `PGSSLMODE=require` and carry it into the
+> Flyway URL, so the v7 upgrade's migrators connect over TLS. (If you want to
+> reproduce the failure: run the v6 `helm upgrade` with the external-DB values and
+> observe the `registry-db-migrator` job fail.)
 
 ## Cleanup
 
 ```bash
-kill %1 2>/dev/null   # the gateway port-forward from step 1
+kill %1 2>/dev/null   # the gateway port-forward
 helm uninstall magda -n "$NS"
-kubectl delete namespace "$NS" --wait=true --timeout=180s
-rm -f /tmp/registry-count.txt /tmp/auth-count.txt /tmp/admin.jwt
+kubectl delete namespace "$NS" --wait=true --timeout=300s
+rm -f /tmp/registry-count.txt /tmp/auth-count.txt /tmp/admin.jwt /tmp/dsid.txt
 ```
 
 ## Notes
@@ -316,14 +325,19 @@ rm -f /tmp/registry-count.txt /tmp/auth-count.txt /tmp/admin.jwt
   against a specific vendor's exact privilege model (RDS `rds_superuser`, Cloud
   SQL's `cloudsqlsuperuser`, Azure's `azure_pg_admin`); the shared-`postgres`-db
   `GRANT` in step 3 approximates what those admin roles allow.
-- **What has been exercised locally.** Steps 0, 3 and 4 (TLS enforcement, the
-  negative `pg_dumpall` control, and the per-database migration with `client`
-  read/write over TLS) were verified on minikube. Steps 5–6 (reconfiguring the
-  full Magda release and the v7 external-DB upgrade) are the broader gate this
-  case defines: run them when validating a release. In particular, watch whether
-  the v7 DB **migrators** run cleanly as the non-superuser master against the
-  already-migrated, pre-populated databases — that is the highest-risk assertion
-  and the main reason to run the full flow.
+- **What has been exercised locally.** The **whole flow was run end-to-end on
+  minikube** (v6 `6.1.2-pr.3759.0` → simulated managed PG17 → v7 `7.0.0-pr.3762.4`):
+  TLS enforcement, the negative `pg_dumpall` control, the per-database migration
+  with `client` read/write over TLS, and the v7 cutover — after which `whoami`
+  returned 200 and the seeded dataset was served through the registry API from the
+  managed DB, row counts intact. Two findings came out of it and are baked into the
+  steps above and the how-to:
+  - The registry restore needs **`CREATE ON DATABASE`** on the target (for the
+    trusted `uuid-ossp` extension) in addition to `CREATE ON SCHEMA public` — a
+    non-superuser master has neither by default (step 3 grants both).
+  - **Pre-v7 migrators cannot reach a TLS-enforcing managed DB** (Flyway URL omits
+    `sslmode`), so the cutover must happen **at** the v7 upgrade, not before it
+    (step 5 caveat).
 - Run this whenever the Pathway B how-to or the external-DB value contract
   (`useAwsRdsDb`/`awsRdsEndpoint`, the master-username key, `sslmode` handling)
   changes.

--- a/docs/docs/migration/in-cluster-postgres-to-managed-db.md
+++ b/docs/docs/migration/in-cluster-postgres-to-managed-db.md
@@ -31,9 +31,8 @@ service you do not control the file system of. This migration is a **logical**
    running in-cluster server and load it into the managed database, and grant
    `client` its privileges.
 4. Verify every database restored and `client` can read its data.
-5. Reconfigure Magda (still v6) to use the managed database; verify.
-6. Upgrade Magda to v7.
-7. Decommission the in-cluster database.
+5. Cut over: `helm upgrade` to **v7** pointed at the managed database, and verify.
+6. Decommission the in-cluster database.
 
 Steps 2–5 are the downtime window. Plan for it: the dump reads the whole database
 over the network and the load replays it, so the window scales with your data
@@ -173,11 +172,21 @@ PGPASSWORD="$SRC_PASSWORD" pg_dump "$SRC dbname=postgres" --no-owner --no-privil
   | PGPASSWORD="$DST_PASSWORD" psql "$DST dbname=postgres" -v ON_ERROR_STOP=1
 ```
 
-> If a `CREATE TABLE` in the `postgres` database is rejected with
-> `permission denied for schema public`, your master account cannot create objects
-> in that database's `public` schema. Grant it first (as the master, or via your
-> provider's console): `GRANT CREATE, USAGE ON SCHEMA public TO "<MASTER_USER>";`
-> then re-run the registry restore.
+> **Two grants the registry restore into `postgres` may need on a managed DB**,
+> because your master is not a superuser. Apply them once (as the master if it has
+> the rights, or via your provider's console / admin role such as RDS
+> `rds_superuser`), then re-run the registry restore:
+>
+> - **`permission denied for schema public`** — the master cannot create objects
+>   in the `postgres` database's `public` schema:
+>   `GRANT CREATE, USAGE ON SCHEMA public TO "<MASTER_USER>";`
+> - **`permission denied to create extension "uuid-ossp"`** — the registry schema
+>   creates the `uuid-ossp` extension. It is a *trusted* extension (PostgreSQL 13+),
+>   so no superuser is required, but the master needs `CREATE` on the database:
+>   `GRANT CREATE ON DATABASE postgres TO "<MASTER_USER>";` (On some providers you
+>   instead pre-create it from the console: `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`.)
+>
+> Both were needed in the minikube verification against a non-superuser master.
 
 **3. Grant `client` its privileges** in every database — this replaces the grants
 the in-cluster migrators normally set up, and includes default privileges so
@@ -234,25 +243,26 @@ Confirm that:
   (key `password`) you used in Step 3, so Magda's services authenticate after
   cutover without any secret change.
 
-## Step 5 — Reconfigure Magda to use the managed database (still v6)
+## Step 5 — Cut over to the managed database (upgrade to v7)
 
-Switch the release over to the managed database with a `helm upgrade` that keeps
-your current Magda version and changes only the database configuration.
+Cut over by upgrading **straight to v7** with the external-database values — do
+**not** run an intermediate `helm upgrade` that points your *current* version at
+the managed database first (see the caveat below for why). This single upgrade
+switches every service to the managed instance and re-runs the schema migrators
+against it.
 
-First, create the master-account secret Magda's migrators use (it is separate from
-the app's `client` credentials):
+First, create (or update) the master-account secret the migrators use — it holds
+the **managed master** password and is separate from the app's `client`
+credentials:
 
 ```bash
 kubectl create secret generic db-main-account-secret --namespace magda \
-  --from-literal=postgresql-password='<MASTER_PASSWORD>'
-# If the secret already exists (in-cluster installs create it), update it instead:
-#   kubectl create secret generic db-main-account-secret -n magda \
-#     --from-literal=postgresql-password='<MASTER_PASSWORD>' \
-#     --dry-run=client -o yaml | kubectl apply -f -
+  --from-literal=postgresql-password='<MASTER_PASSWORD>' \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Then set the external-database values. On **v6** the master username key is
-`global.postgresql.postgresqlUsername`:
+Then upgrade to v7 with the external-database values (the v7 master-username key is
+`global.postgresql.auth.username`):
 
 ```yaml
 global:
@@ -261,57 +271,54 @@ global:
   useAwsRdsDb: true                       # generic direct-endpoint path — RDS and Azure DB
   awsRdsEndpoint: "<MANAGED_ENDPOINT>"    # e.g. mydb.abc123.ap-southeast-2.rds.amazonaws.com
   postgresql:
-    postgresqlUsername: "<MASTER_USER>"   # v6 key
+    auth:
+      username: "<MASTER_USER>"           # master/admin role on the managed instance
     # client sslmode: `require` (default) suits RDS/Azure; use `disable` only for a plaintext DB
     # client:
     #   sslmode: require
 ```
 
-Leave **`tags.combined-db: true`** (the default). Even with no in-cluster database,
-the `combined-db` chart is what creates and preserves the `combined-db-password`
-secret holding the `client` credentials your services use — turning it off would
-drop those credentials.
-
-Setting `useCombinedDb: false` + `useAwsRdsDb: true` turns every `*-db` Service
-(`authorization-db`, `content-db`, `session-db`, `registry-db`, `tenant-db`) into a
-Kubernetes `ExternalName` alias for `awsRdsEndpoint`, so all services resolve to
-your single managed instance. **The value paths above are `global.*` and apply
-unprefixed even on the umbrella `magda` chart.**
-
-Apply it, then scale the services you stopped back up and verify: the gateway is
-reachable, dataset search returns your existing data, and login works. Do not
-proceed to v7 until Magda v6 is healthy against the managed database.
-
-## Step 6 — Upgrade to v7
-
-With Magda running on the managed database, upgrade to v7 as a normal external-DB
-upgrade — this is [Pathway C](../postgres-upgrade-migration-pathways.md#pathway-c--already-on-a-managed--cloud-database).
-The only value change is the master-username key, which v7 moved from
-`global.postgresql.postgresqlUsername` to **`global.postgresql.auth.username`**:
-
-```yaml
-global:
-  useCombinedDb: false
-  useAwsRdsDb: true
-  awsRdsEndpoint: "<MANAGED_ENDPOINT>"
-  postgresql:
-    auth:
-      username: "<MASTER_USER>"           # v7 key (renamed from postgresqlUsername)
-```
-
-Do **not** set any `majorUpgrade.*` value — it applies only to the in-cluster
-option and has no effect on an external database. Use a generous `--timeout` so the
-schema migrators have time to run:
-
 ```bash
 helm upgrade magda <chart> --namespace magda -f your-values.yaml --timeout 3600s
 ```
 
-The v7 upgrade re-applies the Magda schema migrations against the managed database;
-because the data is already present, these are effectively no-ops or forward
+- Leave **`tags.combined-db: true`** (the default). Even with no in-cluster
+  database, the `combined-db` chart is what creates and preserves the
+  `combined-db-password` secret holding the `client` credentials your services use.
+- Do **not** pass `--reuse-values` — v7 restructured the PostgreSQL values contract
+  (`auth.*`, TLS), and reusing the old computed values trips the `validate-tls`
+  guard. Re-supply your values with `-f`.
+- Do **not** set any `majorUpgrade.*` value — it applies only to the in-cluster
+  option and has no effect on an external database.
+- Use a generous `--timeout`; the schema migrators run as hooks and the default 5
+  minutes is too short.
+
+Setting `useCombinedDb: false` + `useAwsRdsDb: true` turns every `*-db` Service
+(`authorization-db`, `content-db`, `session-db`, `registry-db`, `tenant-db`) into a
+Kubernetes `ExternalName` alias for `awsRdsEndpoint`, so all services resolve to
+your single managed instance. The value paths above are `global.*` and apply
+unprefixed even on the umbrella `magda` chart. The migrators find the schema and
+data already present (from Step 3), so they are effectively no-ops or forward
 migrations, not a reload.
 
-## Step 7 — Decommission the in-cluster database
+Then verify: the gateway is reachable, dataset search returns your existing data,
+`GET /api/v0/registry/records/<a known id>` returns it from the managed DB, and
+login works.
+
+> **Why go straight to v7 rather than switching the managed DB in while still on
+> your current version?** Magda's **v7** DB migrators are TLS-aware — they set
+> `PGSSLMODE=require` and carry it into the Flyway (pgjdbc) connection URL, so they
+> connect to a TLS-enforcing managed database. **Pre-v7 migrators do not**: their
+> Flyway URL omits `sslmode`, so against a managed database that enforces TLS (AWS
+> RDS `rds.force_ssl`, Azure) the migrator hook fails with
+> `FATAL: no pg_hba.conf entry ... no encryption` and the upgrade fails — even
+> though the running services (which do append `sslmode`) would connect fine. So a
+> "point my current version at the managed DB first, then upgrade" sequence only
+> works if the managed database does not enforce TLS during that window; with an
+> enforced-TLS managed database, cut over at the v7 upgrade as above. (Verified on
+> minikube against a non-superuser, TLS-enforcing PostgreSQL 17 target.)
+
+## Step 6 — Decommission the in-cluster database
 
 Once v7 is healthy on the managed database and you are confident you will not roll
 back:

--- a/docs/docs/postgres-upgrade-migration-pathways.md
+++ b/docs/docs/postgres-upgrade-migration-pathways.md
@@ -62,17 +62,20 @@ Downtime lasts for the duration of the dump plus the restore; size your
 ## Pathway B — in-cluster PostgreSQL 13 → managed / cloud database
 
 Use this when v7 is the point at which you want to stop running PostgreSQL
-in-cluster and hand it to a cloud provider. You do the database move **while still
-on v6**, then upgrade Magda to v7 pointed at the managed database — at which point
-the version of PostgreSQL is owned by your provider and the in-cluster
-`majorUpgrade` mechanism does not apply.
+in-cluster and hand it to a cloud provider. You copy the data out of the
+still-running in-cluster database into the managed database, then **cut over as
+part of the v7 upgrade** — pointing Magda at the managed database in the same
+`helm upgrade` that moves you to v7. At that point the version of PostgreSQL is
+owned by your provider and the in-cluster `majorUpgrade` mechanism does not apply.
 
 The move is a **logical** `pg_dump` of each database over the network from the
 still-running in-cluster database into the managed database (plus recreating the
-`client` role and its grants), followed by reconfiguring Magda to use the external
-database and decommissioning the in-cluster instance. (A single `pg_dumpall` is
-deliberately **not** used — managed services provide no superuser, so its role and
-ownership assumptions fail; the how-to explains why.)
+`client` role and its grants). Two things are worth knowing up front, both because
+managed services give you **no PostgreSQL superuser**: a single `pg_dumpall` is
+deliberately **not** used (its role/ownership assumptions fail), and you should
+**cut over at the v7 upgrade rather than pointing an earlier version at the managed
+database first** — only v7's DB migrators connect to a TLS-enforcing managed
+database. The how-to explains both.
 
 - **[How to migrate the in-cluster database to a managed / cloud database](./migration/in-cluster-postgres-to-managed-db.md)** —
   the full procedure, including the wal-g caveat, the exact dump/restore commands,


### PR DESCRIPTION
Follow-up to #3765 (already merged). While that PR was merging, I ran the **full end-to-end** on minikube — **v6 `6.1.2-pr.3759.0` → simulated managed PostgreSQL 17 (TLS enforced, non-superuser master) → v7 `7.0.0-pr.3762.4`** — which surfaced two things the docs got wrong. This PR corrects the Pathway B how-to, the pathways overview, and the Pathway B e2e case.

## Findings

1. **Cut over to the managed DB *at* the v7 upgrade, not by pointing an earlier version at it first.** Pre-v7 DB migrators build their Flyway (pgjdbc) connection URL **without an `sslmode` parameter**, so against a TLS-enforcing managed DB (AWS RDS `rds.force_ssl`, Azure) the `registry-db-migrator` post-upgrade hook fails with `FATAL: no pg_hba.conf entry ... no encryption` and the `helm upgrade` fails — even though the running services (which *do* append `sslmode`) connect fine. v7 migrators set `PGSSLMODE=require` and carry it into the Flyway URL (`magda-db-migrator` `migrate.sh` + `magda.postgres-migrator-env`), so the cutover must be the v7 upgrade itself. The old how-to recommended reconfiguring on v6 first — corrected.

2. **The registry restore needs `CREATE ON DATABASE` on the target** (for the trusted `uuid-ossp` extension the registry schema creates) in addition to `CREATE ON SCHEMA public`. A non-superuser managed master has neither by default; `uuid-ossp` is trusted (PG13+) so no superuser is required, just DB-level `CREATE`.

## Result after correction
v7 cutover succeeded; `whoami` = 200 and the seeded dataset was served **through the registry API** from the managed DB over TLS, row counts intact. The e2e case Notes now record that the whole flow was executed (not just the DB-level steps).

Part of #3750.