### PR TITLE
fix(magda-postgres): decide backup retention by count, not wal-g output text

### DIFF
--- a/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
@@ -42,27 +42,44 @@ spec:
                 if [[ $BACKUP_PUSH_RC = "0" ]] 
                 then 
                   echo "New Base Backup Creation Completed!"
-                  echo "Start to trim old backups and retain the recent $RETAIN_BACKUP_NUM backups..."
-                  # Set IFS to avoid new lines being removed
-                  IFS=
-                  OUTPUT=$(/usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g delete --confirm retain FULL $RETAIN_BACKUP_NUM 2>&1)
-                  ERROR_CODE=$?
-                  echo $OUTPUT
-                  if [[ $ERROR_CODE = "1" ]]
-                  then 
-                    # NOTE: this distinguishes "fewer backups than the retention
-                    # count" from a real error by matching wal-g's English output
-                    # text, which is fragile across wal-g versions. Revisit when
-                    # wal-g is upgraded (see epic #3740, sub-project 3).
-                    if [[ ${OUTPUT: -9} = "not found" ]]
-                    then
-                      echo "There are less than $RETAIN_BACKUP_NUM backups available. Nothing needs to be deleted!"
-                    else
-                      # print the error but not exit with error & make job to restart for any triming old backup errors.
-                      echo "Error: failed to trim the old backups."
-                    fi
+                  # Decide retention from the actual backup COUNT, not by matching
+                  # wal-g's output text. The wording is not a stability guarantee and
+                  # changed under v7's forked wal-g build: a benign empty result now
+                  # prints "No backup found for deletion", which the old positional
+                  # `${OUTPUT: -9} = "not found"` suffix match misread as an error.
+                  # Count the FULL backups from `backup-list` and only trim when there
+                  # are more than we retain -- then any non-zero `delete` exit is
+                  # unambiguously a real error, no prose parsing involved. (#3763)
+                  BACKUP_LIST=$(/usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g backup-list 2>&1)
+                  BACKUP_LIST_RC=$?
+                  if [[ $BACKUP_LIST_RC != "0" ]]
+                  then
+                    # The backup itself succeeded; failing to LIST for retention is a
+                    # real error but must not fail the backup Job -- skip trimming this
+                    # run (and surface it, rather than silently pruning on a bad count).
+                    echo "$BACKUP_LIST"
+                    echo "Error: could not list backups to evaluate retention (wal-g backup-list exited $BACKUP_LIST_RC); skipping trim this run."
                   else
-                    echo "Trimming old backups Completed!"
+                    # A full base backup is a `base_<WAL>` entry; a delta backup is
+                    # `base_<WAL>_D_<WAL>`. `delete ... retain FULL N` retains N FULL
+                    # backups, so count those. (INFO lines wal-g writes to stderr are
+                    # folded in by 2>&1 above but never start with `base_`.)
+                    FULL_BACKUP_COUNT=$(printf '%s\n' "$BACKUP_LIST" | awk '/^base_/ && !/_D_/ {n++} END {print n+0}')
+                    echo "Found $FULL_BACKUP_COUNT full backup(s); retention target is $RETAIN_BACKUP_NUM."
+                    if [[ "$FULL_BACKUP_COUNT" -gt "$RETAIN_BACKUP_NUM" ]]
+                    then
+                      echo "Start to trim old backups and retain the recent $RETAIN_BACKUP_NUM backups..."
+                      if /usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g delete --confirm retain FULL $RETAIN_BACKUP_NUM
+                      then
+                        echo "Trimming old backups Completed!"
+                      else
+                        # Print the error but do not exit non-zero: the backup itself
+                        # succeeded, and a retention/trim failure should not fail the Job.
+                        echo "Error: failed to trim the old backups."
+                      fi
+                    else
+                      echo "There are $FULL_BACKUP_COUNT full backup(s), at or below the retention target of $RETAIN_BACKUP_NUM. Nothing needs to be deleted!"
+                    fi
                   fi
                 else 
                   echo "Failed to create new base backup!"

--- a/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
@@ -50,7 +50,7 @@ spec:
                   # Count the FULL backups from `backup-list` and only trim when there
                   # are more than we retain -- then any non-zero `delete` exit is
                   # unambiguously a real error, no prose parsing involved. (#3763;
-                  # output-classification convention: #3778.)
+                  # see ADR docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md.)
                   BACKUP_LIST=$(/usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g backup-list 2>&1)
                   BACKUP_LIST_RC=$?
                   if [[ $BACKUP_LIST_RC != "0" ]]

--- a/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
+++ b/deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml
@@ -49,7 +49,8 @@ spec:
                   # `${OUTPUT: -9} = "not found"` suffix match misread as an error.
                   # Count the FULL backups from `backup-list` and only trim when there
                   # are more than we retain -- then any non-zero `delete` exit is
-                  # unambiguously a real error, no prose parsing involved. (#3763)
+                  # unambiguously a real error, no prose parsing involved. (#3763;
+                  # output-classification convention: #3778.)
                   BACKUP_LIST=$(/usr/bin/envdir /etc/wal-g.d/env /usr/local/bin/wal-g backup-list 2>&1)
                   BACKUP_LIST_RC=$?
                   if [[ $BACKUP_LIST_RC != "0" ]]

--- a/deploy/helm/magda-core/tests/walg-backup-cronjob.sh
+++ b/deploy/helm/magda-core/tests/walg-backup-cronjob.sh
@@ -99,55 +99,99 @@ shift
 exec "$@"
 EOF
 
-# wal-g shim: backup-push honours WALG_PUSH_RC; delete records that it ran.
+# wal-g shim, parameterised by env:
+#   backup-push honours WALG_PUSH_RC.
+#   backup-list honours WALG_LIST_RC and emits WALG_BACKUP_COUNT `base_` rows the
+#     way the real fork does (INFO on stderr, a header + one row per backup on
+#     stdout) so the script's own count/awk logic is exercised for real.
+#   delete records that it ran and honours WALG_DELETE_RC.
 cat > "${BIN_DIR}/wal-g" <<EOF
 #!/usr/bin/env bash
 sub="\$1"
 if [[ "\$sub" == "backup-push" ]]; then
     exit "\${WALG_PUSH_RC:-0}"
 fi
+if [[ "\$sub" == "backup-list" ]]; then
+    echo "INFO: List backups from storages: [default]" >&2
+    if [[ "\${WALG_LIST_RC:-0}" != "0" ]]; then
+        echo "ERROR: simulated backup-list failure" >&2
+        exit "\${WALG_LIST_RC}"
+    fi
+    n="\${WALG_BACKUP_COUNT:-0}"
+    if [[ "\$n" -gt 0 ]]; then
+        echo "backup_name                   modified             wal_file_name            storage_name"
+        i=2
+        while [[ "\$i" -lt \$((n + 2)) ]]; do
+            printf 'base_0000000100000000000000%02d 2026-08-17T00:00:00Z 0000000100000000000000%02d default\n' "\$i" "\$i"
+            i=\$((i + 1))
+        done
+    else
+        echo "INFO: No backups found" >&2
+    fi
+    exit 0
+fi
 if [[ "\$sub" == "delete" ]]; then
     touch "${TMP_DIR}/delete_called"
-    echo "deleted"
-    exit 0
+    exit "\${WALG_DELETE_RC:-0}"
 fi
 exit 0
 EOF
 chmod +x "${BIN_DIR}/adduser.sh" "${BIN_DIR}/envdir" "${BIN_DIR}/wal-g"
 
+# run_case PUSH_RC [BACKUP_COUNT] [LIST_RC] [DELETE_RC] -> prints the script exit code.
+# The default retention (numberOfBackupToRetain) is 7.
 run_case () {
-    local push_rc="$1"
+    local push_rc="$1" count="${2:-0}" list_rc="${3:-0}" delete_rc="${4:-0}"
     rm -f "${TMP_DIR}/delete_called"
     set +e
-    PATH="${BIN_DIR}:${PATH}" WALG_PUSH_RC="${push_rc}" \
+    PATH="${BIN_DIR}:${PATH}" WALG_PUSH_RC="${push_rc}" WALG_BACKUP_COUNT="${count}" \
+        WALG_LIST_RC="${list_rc}" WALG_DELETE_RC="${delete_rc}" \
         bash "${SCRIPT}" > "${TMP_DIR}/case.log" 2>&1
     local rc=$?
     set -e
     echo "${rc}"
 }
 
-# Case A: backup-push fails.
+deleted ()     { [[ -f "${TMP_DIR}/delete_called" ]]; }
+log_has ()     { grep -qF "$1" "${TMP_DIR}/case.log"; }
+fail ()        { echo "FAIL ($1): $2"; cat "${TMP_DIR}/case.log"; exit 1; }
+
+# Case A: backup-push fails -> Job fails, no listing/pruning.
 RC_A="$(run_case 1)"
-if [[ "${RC_A}" == "0" ]]; then
-    echo "FAIL (case A): script exited 0 despite backup-push failing"
-    cat "${TMP_DIR}/case.log"; exit 1
-fi
-if [[ -f "${TMP_DIR}/delete_called" ]]; then
-    echo "FAIL (case A): 'wal-g delete' pruned backups after a failed backup-push"
-    cat "${TMP_DIR}/case.log"; exit 1
-fi
+[[ "${RC_A}" != "0" ]]  || fail "case A" "script exited 0 despite backup-push failing"
+! deleted               || fail "case A" "'wal-g delete' pruned backups after a failed backup-push"
 echo "case A passed (failed backup-push -> Job fails, no pruning)"
 
-# Case B: backup-push succeeds.
-RC_B="$(run_case 0)"
-if [[ "${RC_B}" != "0" ]]; then
-    echo "FAIL (case B): script exited ${RC_B} despite backup-push succeeding"
-    cat "${TMP_DIR}/case.log"; exit 1
-fi
-if [[ ! -f "${TMP_DIR}/delete_called" ]]; then
-    echo "FAIL (case B): retention 'wal-g delete' was not run after a successful backup"
-    cat "${TMP_DIR}/case.log"; exit 1
-fi
-echo "case B passed (successful backup-push -> Job succeeds, retention runs)"
+# Case B: backup-push ok, MORE backups than retained (9 > 7) -> trim runs, Job ok.
+RC_B="$(run_case 0 9)"
+[[ "${RC_B}" == "0" ]]  || fail "case B" "script exited ${RC_B} despite a successful backup"
+deleted                 || fail "case B" "retention 'wal-g delete' did not run when count (9) exceeds retention (7)"
+log_has "Trimming old backups Completed!" || fail "case B" "did not report a successful trim"
+echo "case B passed (count > retention -> trim runs, Job succeeds)"
+
+# Case C: backup-push ok, FEWER backups than retained (3 <= 7) -> no trim, benign, Job ok.
+#   The whole point of #3763: this must be classified from the COUNT, never from
+#   wal-g's output wording.
+RC_C="$(run_case 0 3)"
+[[ "${RC_C}" == "0" ]]  || fail "case C" "script exited ${RC_C} with fewer backups than the retention count"
+! deleted               || fail "case C" "'wal-g delete' ran when count (3) is at/below retention (7)"
+log_has "Nothing needs to be deleted!" || fail "case C" "did not report the benign no-trim outcome"
+echo "case C passed (count <= retention -> no trim, benign, no prose match)"
+
+# Case D: count > retention but the trim itself FAILS -> reported as an error,
+#   delete was attempted, Job still exits 0 (a trim failure must not fail the backup).
+RC_D="$(run_case 0 9 0 1)"
+[[ "${RC_D}" == "0" ]]  || fail "case D" "a trim failure must not fail the backup Job (got ${RC_D})"
+deleted                 || fail "case D" "'wal-g delete' was not attempted"
+log_has "Error: failed to trim the old backups." || fail "case D" "a real trim failure was not reported as an error"
+echo "case D passed (real trim failure -> error reported, Job still succeeds)"
+
+# Case E: backup-push ok but backup-LIST fails -> reported as an error, NO trim on
+#   an unknown count, Job still exits 0.
+RC_E="$(run_case 0 0 1)"
+[[ "${RC_E}" == "0" ]]  || fail "case E" "a backup-list failure must not fail the backup Job (got ${RC_E})"
+! deleted               || fail "case E" "'wal-g delete' ran despite being unable to count backups"
+log_has "could not list backups to evaluate retention" || fail "case E" "a backup-list failure was not reported"
+echo "case E passed (backup-list failure -> error reported, no blind pruning)"
 
 echo "wal-g backup CronJob checks passed"

--- a/docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md
+++ b/docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md
@@ -1,0 +1,98 @@
+# 0002 — Classify outcomes by a stable signal, not by a tool's output text
+
+## Status
+
+Accepted.
+
+## Context
+
+Several places in Magda decide whether an external tool succeeded — or which
+kind of failure occurred — by matching that tool's **human-readable output**.
+Three real examples, all in database/backup plumbing:
+
+- The DB migrator classified a `psql` failure as "object simply missing"
+  (benign) vs. "could not talk to the DB" (fatal) by grepping stderr for the
+  English `... does not exist`.
+- The DB migrator would have surfaced a PostgreSQL 15+ `public`-schema privilege
+  failure as a raw error (easily misread as a TLS/CA problem) by looking at the
+  message text `permission denied for schema public`.
+- The `magda-postgres` backup CronJob decided whether `wal-g delete ... retain FULL N` did anything by matching the **last 9 characters** of wal-g's output
+  against `not found`.
+
+This is fragile for reasons that are easy to miss until they bite in production:
+
+- **Localization.** PostgreSQL localizes server messages via `lc_messages`, a
+  server-side GUC an operator can set to a non-English locale (managed providers
+  allow this). The message the client receives is then translated and an
+  English match silently misses.
+- **Version / fork drift.** Output wording is not a stability guarantee. Magda's
+  v7 wal-g is a forked, major-bumped build whose benign empty-delete now prints
+  `No backup found for deletion` — which no longer ends in `not found`, so the
+  old suffix match reads a benign result as a failure.
+- **Positional/substring matches are especially brittle** (`${OUT: -9}`,
+  "ends with X"): any trailing whitespace, punctuation or newline change flips
+  the branch.
+
+And both failure directions are silent: a benign result misreported as an error
+(noise that trains operators to ignore the message), or a real error misread as
+benign (silent data/retention loss).
+
+## Decision
+
+**Do not decide a program's success/failure — or which kind of failure — by
+matching its human-readable output.** Decide from a stable, machine-readable
+signal instead:
+
+- an **error code** — a PostgreSQL **SQLSTATE**, an HTTP status, a documented
+  process exit code; or
+- the **actual state** — a catalog query, a count, a structured (`--json`)
+  listing —
+
+so that a non-zero exit is _unambiguous_ and the classification does not depend
+on prose. Prefer establishing the state up front (so the tool is only invoked
+when it should succeed) over interpreting an error after the fact.
+
+Each site that must distinguish outcomes this way should add a test that fails
+if the logic regresses to prose-matching.
+
+## Consequences
+
+- Classification is robust to server locale, tool version and fork changes, and
+  to cosmetic output changes.
+- Slightly more work per site (a catalog/count probe, or knowing the relevant
+  SQLSTATE) — but it is local, tool-specific work; see "Alternatives" for why it
+  is not centralized.
+
+## Where this is applied
+
+Keep this list in sync; add new sites here.
+
+- `magda-db-migrator/migrate.sh` — `run_scalar`: database existence via the
+  `pg_database` catalog, not the localized `... does not exist` text
+  ([#3744](https://github.com/magda-io/magda/issues/3744)).
+- `magda-db-migrator/migrate.sh` — `run_flyway`: detect the PG15+ public-schema
+  failure by **SQLSTATE `42501`**, not `permission denied for schema public`
+  text ([#3770](https://github.com/magda-io/magda/issues/3770)).
+- `deploy/helm/internal-charts/magda-postgres/templates/cronjob-backup.yaml` —
+  backup retention decided by the **backup count** (`wal-g backup-list`), not
+  wal-g's `not found` output suffix
+  ([#3763](https://github.com/magda-io/magda/issues/3763)).
+
+Enforcing tests: `magda-db-migrator/tests/migrate-idempotency.sh` (cases 4/5)
+and `deploy/helm/magda-core/tests/walg-backup-cronjob.sh` (cases C/D/E).
+
+## Alternatives considered
+
+- **A shared helper library across the sites.** Rejected: the sites live in
+  different images with no shared runtime (the migrator's `migrate.sh` vs. the
+  wal-g image's rendered CronJob script), and the mechanisms are tool-specific
+  (a `pg_database` catalog query, a Flyway SQLSTATE, a `wal-g backup-list`
+  count) rather than a common algorithm — two of them are even opposites (one
+  avoids parsing entirely; the other parses a stable code). Factoring a shared
+  helper would couple unrelated images for no real reuse. The durable
+  consolidation is this convention plus the per-site tests, not shared code.
+- **Keep matching text but make it more robust** (match more of the message,
+  treat "unrecognised output + non-zero exit" as an error). Better than a
+  9-character suffix, but still tied to prose that a locale or version can
+  change; used only as a fallback where neither a code nor the state is
+  available.

--- a/docs/docs/adrs/README.md
+++ b/docs/docs/adrs/README.md
@@ -19,3 +19,4 @@ wondering "why was it done this way?".
 ## Index
 
 - [0001 — Large file upload/download support for magda-storage-api](./0001-large-file-storage-support.md)
+- [0002 — Classify outcomes by a stable signal, not by a tool's output text](./0002-classify-outcomes-by-stable-signal.md)

--- a/magda-db-migrator/migrate.sh
+++ b/magda-db-migrator/migrate.sh
@@ -32,8 +32,9 @@ cd "${FLYWAY_DIR}"
 # WITHOUT raising. This deliberately no longer inspects the error text —
 # PostgreSQL localizes messages via the server's `lc_messages`, so the old
 # `... does not exist` match was English-only and misclassified a genuinely
-# missing object as fatal on a non-English server. (#3744; see the
-# output-classification convention #3778 -- classify by SQLSTATE/state, not text.)
+# missing object as fatal on a non-English server. (#3744; see ADR
+# docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md -- classify by
+# SQLSTATE/state, not by output text.)
 run_scalar () {
     local db="${1}" query="${2}" out rc err_file
     err_file="$(mktemp)"
@@ -65,8 +66,8 @@ run_scalar () {
 #
 # Matched on the SQLSTATE (`42501`, insufficient_privilege), NOT the message text
 # `permission denied for schema public`: the SQLSTATE is stable, the message is
-# localised by the server's `lc_messages`. (Same rationale as #3744; output-
-# classification convention: #3778.)
+# localised by the server's `lc_messages`. (Same rationale as #3744; see ADR
+# docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md.)
 run_flyway () {
     local db="${1}"; shift
     local out_file rc

--- a/magda-db-migrator/migrate.sh
+++ b/magda-db-migrator/migrate.sh
@@ -32,7 +32,8 @@ cd "${FLYWAY_DIR}"
 # WITHOUT raising. This deliberately no longer inspects the error text —
 # PostgreSQL localizes messages via the server's `lc_messages`, so the old
 # `... does not exist` match was English-only and misclassified a genuinely
-# missing object as fatal on a non-English server. (#3744)
+# missing object as fatal on a non-English server. (#3744; see the
+# output-classification convention #3778 -- classify by SQLSTATE/state, not text.)
 run_scalar () {
     local db="${1}" query="${2}" out rc err_file
     err_file="$(mktemp)"
@@ -64,7 +65,8 @@ run_scalar () {
 #
 # Matched on the SQLSTATE (`42501`, insufficient_privilege), NOT the message text
 # `permission denied for schema public`: the SQLSTATE is stable, the message is
-# localised by the server's `lc_messages`. (Same rationale as #3744.)
+# localised by the server's `lc_messages`. (Same rationale as #3744; output-
+# classification convention: #3778.)
 run_flyway () {
     local db="${1}"; shift
     local out_file rc


### PR DESCRIPTION
Closes #3763. Same family as #3770 / #3744 — stop deciding an outcome by matching a tool's (localized / version-dependent) output text; establish the state directly.

## Problem

`magda-postgres`'s backup CronJob decided whether `wal-g delete ... retain FULL N` succeeded by matching the **last 9 characters** of wal-g's output against the English string `not found`:

```bash
OUTPUT=$(wal-g delete --confirm retain FULL $RETAIN_BACKUP_NUM 2>&1)
if [[ ${OUTPUT: -9} = "not found" ]] ; then ... benign ... ; else ... error ... ; fi
```

wal-g's wording is not a stability guarantee, and v7 runs a **forked, major-bumped** build (`ghcr.io/magda-io/magda-wal-g:3.0.8-magda-…`). I confirmed against that exact image that its benign empty result now prints **`No backup found for deletion`** — which does **not** end in `not found`, so the current check misreads the benign "nothing to trim" case as a failure. The match is also positional, so any trailing whitespace/wording change flips it, and both failure directions are silent.

## Fix

Count the state instead of parsing prose: list the backups and only trim when there are more than we retain, so any non-zero `delete` exit is unambiguously a real error.

```bash
BACKUP_LIST=$(wal-g backup-list 2>&1); BACKUP_LIST_RC=$?
if [[ $BACKUP_LIST_RC != 0 ]]; then
  echo "Error: could not list backups ...; skipping trim this run."   # surfaced, no blind prune
else
  FULL_BACKUP_COUNT=$(printf '%s\n' "$BACKUP_LIST" | awk '/^base_/ && !/_D_/ {n++} END {print n+0}')
  if [[ "$FULL_BACKUP_COUNT" -gt "$RETAIN_BACKUP_NUM" ]]; then
    if wal-g delete --confirm retain FULL $RETAIN_BACKUP_NUM; then echo "...Completed!"
    else echo "Error: failed to trim the old backups."; fi           # real error, unambiguous
  else
    echo "There are $FULL_BACKUP_COUNT full backup(s) ... Nothing needs to be deleted!"
  fi
fi
```

- **Count is structural, not prose.** A full base backup is a `base_<WAL>` entry; a delta is `base_<WAL>_D_<WAL>`. `delete ... retain FULL` counts full backups, so we count those. Verified on the real fork that `backup-list` emits one such row per backup (and that the empty case yields zero rows). `awk`, not `jq` — the wal-g image has no `jq`.
- **A `backup-list` failure is surfaced and skips the trim** rather than pruning on an unknown count.
- **Behaviour preserved:** a trim/list failure still does **not** fail the backup Job (the backup itself succeeded) — but it is now reported accurately instead of being misclassified.
- Removes the dangling `epic #3740, sub-project 3` reference the old comment pointed at (this PR is that follow-up).

## Testing

Extends `deploy/helm/magda-core/tests/walg-backup-cronjob.sh` (renders the real CronJob, extracts its script, runs it with `wal-g` shimmed to emit the fork's real `backup-list` format):

- **A** (existing): push fails → Job fails, no pruning.
- **B** (updated): push ok, count 9 > retain 7 → trim runs, Job ok.
- **C** (new): push ok, count 3 ≤ retain 7 → **no** trim, benign — classified from the **count**, never wal-g's wording.
- **D** (new): count > retain but `delete` **fails** → reported as an error, Job still exits 0.
- **E** (new): `backup-list` **fails** → reported, **no** blind pruning, Job still exits 0.

All pass locally, and the `awk` counter was validated against the real fork's `backup-list` output (2 backups → 2; empty → 0). This test already runs in CI (`.gitlab-ci.yml`).

Helm-template-only change to the CronJob's inline script; no change to the success-path behaviour or to what fails the Job.

## Convention (ADR)

Recorded the shared principle behind #3763 / #3770 / #3744 as an Architecture Decision Record — [`docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md`](https://github.com/magda-io/magda/blob/next/docs/docs/adrs/0002-classify-outcomes-by-stable-signal.md) ("classify outcomes by a stable signal — SQLSTATE / state — never by a tool's output text") — and linked it from the code comments at all three sites (this PR touches `migrate.sh`'s two comments and the CronJob comment).

## E2E test results (real forked wal-g, local minikube)

Two things were validated on a local minikube cluster with the **real** forked image `ghcr.io/magda-io/magda-wal-g:3.0.8-magda-edcda8b` (not a shim):

### 1. Unit suite against the real rendered CronJob

`bash deploy/helm/magda-core/tests/walg-backup-cronjob.sh` (renders the actual CronJob, extracts its script, runs it with `wal-g` shimmed to emit the fork's real `backup-list` format):

```
case A passed (failed backup-push -> Job fails, no pruning)
case B passed (count > retention -> trim runs, Job succeeds)
case C passed (count <= retention -> no trim, benign, no prose match)
case D passed (real trim failure -> error reported, Job still succeeds)
case E passed (backup-list failure -> error reported, no blind pruning)
wal-g backup CronJob checks passed
```

### 2. The committed retention logic in a real wal-g Job

A Job running the exact committed retention logic in the real wal-g image, against real file storage seeded with real backup sentinels:

```
########## Scenario 1: 1 backup, retain 7 -> benign (no delete) ##########
Found 1 full backup(s); retention target is 7.
There are 1 full backup(s), at or below the retention target of 7. Nothing needs to be deleted!
COUNT_AFTER_S1=1
########## Scenario 2: 3 backups, retain 2 -> trim to 2 ##########
Found 3 full backup(s); retention target is 2.
Start to trim old backups and retain the recent 2 backups...
Trimming old backups Completed!
COUNT_AFTER_S2=2
```

- **Scenario 1** (1 backup ≤ retain 7) is exactly the case #3763 fixes: classified benign from the **count**, no `delete`, count unchanged.
- **Scenario 2** (3 backups > retain 2): real `wal-g delete` actually trimmed **3 → 2**.

### 3. Proof the old code misfires against this fork

Same fork, `wal-g delete --confirm retain FULL 7` with nothing to trim, evaluating the **old** `${OUTPUT: -9} = "not found"` check:

```
wal-g said: [INFO: ... No backup found for deletion]
last 9 chars: [ deletion]
OLD-CHECK verdict: ERROR (WRONG - benign misreported as failure)
```

The fork's benign message ends in `" deletion"`, not `"not found"`, so the pre-fix code takes the **error** branch for a benign result — the concrete failure this PR removes.
