### PR TITLE
feat(mgd): support dataset publishers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v6.2.0
 
+- #3715: Add publishing organisation support to `mgd dataset create` and `mgd dataset update`, including site defaults, organisation name resolution/creation, and synchronized publisher aspects.
 - #3758: Upgraded the in-cluster PostgreSQL backup tool wal-g to 3.0.8.
 
 ## v6.1.2

--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -418,14 +418,17 @@ metadata tools, with a distinct `name` marking their CLI provenance.
 `--publisher` accepts an existing `organisation` record ID or a name. A name is
 matched exactly (case-insensitively) against existing publishers; if no match
 exists, `mgd` creates an `organisation` record with an `organization-details`
-aspect, matching the web client's behaviour. When the flag is omitted, `create`
-uses the site's `defaultOrganizationId` when configured; `update` preserves the
-current publisher, or uses that default for older publisher-less datasets. The
-CLI keeps the `dataset-publisher` reference and the
-`dcat-dataset-strings.publisher` display-name mirror in sync. Consequently,
-`dataset create/update --aspect` rejects those two managed aspect IDs; use the
-dedicated metadata options (or the low-level `dataset aspect` commands when you
-intentionally need a manual escape hatch).
+aspect, matching the web client's behaviour. The lookup queries organisation
+records directly, so it is not limited by search-facet pagination or indexing
+lag. When the flag is omitted, `create` uses the site's
+`defaultOrganizationId` when configured; a dataset-metadata `update` preserves
+the current publisher or backfills that default for an older publisher-less
+dataset. A custom-aspect-only update has no publisher side effects. The CLI
+keeps the `dataset-publisher` reference and the
+`dcat-dataset-strings.publisher` display-name mirror in sync. Raw
+`dataset-publisher` values and a `publisher` field inside a raw
+`dcat-dataset-strings` value are therefore rejected; other DCAT fields remain
+supported through `--aspect`.
 
 > **Publishing is a deliberate step.** Create as a draft, review, then publish
 > explicitly. `add-file` / `replace-file` are multi-step operations; if a step
@@ -485,8 +488,8 @@ call the raw endpoint: `mgd api request PATCH /v0/registry/records/<id>/aspects/
 
 Dataset and distribution create/update commands also accept repeatable
 `--aspect <id>=<json|@file|->` to attach custom aspect data. On dataset
-create/update, publisher-bearing standard aspects are reserved as described
-above; use the dedicated metadata options instead.
+create/update, use `--publisher` for publishing-organisation metadata; other
+fields in `dcat-dataset-strings` remain available through `--aspect`.
 
 ## Uploading files directly to storage
 

--- a/packages/mgd/README.md
+++ b/packages/mgd/README.md
@@ -389,6 +389,7 @@ web UI. New datasets are created as **drafts** unless you pass `--publish`.
 mgd dataset create \
   --title "River gauge readings 2025" \
   --desc "Daily river height and flow measurements." \
+  --publisher "Department of Water" \
   --json                                              # -> magda-ds-<uuid>
 
 # 2. Upload a file and attach it as a distribution
@@ -397,8 +398,9 @@ mgd dataset add-file magda-ds-<uuid> ./readings.csv --title "2025 readings" --fo
 # 3. Register a link-only distribution (no upload)
 mgd dataset add-file magda-ds-<uuid> --access-url https://example.org/data.csv --title "Source data"
 
-# 4. Update metadata
-mgd dataset update magda-ds-<uuid> --title "River gauge readings (2025, v2)"
+# 4. Update metadata (publisher accepts an organisation name or record ID)
+mgd dataset update magda-ds-<uuid> --title "River gauge readings (2025, v2)" \
+  --publisher org-dga-<uuid>
 
 # 5. Replace the file behind a distribution (adds a new version entry)
 mgd dist replace-file magda-dist-<uuid> ./readings-corrected.csv
@@ -412,6 +414,18 @@ Datasets created by the CLI are stamped with a `source` aspect
 (`{"id":"magda","name":"Magda CLI (mgd)","type":"internal","url":<site>}`) — the
 same `id` the web client uses, so they show up as editable records in the web
 metadata tools, with a distinct `name` marking their CLI provenance.
+
+`--publisher` accepts an existing `organisation` record ID or a name. A name is
+matched exactly (case-insensitively) against existing publishers; if no match
+exists, `mgd` creates an `organisation` record with an `organization-details`
+aspect, matching the web client's behaviour. When the flag is omitted, `create`
+uses the site's `defaultOrganizationId` when configured; `update` preserves the
+current publisher, or uses that default for older publisher-less datasets. The
+CLI keeps the `dataset-publisher` reference and the
+`dcat-dataset-strings.publisher` display-name mirror in sync. Consequently,
+`dataset create/update --aspect` rejects those two managed aspect IDs; use the
+dedicated metadata options (or the low-level `dataset aspect` commands when you
+intentionally need a manual escape hatch).
 
 > **Publishing is a deliberate step.** Create as a draft, review, then publish
 > explicitly. `add-file` / `replace-file` are multi-step operations; if a step
@@ -432,18 +446,18 @@ metadata tools, with a distinct `name` marking their CLI provenance.
 
 Records carry data in named **aspects**. The ones the CLI reads or writes most:
 
-| Aspect | Record | Holds / notes |
-| --- | --- | --- |
-| `dcat-dataset-strings` | dataset | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified` |
-| `dcat-distribution-strings` | distribution | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize` |
-| `publishing` | dataset & distribution | `{ "state": "draft" \| "published" }` — use `publish`/`unpublish`, don't hand-edit |
-| `dataset-distributions` | dataset | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit |
-| `version` | dataset & distribution | CLI-managed history — don't hand-edit |
-| `access-control` | dataset | `ownerId`, `orgUnitId`, `constraintExemption` |
-| `source` | dataset | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`) |
-| `dataset-publisher` | dataset | `{ "publisher": "<organisation record id>" }` — publishing org shown in the web UI; the CLI does not set it yet ([#3715](https://github.com/magda-io/magda/issues/3715)) |
-| `temporal-coverage` | dataset | *optional* — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range |
-| `spatial-coverage` | dataset | *optional* — bounding box / named region; set manually when the data has a spatial extent |
+| Aspect                      | Record                 | Holds / notes                                                                                                                                                     |
+| --------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dcat-dataset-strings`      | dataset                | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified`, and the publisher name mirror                                                     |
+| `dcat-distribution-strings` | distribution           | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize`                                                                                                |
+| `publishing`                | dataset & distribution | `{ "state": "draft" \| "published" }` — use `publish`/`unpublish`, don't hand-edit                                                                                |
+| `dataset-distributions`     | dataset                | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit                                                                   |
+| `version`                   | dataset & distribution | CLI-managed history — don't hand-edit                                                                                                                             |
+| `access-control`            | dataset                | `ownerId`, `orgUnitId`, `constraintExemption`                                                                                                                     |
+| `source`                    | dataset                | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`)                                                                                              |
+| `dataset-publisher`         | dataset                | `{ "publisher": "<organisation record id>" }` — publishing org shown in the web UI; use `dataset create/update --publisher` so its name mirror stays synchronized |
+| `temporal-coverage`         | dataset                | _optional_ — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range                                                               |
+| `spatial-coverage`          | dataset                | _optional_ — bounding box / named region; set manually when the data has a spatial extent                                                                         |
 
 ### Custom aspects
 
@@ -469,8 +483,10 @@ supplied fields** (a server-side deep merge via the registry's `?merge=true`, so
 untouched fields survive). For advanced RFC 6902 operations (remove/test/move),
 call the raw endpoint: `mgd api request PATCH /v0/registry/records/<id>/aspects/<aspectId> --body @patch.json`.
 
-Every mutation command also accepts repeatable `--aspect <id>=<json|@file|->` to
-attach custom aspect data at create/update time.
+Dataset and distribution create/update commands also accept repeatable
+`--aspect <id>=<json|@file|->` to attach custom aspect data. On dataset
+create/update, publisher-bearing standard aspects are reserved as described
+above; use the dedicated metadata options instead.
 
 ## Uploading files directly to storage
 
@@ -508,8 +524,8 @@ echo '{"active":true}' | mgd api request PUT /v0/some/endpoint --body -
 | `search semantic <query>`                                   | Semantic (embedding) search                                                                         |
 | `dataset get <id>`                                          | Fetch a dataset record                                                                              |
 | `dataset distributions <id>`                                | List a dataset's distributions                                                                      |
-| `dataset create`                                            | Create a dataset (draft by default)                                                                 |
-| `dataset update <id>`                                       | Update dataset metadata                                                                             |
+| `dataset create`                                            | Create a dataset (draft by default; `--publisher` or site default)                                  |
+| `dataset update <id>`                                       | Update dataset metadata, including its publishing organisation                                      |
 | `dataset add-file <id> [file]`                              | Upload/attach a distribution (or `--access-url`)                                                    |
 | `dataset aspect get/set/patch/delete <recordId> <aspectId>` | Read/write custom aspect data on any record (`set`=replace, `patch`=merge)                          |
 | `dist get <id>` / `dist update <id>`                        | Inspect / edit a distribution                                                                       |

--- a/packages/mgd/skills/dataset-elicitation.md
+++ b/packages/mgd/skills/dataset-elicitation.md
@@ -84,7 +84,10 @@ When asked to improve an existing dataset (or after a quick-path creation):
 - Datasets are created as **drafts**. `--publish` (or publishing-state changes)
   only after explicit user confirmation.
 - Before any mutation, show a compact summary of exactly what will be written,
-  marking which values were inferred vs provided.
+  marking which values were inferred vs provided. Use the dedicated
+  `--publisher <name|orgId>` option for the publishing organisation. Explain
+  that a previously unknown name will create an `organisation` record, and
+  include that additional mutation in the confirmation.
 - After mutations, report the record IDs and what changed.
 - Replacing a file (`mgd dist replace-file`) preserves version history; tell
   the user the new version number. Dataset/distribution metadata updates and

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -157,14 +157,14 @@ mgd dataset publish magda-ds-<uuid> --json
 
 **Publishing organisation:** `dataset create/update --publisher <name|orgId>`
 sets both the `dataset-publisher` reference and its DCAT name mirror. An exact,
-case-insensitive name match reuses the existing organisation; otherwise the CLI
-creates an `organisation` record. With no flag, create uses the site's configured
-default; update preserves the current publisher, or backfills that default on an
-older publisher-less dataset. `dataset create/update --aspect` rejects the
-managed `dataset-publisher` and `dcat-dataset-strings` aspect IDs; use the
-dedicated metadata options so the two publisher fields cannot diverge. Because
-a new name can create another record, include that possible mutation in the
-confirmation required by ground rule 5.
+case-insensitive registry match reuses the existing organisation; otherwise the
+CLI creates an `organisation` record. With no flag, create uses the site's
+configured default; a dataset-metadata update preserves the current publisher or
+backfills that default on an older publisher-less dataset, while a
+custom-aspect-only update has no publisher side effects. Use `--publisher` for
+the publisher reference/name; other `dcat-dataset-strings` fields remain
+available through `--aspect`. Because a new name can create another record,
+include that possible mutation in the confirmation required by ground rule 5.
 
 **Publishing commands:**
 

--- a/packages/mgd/skills/mgd-workflows.md
+++ b/packages/mgd/skills/mgd-workflows.md
@@ -30,7 +30,7 @@ your assistant environment, keep the rules.
 5. **Confirm before mutating or publishing.** Never run `dataset create --publish`, `add-file`, `replace-file`, `update`, `aspect create/set/patch/delete`,
    or any `api request` with POST/PUT/PATCH/DELETE without the user's explicit
    go-ahead in this conversation. Uploading or attaching generated artifacts
-   happens only when the user asked for it. For *how* to create and publish once
+   happens only when the user asked for it. For _how_ to create and publish once
    the user has agreed, see "Creating, editing & publishing datasets" below.
 6. **Report identifiers.** Every user-facing summary must include the dataset
    IDs, distribution IDs, local file paths, and upload targets you touched.
@@ -132,7 +132,7 @@ mgd api request GET /v0/registry/records --query limit=3 --query aspect=dcat-dat
 
 Metadata first: when creating or editing dataset metadata, follow
 `dataset-elicitation.md` (infer before asking, quick vs guided path,
-confirm-then-write). This section covers the *command mechanics* once you know
+confirm-then-write). This section covers the _command mechanics_ once you know
 what to write. Every mutation here is subject to ground rule 5 — get the user's
 go-ahead first.
 
@@ -141,7 +141,8 @@ Canonical sequence — **create → enrich → add files → publish**:
 ```sh
 # 1. Create a draft (draft is the default; --publish would create it published)
 mgd dataset create --title "River gauge readings 2025" \
-  --desc "Daily river height and flow measurements." --json   # -> magda-ds-<uuid>
+  --desc "Daily river height and flow measurements." \
+  --publisher "Department of Water" --json                    # -> magda-ds-<uuid>
 
 # 2. Enrich metadata (patch merges these fields, keeping the rest — see set vs patch above)
 mgd dataset aspect patch magda-ds-<uuid> dcat-dataset-strings \
@@ -153,6 +154,17 @@ mgd dataset add-file magda-ds-<uuid> ./readings.csv --title "2025 readings" --fo
 # 4. Publish — cascades to all the dataset's distributions
 mgd dataset publish magda-ds-<uuid> --json
 ```
+
+**Publishing organisation:** `dataset create/update --publisher <name|orgId>`
+sets both the `dataset-publisher` reference and its DCAT name mirror. An exact,
+case-insensitive name match reuses the existing organisation; otherwise the CLI
+creates an `organisation` record. With no flag, create uses the site's configured
+default; update preserves the current publisher, or backfills that default on an
+older publisher-less dataset. `dataset create/update --aspect` rejects the
+managed `dataset-publisher` and `dcat-dataset-strings` aspect IDs; use the
+dedicated metadata options so the two publisher fields cannot diverge. Because
+a new name can create another record, include that possible mutation in the
+confirmation required by ground rule 5.
 
 **Publishing commands:**
 
@@ -175,28 +187,22 @@ aspects directly.
 
 ### Common aspects
 
-| Aspect | Record | Holds / notes |
-| --- | --- | --- |
-| `dcat-dataset-strings` | dataset | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified` |
-| `dcat-distribution-strings` | distribution | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize` |
-| `publishing` | dataset & distribution | `{ "state": "draft" \| "published" }` — use publish/unpublish, don't hand-edit |
-| `dataset-distributions` | dataset | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit |
-| `version` | dataset & distribution | CLI-managed history — never hand-edit (ground rule 7) |
-| `access-control` | dataset | `ownerId`, `orgUnitId`, `constraintExemption` |
-| `source` | dataset | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`) |
-| `dataset-publisher` | dataset | `{ "publisher": "<organisation record id>" }` — the web UI shows this org before the dates. **The CLI does not set it** (see note below) |
-| `temporal-coverage` | dataset | *optional* — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range |
-| `spatial-coverage` | dataset | *optional* — bounding box / named region; set manually when the data has a spatial extent |
+| Aspect                      | Record                 | Holds / notes                                                                                                                                   |
+| --------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dcat-dataset-strings`      | dataset                | `title`, `description`, `keywords`, `themes`, `languages`, `issued`/`modified`, and the publisher name mirror                                   |
+| `dcat-distribution-strings` | distribution           | per-file `title`, `format`, `downloadURL`, `accessURL`, `byteSize`                                                                              |
+| `publishing`                | dataset & distribution | `{ "state": "draft" \| "published" }` — use publish/unpublish, don't hand-edit                                                                  |
+| `dataset-distributions`     | dataset                | `{ "distributions": [<distId>, …] }` — CLI-managed by `add-file`/`dist remove`; don't hand-edit                                                 |
+| `version`                   | dataset & distribution | CLI-managed history — never hand-edit (ground rule 7)                                                                                           |
+| `access-control`            | dataset                | `ownerId`, `orgUnitId`, `constraintExemption`                                                                                                   |
+| `source`                    | dataset                | provenance (`id: "magda"`, `name: "Magda CLI (mgd)"`, `type`, `url`)                                                                            |
+| `dataset-publisher`         | dataset                | `{ "publisher": "<organisation record id>" }` — use `dataset create/update --publisher` so the reference and DCAT name mirror stay synchronized |
+| `temporal-coverage`         | dataset                | _optional_ — `{ "intervals": [{ "start", "end" }] }`; set manually when the data spans a time range                                             |
+| `spatial-coverage`          | dataset                | _optional_ — bounding box / named region; set manually when the data has a spatial extent                                                       |
 
 **Need a field these don't cover?** Define a custom, JSON-schema-validated
 aspect — `mgd aspect create <id> --name "…" --schema @schema.json`, then attach
 data with `dataset aspect set`/`patch` (see "Custom / domain metadata" above).
-
-**Publisher gap.** CLI-created datasets omit `dataset-publisher`, so the web UI
-shows no publishing organisation. Populating it correctly needs an
-`organisation` record ID (not a name), which the CLI doesn't yet resolve —
-tracked in issue #3715. Interim workaround, only if you already know the org's
-record ID: `mgd dataset aspect set <id> dataset-publisher '{"publisher":"<orgId>"}'`.
 
 ## Error triage
 

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -32,6 +32,12 @@ import {
 } from "../recordBuilders.js";
 import { uploadFile } from "../transfer.js";
 import { publishDataset, renderPublishResult } from "../publishing.js";
+import {
+    getDatasetPublisherId,
+    resolveDefaultPublisher,
+    resolvePublisher,
+    ResolvedPublisher
+} from "../publisher.js";
 
 export async function fetchOwner(
     client: MagdaClient
@@ -84,6 +90,59 @@ export async function mergeAspect(
         body: JSON.stringify(merged)
     });
     return { eventId: eventIdFrom(res), merged };
+}
+
+async function updatePublisherMetadata(
+    client: MagdaClient,
+    datasetId: string,
+    publisher: ResolvedPublisher,
+    dcatPatch: Record<string, unknown>
+): Promise<{ eventId: number; merged: Record<string, unknown> }> {
+    let current: Record<string, unknown> = {};
+    try {
+        current = await client.json(
+            "GET",
+            recordAspect(datasetId, "dcat-dataset-strings")
+        );
+    } catch (e) {
+        if (!(e instanceof MgdApiError && e.status === 404)) throw e;
+    }
+    const merged = {
+        ...current,
+        ...dcatPatch,
+        publisher: publisher.name
+    };
+    const res = await client.request("PATCH", REGISTRY_RECORDS, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            recordIds: [datasetId],
+            jsonPath: [
+                {
+                    op: "add",
+                    path: "/aspects/dcat-dataset-strings",
+                    value: merged
+                },
+                {
+                    op: "add",
+                    path: "/aspects/dataset-publisher",
+                    value: { publisher: publisher.id }
+                }
+            ]
+        })
+    });
+    let eventId = eventIdFrom(res);
+    try {
+        const eventIds = (await res.json()) as unknown;
+        if (Array.isArray(eventIds)) {
+            eventId = Math.max(
+                eventId,
+                ...eventIds.map((value) => Number(value) || 0)
+            );
+        }
+    } catch {
+        // Older registry versions may return no JSON body; use the header.
+    }
+    return { eventId, merged };
 }
 
 export function registerDatasetCommands(program: Command): void {
@@ -179,6 +238,10 @@ export function registerDatasetCommands(program: Command): void {
         .description("Create a new dataset record (draft by default)")
         .requiredOption("--title <title>", "dataset title")
         .option("--desc <description>", "dataset description")
+        .option(
+            "--publisher <nameOrOrgId>",
+            "publishing organisation name or record id (default: site configuration)"
+        )
         .option("--publish", "create as published instead of draft")
         .option(
             "--aspect <id=json...>",
@@ -195,6 +258,17 @@ export function registerDatasetCommands(program: Command): void {
                 const { id, data } = await parseAspectArg(arg);
                 extraAspects[id] = data;
             }
+            if (
+                "dataset-publisher" in extraAspects ||
+                "dcat-dataset-strings" in extraAspects
+            ) {
+                throw new UsageError(
+                    "dataset create does not accept --aspect dataset-publisher or --aspect dcat-dataset-strings; use --publisher, --title and --desc so managed metadata stays consistent."
+                );
+            }
+            const publisher = opts.publisher
+                ? await resolvePublisher(client, opts.publisher)
+                : await resolveDefaultPublisher(client);
             const record = buildDatasetRecord({
                 id: createId("ds"),
                 title: opts.title,
@@ -203,6 +277,7 @@ export function registerDatasetCommands(program: Command): void {
                 owner,
                 now: new Date(),
                 sourceUrl: deriveSiteUrl(client.opts.baseUrl),
+                publisher,
                 extraAspects
             });
             let createEventId = 0;
@@ -240,6 +315,10 @@ export function registerDatasetCommands(program: Command): void {
         .option("--desc <description>")
         .option("--license <license>")
         .option(
+            "--publisher <nameOrOrgId>",
+            "publishing organisation name or record id"
+        )
+        .option(
             "--aspect <id=json...>",
             "replace an aspect entirely (repeatable)",
             collect,
@@ -256,17 +335,47 @@ export function registerDatasetCommands(program: Command): void {
                 aspectArgs.push(await parseAspectArg(arg));
             }
             if (
-                Object.keys(scalarPatch).length === 0 &&
-                aspectArgs.length === 0
+                aspectArgs.some(
+                    ({ id }) =>
+                        id === "dataset-publisher" ||
+                        id === "dcat-dataset-strings"
+                )
             ) {
                 throw new UsageError(
-                    "Nothing to update: pass --title/--desc/--license or --aspect."
+                    "dataset update does not accept --aspect dataset-publisher or --aspect dcat-dataset-strings; use --publisher, --title, --desc and --license so managed metadata stays consistent."
+                );
+            }
+            if (
+                Object.keys(scalarPatch).length === 0 &&
+                aspectArgs.length === 0 &&
+                !opts.publisher
+            ) {
+                throw new UsageError(
+                    "Nothing to update: pass --title/--desc/--license/--publisher or --aspect."
                 );
             }
             const client = await clientFromProfile();
+            let publisher: ResolvedPublisher | undefined;
+            if (opts.publisher) {
+                publisher = await resolvePublisher(client, opts.publisher);
+            } else if (!(await getDatasetPublisherId(client, datasetId))) {
+                publisher = await resolveDefaultPublisher(client);
+            }
+
             let lastEventId = 0;
             let mergedTitle: string | undefined;
-            if (Object.keys(scalarPatch).length > 0) {
+            if (publisher) {
+                scalarPatch.modified = new Date().toISOString();
+                const { eventId, merged } = await updatePublisherMetadata(
+                    client,
+                    datasetId,
+                    publisher,
+                    scalarPatch
+                );
+                lastEventId = Math.max(lastEventId, eventId);
+                mergedTitle =
+                    typeof merged.title === "string" ? merged.title : undefined;
+            } else if (Object.keys(scalarPatch).length > 0) {
                 scalarPatch.modified = new Date().toISOString();
                 const { eventId, merged } = await mergeAspect(
                     client,

--- a/packages/mgd/src/commands/dataset.ts
+++ b/packages/mgd/src/commands/dataset.ts
@@ -34,8 +34,10 @@ import { uploadFile } from "../transfer.js";
 import { publishDataset, renderPublishResult } from "../publishing.js";
 import {
     getDatasetPublisherId,
+    removeCreatedPublisher,
     resolveDefaultPublisher,
     resolvePublisher,
+    resolvePublisherId,
     ResolvedPublisher
 } from "../publisher.js";
 
@@ -96,16 +98,19 @@ async function updatePublisherMetadata(
     client: MagdaClient,
     datasetId: string,
     publisher: ResolvedPublisher,
-    dcatPatch: Record<string, unknown>
+    dcatPatch: Record<string, unknown>,
+    replaceDcat = false
 ): Promise<{ eventId: number; merged: Record<string, unknown> }> {
     let current: Record<string, unknown> = {};
-    try {
-        current = await client.json(
-            "GET",
-            recordAspect(datasetId, "dcat-dataset-strings")
-        );
-    } catch (e) {
-        if (!(e instanceof MgdApiError && e.status === 404)) throw e;
+    if (!replaceDcat) {
+        try {
+            current = await client.json(
+                "GET",
+                recordAspect(datasetId, "dcat-dataset-strings")
+            );
+        } catch (e) {
+            if (!(e instanceof MgdApiError && e.status === 404)) throw e;
+        }
     }
     const merged = {
         ...current,
@@ -251,24 +256,43 @@ export function registerDatasetCommands(program: Command): void {
         )
         .option("--json", "output the created record as JSON")
         .action(async (opts) => {
-            const client = await clientFromProfile();
-            const owner = await fetchOwner(client);
             const extraAspects: Record<string, unknown> = {};
             for (const arg of opts.aspect as string[]) {
                 const { id, data } = await parseAspectArg(arg);
                 extraAspects[id] = data;
             }
-            if (
-                "dataset-publisher" in extraAspects ||
-                "dcat-dataset-strings" in extraAspects
-            ) {
+            if ("dataset-publisher" in extraAspects) {
                 throw new UsageError(
-                    "dataset create does not accept --aspect dataset-publisher or --aspect dcat-dataset-strings; use --publisher, --title and --desc so managed metadata stays consistent."
+                    "dataset create does not accept --aspect dataset-publisher; use --publisher so the reference and name mirror stay consistent."
                 );
             }
-            const publisher = opts.publisher
-                ? await resolvePublisher(client, opts.publisher)
-                : await resolveDefaultPublisher(client);
+            const customDcat = extraAspects["dcat-dataset-strings"];
+            if (
+                customDcat !== undefined &&
+                (typeof customDcat !== "object" ||
+                    customDcat === null ||
+                    Array.isArray(customDcat))
+            ) {
+                throw new UsageError(
+                    "--aspect dcat-dataset-strings must contain a JSON object."
+                );
+            }
+            if (
+                customDcat &&
+                Object.prototype.hasOwnProperty.call(customDcat, "publisher")
+            ) {
+                throw new UsageError(
+                    "Set the dcat-dataset-strings publisher field with --publisher instead."
+                );
+            }
+
+            const client = await clientFromProfile();
+            const owner = await fetchOwner(client);
+            const publisher =
+                opts.publisher !== undefined
+                    ? await resolvePublisher(client, opts.publisher)
+                    : await resolveDefaultPublisher(client);
+            delete extraAspects["dcat-dataset-strings"];
             const record = buildDatasetRecord({
                 id: createId("ds"),
                 title: opts.title,
@@ -280,6 +304,12 @@ export function registerDatasetCommands(program: Command): void {
                 publisher,
                 extraAspects
             });
+            if (customDcat) {
+                record.aspects["dcat-dataset-strings"] = {
+                    ...record.aspects["dcat-dataset-strings"],
+                    ...customDcat
+                };
+            }
             let createEventId = 0;
             try {
                 const res = await client.request("POST", REGISTRY_RECORDS, {
@@ -288,6 +318,14 @@ export function registerDatasetCommands(program: Command): void {
                 });
                 createEventId = eventIdFrom(res);
             } catch (e) {
+                if (
+                    publisher?.created &&
+                    !(await removeCreatedPublisher(client, publisher))
+                ) {
+                    note(
+                        `Warning: dataset creation failed and the newly created organisation ${publisher.id} could not be removed.`
+                    );
+                }
                 throw withAspectHint(e);
             }
             // Tag the seeded v0 with the creation event so the next edit
@@ -334,21 +372,36 @@ export function registerDatasetCommands(program: Command): void {
             for (const arg of opts.aspect as string[]) {
                 aspectArgs.push(await parseAspectArg(arg));
             }
+            if (aspectArgs.some(({ id }) => id === "dataset-publisher")) {
+                throw new UsageError(
+                    "dataset update does not accept --aspect dataset-publisher; use --publisher so the reference and name mirror stay consistent."
+                );
+            }
+            const dcatArg = aspectArgs.find(
+                ({ id }) => id === "dcat-dataset-strings"
+            );
             if (
-                aspectArgs.some(
-                    ({ id }) =>
-                        id === "dataset-publisher" ||
-                        id === "dcat-dataset-strings"
-                )
+                dcatArg &&
+                (typeof dcatArg.data !== "object" ||
+                    dcatArg.data === null ||
+                    Array.isArray(dcatArg.data))
             ) {
                 throw new UsageError(
-                    "dataset update does not accept --aspect dataset-publisher or --aspect dcat-dataset-strings; use --publisher, --title, --desc and --license so managed metadata stays consistent."
+                    "--aspect dcat-dataset-strings must contain a JSON object."
+                );
+            }
+            if (
+                dcatArg &&
+                Object.prototype.hasOwnProperty.call(dcatArg.data, "publisher")
+            ) {
+                throw new UsageError(
+                    "Set the dcat-dataset-strings publisher field with --publisher instead."
                 );
             }
             if (
                 Object.keys(scalarPatch).length === 0 &&
                 aspectArgs.length === 0 &&
-                !opts.publisher
+                opts.publisher === undefined
             ) {
                 throw new UsageError(
                     "Nothing to update: pass --title/--desc/--license/--publisher or --aspect."
@@ -356,25 +409,74 @@ export function registerDatasetCommands(program: Command): void {
             }
             const client = await clientFromProfile();
             let publisher: ResolvedPublisher | undefined;
-            if (opts.publisher) {
+            let existingPublisherId: string | undefined;
+            const touchesDatasetMetadata =
+                Object.keys(scalarPatch).length > 0 || Boolean(dcatArg);
+            if (opts.publisher !== undefined) {
                 publisher = await resolvePublisher(client, opts.publisher);
-            } else if (!(await getDatasetPublisherId(client, datasetId))) {
-                publisher = await resolveDefaultPublisher(client);
+            } else if (touchesDatasetMetadata) {
+                existingPublisherId = await getDatasetPublisherId(
+                    client,
+                    datasetId
+                );
+                if (!existingPublisherId) {
+                    publisher = await resolveDefaultPublisher(client);
+                }
+            }
+
+            if (dcatArg) {
+                const publisherName =
+                    publisher?.name ??
+                    (existingPublisherId
+                        ? (
+                              await resolvePublisherId(
+                                  client,
+                                  existingPublisherId
+                              )
+                          ).name
+                        : undefined);
+                if (publisherName) {
+                    dcatArg.data = {
+                        ...(dcatArg.data as Record<string, unknown>),
+                        publisher: publisherName
+                    };
+                }
             }
 
             let lastEventId = 0;
             let mergedTitle: string | undefined;
             if (publisher) {
                 scalarPatch.modified = new Date().toISOString();
-                const { eventId, merged } = await updatePublisherMetadata(
-                    client,
-                    datasetId,
-                    publisher,
-                    scalarPatch
-                );
-                lastEventId = Math.max(lastEventId, eventId);
-                mergedTitle =
-                    typeof merged.title === "string" ? merged.title : undefined;
+                const publisherDcatPatch = dcatArg
+                    ? {
+                          ...(dcatArg.data as Record<string, unknown>),
+                          ...scalarPatch
+                      }
+                    : scalarPatch;
+                try {
+                    const { eventId, merged } = await updatePublisherMetadata(
+                        client,
+                        datasetId,
+                        publisher,
+                        publisherDcatPatch,
+                        Boolean(dcatArg)
+                    );
+                    lastEventId = Math.max(lastEventId, eventId);
+                    mergedTitle =
+                        typeof merged.title === "string"
+                            ? merged.title
+                            : undefined;
+                } catch (e) {
+                    if (
+                        publisher.created &&
+                        !(await removeCreatedPublisher(client, publisher))
+                    ) {
+                        note(
+                            `Warning: the dataset update failed and the newly created organisation ${publisher.id} could not be removed.`
+                        );
+                    }
+                    throw e;
+                }
             } else if (Object.keys(scalarPatch).length > 0) {
                 scalarPatch.modified = new Date().toISOString();
                 const { eventId, merged } = await mergeAspect(
@@ -388,6 +490,7 @@ export function registerDatasetCommands(program: Command): void {
                     typeof merged.title === "string" ? merged.title : undefined;
             }
             for (const { id, data } of aspectArgs) {
+                if (publisher && id === "dcat-dataset-strings") continue;
                 try {
                     const res = await client.request(
                         "PUT",

--- a/packages/mgd/src/publisher.ts
+++ b/packages/mgd/src/publisher.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import { MagdaClient } from "./client.js";
+import { REGISTRY_RECORDS, recordAspect, registryRecord } from "./endpoints.js";
+import { MgdApiError, UsageError } from "./errors.js";
+import { deriveSiteUrl } from "./recordBuilders.js";
+
+export interface ResolvedPublisher {
+    id: string;
+    name: string;
+}
+
+interface OrganisationRecord {
+    id: string;
+    name?: string;
+    aspects?: {
+        "organization-details"?: {
+            name?: string;
+            title?: string;
+        };
+    };
+}
+
+function organisationName(record: OrganisationRecord): string {
+    const details = record.aspects?.["organization-details"];
+    return (
+        [details?.title, details?.name, record.name, record.id].find(
+            (value) => typeof value === "string" && value.trim()
+        ) ?? record.id
+    );
+}
+
+async function fetchOrganisation(
+    client: MagdaClient,
+    id: string
+): Promise<ResolvedPublisher | undefined> {
+    try {
+        const record = await client.json<OrganisationRecord>(
+            "GET",
+            registryRecord(id),
+            { query: [["aspect", "organization-details"]] }
+        );
+        if (!record.aspects?.["organization-details"]) {
+            throw new UsageError(
+                `Record ${record.id} is not an organisation: it has no organization-details aspect.`
+            );
+        }
+        return { id: record.id, name: organisationName(record) };
+    } catch (e) {
+        if (e instanceof MgdApiError && e.status === 404) return undefined;
+        throw e;
+    }
+}
+
+async function findPublisherByName(
+    client: MagdaClient,
+    name: string
+): Promise<ResolvedPublisher | undefined> {
+    const result = await client.json<{
+        options?: { identifier?: string; value?: string }[];
+    }>("GET", "/v0/search/facets/publisher/options", {
+        query: {
+            generalQuery: "*",
+            start: 0,
+            limit: 10,
+            facetQuery: name
+        }
+    });
+    const normalized = name.toLowerCase().trim();
+    const match = result.options?.find(
+        (option) =>
+            typeof option.identifier === "string" &&
+            option.identifier.length > 0 &&
+            typeof option.value === "string" &&
+            option.value.toLowerCase().trim() === normalized
+    );
+    return match ? { id: match.identifier!, name: match.value! } : undefined;
+}
+
+async function createPublisher(
+    client: MagdaClient,
+    name: string
+): Promise<ResolvedPublisher> {
+    const id = randomUUID();
+    await client.request("POST", REGISTRY_RECORDS, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            id,
+            name,
+            aspects: {
+                "organization-details": {
+                    name,
+                    title: name,
+                    imageUrl: "",
+                    description: "Added manually during dataset creation"
+                }
+            }
+        })
+    });
+    return { id, name };
+}
+
+/**
+ * Read the public web-server config. Some API-only deployments do not expose a
+ * web server at the profile's site URL; in that case there is no default to use.
+ */
+export async function fetchDefaultOrganizationId(
+    client: MagdaClient
+): Promise<string | undefined> {
+    const url = new URL("server-config.js", deriveSiteUrl(client.opts.baseUrl));
+    let response: Response;
+    try {
+        response = await fetch(url);
+    } catch {
+        return undefined;
+    }
+    if (!response.ok) return undefined;
+
+    const script = await response.text();
+    const match = /window\.magda_server_config\s*=\s*([\s\S]*?)\s*;\s*$/.exec(
+        script
+    );
+    if (!match) {
+        throw new Error(`Could not parse MAGDA site config from ${url}`);
+    }
+    const config = JSON.parse(match[1]) as { defaultOrganizationId?: unknown };
+    return typeof config.defaultOrganizationId === "string" &&
+        config.defaultOrganizationId.trim()
+        ? config.defaultOrganizationId.trim()
+        : undefined;
+}
+
+function looksLikeOrganisationId(value: string): boolean {
+    return (
+        /^org-/i.test(value) ||
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+            value
+        )
+    );
+}
+
+/** Resolve an explicit publisher as an existing record id or an exact name. */
+export async function resolvePublisher(
+    client: MagdaClient,
+    value: string
+): Promise<ResolvedPublisher> {
+    const input = value.trim();
+    if (!input) throw new UsageError("--publisher must not be empty.");
+    const byId = await fetchOrganisation(client, input);
+    if (byId) return byId;
+    if (looksLikeOrganisationId(input)) {
+        throw new MgdApiError(
+            `Publishing organisation record not found: ${input}`,
+            404,
+            "not-found",
+            "Check the organisation record ID or pass its name instead."
+        );
+    }
+
+    const byName = await findPublisherByName(client, input);
+    return byName ?? createPublisher(client, input);
+}
+
+/** Resolve the site's configured default publisher, when one is available. */
+export async function resolveDefaultPublisher(
+    client: MagdaClient
+): Promise<ResolvedPublisher | undefined> {
+    const id = await fetchDefaultOrganizationId(client);
+    if (!id) return undefined;
+    const publisher = await fetchOrganisation(client, id);
+    if (!publisher) {
+        throw new MgdApiError(
+            `Default organisation record not found: ${id}`,
+            404,
+            "not-found",
+            "Fix the site's defaultOrganizationId or pass --publisher explicitly."
+        );
+    }
+    return publisher;
+}
+
+/** Return the existing publisher reference without dereferencing it. */
+export async function getDatasetPublisherId(
+    client: MagdaClient,
+    datasetId: string
+): Promise<string | undefined> {
+    let aspect: { publisher?: unknown };
+    try {
+        aspect = await client.json(
+            "GET",
+            recordAspect(datasetId, "dataset-publisher")
+        );
+    } catch (e) {
+        if (e instanceof MgdApiError && e.status === 404) return undefined;
+        throw e;
+    }
+    return typeof aspect.publisher === "string" && aspect.publisher
+        ? aspect.publisher
+        : undefined;
+}

--- a/packages/mgd/src/publisher.ts
+++ b/packages/mgd/src/publisher.ts
@@ -7,6 +7,7 @@ import { deriveSiteUrl } from "./recordBuilders.js";
 export interface ResolvedPublisher {
     id: string;
     name: string;
+    created?: boolean;
 }
 
 interface OrganisationRecord {
@@ -51,29 +52,50 @@ async function fetchOrganisation(
     }
 }
 
+function aspectPattern(path: string, value: string): string {
+    const escaped = value.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
+    return `${encodeURIComponent(path)}:?${encodeURIComponent(`%${escaped}%`)}`;
+}
+
 async function findPublisherByName(
     client: MagdaClient,
     name: string
 ): Promise<ResolvedPublisher | undefined> {
-    const result = await client.json<{
-        options?: { identifier?: string; value?: string }[];
-    }>("GET", "/v0/search/facets/publisher/options", {
-        query: {
-            generalQuery: "*",
-            start: 0,
-            limit: 10,
-            facetQuery: name
-        }
-    });
     const normalized = name.toLowerCase().trim();
-    const match = result.options?.find(
-        (option) =>
-            typeof option.identifier === "string" &&
-            option.identifier.length > 0 &&
-            typeof option.value === "string" &&
-            option.value.toLowerCase().trim() === normalized
-    );
-    return match ? { id: match.identifier!, name: match.value! } : undefined;
+    let pageToken: string | undefined;
+
+    do {
+        const query: [string, string][] = [
+            ["aspect", "organization-details"],
+            [
+                "aspectOrQuery",
+                aspectPattern("organization-details.title", name)
+            ],
+            ["aspectOrQuery", aspectPattern("organization-details.name", name)],
+            ["limit", "100"]
+        ];
+        if (pageToken) query.push(["pageToken", pageToken]);
+
+        const page = await client.json<{
+            hasMore?: boolean;
+            nextPageToken?: string;
+            records?: OrganisationRecord[];
+        }>("GET", REGISTRY_RECORDS, { query });
+        const match = page.records?.find((record) => {
+            const details = record.aspects?.["organization-details"];
+            return [details?.title, details?.name].some(
+                (candidate) =>
+                    typeof candidate === "string" &&
+                    candidate.toLowerCase().trim() === normalized
+            );
+        });
+        if (match) {
+            return { id: match.id, name: organisationName(match) };
+        }
+        pageToken = page.hasMore ? page.nextPageToken : undefined;
+    } while (pageToken);
+
+    return undefined;
 }
 
 async function createPublisher(
@@ -96,7 +118,7 @@ async function createPublisher(
             }
         })
     });
-    return { id, name };
+    return { id, name, created: true };
 }
 
 /**
@@ -115,27 +137,37 @@ export async function fetchDefaultOrganizationId(
     }
     if (!response.ok) return undefined;
 
-    const script = await response.text();
-    const match = /window\.magda_server_config\s*=\s*([\s\S]*?)\s*;\s*$/.exec(
-        script
-    );
-    if (!match) {
-        throw new Error(`Could not parse MAGDA site config from ${url}`);
+    try {
+        const script = await response.text();
+        const match =
+            /window\.magda_server_config\s*=\s*([\s\S]*?)\s*;\s*$/.exec(script);
+        if (!match) return undefined;
+        const config = JSON.parse(match[1]) as {
+            defaultOrganizationId?: unknown;
+        };
+        return typeof config.defaultOrganizationId === "string" &&
+            config.defaultOrganizationId.trim()
+            ? config.defaultOrganizationId.trim()
+            : undefined;
+    } catch {
+        return undefined;
     }
-    const config = JSON.parse(match[1]) as { defaultOrganizationId?: unknown };
-    return typeof config.defaultOrganizationId === "string" &&
-        config.defaultOrganizationId.trim()
-        ? config.defaultOrganizationId.trim()
-        : undefined;
 }
 
-function looksLikeOrganisationId(value: string): boolean {
-    return (
-        /^org-/i.test(value) ||
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-            value
-        )
-    );
+export async function resolvePublisherId(
+    client: MagdaClient,
+    id: string
+): Promise<ResolvedPublisher> {
+    const publisher = await fetchOrganisation(client, id);
+    if (!publisher) {
+        throw new MgdApiError(
+            `Publishing organisation record not found: ${id}`,
+            404,
+            "not-found",
+            "Check the organisation record ID or pass its name instead."
+        );
+    }
+    return publisher;
 }
 
 /** Resolve an explicit publisher as an existing record id or an exact name. */
@@ -147,17 +179,22 @@ export async function resolvePublisher(
     if (!input) throw new UsageError("--publisher must not be empty.");
     const byId = await fetchOrganisation(client, input);
     if (byId) return byId;
-    if (looksLikeOrganisationId(input)) {
-        throw new MgdApiError(
-            `Publishing organisation record not found: ${input}`,
-            404,
-            "not-found",
-            "Check the organisation record ID or pass its name instead."
-        );
-    }
 
     const byName = await findPublisherByName(client, input);
     return byName ?? createPublisher(client, input);
+}
+
+export async function removeCreatedPublisher(
+    client: MagdaClient,
+    publisher: ResolvedPublisher | undefined
+): Promise<boolean> {
+    if (!publisher?.created) return false;
+    try {
+        await client.request("DELETE", registryRecord(publisher.id));
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 /** Resolve the site's configured default publisher, when one is available. */

--- a/packages/mgd/src/recordBuilders.ts
+++ b/packages/mgd/src/recordBuilders.ts
@@ -200,6 +200,7 @@ export function buildDatasetRecord(args: {
     owner?: { id?: string; orgUnitId?: string };
     now: Date;
     sourceUrl?: string;
+    publisher?: { id: string; name: string };
     extraAspects?: Record<string, unknown>;
 }) {
     const iso = args.now.toISOString();
@@ -212,9 +213,17 @@ export function buildDatasetRecord(args: {
                 description: args.description ?? "",
                 issued: iso,
                 modified: iso,
-                languages: ["eng"]
+                languages: ["eng"],
+                ...(args.publisher ? { publisher: args.publisher.name } : {})
             },
             publishing: { state: args.publish ? "published" : "draft" },
+            ...(args.publisher
+                ? {
+                      "dataset-publisher": {
+                          publisher: args.publisher.id
+                      }
+                  }
+                : {}),
             ...accessControlAspect(args.owner),
             source: sourceAspect(args.sourceUrl),
             version: buildInitialVersionAspect({

--- a/packages/mgd/src/test/datasetCreate.spec.ts
+++ b/packages/mgd/src/test/datasetCreate.spec.ts
@@ -122,6 +122,96 @@ describe("dataset create", () => {
         }
     });
 
+    it("uses the site's default publisher and writes both publisher fields", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/auth/users/whoami",
+                body: { id: "u1" }
+            },
+            {
+                method: "GET",
+                path: "/server-config.js",
+                body: 'window.magda_server_config = {"defaultOrganizationId":"org-default"};'
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-default",
+                body: {
+                    id: "org-default",
+                    name: "Default Agency",
+                    aspects: {
+                        "organization-details": { title: "Default Agency" }
+                    }
+                }
+            },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "create", "--title", "My data"],
+                    { from: "user" }
+                )
+            );
+            const posted = JSON.parse(
+                server.requests
+                    .find((r) => r.method === "POST")!
+                    .body.toString()
+            );
+            expect(posted.aspects["dataset-publisher"]).to.deep.equal({
+                publisher: "org-default"
+            });
+            expect(posted.aspects["dcat-dataset-strings"].publisher).to.equal(
+                "Default Agency"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    for (const aspectId of ["dataset-publisher", "dcat-dataset-strings"]) {
+        it(`rejects managed publisher aspect ${aspectId}`, async () => {
+            const server = await startMockServer([
+                { method: "GET", path: "/v0/auth/users/whoami", body: {} }
+            ]);
+            process.env.MGD_BASE_URL = server.url;
+            try {
+                const program = new Command();
+                registerDatasetCommands(program);
+                let error: unknown;
+                try {
+                    await captureStdout(() =>
+                        program.parseAsync(
+                            [
+                                "dataset",
+                                "create",
+                                "--title",
+                                "My data",
+                                "--aspect",
+                                `${aspectId}={}`
+                            ],
+                            { from: "user" }
+                        )
+                    );
+                } catch (e) {
+                    error = e;
+                }
+                expect((error as Error).message).to.contain(
+                    "does not accept --aspect"
+                );
+                expect(
+                    server.requests.some((r) => r.method === "POST")
+                ).to.equal(false);
+            } finally {
+                await server.close();
+            }
+        });
+    }
+
     it("skips v0 tagging when the response has no event id header", async () => {
         const server = await startMockServer([
             {

--- a/packages/mgd/src/test/datasetCreate.spec.ts
+++ b/packages/mgd/src/test/datasetCreate.spec.ts
@@ -173,44 +173,204 @@ describe("dataset create", () => {
         }
     });
 
-    for (const aspectId of ["dataset-publisher", "dcat-dataset-strings"]) {
-        it(`rejects managed publisher aspect ${aspectId}`, async () => {
-            const server = await startMockServer([
-                { method: "GET", path: "/v0/auth/users/whoami", body: {} }
-            ]);
-            process.env.MGD_BASE_URL = server.url;
+    it("rejects a raw dataset-publisher aspect", async () => {
+        const program = new Command();
+        registerDatasetCommands(program);
+        let error: unknown;
+        try {
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "create",
+                        "--title",
+                        "My data",
+                        "--aspect",
+                        "dataset-publisher={}"
+                    ],
+                    { from: "user" }
+                )
+            );
+        } catch (e) {
+            error = e;
+        }
+        expect((error as Error).message).to.contain(
+            "does not accept --aspect dataset-publisher"
+        );
+    });
+
+    it("rejects an empty publisher value", async () => {
+        const server = await startMockServer([
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            let error: unknown;
             try {
-                const program = new Command();
-                registerDatasetCommands(program);
-                let error: unknown;
-                try {
-                    await captureStdout(() =>
-                        program.parseAsync(
-                            [
-                                "dataset",
-                                "create",
-                                "--title",
-                                "My data",
-                                "--aspect",
-                                `${aspectId}={}`
-                            ],
-                            { from: "user" }
-                        )
-                    );
-                } catch (e) {
-                    error = e;
-                }
-                expect((error as Error).message).to.contain(
-                    "does not accept --aspect"
+                await captureStdout(() =>
+                    program.parseAsync(
+                        [
+                            "dataset",
+                            "create",
+                            "--title",
+                            "My data",
+                            "--publisher",
+                            ""
+                        ],
+                        { from: "user" }
+                    )
                 );
-                expect(
-                    server.requests.some((r) => r.method === "POST")
-                ).to.equal(false);
-            } finally {
-                await server.close();
+            } catch (e) {
+                error = e;
             }
-        });
-    }
+            expect((error as Error).message).to.equal(
+                "--publisher must not be empty."
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("allows other dcat fields while managing the publisher mirror", async () => {
+        const server = await startMockServer([
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-1",
+                body: {
+                    id: "org-1",
+                    aspects: {
+                        "organization-details": { title: "Data Agency" }
+                    }
+                }
+            },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "create",
+                        "--title",
+                        "My data",
+                        "--publisher",
+                        "org-1",
+                        "--aspect",
+                        'dcat-dataset-strings={"keywords":["water"]}'
+                    ],
+                    { from: "user" }
+                )
+            );
+            const posted = JSON.parse(
+                server.requests
+                    .find((r) => r.method === "POST")!
+                    .body.toString()
+            );
+            expect(posted.aspects["dcat-dataset-strings"]).to.include({
+                title: "My data",
+                description: ""
+            });
+            expect(
+                posted.aspects["dcat-dataset-strings"].keywords
+            ).to.deep.equal(["water"]);
+            expect(posted.aspects["dcat-dataset-strings"].publisher).to.equal(
+                "Data Agency"
+            );
+            expect(posted.aspects["dcat-dataset-strings"].issued).to.be.a(
+                "string"
+            );
+            expect(posted.aspects["dataset-publisher"]).to.deep.equal({
+                publisher: "org-1"
+            });
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("removes a newly created organisation when dataset creation fails", async () => {
+        let postCount = 0;
+        const server = await startMockServer([
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            {
+                method: "GET",
+                path: /\/v0\/registry\/records\//,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { hasMore: false, records: [] }
+            },
+            {
+                method: "POST",
+                path: "/v0/registry/records",
+                handler: (_req, res) => {
+                    postCount++;
+                    if (postCount === 1) {
+                        res.writeHead(200, {
+                            "content-type": "application/json"
+                        });
+                        res.end("{}");
+                    } else {
+                        res.writeHead(500, {
+                            "content-type": "application/json"
+                        });
+                        res.end(JSON.stringify({ message: "create failed" }));
+                    }
+                }
+            },
+            {
+                method: "DELETE",
+                path: /\/v0\/registry\/records\/[0-9a-f-]{36}$/,
+                body: {}
+            }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            let error: unknown;
+            try {
+                await captureStdout(() =>
+                    program.parseAsync(
+                        [
+                            "dataset",
+                            "create",
+                            "--title",
+                            "My data",
+                            "--publisher",
+                            "New Agency"
+                        ],
+                        { from: "user" }
+                    )
+                );
+            } catch (e) {
+                error = e;
+            }
+            expect((error as Error).message).to.equal("create failed");
+            const organisation = JSON.parse(
+                server.requests
+                    .filter((r) => r.method === "POST")[0]
+                    .body.toString()
+            );
+            expect(
+                server.requests.some(
+                    (r) =>
+                        r.method === "DELETE" &&
+                        r.url.endsWith(`/records/${organisation.id}`)
+                )
+            ).to.equal(true);
+        } finally {
+            await server.close();
+        }
+    });
 
     it("skips v0 tagging when the response has no event id header", async () => {
         const server = await startMockServer([

--- a/packages/mgd/src/test/publisher.spec.ts
+++ b/packages/mgd/src/test/publisher.spec.ts
@@ -1,0 +1,217 @@
+import { expect } from "chai";
+import { MagdaClient } from "../client.js";
+import {
+    fetchDefaultOrganizationId,
+    getDatasetPublisherId,
+    resolveDefaultPublisher,
+    resolvePublisher
+} from "../publisher.js";
+import { startMockServer } from "./mockServer.js";
+
+describe("publisher resolution", () => {
+    it("rejects an empty publisher", async () => {
+        let error: unknown;
+        try {
+            await resolvePublisher(
+                new MagdaClient({ baseUrl: "http://127.0.0.1:1" }),
+                "   "
+            );
+        } catch (e) {
+            error = e;
+        }
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.equal(
+            "--publisher must not be empty."
+        );
+    });
+
+    it("uses an organisation record id directly and reads its canonical name", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-1",
+                body: {
+                    id: "org-1",
+                    name: "Data Agency",
+                    aspects: {
+                        "organization-details": { title: "Data Agency" }
+                    }
+                }
+            }
+        ]);
+        try {
+            const result = await resolvePublisher(
+                new MagdaClient({ baseUrl: server.url }),
+                "org-1"
+            );
+            expect(result).to.deep.equal({ id: "org-1", name: "Data Agency" });
+            expect(server.requests[0].url).to.contain(
+                "aspect=organization-details"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("rejects a record without organization-details", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records/ds-1",
+                body: { id: "ds-1", name: "A dataset", aspects: {} }
+            }
+        ]);
+        try {
+            let error: unknown;
+            try {
+                await resolvePublisher(
+                    new MagdaClient({ baseUrl: server.url }),
+                    "ds-1"
+                );
+            } catch (e) {
+                error = e;
+            }
+            expect((error as Error).message).to.contain(
+                "is not an organisation"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("reuses an exact case-insensitive publisher name match", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /\/v0\/registry\/records\//,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/v0/search/facets/publisher/options",
+                body: {
+                    options: [
+                        { identifier: "org-other", value: "Other" },
+                        { identifier: "org-1", value: "Data Agency" }
+                    ]
+                }
+            }
+        ]);
+        try {
+            const result = await resolvePublisher(
+                new MagdaClient({ baseUrl: server.url }),
+                "  data agency  "
+            );
+            expect(result).to.deep.equal({ id: "org-1", name: "Data Agency" });
+            const search = server.requests.find((r) =>
+                r.url.startsWith("/v0/search/facets/publisher/options?")
+            )!;
+            const query = new URL(search.url, server.url).searchParams;
+            expect(query.get("generalQuery")).to.equal("*");
+            expect(query.get("start")).to.equal("0");
+            expect(query.get("limit")).to.equal("10");
+            expect(query.get("facetQuery")).to.equal("data agency");
+            expect(server.requests.some((r) => r.method === "POST")).to.equal(
+                false
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("creates an organisation when no publisher name matches", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /\/v0\/registry\/records\//,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/v0/search/facets/publisher/options",
+                body: { options: [] }
+            },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        try {
+            const result = await resolvePublisher(
+                new MagdaClient({ baseUrl: server.url }),
+                "New Agency"
+            );
+            expect(result.id).to.match(/^[0-9a-f-]{36}$/);
+            expect(result.name).to.equal("New Agency");
+            const body = JSON.parse(
+                server.requests
+                    .find((r) => r.method === "POST")!
+                    .body.toString()
+            );
+            expect(body).to.deep.equal({
+                id: result.id,
+                name: "New Agency",
+                aspects: {
+                    "organization-details": {
+                        name: "New Agency",
+                        title: "New Agency",
+                        imageUrl: "",
+                        description: "Added manually during dataset creation"
+                    }
+                }
+            });
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("reads and resolves the site's default organisation", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/server-config.js",
+                body: 'window.magda_server_config = {"defaultOrganizationId":"org-default"};'
+            },
+            {
+                method: "GET",
+                path: "/api/v0/registry/records/org-default",
+                body: {
+                    id: "org-default",
+                    name: "Default Agency",
+                    aspects: { "organization-details": {} }
+                }
+            }
+        ]);
+        try {
+            const client = new MagdaClient({ baseUrl: `${server.url}/api` });
+            expect(await fetchDefaultOrganizationId(client)).to.equal(
+                "org-default"
+            );
+            expect(await resolveDefaultPublisher(client)).to.deep.equal({
+                id: "org-default",
+                name: "Default Agency"
+            });
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("reads an attached publisher id without dereferencing it", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records/ds-1/aspects/dataset-publisher",
+                body: { publisher: "org-stale" }
+            }
+        ]);
+        try {
+            const result = await getDatasetPublisherId(
+                new MagdaClient({ baseUrl: server.url }),
+                "ds-1"
+            );
+            expect(result).to.equal("org-stale");
+            expect(server.requests).to.have.length(1);
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/mgd/src/test/publisher.spec.ts
+++ b/packages/mgd/src/test/publisher.spec.ts
@@ -89,11 +89,19 @@ describe("publisher resolution", () => {
             },
             {
                 method: "GET",
-                path: "/v0/search/facets/publisher/options",
+                path: "/v0/registry/records",
                 body: {
-                    options: [
-                        { identifier: "org-other", value: "Other" },
-                        { identifier: "org-1", value: "Data Agency" }
+                    hasMore: false,
+                    records: [
+                        {
+                            id: "org-1",
+                            name: "data-agency",
+                            aspects: {
+                                "organization-details": {
+                                    title: "Data Agency"
+                                }
+                            }
+                        }
                     ]
                 }
             }
@@ -105,16 +113,118 @@ describe("publisher resolution", () => {
             );
             expect(result).to.deep.equal({ id: "org-1", name: "Data Agency" });
             const search = server.requests.find((r) =>
-                r.url.startsWith("/v0/search/facets/publisher/options?")
+                r.url.startsWith("/v0/registry/records?")
             )!;
             const query = new URL(search.url, server.url).searchParams;
-            expect(query.get("generalQuery")).to.equal("*");
-            expect(query.get("start")).to.equal("0");
-            expect(query.get("limit")).to.equal("10");
-            expect(query.get("facetQuery")).to.equal("data agency");
+            expect(query.get("aspect")).to.equal("organization-details");
+            expect(query.get("limit")).to.equal("100");
+            expect(query.getAll("aspectOrQuery")).to.have.length(2);
+            expect(query.getAll("aspectOrQuery")[0]).to.contain(
+                "organization-details.title:?"
+            );
             expect(server.requests.some((r) => r.method === "POST")).to.equal(
                 false
             );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("escapes special characters in registry name queries", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /\/v0\/registry\/records\//,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                body: { hasMore: false, records: [] }
+            },
+            { method: "POST", path: "/v0/registry/records", body: {} }
+        ]);
+        try {
+            await resolvePublisher(
+                new MagdaClient({ baseUrl: server.url }),
+                "100%_\\ Agency"
+            );
+            const request = server.requests.find((r) =>
+                r.url.startsWith("/v0/registry/records?")
+            )!;
+            const encodedQuery = new URL(
+                request.url,
+                server.url
+            ).searchParams.getAll("aspectOrQuery")[0];
+            expect(encodedQuery).to.contain("%25");
+            expect(decodeURIComponent(encodedQuery)).to.equal(
+                "organization-details.title:?%100\\%\\_\\\\ Agency%"
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("continues registry name lookup across pages", async () => {
+        let page = 0;
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /\/v0\/registry\/records\//,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records",
+                handler: (_req, res) => {
+                    page++;
+                    res.writeHead(200, { "content-type": "application/json" });
+                    res.end(
+                        JSON.stringify(
+                            page === 1
+                                ? {
+                                      hasMore: true,
+                                      nextPageToken: "101",
+                                      records: []
+                                  }
+                                : {
+                                      hasMore: false,
+                                      records: [
+                                          {
+                                              id: "org-page-2",
+                                              aspects: {
+                                                  "organization-details": {
+                                                      title: "Paged Agency"
+                                                  }
+                                              }
+                                          }
+                                      ]
+                                  }
+                        )
+                    );
+                }
+            }
+        ]);
+        try {
+            const result = await resolvePublisher(
+                new MagdaClient({ baseUrl: server.url }),
+                "Paged Agency"
+            );
+            expect(result).to.deep.equal({
+                id: "org-page-2",
+                name: "Paged Agency"
+            });
+            const registryQueries = server.requests.filter((r) =>
+                r.url.startsWith("/v0/registry/records?")
+            );
+            expect(registryQueries).to.have.length(2);
+            expect(
+                new URL(registryQueries[1].url, server.url).searchParams.get(
+                    "pageToken"
+                )
+            ).to.equal("101");
         } finally {
             await server.close();
         }
@@ -130,8 +240,8 @@ describe("publisher resolution", () => {
             },
             {
                 method: "GET",
-                path: "/v0/search/facets/publisher/options",
-                body: { options: [] }
+                path: "/v0/registry/records",
+                body: { hasMore: false, records: [] }
             },
             { method: "POST", path: "/v0/registry/records", body: {} }
         ]);
@@ -159,6 +269,24 @@ describe("publisher resolution", () => {
                     }
                 }
             });
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("ignores an unparseable 200 response from server-config.js", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/server-config.js",
+                body: "<!doctype html><title>SPA fallback</title>"
+            }
+        ]);
+        try {
+            const result = await fetchDefaultOrganizationId(
+                new MagdaClient({ baseUrl: server.url })
+            );
+            expect(result).to.equal(undefined);
         } finally {
             await server.close();
         }

--- a/packages/mgd/src/test/recordBuilders.spec.ts
+++ b/packages/mgd/src/test/recordBuilders.spec.ts
@@ -117,6 +117,21 @@ describe("recordBuilders", () => {
         expect(record.aspects.version.currentVersionNumber).to.equal(0);
     });
 
+    it("writes the publisher reference and dcat name mirror", () => {
+        const record = buildDatasetRecord({
+            id: "x",
+            title: "t",
+            now: NOW,
+            publisher: { id: "org-1", name: "Data Agency" }
+        });
+        expect(record.aspects["dataset-publisher"]).to.deep.equal({
+            publisher: "org-1"
+        });
+        expect(record.aspects["dcat-dataset-strings"].publisher).to.equal(
+            "Data Agency"
+        );
+    });
+
     it("omits source.url when no sourceUrl is given", () => {
         const record = buildDatasetRecord({ id: "x", title: "t", now: NOW });
         expect(record.aspects.source).to.deep.equal({

--- a/packages/mgd/src/test/recordUpdate.spec.ts
+++ b/packages/mgd/src/test/recordUpdate.spec.ts
@@ -11,12 +11,200 @@ describe("dataset update", () => {
         else process.env.MGD_BASE_URL = origBaseUrl;
     });
 
+    it("sets a publisher reference and name mirror", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-1",
+                body: {
+                    id: "org-1",
+                    name: "record-slug",
+                    aspects: {
+                        "organization-details": { title: "Data Agency" }
+                    }
+                }
+            },
+            {
+                method: "GET",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: { title: "Dataset", description: "keep me" }
+            },
+            {
+                method: "PATCH",
+                path: "/v0/registry/records",
+                body: [42]
+            },
+            {
+                method: "GET",
+                path: /aspects\/version$/,
+                body: {
+                    currentVersionNumber: 0,
+                    versions: [
+                        {
+                            versionNumber: 0,
+                            createTime: "2026-01-01T00:00:00.000Z",
+                            description: "initial version",
+                            title: "Dataset",
+                            eventId: 1
+                        }
+                    ]
+                }
+            },
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "update", "ds-1", "--publisher", "org-1"],
+                    { from: "user" }
+                )
+            );
+            const patchRequest = server.requests.find(
+                (r) => r.method === "PATCH"
+            )!;
+            const patch = JSON.parse(patchRequest.body.toString());
+            expect(patch.recordIds).to.deep.equal(["ds-1"]);
+            expect(patch.jsonPath).to.deep.include({
+                op: "add",
+                path: "/aspects/dcat-dataset-strings",
+                value: {
+                    title: "Dataset",
+                    description: "keep me",
+                    publisher: "Data Agency",
+                    modified: patch.jsonPath[0].value.modified
+                }
+            });
+            expect(patch.jsonPath).to.deep.include({
+                op: "add",
+                path: "/aspects/dataset-publisher",
+                value: { publisher: "org-1" }
+            });
+            const versionPut = server.requests.find(
+                (r) => r.method === "PUT" && r.url.includes("aspects/version")
+            )!;
+            const version = JSON.parse(versionPut.body.toString());
+            expect(version.currentVersionNumber).to.equal(1);
+            expect(version.versions[1].eventId).to.equal(42);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("backfills the site default on a publisher-less dataset", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /aspects\/dataset-publisher$/,
+                status: 404,
+                body: { message: "not found" }
+            },
+            {
+                method: "GET",
+                path: "/server-config.js",
+                body: 'window.magda_server_config = {"defaultOrganizationId":"org-default"};'
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-default",
+                body: {
+                    id: "org-default",
+                    aspects: {
+                        "organization-details": { title: "Default Agency" }
+                    }
+                }
+            },
+            {
+                method: "GET",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: { title: "Old" }
+            },
+            {
+                method: "PATCH",
+                path: "/v0/registry/records",
+                body: [11]
+            },
+            {
+                method: "GET",
+                path: /aspects\/version$/,
+                status: 404,
+                body: { message: "not found" }
+            },
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    ["dataset", "update", "ds-1", "--title", "New"],
+                    { from: "user" }
+                )
+            );
+            const patchRequest = server.requests.find(
+                (r) => r.method === "PATCH"
+            )!;
+            const patch = JSON.parse(patchRequest.body.toString());
+            expect(patch.jsonPath[0].value.publisher).to.equal(
+                "Default Agency"
+            );
+            expect(patch.jsonPath[1]).to.deep.equal({
+                op: "add",
+                path: "/aspects/dataset-publisher",
+                value: { publisher: "org-default" }
+            });
+        } finally {
+            await server.close();
+        }
+    });
+
+    for (const aspectId of ["dataset-publisher", "dcat-dataset-strings"]) {
+        it(`rejects managed publisher aspect ${aspectId}`, async () => {
+            const program = new Command();
+            registerDatasetCommands(program);
+            let error: unknown;
+            try {
+                await captureStdout(() =>
+                    program.parseAsync(
+                        [
+                            "dataset",
+                            "update",
+                            "ds-1",
+                            "--aspect",
+                            `${aspectId}={}`
+                        ],
+                        { from: "user" }
+                    )
+                );
+            } catch (e) {
+                error = e;
+            }
+            expect((error as Error).message).to.contain(
+                "does not accept --aspect"
+            );
+        });
+    }
+
     it("merges scalar fields into dcat-dataset-strings", async () => {
         const server = await startMockServer([
             {
                 method: "GET",
+                path: /aspects\/dataset-publisher$/,
+                body: { publisher: "org-stale" }
+            },
+            {
+                method: "GET",
                 path: /aspects\/dcat-dataset-strings$/,
-                body: { title: "Old", description: "keep me" }
+                body: {
+                    title: "Old",
+                    description: "keep me",
+                    publisher: "Old Agency"
+                }
             },
             {
                 method: "PUT",
@@ -38,7 +226,11 @@ describe("dataset update", () => {
             const body = JSON.parse(put.body.toString());
             expect(body.title).to.equal("New");
             expect(body.description).to.equal("keep me");
+            expect(body.publisher).to.equal("Old Agency");
             expect(body.modified).to.be.a("string");
+            expect(
+                server.requests.some((r) => r.url.includes("records/org-stale"))
+            ).to.equal(false);
         } finally {
             await server.close();
         }

--- a/packages/mgd/src/test/recordUpdate.spec.ts
+++ b/packages/mgd/src/test/recordUpdate.spec.ts
@@ -163,32 +163,138 @@ describe("dataset update", () => {
         }
     });
 
-    for (const aspectId of ["dataset-publisher", "dcat-dataset-strings"]) {
-        it(`rejects managed publisher aspect ${aspectId}`, async () => {
+    it("rejects a raw dataset-publisher aspect", async () => {
+        const program = new Command();
+        registerDatasetCommands(program);
+        let error: unknown;
+        try {
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "update",
+                        "ds-1",
+                        "--aspect",
+                        "dataset-publisher={}"
+                    ],
+                    { from: "user" }
+                )
+            );
+        } catch (e) {
+            error = e;
+        }
+        expect((error as Error).message).to.contain(
+            "does not accept --aspect dataset-publisher"
+        );
+    });
+
+    it("allows other dcat fields and preserves the publisher mirror", async () => {
+        const server = await startMockServer([
+            {
+                method: "GET",
+                path: /aspects\/dataset-publisher$/,
+                body: { publisher: "org-1" }
+            },
+            {
+                method: "GET",
+                path: "/v0/registry/records/org-1",
+                body: {
+                    id: "org-1",
+                    aspects: {
+                        "organization-details": { title: "Data Agency" }
+                    }
+                }
+            },
+            {
+                method: "PUT",
+                path: /aspects\/dcat-dataset-strings$/,
+                body: {},
+                headers: { "x-magda-event-id": "5" }
+            },
+            {
+                method: "GET",
+                path: /aspects\/version$/,
+                status: 404,
+                body: { message: "not found" }
+            },
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
             const program = new Command();
             registerDatasetCommands(program);
-            let error: unknown;
-            try {
-                await captureStdout(() =>
-                    program.parseAsync(
-                        [
-                            "dataset",
-                            "update",
-                            "ds-1",
-                            "--aspect",
-                            `${aspectId}={}`
-                        ],
-                        { from: "user" }
-                    )
-                );
-            } catch (e) {
-                error = e;
-            }
-            expect((error as Error).message).to.contain(
-                "does not accept --aspect"
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "update",
+                        "ds-1",
+                        "--aspect",
+                        'dcat-dataset-strings={"keywords":["water"]}'
+                    ],
+                    { from: "user" }
+                )
             );
-        });
-    }
+            const dcatPut = server.requests.find(
+                (r) =>
+                    r.method === "PUT" &&
+                    r.url.includes("aspects/dcat-dataset-strings")
+            )!;
+            expect(JSON.parse(dcatPut.body.toString())).to.deep.equal({
+                keywords: ["water"],
+                publisher: "Data Agency"
+            });
+        } finally {
+            await server.close();
+        }
+    });
+
+    it("does not backfill a publisher for a custom-aspect-only update", async () => {
+        const server = await startMockServer([
+            {
+                method: "PUT",
+                path: /aspects\/my-aspect$/,
+                body: {},
+                headers: { "x-magda-event-id": "5" }
+            },
+            {
+                method: "GET",
+                path: /aspects\/version$/,
+                status: 404,
+                body: { message: "not found" }
+            },
+            { method: "GET", path: "/v0/auth/users/whoami", body: {} },
+            { method: "PUT", path: /aspects\/version$/, body: {} }
+        ]);
+        process.env.MGD_BASE_URL = server.url;
+        try {
+            const program = new Command();
+            registerDatasetCommands(program);
+            await captureStdout(() =>
+                program.parseAsync(
+                    [
+                        "dataset",
+                        "update",
+                        "ds-1",
+                        "--aspect",
+                        'my-aspect={"value":1}'
+                    ],
+                    { from: "user" }
+                )
+            );
+            expect(
+                server.requests.some(
+                    (r) =>
+                        r.url.includes("dataset-publisher") ||
+                        r.url.includes("server-config.js") ||
+                        r.method === "PATCH"
+                )
+            ).to.equal(false);
+        } finally {
+            await server.close();
+        }
+    });
 
     it("merges scalar fields into dcat-dataset-strings", async () => {
         const server = await startMockServer([


### PR DESCRIPTION
### What this PR does

Fixes #3715

Adds publishing organisation support to `mgd dataset create` and `mgd dataset update`:

- accepts `--publisher <name|orgId>`
- resolves exact case-insensitive publisher names directly against paginated registry organisation records, avoiding search-index lag and top-result limits
- creates an `organisation` record when needed and rolls it back if dataset creation fails
- applies the site `defaultOrganizationId` when appropriate, while avoiding publisher side effects on custom-aspect-only updates
- writes `dataset-publisher` and the `dcat-dataset-strings.publisher` mirror atomically on updates
- preserves support for other `dcat-dataset-strings` fields through `--aspect`
- gracefully handles unavailable or unparseable site configuration
- documents the workflow in the README and packaged agent skill

`organization-details` is a built-in aspect that MAGDA bootstraps; the web client's `ensureAspectExists()` is intentionally a no-op for built-in aspects, so the CLI follows the same deployment assumption.

### Validation

- `npm run typecheck`
- `npm test` (172 passing)
- `npm run build`
- `npm_config_cache=/tmp/mgd-npm-cache npm run smoke:pack`
- verified `dataset create --help` and `dataset update --help`

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.