### PR TITLE
Expose PostgreSQL client CA delivery to external charts (db-client-ca-env-v1) (#3772)

### DIFF
--- a/deploy/helm/magda-common/templates/_db-secrets.tpl
+++ b/deploy/helm/magda-common/templates/_db-secrets.tpl
@@ -195,3 +195,58 @@ data:
 {{- end -}}
 {{- end -}}
 
+{{/*
+  Versioned server-CA delivery for EXTERNAL charts (auth plugins), the companion
+  to `magda.db-client-sslmode-env-v1`. Three thin shims sharing ONE contract
+  version (`db-client-ca-env-v1`), one per YAML position a plugin's
+  `deployment.yaml` needs — container `env:` (PGSSLROOTCERT), container
+  `volumeMounts:`, pod `volumes:` — each running the compatibility check and
+  delegating to the magda-core implementation. They SELF-GUARD: emit nothing
+  when no CA secret is configured (`sslmode: disable`/`require`), so a plugin can
+  include them unconditionally. FROZEN once released — add `-v2` to change.
+
+  Rationale, usage snippet, failure matrix and the Magda-v7+/opt-out rules (all
+  identical to `-sslmode-env-v1`): docs/docs/helm-helper-contracts.md
+  ("Delivering the server CA").
+*/}}
+{{- define "magda.db-client-ca-env-v1" -}}
+{{- if include "magda.magdaCompatibilityCheckEnabled" . -}}
+{{- include "magda.compatibility-check" (dict "helper" "db-client-ca-env-v1" "chart" .Chart.Name) -}}
+{{- include "magda.db-client-ca-env-node" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "magda.postgres-client-ca-volumemount-v1" -}}
+{{- if include "magda.magdaCompatibilityCheckEnabled" . -}}
+{{- include "magda.compatibility-check" (dict "helper" "db-client-ca-env-v1" "chart" .Chart.Name) -}}
+{{- if eq (include "magda.postgres-client-ca-enabled" .) "true" -}}
+{{- include "magda.postgres-client-ca-volumemount" . -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "magda.postgres-client-ca-volume-v1" -}}
+{{- if include "magda.magdaCompatibilityCheckEnabled" . -}}
+{{- include "magda.compatibility-check" (dict "helper" "db-client-ca-env-v1" "chart" .Chart.Name) -}}
+{{- if eq (include "magda.postgres-client-ca-enabled" .) "true" -}}
+{{- include "magda.postgres-client-ca-volume" . -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Shared gate for the versioned shims above: is the compatibility check enabled?
+  Returns a non-empty string (truthy) when it is, empty when the operator set
+  `global.magdaCompatibilityCheck: false`. Uses `hasKey` rather than `default`
+  because Helm's `default` treats an explicit `false` as empty and would flip it
+  back to `true` — the same fail-closed reasoning as `-sslmode-env-v1` above.
+*/}}
+{{- define "magda.magdaCompatibilityCheckEnabled" -}}
+{{- $globalVals := (get .Values "global") | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $globalVals "magdaCompatibilityCheck" -}}
+{{- $enabled = (get $globalVals "magdaCompatibilityCheck") -}}
+{{- end -}}
+{{- if $enabled -}}true{{- end -}}
+{{- end -}}
+

--- a/deploy/helm/magda-core/templates/_helpers.tpl
+++ b/deploy/helm/magda-core/templates/_helpers.tpl
@@ -256,7 +256,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   a new versioned helper; REMOVE one when dropping support, which turns silent
   misbehaviour into a loud, actionable failure at render time.
 */ -}}
-{{- $supported := list "db-client-sslmode-env-v1" -}}
+{{- $supported := list "db-client-sslmode-env-v1" "db-client-ca-env-v1" -}}
 {{- if not (has $helper $supported) -}}
 {{- fail (printf "Chart %q uses the Magda helper contract %q, which this version of Magda does not support (supported: %s). Upgrade or downgrade %q to a release built for this Magda version. If you are intentionally running a mismatched pair and accept the consequences, set `global.magdaCompatibilityCheck=false` to skip this check." $chart $helper (join ", " $supported) $chart) -}}
 {{- end -}}

--- a/deploy/helm/magda-core/tests/compatibility-check.sh
+++ b/deploy/helm/magda-core/tests/compatibility-check.sh
@@ -52,6 +52,11 @@ metadata:
 data:
   env: |
 {{ include "magda.db-client-sslmode-env-v1" . | indent 4 }}
+{{ include "magda.db-client-ca-env-v1" . | indent 4 }}
+  volumemount: |
+{{ include "magda.postgres-client-ca-volumemount-v1" . | indent 4 }}
+  volume: |
+{{ include "magda.postgres-client-ca-volume-v1" . | indent 4 }}
 EOF
 
 UMB="${TMP_DIR}/umbrella"
@@ -68,11 +73,44 @@ if ! grep -q 'value: "require"' "${OUT}"; then
     exit 1
 fi
 
+# 1b. CA-delivery contract, self-guard: the default render has no CA secret
+#     (sslmode resolves to `require`), so the three CA shims must emit NOTHING.
+#     This is what lets a plugin include them unconditionally - `require`/`disable`
+#     pods get no PGSSLROOTCERT and no `postgresql-ca` volume, exactly as intended.
+if grep -q 'PGSSLROOTCERT' "${OUT}" || grep -q 'postgresql-ca' "${OUT}"; then
+    echo "expected the CA shims to emit nothing when no CA secret is configured"
+    exit 1
+fi
+
+# 1c. CA-delivery contract, active: with a CA secret and sslmode=verify-full the
+#     three CA shims must deliver the CA the same way magda-core does for its own
+#     Node workloads - PGSSLROOTCERT env, the read-only volumeMount, and the
+#     `postgresql-ca` secret volume remapped to the fixed `root.crt` path.
+CAOUT="${TMP_DIR}/ca.yaml"
+helm template compat "${UMB}" \
+    --set global.postgresql.client.sslmode=verify-full \
+    --set global.postgresql.client.sslRootCertSecret.name=my-ca > "${CAOUT}"
+grep -q 'name: "PGSSLROOTCERT"' "${CAOUT}" || {
+    echo "expected the CA env shim to emit PGSSLROOTCERT under verify-full"; exit 1; }
+grep -A1 'name: "PGSSLROOTCERT"' "${CAOUT}" | grep -q '/etc/magda/postgresql-ca/root.crt' || {
+    echo "expected PGSSLROOTCERT to point at the mounted CA path"; exit 1; }
+grep -q 'mountPath: /etc/magda/postgresql-ca' "${CAOUT}" || {
+    echo "expected the CA volumeMount shim to mount the CA"; exit 1; }
+grep -q 'secretName: "my-ca"' "${CAOUT}" || {
+    echo "expected the CA volume shim to mount the configured CA secret"; exit 1; }
+grep -q 'path: root.crt' "${CAOUT}" || {
+    echo "expected the CA volume shim to remap the CA key to root.crt"; exit 1; }
+
 # 2. `global.magdaCompatibilityCheck=false` must skip the check entirely - this is
 #    what lets a plugin repo run `helm template`/`helm lint` standalone, and what
 #    lets an operator deliberately run a mismatched pair.
-helm template compat "${UMB}" --set global.magdaCompatibilityCheck=false > /dev/null || {
+OFFOUT="${TMP_DIR}/off.yaml"
+helm template compat "${UMB}" --set global.magdaCompatibilityCheck=false > "${OFFOUT}" || {
     echo "expected global.magdaCompatibilityCheck=false to skip the check"; exit 1; }
+# The flag gates every versioned shim, CA ones included: with it off they all
+# short-circuit and emit nothing rather than reaching into magda-core.
+if grep -q 'PGSSLMODE' "${OFFOUT}" || grep -q 'PGSSLROOTCERT' "${OFFOUT}"; then
+    echo "expected magdaCompatibilityCheck=false to make the shims emit nothing"; exit 1; fi
 
 # 3. The check must actually be capable of failing. Point the fixture at a
 #    contract this Magda version does not support and require a hard error that
@@ -93,4 +131,4 @@ grep -q "zz-fixture-plugin" "${TMP_DIR}/fail.stderr" || {
 grep -q "db-client-sslmode-env-v0" "${TMP_DIR}/fail.stderr" || {
     echo "compatibility failure must name the unsupported helper contract"; exit 1; }
 
-echo "compatibility check: supported contract renders, unsupported fails with an actionable message, opt-out works"
+echo "compatibility check: supported contracts (sslmode + CA) render and self-guard, unsupported fails with an actionable message, opt-out works"

--- a/docs/docs/helm-helper-contracts.md
+++ b/docs/docs/helm-helper-contracts.md
@@ -191,11 +191,83 @@ For the same reason the implementation uses `hasKey` rather than `default`,
 since Helm's `default` treats an explicit `false` as empty and would flip it
 back to `true`.
 
+### Delivering the server CA (`verify-ca`/`verify-full`)
+
+`magda.db-client-sslmode-env-v1` gives your pod `PGSSLMODE`, but under
+`sslmode: verify-ca`/`verify-full` that is not enough on its own: the client
+must also read the PostgreSQL server's CA certificate to verify it. Emitting
+`PGSSLMODE=verify-full` without the CA fails at connect time with
+`UNABLE_TO_VERIFY_LEAF_SIGNATURE` — a runtime failure the render cannot catch,
+because the operator configured the CA on the magda-core side.
+
+The `db-client-ca-env-v1` contract closes that gap. It is three templates
+sharing one contract version, one per YAML position your `deployment.yaml`
+needs:
+
+| Include                                   | Goes under                | Emits                                              |
+| ----------------------------------------- | ------------------------- | -------------------------------------------------- |
+| `magda.db-client-ca-env-v1`               | container `env:`          | `PGSSLROOTCERT=/etc/magda/postgresql-ca/root.crt`  |
+| `magda.postgres-client-ca-volumemount-v1` | container `volumeMounts:` | the read-only mount for the `postgresql-ca` volume |
+| `magda.postgres-client-ca-volume-v1`      | pod `volumes:`            | the `postgresql-ca` secret volume holding the CA   |
+
+Add all three alongside your existing `-sslmode-env-v1` include (this is for a
+Node/`node-postgres` client, which reads the standard libpq `PGSSLROOTCERT`
+variable — the only client class an auth plugin is):
+
+```gotemplate
+containers:
+  - name: my-plugin
+    env:
+      {{- include "magda.db-client-credential-env" (dict "dbName" "session-db" "root" .) | indent 6 }}
+      {{- include "magda.db-client-sslmode-env-v1" . | indent 6 }}
+      {{- include "magda.db-client-ca-env-v1" . | indent 6 }}
+    volumeMounts:
+      {{- include "magda.postgres-client-ca-volumemount-v1" . | nindent 6 }}
+volumes:
+  {{- include "magda.postgres-client-ca-volume-v1" . | nindent 2 }}
+```
+
+Three things to know:
+
+- **They self-guard.** Unlike the raw `magda-core` `magda.postgres-client-ca-*`
+  helpers (which render unconditionally and require every caller to wrap them in
+  an `if magda.postgres-client-ca-enabled`), these shims emit **nothing** when no
+  CA secret is configured — i.e. under `sslmode: disable`/`require`. Include them
+  unconditionally; a `require` pod simply gets no `PGSSLROOTCERT` and no volume,
+  which is correct because `require` never reads a CA. You do **not** need to
+  know or call the internal `magda.postgres-client-ca-enabled` helper. (If your
+  `volumeMounts:`/`volumes:` keys would otherwise be empty, guard the whole
+  block yourself as usual — an empty `volumes:` is invalid YAML.)
+- **Same contract version, same handshake.** All three call
+  `magda.compatibility-check` with `db-client-ca-env-v1`, so everything under
+  [Requires Magda v7+](#requires-magda-v7) and
+  [The opt-out flag](#the-opt-out-flag) applies unchanged — including that a
+  standalone `helm template`/`helm lint` needs
+  `--set global.magdaCompatibilityCheck=false`.
+- **Every DB connection needs it.** If your plugin opens more than one pool
+  (`magda-auth-internal`, for example, connects to both `session-db` and the
+  `auth` DB), the single pod-wide `PGSSLROOTCERT` and mounted volume serve all
+  of them — you emit the includes once, and every pool in that pod verifies the
+  server.
+
 ## Available contracts
 
-| Contract                         | Since        | Emits                                                   | Replaces |
-| -------------------------------- | ------------ | ------------------------------------------------------- | -------- |
-| `magda.db-client-sslmode-env-v1` | Magda v7.0.0 | `PGSSLMODE` env var for the restricted `client` DB role | —        |
+| Contract                                  | Since        | Emits                                                                    | Replaces |
+| ----------------------------------------- | ------------ | ------------------------------------------------------------------------ | -------- |
+| `magda.db-client-sslmode-env-v1`          | Magda v7.0.0 | `PGSSLMODE` env var for the restricted `client` DB role                  | —        |
+| `magda.db-client-ca-env-v1`               | Magda v7.0.0 | `PGSSLROOTCERT` env var pointing at the mounted server CA (Node clients) | —        |
+| `magda.postgres-client-ca-volumemount-v1` | Magda v7.0.0 | The read-only `volumeMount` for the mounted server CA                    | —        |
+| `magda.postgres-client-ca-volume-v1`      | Magda v7.0.0 | The `postgresql-ca` secret `volume` holding the server CA                | —        |
+
+The last three form one **CA-delivery contract**, versioned together as
+`db-client-ca-env-v1` (they share a single `magda.compatibility-check` entry).
+They are split into three templates only because a plugin's `deployment.yaml`
+emits them in three different YAML positions — container `env`, container
+`volumeMounts`, and pod `volumes`. All three **self-guard**: when no CA secret
+is configured (`sslmode: disable`/`require`) they emit nothing, so a plugin can
+include them unconditionally. See
+[Delivering the server CA (`verify-ca`/`verify-full`)](#delivering-the-server-ca-verify-caverify-full)
+below.
 
 For what `PGSSLMODE` resolves to and how to configure it, see
 `global.postgresql.client.sslmode` in the
@@ -208,11 +280,14 @@ For what `PGSSLMODE` resolves to and how to configure it, see
 be able to read the PostgreSQL server's CA certificate. `magda-core`'s
 `templates/_helpers.tpl` publishes a small set of helpers, alongside the
 `sslmode` ones above, that every workload template uses to do this
-consistently. Unlike the `-v1` contract above, these are not (yet) exposed to
-external charts through a versioned `magda-common` shim — no plugin needs them
-today, so they are internal to `magda-core` and used only by Magda's own
-workload templates. Treat their names as an implementation detail rather than
-a stable external API until a versioned shim exists.
+consistently. These names are an **internal `magda-core` implementation
+detail** — Magda's own workload templates call them directly, and external
+charts must **not** call them by name (a future refactor may rename them). An
+external chart that needs the CA — an authentication plugin connecting as the
+restricted `client` role — reaches it through the versioned
+`magda.db-client-ca-env-v1` contract described under
+[For plugin authors](#for-plugin-authors), which is a thin `magda-common` shim
+over these same helpers.
 
 **The render-time contract.** `magda.postgres-client-sslmode` — the helper
 that resolves `global.postgresql.client.sslmode` — fails the render if the
@@ -276,8 +351,12 @@ the configured key name.
 When adding a contract:
 
 - [ ] Implementation goes in `magda-core`, never `magda-common`.
-- [ ] Shim goes in `magda-common`, contains no logic beyond the check and one
-      `include`.
+- [ ] Shim goes in `magda-common`, and stays thin — the compatibility check plus
+      delegation to the magda-core implementation, no behaviour of its own. A
+      self-guard that merely decides whether to delegate is fine (the CA
+      volume/volumeMount shims skip their `include` when no CA secret is
+      configured), but the emitted content must come from magda-core so no
+      vendored copy can change it.
 - [ ] Add the name to `$supported` in `magda.compatibility-check`.
 - [ ] Add a row to the _Available contracts_ table above.
 - [ ] Add coverage to `deploy/helm/magda-core/tests/compatibility-check.sh` —


### PR DESCRIPTION
## Summary

Closes the CA-delivery gap left by #3767. That PR wired the PostgreSQL server CA into magda-core's own 13 DB-connecting workloads, but did **not** expose CA delivery to **external charts** (the bundled authentication plugins). Under `sslmode=verify-ca`/`verify-full` those plugins get `PGSSLMODE` via the `magda.db-client-sslmode-env-v1` contract but have no CA, so their DB connections fail at connect time with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`. `require` is unaffected (it needs no CA).

This PR adds the missing **magda-repo side**: a versioned CA-delivery contract that external charts can call, mirroring how `sslmode` was exposed. It is the counterpart of the plugin TLS rollout in #3742.

## What's in this PR

- **Three thin shims** in `magda-common/templates/_db-secrets.tpl`, sharing **one** contract version `db-client-ca-env-v1` (split only because a plugin's `deployment.yaml` emits them in three different YAML positions):
  - `magda.db-client-ca-env-v1` → container `env:` (`PGSSLROOTCERT`)
  - `magda.postgres-client-ca-volumemount-v1` → container `volumeMounts:`
  - `magda.postgres-client-ca-volume-v1` → pod `volumes:`

  Each runs `magda.compatibility-check` and delegates to the existing magda-core helpers (`magda.db-client-ca-env-node`, `magda.postgres-client-ca-volume{,mount}`), so no vendored copy can change what is emitted. The volume/volumeMount shims **self-guard** on `magda.postgres-client-ca-enabled`, so a plugin can include them unconditionally and never touches the internal helper name — under `disable`/`require` they emit nothing.
- **Register** `db-client-ca-env-v1` in `magda.compatibility-check`'s `$supported` list (magda-core `_helpers.tpl`).
- **Test coverage** — `tests/compatibility-check.sh` now vendors and calls the CA shims: asserts they emit nothing without a CA secret (self-guard), emit `PGSSLROOTCERT` + volumeMount + volume under `verify-full` + a CA secret, and emit nothing when `global.magdaCompatibilityCheck=false`.
- **Docs** — `docs/docs/helm-helper-contracts.md`: rewrote the "not (yet) exposed to external charts" note, added the contracts-table rows, a new *Delivering the server CA* plugin-author section, and a maintainer-checklist tweak.

## Scope / follow-up

This PR is the **contract side only**. Adoption by the 7 bundled auth plugin charts (mounting the volume + emitting `PGSSLROOTCERT` alongside their existing `-sslmode-env-v1` include; `magda-auth-internal` has two DB connections) happens per-plugin in their own repos as part of the #3742 rollout, and the plugin-side `verify-full` E2E case lands there too. So this is **Part of #3772**, not a full close.

## Testing

- `bash deploy/helm/magda-core/tests/compatibility-check.sh` passes (supported contracts render + self-guard, unsupported fails actionably, opt-out works).
- Standalone render with `magdaCompatibilityCheck=false` emits nothing (never references magda-core-only templates), matching `-sslmode-env-v1`.