### PR TITLE
chore(helm): upgrade local-deployment auth plugins to v7 line + drop sslmode coverage exemptions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -874,29 +874,52 @@ dockerize:dockerExtensions:
     - echo "$KUBECTL_CONFIG" > kubectlconfig.yaml
     - export KUBECONFIG=kubectlconfig.yaml
 
+    # Derive a Helm release / namespace name that is safe against the 63-char limit on
+    # generated resource names. The release name prefixes every in-cluster object name and
+    # the longest suffix these charts append is "-magda-embedding-api-appconfig" (30 chars),
+    # so the release name must be <= 33; we cap at 30 for headroom (worst case 30+30 = 60).
+    # When the branch slug is longer we keep its tail (the feature/ticket end), align it to a
+    # word boundary, and append a 6-char sha1 of the FULL slug. The hash is deterministic --
+    # so `helm upgrade` and `Stop Preview` stay idempotent across pipeline runs -- and makes
+    # similar branches that share a tail resolve to distinct names. The public subdomain keeps
+    # the full slug (its DNS label is well under 63), so preview URLs stay unique and readable.
+    - |
+      RELEASE_NAME="$CI_COMMIT_REF_SLUG"
+      MAX_RELEASE_NAME_LEN=30
+      if [ ${#RELEASE_NAME} -gt "$MAX_RELEASE_NAME_LEN" ]; then
+        RELEASE_HASH=$(printf '%s' "$CI_COMMIT_REF_SLUG" | sha1sum | cut -c1-6)
+        RELEASE_BASE=$(printf '%s' "$CI_COMMIT_REF_SLUG" | tail -c $((MAX_RELEASE_NAME_LEN - 7)) | sed 's/^-*//')
+        case "$RELEASE_BASE" in
+          *-*) RELEASE_TRIMMED="${RELEASE_BASE#*-}"; [ -n "$RELEASE_TRIMMED" ] && RELEASE_BASE="$RELEASE_TRIMMED" ;;
+        esac
+        RELEASE_NAME="${RELEASE_BASE}-${RELEASE_HASH}"
+      fi
+      export RELEASE_NAME
+      echo "Helm release/namespace: $RELEASE_NAME (branch slug: $CI_COMMIT_REF_SLUG)"
+
     # Create kube namespace
-    - kubectl get namespace $CI_COMMIT_REF_SLUG || kubectl create namespace $CI_COMMIT_REF_SLUG
+    - kubectl get namespace $RELEASE_NAME || kubectl create namespace $RELEASE_NAME
 
     # Create kube secrets
-    - kubectl create secret docker-registry regcred --namespace $CI_COMMIT_REF_SLUG --docker-server=registry.gitlab.com --docker-username=magdabot --docker-password=$GITLAB_DOCKER_PASSWORD --docker-email=contact@magda.io --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
-    - kubectl create secret generic oauth-secrets --from-literal=facebook-client-secret=$FACEBOOK_CLIENT_SECRET --from-literal=google-client-secret=$GOOGLE_CLIENT_SECRET --from-literal arcgis-client-secret=$ARCGIS_CLIENT_SECRET --from-literal aaf-client-secret=$AAF_SECRET --namespace $CI_COMMIT_REF_SLUG --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
-    - kubectl create secret generic vanguard-secrets --from-literal certificate="$VANGUARD_CERT" --namespace $CI_COMMIT_REF_SLUG --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
-    - kubectl create secret generic smtp-secret --from-literal=username=$SMTP_USERNAME --from-literal=password=$SMTP_PASSWORD --namespace $CI_COMMIT_REF_SLUG --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
+    - kubectl create secret docker-registry regcred --namespace $RELEASE_NAME --docker-server=registry.gitlab.com --docker-username=magdabot --docker-password=$GITLAB_DOCKER_PASSWORD --docker-email=contact@magda.io --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
+    - kubectl create secret generic oauth-secrets --from-literal=facebook-client-secret=$FACEBOOK_CLIENT_SECRET --from-literal=google-client-secret=$GOOGLE_CLIENT_SECRET --from-literal arcgis-client-secret=$ARCGIS_CLIENT_SECRET --from-literal aaf-client-secret=$AAF_SECRET --namespace $RELEASE_NAME --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
+    - kubectl create secret generic vanguard-secrets --from-literal certificate="$VANGUARD_CERT" --namespace $RELEASE_NAME --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
+    - kubectl create secret generic smtp-secret --from-literal=username=$SMTP_USERNAME --from-literal=password=$SMTP_PASSWORD --namespace $RELEASE_NAME --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
     - echo "$DB_SERVICE_ACCOUNT_PRIVATE_KEY" > backup-storage-account.json
-    - kubectl create secret generic backup-storage-account --from-file backup-storage-account.json --from-literal=GOOGLE_APPLICATION_CREDENTIALS=/etc/wal-g.d/env/backup-storage-account.json --namespace $CI_COMMIT_REF_SLUG --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
+    - kubectl create secret generic backup-storage-account --from-file backup-storage-account.json --from-literal=GOOGLE_APPLICATION_CREDENTIALS=/etc/wal-g.d/env/backup-storage-account.json --namespace $RELEASE_NAME --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
   script:
     # Copy db secrets from master deployment (where backup is created) so that there won't be password issues after db recovery
     - CLIENT_DB_PASSWORD=$(kubectl --namespace=default get secret combined-db-password --template={{.data.password}} | base64 -d)
     - SUPER_DB_PASSWORD=$(kubectl --namespace=default get secret db-main-account-secret --template='{{index .data "postgresql-password"}}' | base64 -d)
-    - kubectl create secret generic combined-db-password --from-literal=password=$CLIENT_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
-    - kubectl create secret generic db-main-account-secret --from-literal=postgresql-password=$SUPER_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $CI_COMMIT_REF_SLUG -f -
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set magda.magda-core.authorization-db.migratorBackoffLimit=10,magda.magda-core.registry-db.migratorBackoffLimit=10,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$CI_COMMIT_REF_SLUG --timeout 3600m --wait
+    - kubectl create secret generic combined-db-password --from-literal=password=$CLIENT_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
+    - kubectl create secret generic db-main-account-secret --from-literal=postgresql-password=$SUPER_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set magda.magda-core.authorization-db.migratorBackoffLimit=10,magda.magda-core.registry-db.migratorBackoffLimit=10,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
 
 (UI) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.searchEngine.hybridSearch.enabled=false,global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,tags.minion-linked-data-rating=false,tags.minion-visualization=false,tags.minion-format=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.searchEngine.hybridSearch.enabled=false,global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,tags.minion-linked-data-rating=false,tags.minion-visualization=false,tags.minion-format=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
 
 (UI - Auto) Run As Preview:
@@ -906,18 +929,18 @@ dockerize:dockerExtensions:
     variables:
       - $CI_COMMIT_MESSAGE =~ /#deploy-ui-preview/
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
 
 (No Data) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$CI_COMMIT_REF_SLUG --timeout 3600m --wait
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
 (No Data) Run As Multi-tenant Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $CI_COMMIT_REF_SLUG deploy/helm/local-deployment --install --recreate-pods --namespace $CI_COMMIT_REF_SLUG -f deploy/helm/preview-multi-tenant.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.magdaAdminPortalName=${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$CI_COMMIT_REF_SLUG --timeout 3600m --wait
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview-multi-tenant.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.magdaAdminPortalName=${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
     - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
 
 
@@ -943,8 +966,23 @@ Stop Preview: &stopPreview
   script:
     - echo "$KUBECTL_CONFIG" > kubectlconfig.yaml
     - export KUBECONFIG=kubectlconfig.yaml
-    - helm --namespace $CI_COMMIT_REF_SLUG del $CI_COMMIT_REF_SLUG
-    - kubectl delete namespace $CI_COMMIT_REF_SLUG
+    # Recompute the same release/namespace name the deploy jobs used (see the note in
+    # `(Full) Run As Preview`). Must stay identical so the right release/namespace is torn down.
+    - |
+      RELEASE_NAME="$CI_COMMIT_REF_SLUG"
+      MAX_RELEASE_NAME_LEN=30
+      if [ ${#RELEASE_NAME} -gt "$MAX_RELEASE_NAME_LEN" ]; then
+        RELEASE_HASH=$(printf '%s' "$CI_COMMIT_REF_SLUG" | sha1sum | cut -c1-6)
+        RELEASE_BASE=$(printf '%s' "$CI_COMMIT_REF_SLUG" | tail -c $((MAX_RELEASE_NAME_LEN - 7)) | sed 's/^-*//')
+        case "$RELEASE_BASE" in
+          *-*) RELEASE_TRIMMED="${RELEASE_BASE#*-}"; [ -n "$RELEASE_TRIMMED" ] && RELEASE_BASE="$RELEASE_TRIMMED" ;;
+        esac
+        RELEASE_NAME="${RELEASE_BASE}-${RELEASE_HASH}"
+      fi
+      export RELEASE_NAME
+      echo "Tearing down release/namespace: $RELEASE_NAME (branch slug: $CI_COMMIT_REF_SLUG)"
+    - helm --namespace $RELEASE_NAME del $RELEASE_NAME
+    - kubectl delete namespace $RELEASE_NAME
 
 Deploy Main Branch To Dev:
   stage: deploy-dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -858,9 +858,16 @@ dockerize:dockerExtensions:
   image:
     name: ghcr.io/magda-io/magda-builder-docker:node22-ubuntu20-july-2026
   retry: 1
+  # `environment.url` is YAML, not shell, so it cannot read the bash-computed
+  # RELEASE_NAME directly. The before_script writes the resolved preview URL to a
+  # dotenv report and GitLab expands $DYNAMIC_ENVIRONMENT_URL from it, so the GitLab
+  # environment link matches the host the deployment actually serves on.
+  artifacts:
+    reports:
+      dotenv: deploy.env
   environment:
     name: preview/$CI_COMMIT_REF_NAME
-    url: https://${CI_COMMIT_REF_SLUG}-dev.magda.io
+    url: $DYNAMIC_ENVIRONMENT_URL
     on_stop: Stop Preview
   before_script:
     # Add PWGEN for generating passwords
@@ -895,7 +902,9 @@ dockerize:dockerExtensions:
         RELEASE_NAME="${RELEASE_BASE}-${RELEASE_HASH}"
       fi
       export RELEASE_NAME
-      echo "Helm release/namespace: $RELEASE_NAME (branch slug: $CI_COMMIT_REF_SLUG)"
+      PREVIEW_URL="https://${RELEASE_NAME}-dev.magda.io"
+      echo "DYNAMIC_ENVIRONMENT_URL=${PREVIEW_URL}" > deploy.env
+      echo "Helm release/namespace: $RELEASE_NAME | preview URL: $PREVIEW_URL (branch slug: $CI_COMMIT_REF_SLUG)"
 
     # Create kube namespace
     - kubectl get namespace $RELEASE_NAME || kubectl create namespace $RELEASE_NAME
@@ -913,14 +922,14 @@ dockerize:dockerExtensions:
     - SUPER_DB_PASSWORD=$(kubectl --namespace=default get secret db-main-account-secret --template='{{index .data "postgresql-password"}}' | base64 -d)
     - kubectl create secret generic combined-db-password --from-literal=password=$CLIENT_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
     - kubectl create secret generic db-main-account-secret --from-literal=postgresql-password=$SUPER_DB_PASSWORD --dry-run=client -o json | kubectl apply --namespace $RELEASE_NAME -f -
-    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set magda.magda-core.authorization-db.migratorBackoffLimit=10,magda.magda-core.registry-db.migratorBackoffLimit=10,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
-    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set magda.magda-core.authorization-db.migratorBackoffLimit=10,magda.magda-core.registry-db.migratorBackoffLimit=10,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,global.externalUrl=https://${RELEASE_NAME}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
+    - echo "Successfully deployed to https://${RELEASE_NAME}-dev.magda.io"
 
 (UI) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.searchEngine.hybridSearch.enabled=false,global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,tags.minion-linked-data-rating=false,tags.minion-visualization=false,tags.minion-format=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
-    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.searchEngine.hybridSearch.enabled=false,global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,tags.minion-linked-data-rating=false,tags.minion-visualization=false,tags.minion-format=false,magda.magda-core.web-server.registryApiBaseUrlInternal=https://dev.magda.io/api/v0/registry,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${RELEASE_NAME}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - echo "Successfully deployed to https://${RELEASE_NAME}-dev.magda.io"
 
 (UI - Auto) Run As Preview:
   <<: *runAsPreview
@@ -929,19 +938,19 @@ dockerize:dockerExtensions:
     variables:
       - $CI_COMMIT_MESSAGE =~ /#deploy-ui-preview/
   script:
-    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
-    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.openfaas.enabled=false,global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.ingress.targetService=web,tags.all=false,tags.web-server=true,tags.correspondence-api=false,magda.magda-core.web-server.baseUrl=https://dev.magda.io,global.externalUrl=https://${RELEASE_NAME}-dev.magda.io,magda.magda-core.web-server.useLocalStyleSheet=true --timeout 3600m --wait
+    - echo "Successfully deployed to https://${RELEASE_NAME}-dev.magda.io"
 
 (No Data) Run As Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
-    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${RELEASE_NAME}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
+    - echo "Successfully deployed to https://${RELEASE_NAME}-dev.magda.io"
 (No Data) Run As Multi-tenant Preview:
   <<: *runAsPreview
   script:
-    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview-multi-tenant.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${CI_COMMIT_REF_SLUG}-dev.magda.io,global.magdaAdminPortalName=${CI_COMMIT_REF_SLUG}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
-    - echo "Successfully deployed to https://${CI_COMMIT_REF_SLUG}-dev.magda.io"
+    - helm upgrade $RELEASE_NAME deploy/helm/local-deployment --install --recreate-pods --namespace $RELEASE_NAME -f deploy/helm/preview-multi-tenant.yml --set global.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.postgresql.image.tag=$CI_COMMIT_REF_SLUG,magda.magda-core.combined-db.magda-postgres.backupRestore.recoveryMode.enabled=false,global.externalUrl=https://${RELEASE_NAME}-dev.magda.io,global.magdaAdminPortalName=${RELEASE_NAME}-dev.magda.io,global.namespace=$RELEASE_NAME --timeout 3600m --wait
+    - echo "Successfully deployed to https://${RELEASE_NAME}-dev.magda.io"
 
 
 Stop Preview: &stopPreview

--- a/deploy/helm/local-deployment/Chart.lock
+++ b/deploy/helm/local-deployment/Chart.lock
@@ -4,16 +4,16 @@ dependencies:
   version: 6.2.0
 - name: magda-auth-google
   repository: oci://ghcr.io/magda-io/charts
-  version: 3.0.0
+  version: 4.0.0-alpha.1
 - name: magda-auth-internal
   repository: oci://ghcr.io/magda-io/charts
-  version: 3.0.0
+  version: 4.0.0-alpha.0
 - name: magda-auth-arcgis
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.1
+  version: 3.0.0-alpha.0
 - name: magda-auth-facebook
   repository: oci://ghcr.io/magda-io/charts
-  version: 2.0.0
+  version: 3.0.0-alpha.0
 - name: magda-ckan-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.1.0
@@ -107,5 +107,5 @@ dependencies:
 - name: magda-project-open-data-connector
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
-digest: sha256:720b384cfe14f51f2668ce8757777aff1f109274ccd745bf557795f2c29eb610
-generated: "2026-08-03T14:18:45.628911698Z"
+digest: sha256:5e16df4abb09c8ed7cc57f9ebe486cb8b1da02f13cdeeb6eaf21b7bdd67a2001
+generated: "2026-08-17T10:08:10.356666+10:00"

--- a/deploy/helm/local-deployment/Chart.yaml
+++ b/deploy/helm/local-deployment/Chart.yaml
@@ -9,28 +9,28 @@ dependencies:
     repository: "file://../magda"
 
   - name: magda-auth-google
-    version: "3.0.0"
+    version: "4.0.0-alpha.1"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - all
       - magda-auth-google
 
   - name: magda-auth-internal
-    version: "3.0.0"
+    version: "4.0.0-alpha.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - all
       - magda-auth-internal
 
   - name: magda-auth-arcgis
-    version: "2.0.1"
+    version: "3.0.0-alpha.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - all
       - magda-auth-arcgis
 
   - name: magda-auth-facebook
-    version: "2.0.0"
+    version: "3.0.0-alpha.0"
     repository: "oci://ghcr.io/magda-io/charts"
     tags:
       - all

--- a/deploy/helm/magda-core/tests/postgres-sslmode.sh
+++ b/deploy/helm/magda-core/tests/postgres-sslmode.sh
@@ -308,12 +308,13 @@ fi
 
 assert_sslmode_coverage "${ROOT_DIR}/deploy/helm/magda" "umbrella (magda)" ""
 
-# `local-deployment` additionally pulls in the authentication plugins. Those call
-# `magda.db-client-credential-env` from their own vendored `magda-common` and do
-# NOT yet emit PGSSLMODE, so they connect to the session DB in plaintext. That is
-# pre-existing (nothing set PGSSLMODE before this change) and is tracked
-# separately; the plugins need both a chart release and an SDK bump. They are
-# exempted by name here rather than by weakening the check, so that any NEW
-# regression still fails and this list doubles as the outstanding work.
-AUTH_PLUGIN_EXEMPTIONS="Deployment/magda-auth-google,Deployment/magda-auth-internal,Deployment/magda-auth-oidc,Deployment/magda-auth-arcgis,Deployment/magda-auth-facebook"
-assert_sslmode_coverage "${ROOT_DIR}/deploy/helm/local-deployment" "local-deployment" "${AUTH_PLUGIN_EXEMPTIONS}"
+# `local-deployment` additionally pulls in the authentication plugins. As of the
+# v7 rollout (magda-io/magda#3742) every bundled plugin adopts the versioned
+# `magda.db-client-sslmode-env-v1` (and `magda.db-client-ca-env-v1`) helper
+# contract, so each one now emits PGSSLMODE on its session-db client just like
+# every other DB-credential workload. There is therefore no exemption list any
+# more: the plugins are held to the same coverage check as the core services, so
+# any future plugin that regresses to a plaintext session-db connection fails
+# here. (This depends on local-deployment pinning plugin chart versions that
+# carry the contract — see deploy/helm/local-deployment/Chart.yaml.)
+assert_sslmode_coverage "${ROOT_DIR}/deploy/helm/local-deployment" "local-deployment" ""

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -124,8 +124,8 @@ magda:
             extraVolumeMounts:
               - name: storage-account
                 mountPath: /etc/wal-g.d/env
-          persistence:
-            size: "250Gi"
+            persistence:
+              size: "250Gi"
 
     opensearch:
       data:

--- a/deploy/helm/preview-multi-tenant.yml
+++ b/deploy/helm/preview-multi-tenant.yml
@@ -104,11 +104,11 @@ magda:
             extraVolumeMounts:
               - name: storage-account
                 mountPath: /etc/wal-g.d/env
-          persistence:
-            size: "250Gi"
-          resources:
-            limits:
-              cpu: 2000m
+            persistence:
+              size: "250Gi"
+            resources:
+              limits:
+                cpu: 2000m
 
     elasticsearch:
       data:

--- a/deploy/helm/preview.yml
+++ b/deploy/helm/preview.yml
@@ -101,11 +101,11 @@ magda:
             extraVolumeMounts:
               - name: storage-account
                 mountPath: /etc/wal-g.d/env
-          persistence:
-            size: "250Gi"
-          resources:
-            limits:
-              cpu: 2000m
+            persistence:
+              size: "250Gi"
+            resources:
+              limits:
+                cpu: 2000m
 
     registry-api:
       autoscaler:


### PR DESCRIPTION
Part of #3742 (final cleanup) / epic #3738.

Now that all seven bundled authentication plugins have been released on their v7 line (each adopting the `magda.db-client-sslmode-env-v1` and `magda.db-client-ca-env-v1` helper contracts and emitting `PGSSLMODE` on their `session-db` client), this wires the dev-site umbrella up to them and removes the temporary coverage exemption.

## Changes

**`deploy/helm/local-deployment/Chart.yaml`** (+ regenerated `Chart.lock`) — point the four bundled auth plugins at their v7-line releases:

| Plugin | Before | After |
| --- | --- | --- |
| magda-auth-google | `3.0.0` | `4.0.0-alpha.1` |
| magda-auth-internal | `3.0.0` | `4.0.0-alpha.0` |
| magda-auth-arcgis | `2.0.1` | `3.0.0-alpha.0` |
| magda-auth-facebook | `2.0.0` | `3.0.0-alpha.0` |

(`local-deployment` bundles only these four; oidc/okta/aaf are not part of the dev-site umbrella.)

**`deploy/helm/magda-core/tests/postgres-sslmode.sh`** — drop the by-name `AUTH_PLUGIN_EXEMPTIONS` list. The exemption existed only because the plugins used to connect to `session-db` in plaintext (no `PGSSLMODE`). With the v7 plugins in place they emit `PGSSLMODE` like every other DB-credential workload, so they are now held to the same per-workload coverage check. The exemption list was explicitly designed to double as the outstanding-work list — removing it means any future plugin that regresses to a plaintext `session-db` connection fails this test instead of being silently tolerated.

## Compatibility note

`next`'s chart version strings are still `6.2.0` (the bump to `7.0.0-alpha.x` happens on release branches), but `next`'s `magda-core` code already ships both helper contracts, and the compatibility handshake is a contract-name check rather than a version-number comparison — so the v7 alpha plugins render correctly in the same release.

## Verification (local)

- `bash deploy/helm/magda-core/tests/postgres-sslmode.sh` → exit 0:
  - `umbrella (magda): PGSSLMODE present on all 9 DB-credential workloads`
  - `local-deployment: PGSSLMODE present on all 13 DB-credential workloads` (9 core + 4 plugins), no exemptions
- `helm template` of `local-deployment` under `sslmode=verify-full` + a CA secret renders cleanly (exit 0) with the CA delivered to the plugin pods — plugins do not fail closed.

---

## Follow-up fix: v7 postgres persistence path in deploy values (commit 2)

A `(Full) Run As Preview` deploy of this branch surfaced a **pre-existing** v6→v7 migration gap in the deploy values files (unrelated to the plugin bump). The magda-postgres bump to bitnami postgresql `16.7.24` moved `persistence`/`resources` under `postgresql.primary.*`, and the subchart's `validate-names.yaml` now hard-fails at render time on the old top-level paths:

```
Error: ...combined-db/charts/magda-postgres/templates/validate-names.yaml:
postgresql.persistence is set, but subchart 16.7.24 moved it to
postgresql.primary.persistence and no longer reads the old path.
```

Moved the stale keys under `postgresql.primary` in:

- `deploy/helm/preview.yml` — `persistence` + `resources`
- `deploy/helm/preview-multi-tenant.yml` — `persistence` + `resources`
- `deploy/helm/magda-dev.yml` — `persistence` (no stale `resources`)

Verified: rendering `local-deployment` with `preview.yml` (the exact failing CI helm command) now succeeds, and the previously-silently-dropped `250Gi` PVC size + `2000m` CPU limit are now applied. `preview-multi-tenant.yml` / `magda-dev.yml` lint clean.

---

## Follow-up fix: cap preview release/namespace name (commit 3)

With the render + persistence issues resolved, the preview deploy then failed at resource creation because the Helm release name (= branch slug) prefixes every generated resource name, and a long branch overflowed Kubernetes' 63-char name limit:

```
Service "fix-local-deployment-v7-auth-plugins-3742-opensearch-data-headless"
is invalid: metadata.name: must be no more than 63 characters
```

`.gitlab-ci.yml` now derives a `RELEASE_NAME` in the preview jobs:

- Short slugs pass through unchanged.
- Long slugs → keep the tail (feature/ticket end) aligned to a word boundary + a 6-char **sha1 of the full slug**, capped at **30** chars (longest chart-added suffix is `-magda-embedding-api-appconfig` = 30, so 30 + 30 = 60 ≤ 63).
- The hash is **deterministic** (so `helm upgrade` and `Stop Preview` stay idempotent across runs) and keeps similar branches that share a tail distinct.
- `RELEASE_NAME` is used only for the helm release name, `--namespace`, and `global.namespace`; the public subdomain / `externalUrl` keep the full slug (its DNS label is well under 63), so preview URLs stay unique and readable. `Stop Preview` recomputes the same name.

e.g. `fix-local-deployment-v7-auth-plugins-3742` → `v7-auth-plugins-3742-389741`.

**Consistency refinement:** the preview **subdomain** also uses `RELEASE_NAME` (not the raw slug), so URL host == namespace == helm release — one identifier to browse and to `kubectl` against, and robust against very long branches whose `${slug}-dev` DNS label could itself exceed 63 chars. `environment.url` reads the resolved URL via a dotenv report (it's YAML and can't read the bash-computed name). Image tags stay on `CI_COMMIT_REF_SLUG` (they reference the built images, unrelated to naming limits).
