### PR TITLE
fix(migrator): clearer PG15+ public-schema privilege error + locale-independent probe classification

### DIFF
--- a/docs/docs/e2e-test-cases/README.md
+++ b/docs/docs/e2e-test-cases/README.md
@@ -23,6 +23,7 @@ scripted, assertion/checksum-based driver), and how to clean up.
 - [In-cluster PostgreSQL major upgrade (PG 13 → 17 logical dump / restore)](./postgres-major-upgrade.md)
 - [Migrate the in-cluster PostgreSQL to a managed/cloud database (Pathway B)](./postgres-in-cluster-to-managed-db-migration.md)
 - [Fresh install on PostgreSQL 17 — client authentication (SCRAM)](./postgres-fresh-install-auth.md)
+- [DB migrator surfaces the PG15+ `public`-schema privilege failure (and classifies a missing database locale-independently)](./migrator-public-schema-privilege-error.md)
 
 ## Adding a new case
 

--- a/docs/docs/e2e-test-cases/migrator-public-schema-privilege-error.md
+++ b/docs/docs/e2e-test-cases/migrator-public-schema-privilege-error.md
@@ -1,0 +1,309 @@
+# E2E Test Case: DB migrator surfaces the PG15+ `public`-schema privilege failure (and classifies a missing database locale-independently)
+
+A step-by-step end-to-end test that `magda-db-migrator`'s `migrate.sh`
+([magda-io/magda#3770](https://github.com/magda-io/magda/issues/3770),
+[#3744](https://github.com/magda-io/magda/issues/3744)):
+
+1. **turns a PostgreSQL 15+ `public`-schema privilege failure into actionable
+   guidance** — when the migrator user can connect but cannot create objects in
+   the target database's `public` schema, the real Flyway error
+   (`SQL State : 42501`, `permission denied for schema public`) is translated
+   into a message that names the database, the user and the one-time fix, and
+   explicitly says it is **not** a TLS problem — while still failing the
+   migrator; and
+2. **classifies a genuinely-missing per-service database as benign via a catalog
+   check**, not by matching the (server-localized) `... does not exist` message
+   text, so it does not spuriously abort on a non-English `lc_messages` server.
+
+Because a CI cluster has no real RDS/Azure/Cloud SQL instance, the managed
+database is **simulated in-cluster** with a stock `postgres:17` pod configured
+to enforce TLS, and a **non-superuser master** — exactly the
+[`sslmode=verify-full`](./db-tls-verify-full.md) and
+[Pathway B migration](./postgres-in-cluster-to-managed-db-migration.md) pattern.
+This case is the deliberate **negative** of `db-tls-verify-full.md`'s `init.sql`:
+that case runs `ALTER SCHEMA public OWNER TO <master>` so the registry migrator
+can proceed; here we **omit** it, so the migrator hits `42501` — and assert the
+diagnostic, rather than the raw error, is what an operator sees.
+
+This complements the unit test
+[`magda-db-migrator/tests/migrate-idempotency.sh`](https://github.com/magda-io/magda/blob/main/magda-db-migrator/tests/migrate-idempotency.sh)
+(cases 4 and 5), which shim `psql`/`flyway`. What that harness cannot reach is
+the thing this case exists to prove: that **real Flyway 12.x** actually emits
+`SQL State : 42501` for this failure (so the translation fires), and that **real
+`psql`** returns an empty result — with no error — for a missing database in the
+catalog (so the benign classification works).
+
+## What it covers
+
+1. **Negative (42501):** a non-superuser master against a pre-created database it
+   does **not** own → real Flyway fails with `SQL State : 42501` → the migrator
+   prints the actionable guidance and still exits non-zero.
+2. **Positive control:** run the documented fix
+   (`ALTER SCHEMA public OWNER TO <master>`) and re-run → the migration succeeds,
+   with **no** guidance emitted.
+3. **Missing-database is benign (#3744):** a role without `CREATEDB` pointed at a
+   database that does not exist → the migrator detects non-existence via the
+   `pg_database` catalog and takes the benign "skipping" path, **without** the
+   `could not determine ...` abort that a localized-text classifier would produce
+   on a non-English server.
+4. **Why a catalog check (not SQLSTATE):** a real `psql` connection to a missing
+   database reports `FATAL: database "..." does not exist` with **no SQLSTATE
+   line, even under `VERBOSITY=verbose`** — so the existence check cannot be done
+   by parsing the connection error and must consult the catalog.
+
+## Prerequisites
+
+- A cluster with your `kubectl` context pointed at it (e.g. `minikube start`),
+  plus `openssl`.
+- The `magda-db-migrator` image **for the version under test**, available to the
+  cluster. Either a published tag, or build it into the cluster from a repo
+  checkout (used below):
+
+  ```bash
+  # from a magda repo checkout, into minikube's docker
+  minikube image build -t magda-db-migrator:e2e magda-db-migrator
+  ```
+
+```bash
+export NS=migrator-pubschema-e2e
+export MASTER_USER=magda_admin
+export MASTER_PW=dstpass
+export MIGRATOR_IMAGE=magda-db-migrator:e2e   # imagePullPolicy: Never below assumes a locally-built image
+kubectl create namespace "$NS"
+```
+
+## 0. Deploy the simulated managed database
+
+A TLS-enforcing `postgres:17` pod with a **non-superuser master** and — the
+crux — a **pre-created `registry` database owned by the bootstrap superuser, not
+the master**, and **no** `ALTER SCHEMA public OWNER` / `GRANT CREATE`. On
+PostgreSQL 15+ the master can connect but cannot create objects in that
+database's `public` schema.
+
+```bash
+cd $(mktemp -d)
+# sslmode=require does not verify the cert, so any self-signed cert works.
+openssl req -new -x509 -days 365 -nodes -text -out server.crt -keyout server.key \
+  -subj "/CN=managed-pg" -addext "subjectAltName=DNS:managed-pg"
+kubectl -n "$NS" create secret generic managed-certs \
+  --from-file=server.crt=server.crt --from-file=server.key=server.key
+
+cat > pg_hba.conf <<'EOF'
+local   all   all               trust
+# TCP MUST use TLS (mimics RDS/Azure force-ssl): hostssl only
+hostssl all   all   0.0.0.0/0   md5
+hostssl all   all   ::/0        md5
+EOF
+
+cat > init.sql <<EOF
+-- Non-superuser master, mimicking a managed-provider admin login.
+CREATE ROLE $MASTER_USER WITH LOGIN CREATEDB CREATEROLE PASSWORD '$MASTER_PW';
+-- A PRE-CREATED application database owned by the bootstrap superuser, NOT the
+-- master (the "pre-created app DB / shared instance" case from #3770). The master
+-- can connect but, on PG15+, cannot create objects in this DB's public schema.
+CREATE DATABASE registry OWNER postgres;
+-- DELIBERATELY OMITTED (the whole point of the negative test):
+--   ALTER SCHEMA public OWNER TO $MASTER_USER;   -- or GRANT CREATE ON SCHEMA public
+-- so the registry migrator connects fine over TLS and then fails Flyway with
+-- permission denied for schema public (SQLSTATE 42501).
+-- A role without CREATEDB, for the missing-database (#3744) part of the test.
+CREATE ROLE restricted WITH LOGIN PASSWORD 'rpw' NOCREATEDB;
+EOF
+kubectl -n "$NS" create configmap managed-pgcfg \
+  --from-file=pg_hba.conf=pg_hba.conf --from-file=init.sql=init.sql
+
+kubectl -n "$NS" apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata: { name: managed-pg, labels: { app: managed-pg } }
+spec:
+  initContainers:
+    - name: prep-certs
+      image: busybox:1.36
+      command: ["sh","-c","cp /in/* /certs/ && chown 999:999 /certs/server.* && chmod 600 /certs/server.key && chmod 644 /certs/server.crt"]
+      volumeMounts: [{ name: certs-in, mountPath: /in }, { name: certs, mountPath: /certs }]
+  containers:
+    - name: pg
+      image: postgres:17
+      env: [{ name: POSTGRES_PASSWORD, value: bootstrap }]
+      args: ["-c","ssl=on","-c","ssl_cert_file=/certs/server.crt","-c","ssl_key_file=/certs/server.key","-c","hba_file=/etc/pgcfg/pg_hba.conf"]
+      volumeMounts:
+        - { name: certs, mountPath: /certs }
+        - { name: pgcfg, mountPath: /etc/pgcfg }
+        - { name: initdb, mountPath: /docker-entrypoint-initdb.d }
+  volumes:
+    - { name: certs-in, secret: { secretName: managed-certs } }
+    - { name: certs, emptyDir: {} }
+    - name: pgcfg
+      configMap: { name: managed-pgcfg, items: [{ key: pg_hba.conf, path: pg_hba.conf }] }
+    - name: initdb
+      configMap: { name: managed-pgcfg, items: [{ key: init.sql, path: init.sql }] }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: managed-pg }
+spec: { selector: { app: managed-pg }, ports: [{ port: 5432, targetPort: 5432 }] }
+EOF
+kubectl -n "$NS" wait --for=condition=Ready pod/managed-pg --timeout=180s
+```
+
+Confirm the setup before going further — the master must be a non-superuser that
+cannot create in `registry`'s `public` schema:
+
+```bash
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -tAc "
+  SELECT rolsuper, rolcreatedb FROM pg_roles WHERE rolname='$MASTER_USER';"        # expect: f|t
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -d registry -tAc "
+  SELECT has_schema_privilege('$MASTER_USER','public','CREATE');"                  # expect: f
+```
+
+The two migration payloads (one per logical database the migrator will handle):
+
+```bash
+kubectl -n "$NS" create configmap registry-sql \
+  --from-literal=V1__init.sql="CREATE TABLE public.e2e_probe (id int primary key, note text);"
+kubectl -n "$NS" create configmap ghostdb-sql \
+  --from-literal=V1__init.sql="CREATE TABLE public.ghost (id int);"
+```
+
+## 1. Negative: the 42501 failure must surface actionable guidance
+
+Run the migrator as the master against the pre-created `registry` database. The
+`sslmode=require` proves the failure lands **after** a working TLS connection.
+
+```bash
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata: { name: registry-migrator-negative }
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrator
+          image: $MIGRATOR_IMAGE
+          imagePullPolicy: Never
+          env:
+            - { name: DB_HOST,         value: managed-pg }
+            - { name: PGUSER,          value: "$MASTER_USER" }
+            - { name: PGPASSWORD,      value: "$MASTER_PW" }
+            - { name: PGSSLMODE,       value: require }
+            - { name: CLIENT_USERNAME, value: client }
+            - { name: CLIENT_PASSWORD, value: clientpw }
+          volumeMounts:
+            - { name: registry-sql, mountPath: /flyway/sql/registry }
+      volumes:
+        - name: registry-sql
+          configMap: { name: registry-sql, items: [{ key: V1__init.sql, path: V1__init.sql }] }
+EOF
+kubectl -n "$NS" wait --for=condition=Failed job/registry-migrator-negative --timeout=120s
+kubectl -n "$NS" logs job/registry-migrator-negative
+```
+
+Assert the log shows:
+
+- a working TLS connection: `Database: jdbc:postgresql://managed-pg/registry?sslmode=require (PostgreSQL 17.x)`;
+- the real Flyway error `SQL State : 42501` / `permission denied for schema public`; and
+- the translated guidance — `SQLSTATE 42501`, `This is NOT a TLS/SSL problem`,
+  and `ALTER SCHEMA public OWNER TO "$MASTER_USER"`.
+
+The Job **must** have failed (the error is translated, not swallowed).
+
+## 2. Positive control: grant the privilege → migration succeeds, no guidance
+
+```bash
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -d registry \
+  -c "ALTER SCHEMA public OWNER TO $MASTER_USER;"
+
+# same Job, different name
+kubectl -n "$NS" get job registry-migrator-negative -o json \
+  | sed 's/registry-migrator-negative/registry-migrator-positive/' \
+  | kubectl -n "$NS" create -f - 2>/dev/null || true
+# (or re-apply the Job manifest from step 1 with a new metadata.name)
+kubectl -n "$NS" wait --for=condition=Complete job/registry-migrator-positive --timeout=120s
+kubectl -n "$NS" logs job/registry-migrator-positive | grep -E "Successfully applied|SQLSTATE 42501"
+# expect: "Successfully applied 1 migration ... v1"; NO "SQLSTATE 42501" line
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -d registry -tAc "
+  SELECT to_regclass('public.e2e_probe') IS NOT NULL, count(*) FROM public.flyway_schema_history;"
+# expect: t | 1
+```
+
+## 3. Missing database is benign, locale-independently (#3744)
+
+First the two facts the fix relies on — a missing database is empty-without-error
+in the catalog, and its connection error carries no parseable SQLSTATE:
+
+```bash
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap psql -U postgres -tAc \
+  "SELECT 1 FROM pg_database WHERE datname='ghostdb'"          # expect: empty, exit 0 (no error)
+kubectl -n "$NS" exec managed-pg -- env PGPASSWORD=bootstrap PGSSLMODE=require \
+  psql "host=127.0.0.1 dbname=ghostdb user=postgres" -v VERBOSITY=verbose -tAc "select 1"
+# expect: FATAL: database "ghostdb" does not exist -- and NO "SQLSTATE" line
+```
+
+Then the migrator, as a role that cannot create the database, must take the
+benign path rather than aborting:
+
+```bash
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata: { name: migrator-missing-db }
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrator
+          image: $MIGRATOR_IMAGE
+          imagePullPolicy: Never
+          env:
+            - { name: DB_HOST,         value: managed-pg }
+            - { name: PGUSER,          value: restricted }   # no CREATEDB -> ghostdb stays missing
+            - { name: PGPASSWORD,      value: rpw }
+            - { name: PGSSLMODE,       value: require }
+            - { name: CLIENT_USERNAME, value: client }
+            - { name: CLIENT_PASSWORD, value: clientpw }
+          volumeMounts:
+            - { name: ghostdb-sql, mountPath: /flyway/sql/ghostdb }
+      volumes:
+        - name: ghostdb-sql
+          configMap: { name: ghostdb-sql, items: [{ key: V1__init.sql, path: V1__init.sql }] }
+EOF
+kubectl -n "$NS" wait --for=condition=Failed job/migrator-missing-db --timeout=120s
+kubectl -n "$NS" logs job/migrator-missing-db
+```
+
+Assert the log contains `Database ghostdb does not exist after the create step; skipping legacy Flyway 4 history detection` and does **not** contain
+`Aborting: could not determine` — the migrator classified the missing database
+as benign via the catalog, then let Flyway be the gate (it then reports
+`FATAL: database "ghostdb" does not exist`, which is expected).
+
+## Cleanup
+
+```bash
+kubectl delete namespace "$NS" --wait=true --timeout=180s
+minikube image rm "$MIGRATOR_IMAGE" 2>/dev/null || true
+```
+
+## Notes
+
+- **What is simulated vs. real.** The managed database is a local `postgres:17`
+  pod with TLS enforced and a non-superuser master. Flyway, `psql`, the JDBC
+  driver and the privilege enforcement are all real — which is the whole point:
+  the unit tests shim Flyway/`psql`, so only a real run proves Flyway emits
+  `SQL State : 42501` and `psql` reports a missing catalog row without error.
+- **Why `sslmode=require`.** It puts a genuine TLS handshake in front of the
+  `42501` failure, matching the real-world misdiagnosis this change fixes — the
+  error arrives on a fully-established, encrypted connection. `require` does not
+  verify the certificate, so no SAN/CA setup is needed; the certificate-
+  verification behaviour itself is covered by
+  [`db-tls-verify-full.md`](./db-tls-verify-full.md).
+- **Relation to `db-tls-verify-full.md`.** That case includes
+  `ALTER SCHEMA public OWNER TO <master>` in its `init.sql` precisely so the
+  registry migrator can proceed; this case is its negative — omit that line and
+  assert the migrator now explains the failure instead of leaving a raw,
+  TLS-looking error.

--- a/magda-db-migrator/migrate.sh
+++ b/magda-db-migrator/migrate.sh
@@ -18,17 +18,21 @@ cd "${FLYWAY_DIR}"
 
 # Run a scalar SQL query against a specific database and print the single value.
 #
-# Distinguishes "the query legitimately found nothing" from "could not talk to the
-# database":
-#   - a missing relation/database (expected: that is exactly what the legacy-history
-#     probes below are testing for) prints nothing and returns 0;
-#   - any other psql failure — connectivity, auth, TLS negotiation, a DB pod still
-#     rolling — prints the error and returns non-zero so the caller can abort.
-# Swallowing the second kind would let the legacy-history detection below silently
+# ANY psql failure — connectivity, auth, TLS negotiation, a DB pod still rolling,
+# or a query error — is fatal: print it and return non-zero so the caller aborts.
+# Swallowing a failure would let the legacy-history detection below silently
 # conclude "no legacy Flyway 4 history", after which `flyway migrate
 # -baselineOnMigrate=true` baselines at Flyway's DEFAULT version 1 and re-applies
 # V1_1..Vn onto an already-migrated schema, permanently poisoning
 # flyway_schema_history.
+#
+# Expected "object does not exist" conditions are avoided by the CALLER, not
+# classified here: the table probes use `to_regclass(...)` and database existence
+# is checked against `pg_database`, both of which return an empty/false scalar
+# WITHOUT raising. This deliberately no longer inspects the error text —
+# PostgreSQL localizes messages via the server's `lc_messages`, so the old
+# `... does not exist` match was English-only and misclassified a genuinely
+# missing object as fatal on a non-English server. (#3744)
 run_scalar () {
     local db="${1}" query="${2}" out rc err_file
     err_file="$(mktemp)"
@@ -37,11 +41,6 @@ run_scalar () {
     rc=$?
     set -e
     if [[ ${rc} -ne 0 ]]; then
-        if grep -qiE '(relation|database|table|schema|column)[^:]*does not exist' "${err_file}"; then
-            # Nothing to report, and nothing wrong: the object simply isn't there.
-            rm -f "${err_file}"
-            return 0
-        fi
         echo "Failed to query database ${db} (psql exited ${rc}):" >&2
         cat "${err_file}" >&2
         rm -f "${err_file}"
@@ -147,13 +146,39 @@ for d in "${FLYWAY_HOME}"/sql/*; do
         # skip the baseline below and let Flyway baseline at its default version 1,
         # re-applying already-applied migrations. Abort instead — the next run (or a
         # retried hook) can try again against a healthy database.
-        if ! has_legacy="$(run_scalar "${dbName}" "SELECT to_regclass('public.schema_version') IS NOT NULL")"; then
-            echo "Aborting: could not determine whether ${dbName} has a legacy Flyway 4 history table." >&2
+        # Does the per-service database actually exist? The legacy-history probes
+        # below connect directly to ${dbName}; if the CREATE DATABASE above genuinely
+        # failed to create it, that connection fails with `database "…" does not exist`
+        # (SQLSTATE 3D000) — a *connection*-level failure whose SQLSTATE psql does not
+        # surface, so it can't be classified from the error the way a query error can.
+        # Ask the catalog on the maintenance `postgres` database instead: a boolean
+        # that returns empty WITHOUT raising, exactly like the `to_regclass` table
+        # probes. An error HERE (couldn't reach `postgres`) is a genuine
+        # connectivity/auth/TLS failure and aborts. (#3744)
+        #
+        # (${dbName} is interpolated into a SQL string literal; a single quote in it
+        # would need doubling, but Magda's per-service database names never contain one.)
+        if ! db_exists="$(run_scalar postgres "SELECT 1 FROM pg_database WHERE datname = '${dbName}'")"; then
+            echo "Aborting: could not check whether database ${dbName} exists." >&2
             exit 1
         fi
-        if ! has_new="$(run_scalar "${dbName}" "SELECT to_regclass('public.flyway_schema_history') IS NOT NULL")"; then
-            echo "Aborting: could not determine whether ${dbName} has a flyway_schema_history table." >&2
-            exit 1
+
+        has_legacy=""
+        has_new=""
+        if [[ -z "${db_exists}" ]]; then
+            # No database in place (a real CREATE DATABASE failure was already logged
+            # above). Skip legacy-history detection; the Flyway step below surfaces the
+            # connection failure clearly.
+            echo "Database ${dbName} does not exist after the create step; skipping legacy Flyway 4 history detection."
+        else
+            if ! has_legacy="$(run_scalar "${dbName}" "SELECT to_regclass('public.schema_version') IS NOT NULL")"; then
+                echo "Aborting: could not determine whether ${dbName} has a legacy Flyway 4 history table." >&2
+                exit 1
+            fi
+            if ! has_new="$(run_scalar "${dbName}" "SELECT to_regclass('public.flyway_schema_history') IS NOT NULL")"; then
+                echo "Aborting: could not determine whether ${dbName} has a flyway_schema_history table." >&2
+                exit 1
+            fi
         fi
         if [[ "${has_legacy}" == "t" && "${has_new}" != "t" ]]; then
             # `ORDER BY installed_rank DESC LIMIT 1` is the LAST-INSTALLED version, not

--- a/magda-db-migrator/migrate.sh
+++ b/magda-db-migrator/migrate.sh
@@ -51,6 +51,58 @@ run_scalar () {
     printf '%s' "${out}"
 }
 
+# Run the Flyway CLI and, on the PostgreSQL 15+ `public`-schema privilege failure,
+# translate Flyway's raw error into actionable guidance instead of leaving it to
+# look like a TLS/connectivity problem.
+#
+# PostgreSQL 15 removed the implicit CREATE grant every role used to have on a
+# database's `public` schema. A migrator user that does not own — or hold CREATE
+# on — the target database's `public` schema now connects fine (password + TLS
+# both pass) and then fails mid-migration with `permission denied for schema
+# public`. Because that lands immediately after a fully established and — under
+# sslmode=verify-ca/verify-full — certificate-verified connection, it is very
+# easy to misdiagnose as an SSL/CA problem. It is not. See magda-io/magda#3770.
+#
+# Matched on the SQLSTATE (`42501`, insufficient_privilege), NOT the message text
+# `permission denied for schema public`: the SQLSTATE is stable, the message is
+# localised by the server's `lc_messages`. (Same rationale as #3744.)
+run_flyway () {
+    local db="${1}"; shift
+    local out_file rc
+    out_file="$(mktemp)"
+    set +e
+    ./flyway "$@" 2>&1 | tee "${out_file}"
+    rc=${PIPESTATUS[0]}
+    set -e
+    if [[ ${rc} -ne 0 ]]; then
+        if grep -qE 'SQL State[[:space:]]*:[[:space:]]*42501' "${out_file}"; then
+            {
+                echo ""
+                echo "=============================================================================="
+                echo "The migrator connected to database \"${db}\" successfully but is not permitted"
+                echo "to create objects in its \"public\" schema (PostgreSQL SQLSTATE 42501,"
+                echo "insufficient_privilege). This is NOT a TLS/SSL problem -- the connection was"
+                echo "established. Since PostgreSQL 15, only the database owner, or a role granted"
+                echo "CREATE on the schema, may create objects in \"public\"."
+                echo ""
+                echo "Grant the migrator user \"${MIGRATOR_USERNAME}\" the privilege on database"
+                echo "\"${db}\" -- run as that database's owner or a superuser:"
+                echo ""
+                echo "    ALTER SCHEMA public OWNER TO \"${MIGRATOR_USERNAME}\";"
+                echo "    -- or, without transferring ownership:"
+                echo "    GRANT CREATE ON SCHEMA public TO \"${MIGRATOR_USERNAME}\";"
+                echo ""
+                echo "See https://github.com/magda-io/magda/issues/3770 and the deploy-to-aws /"
+                echo "deploy-to-azure guides for details."
+                echo "=============================================================================="
+                echo ""
+            } >&2
+        fi
+    fi
+    rm -f "${out_file}"
+    return ${rc}
+}
+
 for d in "${FLYWAY_HOME}"/sql/*; do
     if [[ -d "$d" ]]; then
         dbName="$(basename "$d")"
@@ -113,7 +165,7 @@ for d in "${FLYWAY_HOME}"/sql/*; do
             fi
             if [[ -n "${legacy_version}" ]]; then
                 echo "Detected legacy Flyway 4 history in ${dbName}; baselining flyway_schema_history at version ${legacy_version} (already-applied migrations are not re-run)."
-                ./flyway baseline \
+                run_flyway "${dbName}" baseline \
                     -url="${dbUrl}" \
                     -user="${MIGRATOR_USERNAME}" -password="${PGPASSWORD}" \
                     -baselineVersion="${legacy_version}" \
@@ -125,7 +177,7 @@ for d in "${FLYWAY_HOME}"/sql/*; do
         # -ignoreMigrationPatterns="*:missing" is the Flyway 10+ replacement for the
         # removed -ignoreMissingMigrations flag: tolerate history entries whose files
         # are no longer present. (The legacy `-n` flag was dropped in Flyway 10+.)
-        ./flyway migrate -ignoreMigrationPatterns="*:missing" -baselineOnMigrate=true \
+        run_flyway "${dbName}" migrate -ignoreMigrationPatterns="*:missing" -baselineOnMigrate=true \
             -url="${dbUrl}" \
             -locations="filesystem:${d}" \
             -user="${MIGRATOR_USERNAME}" -password="${PGPASSWORD}" \

--- a/magda-db-migrator/tests/migrate-idempotency.sh
+++ b/magda-db-migrator/tests/migrate-idempotency.sh
@@ -57,6 +57,10 @@ if [[ "$args" == *"CREATE DATABASE"* ]]; then
     echo "ERROR:  database already exists" >&2
     exit 1
 fi
+if [[ "$args" == *"pg_database"* ]]; then
+    echo "1"   # database exists (re-run)
+    exit 0
+fi
 if [[ "$args" == *"SELECT script"* ]]; then
     echo "ERROR:  relation \"schema_version\" does not exist" >&2
     exit 1
@@ -113,7 +117,9 @@ if [[ "$args" == *"CREATE DATABASE"* ]]; then
     echo "ERROR:  database already exists" >&2
     exit 1
 fi
-if [[ "$args" == *"to_regclass"* ]]; then
+if [[ "$args" == *"pg_database"* || "$args" == *"to_regclass"* ]]; then
+    # Unreachable: every probe connection fails (the pg_database existence
+    # pre-check is the first one migrate.sh runs).
     echo "psql: error: connection to server at \"db.example.test\" failed: Connection refused" >&2
     exit 2
 fi
@@ -184,6 +190,10 @@ args="$*"
 if [[ "$args" == *"CREATE DATABASE"* ]]; then
     echo "ERROR:  database already exists" >&2
     exit 1
+fi
+if [[ "$args" == *"pg_database"* ]]; then
+    echo "1"   # database exists
+    exit 0
 fi
 exit 0
 EOF
@@ -297,6 +307,11 @@ BIN_DIR4="${TMP_DIR}/bin4"
 mkdir -p "${BIN_DIR4}"
 cat > "${BIN_DIR4}/psql" <<'EOF'
 #!/usr/bin/env bash
+args="$*"
+if [[ "$args" == *"pg_database"* ]]; then
+    echo "1"   # database exists -> the run proceeds to the migrate step
+    exit 0
+fi
 exit 0
 EOF
 chmod +x "${BIN_DIR4}/psql"
@@ -330,5 +345,78 @@ for needle in "SQLSTATE 42501" "ALTER SCHEMA public OWNER TO" "NOT a TLS/SSL pro
 done
 
 echo "case 4 passed (PG15+ public-schema 42501 failure surfaces actionable guidance)"
+
+# --- Case 5: on a NON-ENGLISH server, a per-service database that does not exist
+# must be classified benign via the pg_database catalog check — NOT aborted the way
+# the old English-only "does not exist" text match would on a translated message
+# (#3744). CREATE DATABASE and a direct connect both emit German here, and the
+# catalog reports the database missing. The old text-matching code would misread
+# the German connect error as fatal and abort; the catalog check must not.
+FLYWAY_MARKER5="${TMP_DIR}/flyway_invoked_5"
+cat > "${FLYWAY_DIR}/flyway" <<EOF
+#!/usr/bin/env bash
+echo "flyway stub called: \$*"
+touch "${FLYWAY_MARKER5}"
+exit 0
+EOF
+chmod +x "${FLYWAY_DIR}/flyway"
+
+BIN_DIR5="${TMP_DIR}/bin5"
+mkdir -p "${BIN_DIR5}"
+cat > "${BIN_DIR5}/psql" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+if [[ "$args" == *"CREATE DATABASE"* ]]; then
+    # German lc_messages: "database ... already exists" (always tolerated).
+    echo "FEHLER:  Datenbank »testdb« existiert bereits" >&2
+    exit 1
+fi
+if [[ "$args" == *"pg_database"* ]]; then
+    # Catalog says the database does not exist: empty result, NO error. This is how
+    # the fix detects non-existence, independent of the server message locale.
+    exit 0
+fi
+if [[ "$args" == *"to_regclass"* ]]; then
+    # A direct connect to the (missing) database fails in German. The fix must NOT
+    # reach here (the catalog check short-circuits); a translated error proves the
+    # classification does not depend on English text -- the old code would abort here.
+    echo "psql: Fehler: Verbindung fehlgeschlagen: FATAL:  Datenbank »testdb« existiert nicht" >&2
+    exit 2
+fi
+exit 0
+EOF
+chmod +x "${BIN_DIR5}/psql"
+
+set +e
+PATH="${BIN_DIR5}:${PATH}" \
+FLYWAY_HOME="${FLYWAY_HOME}" \
+FLYWAY_VERSION="${FLYWAY_VERSION}" \
+DB_HOST="db.example.test" \
+PGUSER="magda_admin" \
+PGPASSWORD="secret" \
+CLIENT_USERNAME="client" \
+CLIENT_PASSWORD="client_secret" \
+    bash "${MIGRATE_SH}" > "${TMP_DIR}/out6.log" 2>&1
+rc=$?
+set -e
+
+# Benign: a missing database must NOT abort the migrator on a non-English server.
+if [[ $rc -ne 0 ]]; then
+    echo "FAIL: migrate.sh aborted (${rc}) on a non-English 'database does not exist'; a missing DB should be benign via the pg_database catalog check."
+    echo "----- output -----"; cat "${TMP_DIR}/out6.log"
+    exit 1
+fi
+if grep -q "Aborting:" "${TMP_DIR}/out6.log"; then
+    echo "FAIL: migrate.sh printed an abort message for a benign missing database."
+    echo "----- output -----"; cat "${TMP_DIR}/out6.log"
+    exit 1
+fi
+if [[ ! -f "${FLYWAY_MARKER5}" ]]; then
+    echo "FAIL: Flyway was not reached; the benign missing-DB path should fall through to Flyway."
+    echo "----- output -----"; cat "${TMP_DIR}/out6.log"
+    exit 1
+fi
+
+echo "case 5 passed (non-English 'database does not exist' is benign via the pg_database catalog check)"
 
 echo "migrate idempotency checks passed"

--- a/magda-db-migrator/tests/migrate-idempotency.sh
+++ b/magda-db-migrator/tests/migrate-idempotency.sh
@@ -266,4 +266,69 @@ fi
 
 echo "case 3b passed (Flyway URL carries sslmode only when PGSSLROOTCERT is unset, no stray separators)"
 
+# --- Case 4: a PostgreSQL 15+ `public`-schema privilege failure (SQLSTATE 42501)
+# during migrate must FAIL the migrator AND print actionable guidance, rather than
+# leaving Flyway's raw error to look like a TLS/connectivity problem (#3770).
+cat > "${FLYWAY_DIR}/flyway" <<'EOF'
+#!/usr/bin/env bash
+echo "flyway stub called: $*"
+# Only the migrate step simulates the failure. Flyway prints the SQLSTATE on its
+# own line ("SQL State  : 42501"), which is what migrate.sh keys off.
+case "$*" in
+  *migrate*)
+    cat >&2 <<'FLYERR'
+ERROR: Migration V1__init.sql failed
+-------------------------------------
+SQL State  : 42501
+Error Code : 0
+Message    : ERROR: permission denied for schema public
+FLYERR
+    exit 1
+    ;;
+esac
+exit 0
+EOF
+chmod +x "${FLYWAY_DIR}/flyway"
+
+# psql shim: succeed at everything (CREATE DATABASE ok; legacy-history probes
+# return empty -> no baseline) so the run reaches the migrate step, where the
+# flyway stub raises the 42501 failure.
+BIN_DIR4="${TMP_DIR}/bin4"
+mkdir -p "${BIN_DIR4}"
+cat > "${BIN_DIR4}/psql" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${BIN_DIR4}/psql"
+
+set +e
+PATH="${BIN_DIR4}:${PATH}" \
+FLYWAY_HOME="${FLYWAY_HOME}" \
+FLYWAY_VERSION="${FLYWAY_VERSION}" \
+DB_HOST="db.example.test" \
+PGUSER="magda_admin" \
+PGPASSWORD="secret" \
+CLIENT_USERNAME="client" \
+CLIENT_PASSWORD="client_secret" \
+    bash "${MIGRATE_SH}" > "${TMP_DIR}/out5.log" 2>&1
+rc=$?
+set -e
+
+# The migrator must still fail — the error is translated, not swallowed.
+if [[ $rc -eq 0 ]]; then
+    echo "FAIL: migrate.sh exited 0 despite the migrate step failing with SQLSTATE 42501."
+    echo "----- output -----"; cat "${TMP_DIR}/out5.log"
+    exit 1
+fi
+# ...and it must surface the actionable guidance (keyed on the SQLSTATE).
+for needle in "SQLSTATE 42501" "ALTER SCHEMA public OWNER TO" "NOT a TLS/SSL problem"; do
+    if ! grep -qF "${needle}" "${TMP_DIR}/out5.log"; then
+        echo "FAIL: expected the 42501 guidance to contain '${needle}', but it did not."
+        echo "----- output -----"; cat "${TMP_DIR}/out5.log"
+        exit 1
+    fi
+done
+
+echo "case 4 passed (PG15+ public-schema 42501 failure surfaces actionable guidance)"
+
 echo "migrate idempotency checks passed"


### PR DESCRIPTION
Closes #3770 and #3744. Part of #3738. Two related hardening changes to `magda-db-migrator/migrate.sh`, both about not letting a DB error masquerade as something it isn't.

## 1. Surface the PG15+ `public`-schema privilege failure (#3770)

Since PostgreSQL 15 removed the implicit `CREATE` grant on a database's `public` schema, a migrator user that doesn't own (or hold `CREATE` on) the target `public` schema **connects fine** (password + TLS pass) and then fails mid-migration with `permission denied for schema public`. Landing right after a verified TLS handshake, it's easily misread as an SSL/CA problem.

The Flyway `baseline`/`migrate` calls are now wrapped in a `run_flyway` helper that, on failure, detects **SQLSTATE `42501`** (`insufficient_privilege`) and prints guidance — naming the database, the migrator user, and the one-time fix — while **still failing** the migrator:

```
The migrator connected to database "registry" successfully but is not permitted
to create objects in its "public" schema (... SQLSTATE 42501 ...).
This is NOT a TLS/SSL problem ...
    ALTER SCHEMA public OWNER TO "magda_admin";
    GRANT CREATE ON SCHEMA public TO "magda_admin";
```

## 2. Classify probe errors by catalog check, not localized text (#3744)

`run_scalar()` previously distinguished benign-missing from fatal by grepping psql stderr for `... does not exist`. That text is localized by the server's `lc_messages`, so on a non-English server the regex misses and a genuinely-missing object is misclassified as **fatal** — a spurious migrator abort (fail-safe, but wrong).

The only benign "missing" case it actually saw was a per-service database that `CREATE DATABASE` didn't create — a **connection**-level `3D000` whose SQLSTATE psql doesn't even surface in verbose mode, so it can't be reclassified from the error text either. Fixed by checking existence up front against the catalog — `SELECT 1 FROM pg_database WHERE datname = …` on the maintenance `postgres` DB, a boolean that returns empty **without raising**, exactly like the existing `to_regclass` table probes. With the expected-missing case handled by the caller, `run_scalar` now treats **any** psql error as fatal and no longer inspects message text.

## Why SQLSTATE / catalog, not message text (both)

Both changes deliberately avoid matching localized PostgreSQL message strings — `42501` is matched by SQLSTATE, database existence by a catalog boolean — so they hold under a non-English server `lc_messages` (which managed providers can be configured with).

## Testing

`magda-db-migrator/tests/migrate-idempotency.sh` (shimmed psql/flyway, no real DB; already wired into CI):

- **Case 4** (new): a Flyway `SQL State : 42501` failure → migrator still exits non-zero **and** prints the guidance.
- **Case 5** (new): a **non-English** (German) "database does not exist" → benign via the `pg_database` catalog check (the old text match would have aborted).
- Cases 1–3 shims updated to answer the new `pg_database` existence probe; unreachable-DB abort (Case 2) and the TLS-URL cases (3/3b) unchanged in intent.

Full suite passes locally: cases 1, 2, 3, 3b, 4, 5 → `migrate idempotency checks passed`.

Shell-only change to the migrator; success-path behavior and what counts as success/failure are unchanged — only the diagnostics and the (locale-independent) benign/fatal classification.

## E2E validation (real Flyway + PostgreSQL 17, local minikube)

Reproduced on a real cluster with the actual migrator image (built from this branch) against a simulated managed PostgreSQL 17 — a TLS-enforcing `postgres:17` pod with a **non-superuser master** and a **pre-created `registry` database the master does not own** (the deliberate negative of [`db-tls-verify-full.md`](https://github.com/magda-io/magda/blob/main/docs/docs/e2e-test-cases/db-tls-verify-full.md)'s `init.sql`, which grants `ALTER SCHEMA public OWNER` so the migrator can proceed). New case doc: [`docs/docs/e2e-test-cases/migrator-public-schema-privilege-error.md`](https://github.com/magda-io/magda/blob/next/docs/docs/e2e-test-cases/migrator-public-schema-privilege-error.md).

**#3770 — negative (the key check the unit test can't reach):** over a live TLS connection (`jdbc:postgresql://managed-pg/registry?sslmode=require`, PostgreSQL 17.10), **real Flyway 12.11.0 emits `SQL State : 42501`**, the grep matches, and the guidance fires — while the Job still fails:
```
ERROR: Failed to execute script
SQL State  : 42501
Message    : ERROR: permission denied for schema public
==============================================================================
The migrator connected to database "registry" successfully but is not permitted
to create objects in its "public" schema (PostgreSQL SQLSTATE 42501, ...).
This is NOT a TLS/SSL problem -- the connection was established. ...
    ALTER SCHEMA public OWNER TO "magda_admin"; ...
==============================================================================
```

**#3770 — positive control:** after `ALTER SCHEMA public OWNER TO magda_admin`, re-run → Job **Completed**, `Successfully applied 1 migration ... v1`, **no** guidance, table + `flyway_schema_history` row present. The `run_flyway` wrapper doesn't disturb the happy path.

**#3744 — assumptions confirmed on real PG:** the catalog query for a missing DB returns empty **without error**; a real `psql` connection to a missing DB reports `FATAL: database "ghostdb" does not exist` with **no SQLSTATE line even under `VERBOSITY=verbose`** — the concrete proof that DB-existence can't be classified from the connection error (why the catalog check, not SQLSTATE parsing, is required).

**#3744 — behavior:** a role without `CREATEDB` → catalog reports the DB missing → `Database ghostdb does not exist after the create step; skipping legacy Flyway 4 history detection` (benign path), **no** `could not determine` abort; Flyway then surfaces the missing DB itself.
