### PR TITLE
fix(ci): pull test minio image from GHCR instead of deprecated Docker Hub tag

### DIFF
--- a/magda-storage-api/docker-compose.yml
+++ b/magda-storage-api/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.3"
 # 9001 through 9004.
 services:
   minio:
-    image: minio/minio:RELEASE.2020-09-26T03-44-56Z
+    image: ghcr.io/magda-io/minio:7.1.2
     # volumes:
     #   - data1-1:/data1
     #   - data1-2:/data2


### PR DESCRIPTION
## Problem

CI is failing on `main` (and blocked the `v6.2.1` release). The `buildtest:storage-api` and `buildtest:integration-tests` jobs fail because the pinned test image `minio/minio:RELEASE.2020-09-26T03-44-56Z` can no longer be pulled:

```
Pulling minio (minio/minio:RELEASE.2020-09-26T03-44-56Z)...
pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

MinIO deprecated their Docker Hub images — the tag now 404s and even `minio/minio:latest` is denied anonymously; quay.io only retains recent tags and Google's `mirror.gcr.io` has no cached copy. The exact version is no longer available from any public registry.

## Impact (one image, three failures)

`magda-storage-api/docker-compose.yml` is the single source of the broken image. It breaks:

- `buildtest:storage-api` — `docker-compose up` can't pull minio.
- `buildtest:integration-tests` → **both** before-all timeouts: `storageApiAuth.spec.ts` and `walgBackupRestore.spec.ts` each start minio via `ServiceRunner.createMinio()`, which loads this same `@magda/storage-api` compose file (`magda-int-test-ts/src/ServiceRunner.ts:362`). minio never comes up → 600s hook timeout (hence the orphaned `walg-restore-*` container/volume).

Unrelated to the recent DinD MTU change (#3779) — this is a registry access error, not a network fault.

## Fix

Pull the same minio version from magda's own GHCR instead of Docker Hub:

```diff
- image: minio/minio:RELEASE.2020-09-26T03-44-56Z
+ image: ghcr.io/magda-io/minio:7.1.2
```

`ghcr.io/magda-io/minio:7.1.2` is magda's repackaged copy of the **exact same** minio version — `docker run --entrypoint minio ghcr.io/magda-io/minio:7.1.2 --version` → `RELEASE.2020-09-26T03-44-56Z` — and is already the image magda deploys in production. It uses the same `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` env vars, so no other test or `ServiceRunner` change is needed. Pulling from magda's own registry also avoids future Docker Hub deprecation/rate-limit exposure.

## Verification

Smoke-tested locally with the compose's exact settings (`server /tmp`, legacy env vars): the container boots and both `/minio/health/live` and `/minio/health/ready` return healthy within ~3s. Full validation is via this branch's GitLab pipeline (`buildtest:storage-api` + `buildtest:integration-tests`).
